### PR TITLE
Fix garbled visitor counter text on homepage footer

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2558,7 +2558,9 @@ const recentPhotos = (photosData as Array<any>)
       }
 
       if (counted) {
-        show(parseInt(counted, 10));
+        window._i18nReady.then(function () {
+          show(parseInt(counted, 10));
+        });
         return;
       }
 
@@ -2574,13 +2576,19 @@ const recentPhotos = (photosData as Array<any>)
         .then(function (r) { return r.json(); })
         .then(function (count) {
           sessionStorage.setItem('visitor_counted', count);
-          show(count);
+          window._i18nReady.then(function () {
+            show(count);
+          });
         })
         .catch(function () { });
 
       window.addEventListener('langchange', function() {
         var c = sessionStorage.getItem('visitor_counted');
-        if (c) show(parseInt(c, 10));
+        if (c) {
+          window._i18nReady.then(function () {
+            show(parseInt(c, 10));
+          });
+        }
       });
     })();
   </script>


### PR DESCRIPTION
### Motivation
- The visitor counter could render before translations finished loading, producing raw keys like `visitor_prefix00030892visitor_suffix` in the footer.
- Ensure the counter always formats with localized `visitor_prefix`/`visitor_suffix` instead of falling back to translation keys.

### Description
- Updated `src/pages/index.astro` to wait for `window._i18nReady` before rendering the counter when a cached count exists.
- Also wait for `window._i18nReady` before showing the freshly fetched count after the Supabase `increment_visitor` call.
- Wrapped the `langchange` re-render path to wait for `window._i18nReady` before updating the displayed text.

### Testing
- Attempted site build with `npm run build`, which failed due to the local Node.js version (`v20.19.6`) being older than the Astro requirement (`>=22.12.0`), so the change could not be validated via a full build in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9751dbb208330b49331309254a55b)