### PR TITLE
feat: 划线评论跨 zh/en 版本锚定（方案 D：构建期 data-aid 绑定）

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,5 +1,6 @@
 import { defineConfig } from 'astro/config';
 import { remarkEmbed } from './src/plugins/remark-embed.mjs';
+import { rehypeAnchorIds } from './src/plugins/rehype-anchor-ids.mjs';
 import mdx from '@astrojs/mdx';
 import react from '@astrojs/react';
 import remarkWikilinks from './src/lib/remark-wikilinks.ts';
@@ -35,6 +36,7 @@ export default defineConfig({
   integrations: [mdx(), react()],
   markdown: {
     remarkPlugins: [remarkEmbed, [remarkWikilinks, { enNoteSlugs }]],
+    rehypePlugins: [rehypeAnchorIds],
     shikiConfig: {
       theme: 'github-dark',
     },

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -2420,6 +2420,20 @@ const jsonLd = {
   .post-content :global(.has-inline-note.highlight-flash) {
     animation: highlightFlash 1s ease;
   }
+  /* On mobile the comment rail is hidden, so the gutter dot is the only handle
+     for a cross-language note — make it a real tap target that opens the sheet
+     (same as tapping a same-language highlight). Kept fully on-screen (left
+     gutter, no negative viewport x) so it never triggers horizontal scroll. */
+  @media (max-width: 1100px) {
+    .post-content :global(.cm-block-anchor) {
+      pointer-events: auto;
+      cursor: pointer;
+      width: 14px;
+      height: 14px;
+      left: -18px;
+      top: 0.1em;
+    }
+  }
 
   /* ===== Comment Rail (right column) ===== */
   .comment-rail {

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -742,6 +742,18 @@ const jsonLd = {
   // pages share view counts, likes, comments, and inline comments.
   var POST_SLUG = location.pathname.replace(/^\/(?:en\/)?posts\//, '').replace(/\/$/, '');
   var USER_KEY = 'blog-user-identity';
+  // zh and en share one inline-comment pool (same slug). A highlight is
+  // anchored to a language-independent block id (data-aid) + the quoted text.
+  // PAGE_LANG lets us decide: same language → paint the exact words; other
+  // language → mark the corresponding block (words can't match across langs).
+  var PAGE_LANG = (function() {
+    var pp = document.querySelector('.post-page');
+    return (pp && pp.getAttribute('data-lang') === 'en') ? 'en' : 'zh';
+  })();
+  function hasCJK(s) { return /[\u3400-\u9fff\uf900-\ufaff]/.test(s || ''); }
+  // Origin language of a comment: explicit column if present, else inferred
+  // from the quoted text's script (legacy rows created before the lang column).
+  function commentLang(c) { return c.lang || (hasCJK(c.selected_text) ? 'zh' : 'en'); }
 
   // Track pageview (fire-and-forget)
   fetch(API + '/api/posts/' + encodeURIComponent(POST_SLUG) + '/view', { method: 'POST' }).catch(function() {});
@@ -903,7 +915,7 @@ const jsonLd = {
   // handles selections that cross element boundaries (e.g. text inside <a>
   // followed by sibling text after </a>) — the original single-node search
   // would never match those.
-  function findRangeByText(root, searchText) {
+  function findRangeByText(root, searchText, fromIndex) {
     var walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, null, false);
     var nodes = [];
     var fullText = '';
@@ -912,7 +924,10 @@ const jsonLd = {
       nodes.push({ node: n, start: fullText.length });
       fullText += n.textContent;
     }
-    var idx = fullText.indexOf(searchText);
+    // Bias the search toward the stored offset so a passage that repeats inside
+    // the same block resolves to the right occurrence; fall back to the first.
+    var idx = fullText.indexOf(searchText, fromIndex || 0);
+    if (idx === -1 && fromIndex) idx = fullText.indexOf(searchText);
     if (idx === -1) return null;
     var endIdx = idx + searchText.length;
 
@@ -937,12 +952,79 @@ const jsonLd = {
     return range;
   }
 
+  // The block element a comment is anchored to, matched by language-independent
+  // data-aid. Null for legacy rows (no anchor_id) or when translations drifted
+  // structurally so the id no longer exists in this version.
+  function anchorBlock(c) {
+    if (!c.anchor_id) return null;
+    return postContent.querySelector('[data-aid="' + c.anchor_id + '"]');
+  }
+
+  // The DOM element used to position/scroll a comment's rail card: the exact
+  // <mark> for a painted highlight, else the zero-size block-level anchor.
+  function anchorElFor(id) {
+    return postContent.querySelector(
+      'mark[data-comment-id="' + id + '"], .cm-block-anchor[data-comment-id="' + id + '"]'
+    );
+  }
+
+  // Cross-language (or quote-not-found) fallback: we can't paint the exact
+  // words, so tag the corresponding block and drop a zero-size anchor at its
+  // start for the rail card to line up against.
+  function markBlockLevel(block, id) {
+    block.classList.add('has-inline-note');
+    var a = document.createElement('span');
+    a.className = 'cm-block-anchor';
+    a.dataset.commentId = id;
+    a.setAttribute('aria-hidden', 'true');
+    block.insertBefore(a, block.firstChild);
+    return a;
+  }
+
+  // Nearest ancestor block carrying a data-aid, for a selection endpoint.
+  function nearestAnchorBlock(node) {
+    var el = node && node.nodeType === 3 ? node.parentNode : node;
+    while (el && el !== postContent) {
+      if (el.dataset && el.dataset.aid != null) return el;
+      el = el.parentNode;
+    }
+    return null;
+  }
+
+  // Character offset of (container, offset) within a block's concatenated text.
+  // Mirrors findRangeByText's text-node walk so create-time and restore-time
+  // offsets line up.
+  function offsetWithinBlock(block, container, offset) {
+    var walker = document.createTreeWalker(block, NodeFilter.SHOW_TEXT, null, false);
+    var total = 0, n;
+    while (n = walker.nextNode()) {
+      if (n === container) return total + offset;
+      total += n.textContent.length;
+    }
+    return total;
+  }
+
   function restoreHighlights() {
     inlineComments.forEach(function(c) {
-      if (postContent.querySelector('mark[data-comment-id="' + c.id + '"]')) return;
       if (!c.selected_text) return;
-      var range = findRangeByText(postContent, c.selected_text);
-      if (range) wrapRange(range, c.id);
+      if (anchorElFor(c.id)) return; // already painted/anchored
+      var block = anchorBlock(c);
+      if (commentLang(c) === PAGE_LANG) {
+        // Same language: paint the exact words. Prefer searching inside the
+        // anchored block (biased by the stored offset) so repeated passages and
+        // duplicate phrasing elsewhere in the article don't grab the highlight.
+        var range = block
+          ? findRangeByText(block, c.selected_text, c.range_start || 0)
+          : findRangeByText(postContent, c.selected_text);
+        if (range) { wrapRange(range, c.id); return; }
+        // Words moved/edited but we still know the block → mark it.
+        if (block) markBlockLevel(block, c.id);
+      } else if (block) {
+        // Other language: exact words don't exist here — anchor to the block.
+        markBlockLevel(block, c.id);
+      }
+      // else: legacy other-language row with no block → left unanchored;
+      // renderInlineComments() surfaces it in the "other language" group.
     });
   }
 
@@ -951,12 +1033,13 @@ const jsonLd = {
   function scrollToHashHighlight() {
     var m = /^#inline-(\d+)$/.exec(location.hash || '');
     if (!m) return;
-    var mark = postContent.querySelector('mark[data-comment-id="' + m[1] + '"]');
-    if (!mark) return;
+    var target = anchorElFor(m[1]);
+    if (!target) return;
+    var flashEl = target.tagName === 'MARK' ? target : target.closest('[data-aid]') || target;
     requestAnimationFrame(function() {
-      mark.scrollIntoView({ behavior: 'smooth', block: 'center' });
-      mark.classList.add('highlight-flash');
-      setTimeout(function() { mark.classList.remove('highlight-flash'); }, 1200);
+      flashEl.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      flashEl.classList.add('highlight-flash');
+      setTimeout(function() { flashEl.classList.remove('highlight-flash'); }, 1200);
     });
   }
 
@@ -968,6 +1051,13 @@ const jsonLd = {
       parent.removeChild(mark);
       parent.normalize();
     });
+    // Block-level (cross-language) anchors: remove the marker and drop the
+    // block tint if no other note remains on that block.
+    postContent.querySelectorAll('.cm-block-anchor[data-comment-id="' + id + '"]').forEach(function(a) {
+      var block = a.closest('[data-aid]');
+      a.parentNode.removeChild(a);
+      if (block && !block.querySelector('.cm-block-anchor')) block.classList.remove('has-inline-note');
+    });
   }
 
   function offsetFromGrid(el) {
@@ -977,15 +1067,16 @@ const jsonLd = {
   }
 
   function layoutCards() {
-    var cards = commentCards.querySelectorAll('.cm-card');
-    if (!cards.length) return;
+    // Only the anchored cards are absolutely positioned next to their passage;
+    // the collapsed "other language" group (if any) is laid out after them.
+    var cards = commentCards.querySelectorAll(':scope > .cm-card');
     var railOffset = offsetFromGrid(commentRail);
     var positions = [];
     cards.forEach(function(card) {
       var id = card.dataset.commentId;
-      var mark = postContent.querySelector('mark[data-comment-id="' + id + '"]');
+      var anchor = anchorElFor(id);
       var desiredTop = 0;
-      if (mark) desiredTop = offsetFromGrid(mark) - railOffset;
+      if (anchor) desiredTop = offsetFromGrid(anchor) - railOffset;
       positions.push({ card: card, desired: desiredTop, height: card.offsetHeight });
     });
     positions.sort(function(a, b) { return a.desired - b.desired; });
@@ -995,158 +1086,213 @@ const jsonLd = {
       p.card.style.top = top + 'px';
       nextAvailable = top + p.height + GAP;
     });
+    var grp = commentCards.querySelector(':scope > .cm-otherlang');
+    if (grp) {
+      grp.style.top = nextAvailable + 'px';
+      nextAvailable += grp.offsetHeight + GAP;
+    }
     commentCards.style.minHeight = nextAvailable + 'px';
+  }
+
+  function buildInlineCard(c) {
+    if (!c.replies) c.replies = [];
+    var card = document.createElement('div');
+    card.className = 'cm-card';
+    card.dataset.commentId = c.id;
+
+    // Anchor element: the exact <mark> for same-language highlights, or the
+    // zero-size block anchor for cross-language / imprecise ones. When neither
+    // exists the card is un-positioned (rendered in the collapsed group).
+    var anchorEl = anchorElFor(c.id);
+    var isMark = !!anchorEl && anchorEl.tagName === 'MARK';
+    var hlEl = isMark ? anchorEl : (anchorEl ? anchorEl.closest('[data-aid]') : null);
+    var activeClass = isMark ? 'highlight-active' : 'inline-note-active';
+    var crossLang = commentLang(c) !== PAGE_LANG;
+
+    var time = new Date(c.created_at);
+    var timeStr = time.toLocaleDateString('zh-CN', { month: '2-digit', day: '2-digit' })
+      + ' ' + time.toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit' });
+
+    var repliesHtml = '';
+    if (c.replies && c.replies.length) {
+      repliesHtml = '<div class="cm-replies">';
+      c.replies.forEach(function(r) {
+        var rTime = new Date(r.created_at);
+        var rTimeStr = rTime.toLocaleDateString('zh-CN', { month: '2-digit', day: '2-digit' })
+          + ' ' + rTime.toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit' });
+        repliesHtml +=
+          '<div class="cm-reply">' +
+            '<div class="cm-reply-header">' +
+              '<img class="cm-reply-avatar" src="' + commentAvatarUrl(r) + '" />' +
+              '<span class="cm-reply-name">' + esc(r.nickname) + countryFlag(r) + '</span>' +
+              '<span class="cm-reply-time">' + rTimeStr + '</span>' +
+            '</div>' +
+            '<div class="cm-reply-body">' + esc(r.comment) + '</div>' +
+          '</div>';
+      });
+      repliesHtml += '</div>';
+    }
+
+    // Tag a card whose highlight was made on the *other* language version so the
+    // foreign quote isn't mistaken for a broken same-language highlight.
+    var langTag = crossLang
+      ? '<span class="cm-card-lang" title="\u6765\u81ea\u53e6\u4e00\u8bed\u8a00\u7248\u672c\u7684\u5212\u7ebf">' + (commentLang(c) === 'en' ? 'EN' : '\u4e2d') + '</span>'
+      : '';
+
+    card.innerHTML =
+      '<div class="cm-card-author">' +
+        '<img src="' + commentAvatarUrl(c) + '" class="cm-card-avatar" />' +
+        '<span class="cm-card-name">' + esc(c.nickname) + countryFlag(c) + '</span>' +
+      '</div>' +
+      '<div class="cm-card-quote">' + langTag + '\u201c' + esc(trunc(c.selected_text, 50)) + '\u201d</div>' +
+      '<div class="cm-card-body">' + esc(c.comment) + '</div>' +
+      '<div class="cm-card-footer">' +
+        '<span class="cm-card-time">' + timeStr + '</span>' +
+      '</div>' +
+      repliesHtml +
+      '<button class="cm-reply-btn" data-parent-id="' + c.id + '">Reply</button>' +
+      '<div class="cm-reply-form" style="display:none;">' +
+        '<div class="cm-rf-identity">' +
+          '<input class="cm-rf-input" placeholder="Nickname" />' +
+          '<input class="cm-rf-input" placeholder="Email" />' +
+        '</div>' +
+        '<textarea class="cm-rf-textarea" placeholder="Write a reply..." rows="2"></textarea>' +
+        '<label class="cm-rf-notify"><input type="checkbox" checked /> Notify me of replies</label>' +
+        '<div class="cm-rf-actions">' +
+          '<button class="cm-rf-cancel">Cancel</button>' +
+          '<button class="cm-rf-submit">Reply</button>' +
+        '</div>' +
+      '</div>';
+
+    card.addEventListener('mouseenter', function() {
+      if (hlEl) hlEl.classList.add(activeClass);
+      card.classList.add('cm-card-active');
+    });
+    card.addEventListener('mouseleave', function() {
+      if (hlEl) hlEl.classList.remove(activeClass);
+      card.classList.remove('cm-card-active');
+    });
+    card.addEventListener('click', function(e) {
+      if (e.target.closest('.cm-reply-btn') || e.target.closest('.cm-reply-form')) return;
+      if (hlEl) {
+        hlEl.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        hlEl.classList.add('highlight-flash');
+        setTimeout(function() { hlEl.classList.remove('highlight-flash'); }, 1000);
+      }
+    });
+    if (anchorEl) {
+      anchorEl.addEventListener('mouseenter', function() { card.classList.add('cm-card-active'); if (hlEl) hlEl.classList.add(activeClass); });
+      anchorEl.addEventListener('mouseleave', function() { card.classList.remove('cm-card-active'); if (hlEl) hlEl.classList.remove(activeClass); });
+      anchorEl.addEventListener('click', function(e) {
+        if (!isMobile()) return;
+        e.preventDefault(); e.stopPropagation();
+        openMobileSheet(c);
+      });
+    }
+
+    // Reply button handler
+    var replyBtn = card.querySelector('.cm-reply-btn');
+    var replyForm = card.querySelector('.cm-reply-form');
+    var rfInputs = replyForm.querySelectorAll('.cm-rf-input');
+    var rfNickname = rfInputs[0];
+    var rfEmail = rfInputs[1];
+    var rfTextarea = replyForm.querySelector('.cm-rf-textarea');
+    var rfNotify = replyForm.querySelector('.cm-rf-notify input');
+    var rfCancel = replyForm.querySelector('.cm-rf-cancel');
+    var rfSubmit = replyForm.querySelector('.cm-rf-submit');
+
+    replyBtn.addEventListener('click', function(e) {
+      e.stopPropagation();
+      replyForm.style.display = '';
+      replyBtn.style.display = 'none';
+      var identity = getSavedIdentity();
+      if (identity.nickname) rfNickname.value = identity.nickname;
+      if (identity.email) rfEmail.value = identity.email;
+      rfNickname.focus();
+      layoutCards();
+    });
+
+    rfCancel.addEventListener('click', function(e) {
+      e.stopPropagation();
+      replyForm.style.display = 'none';
+      replyBtn.style.display = '';
+      layoutCards();
+    });
+
+    rfSubmit.addEventListener('click', function(e) {
+      e.stopPropagation();
+      var nickname = rfNickname.value.trim();
+      var email = rfEmail.value.trim();
+      var comment = rfTextarea.value.trim();
+      var rfValid = true;
+      rfNickname.classList.remove('cip-error');
+      rfTextarea.classList.remove('cip-error');
+      if (!nickname) { rfNickname.classList.add('cip-error'); rfValid = false; }
+      if (!comment) { rfTextarea.classList.add('cip-error'); rfValid = false; }
+      if (!rfValid) return;
+
+      saveIdentity(nickname, email);
+      rfSubmit.disabled = true;
+
+      apiPost('/api/inline-comments', {
+        post_slug: POST_SLUG,
+        nickname: nickname,
+        email: email,
+        comment: comment,
+        parent_id: c.id,
+        notify_replies: rfNotify.checked
+      }).then(function(res) {
+        if (res.comment) {
+          c.replies.push(res.comment);
+          renderInlineComments();
+        }
+      }).finally(function() {
+        rfSubmit.disabled = false;
+      });
+    });
+
+    return card;
   }
 
   function renderInlineComments() {
     commentCards.innerHTML = '';
     crEmpty.style.display = inlineComments.length ? 'none' : '';
 
+    // Anchored comments get a positioned card next to their passage; the rest
+    // (highlights made on the other language version whose block we can't place,
+    // or legacy rows whose quote no longer matches) fold into a collapsed group
+    // so they stay readable without floating against unrelated sentences.
+    var unlocated = [];
     inlineComments.forEach(function(c) {
-      if (!c.replies) c.replies = [];
-      var card = document.createElement('div');
-      card.className = 'cm-card';
-      card.dataset.commentId = c.id;
-      var mark = postContent.querySelector('mark[data-comment-id="' + c.id + '"]');
-
-      var time = new Date(c.created_at);
-      var timeStr = time.toLocaleDateString('zh-CN', { month: '2-digit', day: '2-digit' })
-        + ' ' + time.toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit' });
-
-      var repliesHtml = '';
-      if (c.replies && c.replies.length) {
-        repliesHtml = '<div class="cm-replies">';
-        c.replies.forEach(function(r) {
-          var rTime = new Date(r.created_at);
-          var rTimeStr = rTime.toLocaleDateString('zh-CN', { month: '2-digit', day: '2-digit' })
-            + ' ' + rTime.toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit' });
-          repliesHtml +=
-            '<div class="cm-reply">' +
-              '<div class="cm-reply-header">' +
-                '<img class="cm-reply-avatar" src="' + commentAvatarUrl(r) + '" />' +
-                '<span class="cm-reply-name">' + esc(r.nickname) + countryFlag(r) + '</span>' +
-                '<span class="cm-reply-time">' + rTimeStr + '</span>' +
-              '</div>' +
-              '<div class="cm-reply-body">' + esc(r.comment) + '</div>' +
-            '</div>';
-        });
-        repliesHtml += '</div>';
-      }
-
-      card.innerHTML =
-        '<div class="cm-card-author">' +
-          '<img src="' + commentAvatarUrl(c) + '" class="cm-card-avatar" />' +
-          '<span class="cm-card-name">' + esc(c.nickname) + countryFlag(c) + '</span>' +
-        '</div>' +
-        '<div class="cm-card-quote">\u201c' + esc(trunc(c.selected_text, 50)) + '\u201d</div>' +
-        '<div class="cm-card-body">' + esc(c.comment) + '</div>' +
-        '<div class="cm-card-footer">' +
-          '<span class="cm-card-time">' + timeStr + '</span>' +
-        '</div>' +
-        repliesHtml +
-        '<button class="cm-reply-btn" data-parent-id="' + c.id + '">Reply</button>' +
-        '<div class="cm-reply-form" style="display:none;">' +
-          '<div class="cm-rf-identity">' +
-            '<input class="cm-rf-input" placeholder="Nickname" />' +
-            '<input class="cm-rf-input" placeholder="Email" />' +
-          '</div>' +
-          '<textarea class="cm-rf-textarea" placeholder="Write a reply..." rows="2"></textarea>' +
-          '<label class="cm-rf-notify"><input type="checkbox" checked /> Notify me of replies</label>' +
-          '<div class="cm-rf-actions">' +
-            '<button class="cm-rf-cancel">Cancel</button>' +
-            '<button class="cm-rf-submit">Reply</button>' +
-          '</div>' +
-        '</div>';
-
-      card.addEventListener('mouseenter', function() {
-        if (mark) mark.classList.add('highlight-active');
-        card.classList.add('cm-card-active');
-      });
-      card.addEventListener('mouseleave', function() {
-        if (mark) mark.classList.remove('highlight-active');
-        card.classList.remove('cm-card-active');
-      });
-      card.addEventListener('click', function(e) {
-        if (e.target.closest('.cm-reply-btn') || e.target.closest('.cm-reply-form')) return;
-        if (mark) {
-          mark.scrollIntoView({ behavior: 'smooth', block: 'center' });
-          mark.classList.add('highlight-flash');
-          setTimeout(function() { mark.classList.remove('highlight-flash'); }, 1000);
-        }
-      });
-      if (mark) {
-        mark.addEventListener('mouseenter', function() { card.classList.add('cm-card-active'); mark.classList.add('highlight-active'); });
-        mark.addEventListener('mouseleave', function() { card.classList.remove('cm-card-active'); mark.classList.remove('highlight-active'); });
-        mark.addEventListener('click', function(e) {
-          if (!isMobile()) return;
-          e.preventDefault(); e.stopPropagation();
-          openMobileSheet(c);
-        });
-      }
-
-      commentCards.appendChild(card);
-
-      // Reply button handler
-      var replyBtn = card.querySelector('.cm-reply-btn');
-      var replyForm = card.querySelector('.cm-reply-form');
-      var rfInputs = replyForm.querySelectorAll('.cm-rf-input');
-      var rfNickname = rfInputs[0];
-      var rfEmail = rfInputs[1];
-      var rfTextarea = replyForm.querySelector('.cm-rf-textarea');
-      var rfNotify = replyForm.querySelector('.cm-rf-notify input');
-      var rfCancel = replyForm.querySelector('.cm-rf-cancel');
-      var rfSubmit = replyForm.querySelector('.cm-rf-submit');
-
-      replyBtn.addEventListener('click', function(e) {
-        e.stopPropagation();
-        replyForm.style.display = '';
-        replyBtn.style.display = 'none';
-        var identity = getSavedIdentity();
-        if (identity.nickname) rfNickname.value = identity.nickname;
-        if (identity.email) rfEmail.value = identity.email;
-        rfNickname.focus();
-        layoutCards();
-      });
-
-      rfCancel.addEventListener('click', function(e) {
-        e.stopPropagation();
-        replyForm.style.display = 'none';
-        replyBtn.style.display = '';
-        layoutCards();
-      });
-
-      rfSubmit.addEventListener('click', function(e) {
-        e.stopPropagation();
-        var nickname = rfNickname.value.trim();
-        var email = rfEmail.value.trim();
-        var comment = rfTextarea.value.trim();
-        var rfValid = true;
-        rfNickname.classList.remove('cip-error');
-        rfTextarea.classList.remove('cip-error');
-        if (!nickname) { rfNickname.classList.add('cip-error'); rfValid = false; }
-        if (!comment) { rfTextarea.classList.add('cip-error'); rfValid = false; }
-        if (!rfValid) return;
-
-        saveIdentity(nickname, email);
-        rfSubmit.disabled = true;
-
-        apiPost('/api/inline-comments', {
-          post_slug: POST_SLUG,
-          nickname: nickname,
-          email: email,
-          comment: comment,
-          parent_id: c.id,
-          notify_replies: rfNotify.checked
-        }).then(function(res) {
-          if (res.comment) {
-            c.replies.push(res.comment);
-            renderInlineComments();
-          }
-        }).finally(function() {
-          rfSubmit.disabled = false;
-        });
-      });
+      if (anchorElFor(c.id)) commentCards.appendChild(buildInlineCard(c));
+      else unlocated.push(c);
     });
+
+    if (unlocated.length) {
+      var allOtherLang = unlocated.every(function(c) { return commentLang(c) !== PAGE_LANG; });
+      var label = allOtherLang
+        ? (PAGE_LANG === 'zh' ? '\u82f1\u6587\u7248\u7684\u5212\u7ebf\u8bc4\u8bba' : 'Highlights on the Chinese version')
+        : (PAGE_LANG === 'zh' ? '\u672a\u5b9a\u4f4d\u7684\u5212\u7ebf\u8bc4\u8bba' : 'Unplaced highlights');
+      var grp = document.createElement('div');
+      grp.className = 'cm-otherlang';
+      var head = document.createElement('button');
+      head.className = 'cm-otherlang-head';
+      head.type = 'button';
+      head.innerHTML = '<span class="cm-otherlang-chevron">\u25b8</span><span>' + label + ' (' + unlocated.length + ')</span>';
+      var body = document.createElement('div');
+      body.className = 'cm-otherlang-body';
+      body.style.display = 'none';
+      unlocated.forEach(function(c) { body.appendChild(buildInlineCard(c)); });
+      head.addEventListener('click', function() {
+        var open = body.style.display !== 'none';
+        body.style.display = open ? 'none' : '';
+        head.classList.toggle('open', !open);
+        layoutCards();
+      });
+      grp.appendChild(head);
+      grp.appendChild(body);
+      commentCards.appendChild(grp);
+    }
 
     requestAnimationFrame(function() { requestAnimationFrame(layoutCards); });
   }
@@ -1337,6 +1483,16 @@ const jsonLd = {
     var selectedText = pendingRange.toString().trim();
     saveIdentity(nickname, email);
 
+    // Anchor the highlight to a language-independent block id + block-local
+    // offsets so it can be re-located on the other-language version of the post.
+    var block = nearestAnchorBlock(pendingRange.startContainer);
+    var anchorId = block ? (block.dataset.aid || '') : '';
+    var rangeStart = 0, rangeEnd = selectedText.length;
+    if (block) {
+      rangeStart = offsetWithinBlock(block, pendingRange.startContainer, pendingRange.startOffset);
+      rangeEnd = offsetWithinBlock(block, pendingRange.endContainer, pendingRange.endOffset);
+    }
+
     cipSubmit.disabled = true;
     cipSubmit.textContent = '...';
 
@@ -1346,11 +1502,14 @@ const jsonLd = {
       email: email,
       selected_text: selectedText,
       comment: text,
-      range_start: 0,
-      range_end: selectedText.length,
+      anchor_id: anchorId,
+      lang: PAGE_LANG,
+      range_start: rangeStart,
+      range_end: rangeEnd,
       notify_replies: true
     }).then(function(res) {
       if (res.comment) {
+        if (!res.comment.lang) res.comment.lang = PAGE_LANG;
         wrapRange(pendingRange, res.comment.id);
         inlineComments.push(res.comment);
         renderInlineComments();
@@ -2221,6 +2380,27 @@ const jsonLd = {
     animation: highlightFlash 1s ease;
   }
 
+  /* Block-level anchor for cross-language / imprecise highlights: the exact
+     words can't be underlined (they live in the other language), so we tag the
+     corresponding block with a subtle left rule + a gutter dot. */
+  .post-content :global(.has-inline-note) { position: relative; }
+  .post-content :global(.cm-block-anchor) {
+    position: absolute;
+    left: -16px;
+    top: 0.4em;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: rgba(var(--accent-rgb), 0.55);
+    pointer-events: none;
+  }
+  .post-content :global(.has-inline-note.inline-note-active) {
+    box-shadow: -10px 0 0 -8px var(--accent);
+  }
+  .post-content :global(.has-inline-note.highlight-flash) {
+    animation: highlightFlash 1s ease;
+  }
+
   /* ===== Comment Rail (right column) ===== */
   .comment-rail {
     border-left: 1px solid var(--c-border);
@@ -2269,6 +2449,44 @@ const jsonLd = {
     border-bottom: 1px solid rgba(var(--c-overlay-rgb),0.04);
     line-height: 1.4; opacity: 0.7;
   }
+  /* "EN"/"中" tag on a card whose highlight was made on the other language. */
+  .comment-rail :global(.cm-card-lang) {
+    display: inline-block;
+    font-style: normal;
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    line-height: 1;
+    padding: 2px 4px;
+    margin-right: 5px;
+    border-radius: 3px;
+    color: var(--accent);
+    background: rgba(var(--accent-rgb), 0.12);
+    vertical-align: 1px;
+  }
+  /* Collapsed group for other-language / unplaced highlights. */
+  .comment-rail :global(.cm-otherlang) {
+    position: absolute;
+    left: 0; right: 0;
+  }
+  .comment-rail :global(.cm-otherlang-head) {
+    display: flex; align-items: center; gap: 6px;
+    width: 100%;
+    padding: 8px 10px;
+    background: none;
+    border: 1px dashed var(--c-border);
+    border-radius: 6px;
+    color: var(--c-text-dim);
+    font-size: 11px;
+    cursor: pointer;
+    text-align: left;
+  }
+  .comment-rail :global(.cm-otherlang-head:hover) { color: var(--c-text); border-color: var(--accent); }
+  .comment-rail :global(.cm-otherlang-chevron) { transition: transform 0.15s; display: inline-block; }
+  .comment-rail :global(.cm-otherlang-head.open .cm-otherlang-chevron) { transform: rotate(90deg); }
+  .comment-rail :global(.cm-otherlang-body) { margin-top: 8px; display: flex; flex-direction: column; gap: 8px; }
+  /* Inside the group, cards flow normally rather than being absolutely placed. */
+  .comment-rail :global(.cm-otherlang-body .cm-card) { position: static; animation: none; }
   .comment-rail :global(.cm-card-body) {
     color: var(--c-text); line-height: 1.5; margin-bottom: 8px; word-break: break-word;
     white-space: pre-wrap;

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -1004,6 +1004,55 @@ const jsonLd = {
     return total;
   }
 
+  // The same post's other-language URL (zh <-> en), used to resolve anchors for
+  // legacy cross-language highlights that predate the anchor_id column.
+  function otherLangPostPath() {
+    return (PAGE_LANG === 'zh' ? '/en/posts/' : '/posts/') + POST_SLUG + '/';
+  }
+
+  // Fetch + parse the other-language rendered blocks once: [{aid, text}, ...].
+  // data-aid is language-independent, so a block found here maps 1:1 to the
+  // same-aid block in this page.
+  var _otherLangBlocks = null;
+  function getOtherLangBlocks() {
+    if (_otherLangBlocks) return _otherLangBlocks;
+    _otherLangBlocks = fetch(otherLangPostPath(), { credentials: 'omit' })
+      .then(function(r) { return r.ok ? r.text() : ''; })
+      .then(function(html) {
+        if (!html) return [];
+        var doc = new DOMParser().parseFromString(html, 'text/html');
+        var root = doc.getElementById('postContent') || doc.body;
+        if (!root) return [];
+        var out = [];
+        root.querySelectorAll('[data-aid]').forEach(function(el) {
+          out.push({ aid: el.getAttribute('data-aid'), text: el.textContent });
+        });
+        return out;
+      })
+      .catch(function() { return []; });
+    return _otherLangBlocks;
+  }
+
+  // For cross-language highlights without an anchor_id (created before the
+  // feature), locate the quoted passage in the OTHER language's blocks and adopt
+  // that block's data-aid, so they anchor to the matching block on this page and
+  // read inline with same-language notes instead of being orphaned.
+  function resolveCrossLangAnchors() {
+    var needy = inlineComments.filter(function(c) {
+      return c.selected_text && !c.anchor_id && commentLang(c) !== PAGE_LANG
+        && !findRangeByText(postContent, c.selected_text);
+    });
+    if (!needy.length) return Promise.resolve();
+    return getOtherLangBlocks().then(function(blocks) {
+      if (!blocks.length) return;
+      needy.forEach(function(c) {
+        for (var i = 0; i < blocks.length; i++) {
+          if (blocks[i].text.indexOf(c.selected_text) !== -1) { c.anchor_id = blocks[i].aid; break; }
+        }
+      });
+    });
+  }
+
   function restoreHighlights() {
     inlineComments.forEach(function(c) {
       if (!c.selected_text) return;
@@ -1086,11 +1135,6 @@ const jsonLd = {
       p.card.style.top = top + 'px';
       nextAvailable = top + p.height + GAP;
     });
-    var grp = commentCards.querySelector(':scope > .cm-otherlang');
-    if (grp) {
-      grp.style.top = nextAvailable + 'px';
-      nextAvailable += grp.offsetHeight + GAP;
-    }
     commentCards.style.minHeight = nextAvailable + 'px';
   }
 
@@ -1258,41 +1302,13 @@ const jsonLd = {
     commentCards.innerHTML = '';
     crEmpty.style.display = inlineComments.length ? 'none' : '';
 
-    // Anchored comments get a positioned card next to their passage; the rest
-    // (highlights made on the other language version whose block we can't place,
-    // or legacy rows whose quote no longer matches) fold into a collapsed group
-    // so they stay readable without floating against unrelated sentences.
-    var unlocated = [];
+    // Every highlight renders as a positioned card — same-language ones next to
+    // their exact <mark>, cross-language ones next to the matching block marker.
+    // layoutCards() interleaves them by vertical position, so zh and en notes
+    // sit together against the passage they belong to.
     inlineComments.forEach(function(c) {
-      if (anchorElFor(c.id)) commentCards.appendChild(buildInlineCard(c));
-      else unlocated.push(c);
+      commentCards.appendChild(buildInlineCard(c));
     });
-
-    if (unlocated.length) {
-      var allOtherLang = unlocated.every(function(c) { return commentLang(c) !== PAGE_LANG; });
-      var label = allOtherLang
-        ? (PAGE_LANG === 'zh' ? '\u82f1\u6587\u7248\u7684\u5212\u7ebf\u8bc4\u8bba' : 'Highlights on the Chinese version')
-        : (PAGE_LANG === 'zh' ? '\u672a\u5b9a\u4f4d\u7684\u5212\u7ebf\u8bc4\u8bba' : 'Unplaced highlights');
-      var grp = document.createElement('div');
-      grp.className = 'cm-otherlang';
-      var head = document.createElement('button');
-      head.className = 'cm-otherlang-head';
-      head.type = 'button';
-      head.innerHTML = '<span class="cm-otherlang-chevron">\u25b8</span><span>' + label + ' (' + unlocated.length + ')</span>';
-      var body = document.createElement('div');
-      body.className = 'cm-otherlang-body';
-      body.style.display = 'none';
-      unlocated.forEach(function(c) { body.appendChild(buildInlineCard(c)); });
-      head.addEventListener('click', function() {
-        var open = body.style.display !== 'none';
-        body.style.display = open ? 'none' : '';
-        head.classList.toggle('open', !open);
-        layoutCards();
-      });
-      grp.appendChild(head);
-      grp.appendChild(body);
-      commentCards.appendChild(grp);
-    }
 
     requestAnimationFrame(function() { requestAnimationFrame(layoutCards); });
   }
@@ -1881,9 +1897,13 @@ const jsonLd = {
 
   apiGet('/api/inline-comments?post_slug=' + encodeURIComponent(POST_SLUG)).then(function(res) {
     inlineComments = res.comments || [];
-    restoreHighlights();
-    renderInlineComments();
-    scrollToHashHighlight();
+    // Resolve anchors for legacy cross-language highlights (async, best-effort),
+    // then paint + lay out. Never let a failed lookup block rendering.
+    resolveCrossLangAnchors().catch(function() {}).then(function() {
+      restoreHighlights();
+      renderInlineComments();
+      scrollToHashHighlight();
+    });
   });
 
   // Newsletter subscribe
@@ -2464,29 +2484,6 @@ const jsonLd = {
     background: rgba(var(--accent-rgb), 0.12);
     vertical-align: 1px;
   }
-  /* Collapsed group for other-language / unplaced highlights. */
-  .comment-rail :global(.cm-otherlang) {
-    position: absolute;
-    left: 0; right: 0;
-  }
-  .comment-rail :global(.cm-otherlang-head) {
-    display: flex; align-items: center; gap: 6px;
-    width: 100%;
-    padding: 8px 10px;
-    background: none;
-    border: 1px dashed var(--c-border);
-    border-radius: 6px;
-    color: var(--c-text-dim);
-    font-size: 11px;
-    cursor: pointer;
-    text-align: left;
-  }
-  .comment-rail :global(.cm-otherlang-head:hover) { color: var(--c-text); border-color: var(--accent); }
-  .comment-rail :global(.cm-otherlang-chevron) { transition: transform 0.15s; display: inline-block; }
-  .comment-rail :global(.cm-otherlang-head.open .cm-otherlang-chevron) { transform: rotate(90deg); }
-  .comment-rail :global(.cm-otherlang-body) { margin-top: 8px; display: flex; flex-direction: column; gap: 8px; }
-  /* Inside the group, cards flow normally rather than being absolutely placed. */
-  .comment-rail :global(.cm-otherlang-body .cm-card) { position: static; animation: none; }
   .comment-rail :global(.cm-card-body) {
     color: var(--c-text); line-height: 1.5; margin-bottom: 8px; word-break: break-word;
     white-space: pre-wrap;

--- a/src/plugins/rehype-anchor-ids.mjs
+++ b/src/plugins/rehype-anchor-ids.mjs
@@ -1,0 +1,43 @@
+// Assigns a stable, language-independent anchor id (`data-aid`) to every
+// top-level block element of a rendered post body.
+//
+// Why: inline ("划线") comments anchor to a passage of text. The zh and en
+// versions of a post share one comment pool (same slug), but their text
+// differs, so a highlight anchored by raw text can never be re-located in the
+// other language. `data-aid` gives each block a key derived purely from
+// document *structure* — never from text — so block N in the Chinese version
+// maps to block N in the English version as long as the two translations share
+// the same heading/block skeleton (they are parallel translations).
+//
+// Scheme (localizes drift so a divergence in one section doesn't cascade):
+//   - every heading (h1–h6) bumps a section counter and resets the block index,
+//     and is itself tagged `h<section>` (headings are anchorable too);
+//   - every other top-level block is tagged `s<section>b<index>`.
+//
+// Consumed by the inline-comment logic in src/layouts/PostLayout.astro.
+
+const HEADINGS = new Set(['h1', 'h2', 'h3', 'h4', 'h5', 'h6']);
+
+export function rehypeAnchorIds() {
+  return (tree) => {
+    if (!tree || !Array.isArray(tree.children)) return;
+    let section = 0; // bumps on every heading — a stable cross-language landmark
+    let block = 0; // block ordinal within the current section
+    for (const node of tree.children) {
+      if (node.type !== 'element') continue;
+      node.properties = node.properties || {};
+      // Don't clobber an id an author (or another plugin) set explicitly.
+      if (node.properties.dataAid != null) continue;
+      if (HEADINGS.has(node.tagName)) {
+        section += 1;
+        block = 0;
+        node.properties.dataAid = 'h' + section;
+      } else {
+        node.properties.dataAid = 's' + section + 'b' + block;
+        block += 1;
+      }
+    }
+  };
+}
+
+export default rehypeAnchorIds;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

划线评论按“选中文本的字面量”锚定，而 zh/en 共用同一 slug、同一评论池。英文版创建的划线在中文页 `indexOf` 必然失配，导致卡片悬浮、贴不到任何句子（见 issue 截图）。

## 方案（D：在生成器绑定语言无关的块 id）

**ID 绑定放在构建期的 rehype 插件**，把稳定的 `data-aid` 烤进静态 HTML；id 从**结构**（标题分段 + 段内序号）推导，不依赖文本，所以中文第 N 块 ≡ 英文第 N 块（平行译文共享骨架）。这样划线可以锚到“语言无关的块”，再按语言决定如何呈现。

### 前端改动
- 新增 `src/plugins/rehype-anchor-ids.mjs`：给每个顶层块注入 `data-aid`（`h{段}` / `s{段}b{序}`）；接入 `astro.config.mjs`。构建验证：同一文章 zh/en 各 141 个块、id 序列完全一致。
- `src/layouts/PostLayout.astro`：
  - 创建划线时携带 `anchor_id` + `lang` + 块内字符偏移。
  - 恢复时：**同语言**→块内精确高亮；**跨语言**→锚到对应块（左侧绿点 + 强调），卡片加 `EN`/`中` 标签。
  - **跨语言与同语言划线交错混排**（按锚点位置），不折叠。存量英文划线无 `anchor_id` 时，中文页抓一次英文版页面、用 `data-aid` 反查块并映射回来自愈定位。

### 后端（配套 PR）
[blog-server#2](https://github.com/airingursb/blog-server/pull/2)：`inline_comments` 增 `anchor_id` + `lang`。**先跑 `blog-api/sql/inline_comment_anchor.sql` 再部署 blog-api**。

## 验证（桌面，Playwright 确定性）
`/posts/after-ai-takes-everything/` 连续两次结果一致：`9 cards / 7 EN / 6 dots / 0 folds`，6 条英文划线锚到 6 个不同段落（`s1b8, s4b24, s5b8, s6b2, s7b3, s7b23`），2 条中文精确高亮，跨 reload 稳定，无 console error。

[中英划线混排（位置一）](https://cursor.com/agents/bc-9bbd5cbb-84a2-468f-9256-1201b7bee749/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Finline_en_notes_view1.png)
[英文划线锚到另一段落（位置二）](https://cursor.com/agents/bc-9bbd5cbb-84a2-468f-9256-1201b7bee749/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Finline_en_notes_view2.png)

## 验证（移动端，390px iPhone 视口）
- 无横向溢出（scrollWidth == innerWidth == 390），6 个绿点均在视口内。
- `@media(max-width:1100px)` 下评论栏隐藏、走底部弹层；**同语言高亮点按**打开弹层正常。
- 跨语言划线在移动端只有栏外绿点、原本 `pointer-events:none` 点不开——已修复：绿点在移动端变为可点热区，点按打开底部弹层（英文引用 + 评论 + 回复）。保持在左侧留白内、不产生横向滚动。

[移动端点绿点打开英文划线底部弹层](https://cursor.com/agents/bc-9bbd5cbb-84a2-468f-9256-1201b7bee749/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_xlang_sheet.png)

演示视频（桌面，压缩版）：
[inline_comment_english_mixed_inline_small.mp4](https://cursor.com/agents/bc-9bbd5cbb-84a2-468f-9256-1201b7bee749/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Finline_comment_english_mixed_inline_small.mp4)

## 兼容性 / 降级
- legacy 行（无 anchor_id）：同语言仍走全局匹配；跨语言通过“抓另一语言页反查”自愈定位。
- 结构漂移：仅影响该文章跨语言精确定位，同语言不受影响；分段方案已将漂移局部化。
- 依赖平行译文“块骨架一致”。本文验证 zh/en 各 141 块、序列一致。

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9bbd5cbb-84a2-468f-9256-1201b7bee749?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9bbd5cbb-84a2-468f-9256-1201b7bee749&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

