### PR TITLE
refactor(home): GitHub 卡片直接从 src/data/github.json 取数（消除内联双写）

### DIFF
--- a/scripts/update_feed.py
+++ b/scripts/update_feed.py
@@ -695,12 +695,15 @@ def main():
         print(f'Readwise: error - {e}', file=sys.stderr)
 
     # GitHub
+    # The homepage (src/pages/index.astro) imports src/data/github.json directly
+    # and emits window.__GITHUB_DATA__ at build time, so there is no inline block
+    # to sync into index.astro. We still refresh the legacy root index.html block
+    # and always rewrite github.json below (via write_json), which is what the
+    # page and /api/status.json read.
     try:
         gh_data = fetch_github_data()
         gh_html = generate_github_script(gh_data)
         content = replace_section(content, '<!-- GITHUB_DATA_START -->', '<!-- GITHUB_DATA_END -->', gh_html)
-        astro_script = gh_html.replace('<script>', '<script is:inline>')
-        sync_to_astro('<!-- GITHUB_DATA_START -->', '<!-- GITHUB_DATA_END -->', astro_script, 'GitHub')
         print(f'GitHub: @{gh_data["login"]} - {gh_data["followers"]} followers, {gh_data["repos"]} repos')
         changed = True
     except Exception as e:

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import BaseLayout from '../layouts/BaseLayout.astro';
 import photosData from '../data/photos.json';
+import githubData from '../data/github.json';
 import '../styles/workouts.css';
 import WorkoutCardPreview from '../components/workouts/WorkoutCardPreview.astro';
 import { FIXED_DATES, FLOATING_DATES } from '../lib/easter-egg-themes';
@@ -1052,9 +1053,7 @@ const dataUpdatedEn = dataUpdatedDate.toLocaleDateString('en-US', { month: 'shor
             <div class="gh-stat-label" data-i18n="gh_since">Since</div>
           </div>
         </div>
-        <!-- GITHUB_DATA_START -->
-            <script is:inline>window.__GITHUB_DATA__={"login":"airingursb","avatar":"https://avatars.githubusercontent.com/u/10513408?v=4","bio":"I dream of coding and then I code my dream. \r\n🏆 2019 WWDC Scholarship Winner ","followers":1877,"following":36,"repos":129,"sinceYear":"2015"}</script>
-        <!-- GITHUB_DATA_END -->
+        <script define:vars={{ githubData }}>window.__GITHUB_DATA__ = githubData;</script>
       </div>
 
       <div class="card card-moflow" id="moflow">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

承接 [#13](https://github.com/airingursb/airingursb.github.io/pull/13)。#13 通过在 CI 的 `git add` 里补上 `src/pages/index.astro` 修复了“漏提交导致内联数据冻结”的问题。本 PR 从架构上根除 GitHub 卡片这一处的隐患：不再依赖“内联脚本 + `sync_to_astro` 同步”，而是让页面在构建时直接从 `src/data/github.json` 取数。

## 改动

- `src/pages/index.astro`
  - 新增 `import githubData from '../data/github.json';`
  - 卡片数据块由手工注入的 `<!-- GITHUB_DATA_START -->…<script>window.__GITHUB_DATA__={…1877…}</script>…<!-- GITHUB_DATA_END -->` 改为构建时注入：
    ```astro
    <script define:vars={{ githubData }}>window.__GITHUB_DATA__ = githubData;</script>
    ```
  - 下游渲染脚本仍读取 `window.__GITHUB_DATA__`，无需改动。
- `scripts/update_feed.py`
  - 移除 GitHub 的 `sync_to_astro(...)` 调用（不再需要同步到 index.astro）。
  - 保留 `fetch_github_data()` → 刷新根 `index.html`（遗留模板）与 `write_json('github')`。`github.json` 本就被 CI 的 `git add src/data/` 每日提交，页面构建时即取到最新值。

## 为什么这样更稳

`github.json` 是 CI 每天提交的单一数据源，且已被 `/api/status.json` 复用。让首页也从它取数后，GitHub 卡片不再有“数据写了两份、其中一份漏提交”的可能，天然随每日 feed 更新刷新。

## 验证

- `npm run build`：成功。构建产物 `dist/index.html` 内联为 `const githubData = {…,"followers":1898,…}`，`"followers":1877` 已不存在。
- `npm test`：139/139 通过。
- 浏览器实测（本地 preview）：GitHub 卡片显示 **FOLLOWERS 1,898 / REPOS 129 / FOLLOWING 36**。

[github_card_updated_1898.mp4](https://cursor.com/agents/bc-9bbd5cbb-84a2-468f-9256-1201b7bee749/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgithub_card_updated_1898.mp4)

[GitHub 卡片显示 1,898 关注](https://cursor.com/agents/bc-9bbd5cbb-84a2-468f-9256-1201b7bee749/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgithub_card_1898.webp)

## 与 #13 的关系

两者互补、互不冲突（改动文件不同）。#13 仍然必要：`index.astro` 里其它内联模块（音乐、文章、Readwise、Raindrop、Now Playing、本地数据等）目前仍走 `sync_to_astro`，依赖 #13 才能被提交刷新。后续可视需要按同样思路逐步把它们也迁移为从 `src/data/*.json` 直接取数。

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9bbd5cbb-84a2-468f-9256-1201b7bee749?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9bbd5cbb-84a2-468f-9256-1201b7bee749&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

