### PR TITLE
fix: notes 移动端水平滚动及评论表单适配

### DIFF
--- a/src/pages/notes/[...slug].astro
+++ b/src/pages/notes/[...slug].astro
@@ -1538,6 +1538,18 @@ const readingTime = `约 ${Math.max(1, Math.ceil((cjkChars / 300) + (latinWords 
     0%, 100% { background: rgba(var(--accent-rgb, 74,222,128), 0.08); }
     50% { background: rgba(var(--accent-rgb, 74,222,128), 0.32); }
   }
+
+  /* ===== Mobile overrides for globally-defined classes ===== */
+  @media (max-width: 960px) {
+    .note-detail-page { overflow-x: hidden; }
+    .bc-compose-fields { flex-direction: column; gap: 8px; }
+    .bc-compose-avatar .bc-avatar-img { width: 32px; height: 32px; }
+    .bc-compose { gap: 12px; }
+    .comment-input-popover { width: calc(100vw - 40px); max-width: 360px; }
+    .cip-identity { flex-direction: column; gap: 6px; }
+    .article-like-section { gap: 16px; }
+    .article-like-btn { padding: 10px 20px; }
+  }
 </style>
 
 <style>


### PR DESCRIPTION
- 底部评论表单输入框在移动端改为垂直排列，防止水平溢出
- 划线评论输入弹窗适配移动端宽度
- 添加 overflow-x: hidden 防止页面水平滚动
- 对齐 blog 文章详情页的移动端样式处理

https://claude.ai/code/session_01CFiYa3C6SGWEc6AGtwuxpa