### PR TITLE
Add total unique visitors metric to daily blog report

### DIFF
--- a/.github/workflows/daily-report.yml
+++ b/.github/workflows/daily-report.yml
@@ -93,6 +93,10 @@ jobs:
             "post_likes?select=id&created_at=gte.${YESTERDAY}T00:00:00Z&created_at=lt.${TODAY}T00:00:00Z" \
             /tmp/lk_h)
 
+          blog_total_uv=$(curl -sf "${BLOG_SB_URL}/rest/v1/post_views?select=ip" \
+            -H "apikey: ${BLOG_SB_KEY}" -H "Authorization: Bearer ${BLOG_SB_KEY}" 2>/dev/null \
+            | python3 -c 'import sys,json;d=json.load(sys.stdin);print(len(set(r["ip"] for r in d)))' 2>/dev/null || echo "N/A")
+
           top_articles=$(curl -sf "${BLOG_SB_URL}/rest/v1/post_views?select=post_slug&viewed_at=gte.${YESTERDAY}T00:00:00Z&viewed_at=lt.${TODAY}T00:00:00Z" \
             -H "apikey: ${BLOG_SB_KEY}" -H "Authorization: Bearer ${BLOG_SB_KEY}" 2>/dev/null \
             | python3 -c '
@@ -140,6 +144,7 @@ jobs:
 
           📝 *博客*
             PV: ${daily_pv}  |  UV: ${blog_uv}
+            累计访客: ${blog_total_uv}
             评论: ${daily_comments}  |  划线评论: ${daily_inline}
             点赞: ${daily_likes}
 

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -339,7 +339,6 @@ rankedPosts.forEach((p, i) => rankIndex.set(p.id, i));
 
     <!-- Footer -->
     <footer class="blog-footer">
-      <div class="blog-visitor-counter" id="blogVisitorCounter"></div>
       <div class="footer-inner">
         <span>&copy; 2026 Airing</span>
         <div class="footer-links">
@@ -428,42 +427,6 @@ rankedPosts.forEach((p, i) => rankIndex.set(p.id, i));
       });
     }
   } catch { /* ignore */ }
-
-  // ── Blog Visitor Counter ──
-  (function () {
-    const SB_URL = 'https://pcoyocvqfipuydhvdsle.supabase.co';
-    const SB_KEY = 'sb_publishable_jieHU6yu3dPxSww2_B_KIg_9KcWg6wl';
-    const el = document.getElementById('blogVisitorCounter');
-    if (!el) return;
-    const counted = sessionStorage.getItem('blog_visitor_counted');
-
-    function show(n: number) {
-      const padded = String(n).padStart(8, '0');
-      el!.innerHTML = '累计访客 <span class="blog-visitor-count">' + padded + '</span>';
-      el!.classList.add('loaded');
-    }
-
-    if (counted) {
-      show(parseInt(counted, 10));
-      return;
-    }
-
-    fetch(SB_URL + '/rest/v1/rpc/increment_blog_visitor', {
-      method: 'POST',
-      headers: {
-        'apikey': SB_KEY,
-        'Authorization': 'Bearer ' + SB_KEY,
-        'Content-Type': 'application/json'
-      },
-      body: '{}'
-    })
-      .then(r => r.json())
-      .then(count => {
-        sessionStorage.setItem('blog_visitor_counted', String(count));
-        show(count);
-      })
-      .catch(() => {});
-  })();
 </script>
 
 <style is:global>
@@ -914,22 +877,6 @@ rankedPosts.forEach((p, i) => rankIndex.set(p.id, i));
   }
   .subscribe-msg {
     font-size: 12px; min-height: 16px; margin: 4px 0 0;
-  }
-
-  /* ── Blog Visitor Counter ───────────────────────────── */
-  .blog-visitor-counter {
-    text-align: center;
-    padding: 8px 0 0;
-    font-size: 11px;
-    color: var(--c-text-muted);
-    letter-spacing: 1px;
-    opacity: 0;
-    transition: opacity 0.5s;
-  }
-  .blog-visitor-counter.loaded { opacity: 1; }
-  .blog-visitor-count {
-    font-weight: 700;
-    font-variant-numeric: tabular-nums;
   }
 
   /* ── Footer ────────────────────────────────────────── */

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -339,6 +339,7 @@ rankedPosts.forEach((p, i) => rankIndex.set(p.id, i));
 
     <!-- Footer -->
     <footer class="blog-footer">
+      <div class="blog-visitor-counter" id="blogVisitorCounter"></div>
       <div class="footer-inner">
         <span>&copy; 2026 Airing</span>
         <div class="footer-links">
@@ -427,6 +428,42 @@ rankedPosts.forEach((p, i) => rankIndex.set(p.id, i));
       });
     }
   } catch { /* ignore */ }
+
+  // ── Blog Visitor Counter ──
+  (function () {
+    const SB_URL = 'https://pcoyocvqfipuydhvdsle.supabase.co';
+    const SB_KEY = 'sb_publishable_jieHU6yu3dPxSww2_B_KIg_9KcWg6wl';
+    const el = document.getElementById('blogVisitorCounter');
+    if (!el) return;
+    const counted = sessionStorage.getItem('blog_visitor_counted');
+
+    function show(n: number) {
+      const padded = String(n).padStart(8, '0');
+      el!.innerHTML = '累计访客 <span class="blog-visitor-count">' + padded + '</span>';
+      el!.classList.add('loaded');
+    }
+
+    if (counted) {
+      show(parseInt(counted, 10));
+      return;
+    }
+
+    fetch(SB_URL + '/rest/v1/rpc/increment_blog_visitor', {
+      method: 'POST',
+      headers: {
+        'apikey': SB_KEY,
+        'Authorization': 'Bearer ' + SB_KEY,
+        'Content-Type': 'application/json'
+      },
+      body: '{}'
+    })
+      .then(r => r.json())
+      .then(count => {
+        sessionStorage.setItem('blog_visitor_counted', String(count));
+        show(count);
+      })
+      .catch(() => {});
+  })();
 </script>
 
 <style is:global>
@@ -877,6 +914,22 @@ rankedPosts.forEach((p, i) => rankIndex.set(p.id, i));
   }
   .subscribe-msg {
     font-size: 12px; min-height: 16px; margin: 4px 0 0;
+  }
+
+  /* ── Blog Visitor Counter ───────────────────────────── */
+  .blog-visitor-counter {
+    text-align: center;
+    padding: 8px 0 0;
+    font-size: 11px;
+    color: var(--c-text-muted);
+    letter-spacing: 1px;
+    opacity: 0;
+    transition: opacity 0.5s;
+  }
+  .blog-visitor-counter.loaded { opacity: 1; }
+  .blog-visitor-count {
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
   }
 
   /* ── Footer ────────────────────────────────────────── */


### PR DESCRIPTION
## Summary
Added a new metric to track cumulative unique visitors (UV) for the blog in the daily report workflow.

## Changes
- **New metric calculation**: Added `blog_total_uv` variable that queries the `post_views` table and counts unique IP addresses across all time (not just daily)
  - Uses curl to fetch all post view records with IP information
  - Processes the response with Python to extract and count unique IPs
  - Includes error handling with fallback to "N/A" if the query fails
  
- **Report output**: Updated the daily report message template to display the new cumulative unique visitors metric alongside the existing daily PV/UV metrics

## Implementation Details
- The unique visitor count is calculated by extracting the `ip` field from all post view records and using a Python set to deduplicate
- Maintains consistency with existing error handling patterns in the workflow (2>/dev/null redirects and || echo "N/A" fallbacks)
- The metric is positioned in the blog section of the report, clearly labeled as "累计访客" (cumulative visitors)

https://claude.ai/code/session_01636HZgioLwAbAgnF5a5PmA