### PR TITLE
fix(ci): 首页 GitHub 卡片数据不更新（feed CI 未提交 index.astro）

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,7 +73,13 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add src/data/ index.html
+          # NOTE: src/pages/index.astro must be committed too. update_feed.py's
+          # sync_to_astro() rewrites the inline <!-- *_DATA_START --> blocks
+          # (e.g. window.__GITHUB_DATA__) in index.astro, and the live homepage
+          # is built from index.astro — NOT from the root index.html template.
+          # Omitting it froze those inline modules (e.g. the GitHub card) at the
+          # last hand-commit while src/data/*.json kept updating.
+          git add src/data/ index.html src/pages/index.astro
           if git diff --staged --quiet; then
             echo "No feed changes to commit, skipping."
             exit 0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

首页 GitHub 模块的关注/仓库数据长期停在 `followers: 1877`，而真实值已是 `1898`。

## 根因

线上首页是用 `src/pages/index.astro` 构建的，GitHub 卡片的数据来源是该文件里的内联脚本：

```html
<script is:inline>window.__GITHUB_DATA__={...,"followers":1877,...}</script>
```

数据管线 `scripts/update_feed.py` 每次运行时：
- `replace_section()` 更新根目录 `index.html`（模板）
- `sync_to_astro()` 把同样的数据写进 `src/pages/index.astro` 的 `<!-- *_DATA_START -->` 内联块
- `write_json()` 写 `src/data/*.json`

但 `.github/workflows/deploy.yml` 的提交步骤只暂存了：

```
git add src/data/ index.html
```

**漏掉了 `src/pages/index.astro`**。于是 `sync_to_astro()` 在 runner 上对 `index.astro` 的改动每次都被丢弃，卡片冻结在最后一次手动提交（2026-07-04，`followers: 1877`），而 `src/data/*.json`（1898）和根 `index.html`（1898）却在每天更新——只是首页不读它们。

证据：
- `git log src/pages/index.astro` 最新提交是 2026-07-04，之后所有 `chore: update feed articles` 都没碰它。
- 构建产物 `dist/index.html` 内联值为 `1877`；根 `index.html` 为 `1898`。
- `src/data/github.json`（1898）只被 `src/pages/api/status.json.ts` 引用，首页不使用。

## 修复

在 feed 更新提交步骤的 `git add` 中补上 `src/pages/index.astro`，并加注释说明原因。这样 `sync_to_astro()` 的输出会被提交并部署，所有内联数据模块（GitHub 卡片等）恢复每日刷新。

合并到 `master` 会触发 Deploy workflow：`update_feed.py` 重新生成 `index.astro` → 新的 `git add` 纳入它 → 提交并构建部署，首页数字随即刷新。

## 验证

本地用真实 GitHub 公共 API 走了一遍抓取 + 同步路径：

```
BEFORE (committed index.astro):  followers: 1877
Fetched from GitHub API ->       followers: 1898  repos: 129  following: 36
GitHub: synced to src/pages/index.astro
AFTER sync_to_astro:             followers: 1898
```

确认 `sync_to_astro()` 能正确把 `index.astro` 更新到最新值——唯一缺口就是它此前未被提交。（演示产生的 `index.astro` 改动已还原，本 PR 仅含 `deploy.yml` 一处改动，因为 CI 会在下次部署时完整重新生成并提交。）
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9bbd5cbb-84a2-468f-9256-1201b7bee749?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9bbd5cbb-84a2-468f-9256-1201b7bee749&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

