### PR TITLE
feat(notes): Pi Agent 沉浸式长文 — 对照 pi-textbook 的 26 站源码 walkthrough

### DIFF
--- a/public/immersive/pi-agent/index.html
+++ b/public/immersive/pi-agent/index.html
@@ -1142,6 +1142,30 @@
   }
   body.has-filmstrip { padding-top: 52px; }
   body.has-filmstrip .ursb-backlink { top: 58px; }
+  .trace-walk {
+    margin: 36px 0; padding: 22px 24px 8px;
+    border: 2px solid var(--accent); border-radius: 4px;
+    background: linear-gradient(135deg, rgba(31,92,140,0.03) 0%, var(--paper) 50%);
+  }
+  .trace-walk .tw-head {
+    font-family: var(--mono); font-size: 11px; letter-spacing: 0.12em;
+    text-transform: uppercase; margin-bottom: 18px; line-height: 1.6;
+  }
+  .trace-walk .tw-tag {
+    display: block; color: var(--accent); font-weight: 700;
+    margin-bottom: 6px; letter-spacing: 0.18em;
+  }
+  .trace-walk .src-stack { margin: 16px 0 20px; }
+  .trace-walk .src-ln {
+    display: inline-block; width: 44px; text-align: right;
+    color: var(--ink-mute); user-select: none; margin-right: 8px;
+  }
+  .trace-walk .src-hl { font-family: var(--mono); font-size: 12px; }
+  .trace-steps { margin: 24px 0; }
+  .trace-steps .ts-label {
+    font-family: var(--mono); font-size: 10px; letter-spacing: 0.16em;
+    text-transform: uppercase; color: var(--copper); margin-bottom: 10px;
+  }
 
 </style>
 <script async defer src="https://analytics.ursb.me/script.js" data-website-id="aa8d5a16-df21-4058-a0a8-0191cdd3798d"></script>
@@ -4245,6 +4269,265 @@
       <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 03</strong>: Message IR (<code>types.ts</code>) · production: <code>packages/agent/src/types.ts · packages/coding-agent/src/core/messages.ts</code></span>
     </div>
 
+    <div class="trace-walk">
+      <div class="tw-head">
+        <span class="tw-tag">SOURCE TRACE · C09</span>
+        <span class="lang-zh-only">主线 prompt「读取 README.md，用一句话告诉我这个项目做什么」在消息 IR 层的变形</span>
+        <span class="lang-en-only">Through-line prompt message IR transformation</span>
+      </div>
+
+    <div class="lang-zh-only"><p>本章 trace 只盯住一件事：<strong>同一条用户输入在 agent-core 内永远是 AgentMessage</strong>，直到 <code>streamAssistantResponse</code> 调用 <code>convertToLlm</code> 才投影成 pi-ai 的 <code>Message[]</code>。主线 prompt 的 user 消息、read 的 toolResult、最终 assistant 回答——三者形状不同，但 JSONL 里存的全是 AgentMessage 变体。</p></div>
+    <div class="lang-en-only"><p>This trace tracks one thing: <strong>the same user input stays AgentMessage inside agent-core</strong> until <code>streamAssistantResponse</code> calls <code>convertToLlm</code> to project into pi-ai <code>Message[]</code>. User message, read toolResult, final assistant — different shapes, all AgentMessage variants in JSONL.</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/types.ts</span>
+        <span class="src-tag">types</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 149</span> <span class="src-hl"><span class="src-kw">export</span> <span class="src-kw">interface</span> <span class="src-cls">AgentLoopConfig</span> extends <span class="src-cls">SimpleStreamOptions</span> {</span></span>
+      <span class="src-line">      <span class="src-ln"> 150</span> <span class="src-hl">	model: <span class="src-cls">Model</span>&lt;any&gt;;</span></span>
+      <span class="src-line">      <span class="src-ln"> 151</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 152</span> <span class="src-hl">	/**</span></span>
+      <span class="src-line">      <span class="src-ln"> 153</span> <span class="src-hl">	 * <span class="src-cls">Converts</span> AgentMessage[] to <span class="src-cls">LLM</span>-compatible <span class="src-cls">Message</span>[] before each <span class="src-cls">LLM</span> call.</span></span>
+      <span class="src-line">      <span class="src-ln"> 154</span> <span class="src-hl">	 *</span></span>
+      <span class="src-line">      <span class="src-ln"> 155</span> <span class="src-hl">	 * <span class="src-cls">Each</span> AgentMessage must be converted to a <span class="src-cls">UserMessage</span>, <span class="src-cls">AssistantMessage</span>, or <span class="src-cls">ToolResultMessage</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 156</span> <span class="src-hl">	 * that the <span class="src-cls">LLM</span> can understand. <span class="src-cls">AgentMessages</span> that cannot be converted (e.g., <span class="src-cls">UI</span>-only notifications,</span></span>
+      <span class="src-line">      <span class="src-ln"> 157</span> <span class="src-hl">	 * status messages) should be filtered out.</span></span>
+      <span class="src-line">      <span class="src-ln"> 158</span> <span class="src-hl">	 *</span></span>
+      <span class="src-line">      <span class="src-ln"> 159</span> <span class="src-hl">	 * <span class="src-cls">Contract</span>: must not <span class="src-kw">throw</span> or reject. <span class="src-cls">Return</span> a safe fallback value instead.</span></span>
+      <span class="src-line">      <span class="src-ln"> 160</span> <span class="src-hl">	 * <span class="src-cls">Throwing</span> interrupts the low-level agent loop without producing a normal event sequence.</span></span>
+      <span class="src-line">      <span class="src-ln"> 161</span> <span class="src-hl">	 *</span></span>
+      <span class="src-line">      <span class="src-ln"> 162</span> <span class="src-hl">	 * @example</span></span>
+      <span class="src-line">      <span class="src-ln"> 163</span> <span class="src-hl">	 * ```typescript</span></span>
+      <span class="src-line">      <span class="src-ln"> 164</span> <span class="src-hl">	 * convertToLlm: (messages) =&gt; messages.flatMap(m =&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln"> 165</span> <span class="src-hl">	 *   <span class="src-kw">if</span> (m.role === &quot;custom&quot;) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 166</span> <span class="src-hl">	 *     <span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Convert</span> custom message to user message</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 167</span> <span class="src-hl">	 *     <span class="src-kw">return</span> [{ role: &quot;user&quot;, content: m.content, timestamp: m.timestamp }];</span></span>
+      <span class="src-line">      <span class="src-ln"> 168</span> <span class="src-hl">	 *   }</span></span>
+      <span class="src-line">      <span class="src-ln"> 169</span> <span class="src-hl">	 *   <span class="src-kw">if</span> (m.role === &quot;notification&quot;) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 170</span> <span class="src-hl">	 *     <span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Filter</span> out <span class="src-cls">UI</span>-only messages</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 171</span> <span class="src-hl">	 *     <span class="src-kw">return</span> [];</span></span>
+      <span class="src-line">      <span class="src-ln"> 172</span> <span class="src-hl">	 *   }</span></span>
+      <span class="src-line">      <span class="src-ln"> 173</span> <span class="src-hl">	 *   <span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Pass</span> through standard <span class="src-cls">LLM</span> messages</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 174</span> <span class="src-hl">	 *   <span class="src-kw">return</span> [m];</span></span>
+      <span class="src-line">      <span class="src-ln"> 175</span> <span class="src-hl">	 * })</span></span>
+      <span class="src-line">      <span class="src-ln"> 176</span> <span class="src-hl">	 * ```</span></span>
+      <span class="src-line">      <span class="src-ln"> 177</span> <span class="src-hl">	 */</span></span>
+      <span class="src-line">      <span class="src-ln"> 178</span> <span class="src-hl">	convertToLlm: (messages: AgentMessage[]) =&gt; <span class="src-cls">Message</span>[] | <span class="src-cls">Promise</span>&lt;<span class="src-cls">Message</span>[]&gt;;</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">convertToLlm：AgentMessage[] → Message[]，每次 LLM 调用前执行</span><span class="lang-en-only">convertToLlm: AgentMessage[] → Message[] before each LLM call</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 179</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 180</span> <span class="src-hl">	/**</span></span>
+      <span class="src-line">      <span class="src-ln"> 181</span> <span class="src-hl">	 * <span class="src-cls">Optional</span> transform applied to the context before <span class=<span class="src-str">"src-str"</span>>`convertToLlm`</span>.</span></span>
+      <span class="src-line">      <span class="src-ln"> 182</span> <span class="src-hl">	 *</span></span>
+      <span class="src-line">      <span class="src-ln"> 183</span> <span class="src-hl">	 * <span class="src-cls">Use</span> this <span class="src-kw">for</span> operations that work at the AgentMessage level:</span></span>
+      <span class="src-line">      <span class="src-ln"> 184</span> <span class="src-hl">	 * - <span class="src-cls">Context</span> window management (pruning old messages)</span></span>
+      <span class="src-line">      <span class="src-ln"> 185</span> <span class="src-hl">	 * - <span class="src-cls">Injecting</span> context <span class="src-kw">from</span> external sources</span></span>
+      <span class="src-line">      <span class="src-ln"> 186</span> <span class="src-hl">	 *</span></span>
+      <span class="src-line">      <span class="src-ln"> 187</span> <span class="src-hl">	 * <span class="src-cls">Contract</span>: must not <span class="src-kw">throw</span> or reject. <span class="src-cls">Return</span> the original messages or another</span></span>
+      <span class="src-line">      <span class="src-ln"> 188</span> <span class="src-hl">	 * safe fallback value instead.</span></span>
+      <span class="src-line">      <span class="src-ln"> 189</span> <span class="src-hl">	 *</span></span>
+      <span class="src-line">      <span class="src-ln"> 190</span> <span class="src-hl">	 * @example</span></span>
+      <span class="src-line">      <span class="src-ln"> 191</span> <span class="src-hl">	 * ```typescript</span></span>
+      <span class="src-line">      <span class="src-ln"> 192</span> <span class="src-hl">	 * transformContext: <span class="src-kw">async</span> (messages) =&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln"> 193</span> <span class="src-hl">	 *   <span class="src-kw">if</span> (estimateTokens(messages) &gt; MAX_TOKENS) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 194</span> <span class="src-hl">	 *     <span class="src-kw">return</span> pruneOldMessages(messages);</span></span>
+      <span class="src-line">      <span class="src-ln"> 195</span> <span class="src-hl">	 *   }</span></span>
+      <span class="src-line">      <span class="src-ln"> 196</span> <span class="src-hl">	 *   <span class="src-kw">return</span> messages;</span></span>
+      <span class="src-line">      <span class="src-ln"> 197</span> <span class="src-hl">	 * }</span></span>
+      <span class="src-line">      <span class="src-ln"> 198</span> <span class="src-hl">	 * ```</span></span>
+      <span class="src-line">      <span class="src-ln"> 199</span> <span class="src-hl">	 */</span></span>
+      <span class="src-line">      <span class="src-ln"> 200</span> <span class="src-hl">	transformContext?: (messages: AgentMessage[], signal?: <span class="src-cls">AbortSignal</span>) =&gt; <span class="src-cls">Promise</span>&lt;AgentMessage[]&gt;;</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">transformContext：在 convert 之前做 compaction / 剪枝</span><span class="lang-en-only">transformContext: compaction/prune before convert</span></span></span>
+    </div>
+
+    <div class="lang-zh-only"><p><code>AgentLoopConfig</code> 的 JSDoc 把契约写得很硬：<code>convertToLlm</code> <strong>must not throw</strong>——抛错会打断低层循环且不会产生正常 event 序列。这就是为什么 compaction 和 custom message 过滤都在 Message 层做投影，而不是在 agent-loop 里 try/catch 糊过去。</p></div>
+    <div class="lang-en-only"><p><code>AgentLoopConfig</code> JSDoc is strict: <code>convertToLlm</code> <strong>must not throw</strong> — throws break the low-level loop without a normal event sequence. Compaction and custom message filtering project at Message layer, not try/catch in agent-loop.</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/messages.ts</span>
+        <span class="src-tag">convert</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 140</span> <span class="src-hl">/**</span></span>
+      <span class="src-line">      <span class="src-ln"> 141</span> <span class="src-hl"> * <span class="src-cls">Transform</span> <span class="src-cls">AgentMessages</span> (including custom types) to <span class="src-cls">LLM</span>-compatible <span class="src-cls">Messages</span>.</span></span>
+      <span class="src-line">      <span class="src-ln"> 142</span> <span class="src-hl"> *</span></span>
+      <span class="src-line">      <span class="src-ln"> 143</span> <span class="src-hl"> * <span class="src-cls">This</span> is used by:</span></span>
+      <span class="src-line">      <span class="src-ln"> 144</span> <span class="src-hl"> * - <span class="src-cls">Agent</span>&#x27;s transormToLlm option (<span class="src-kw">for</span> prompt calls and queued messages)</span></span>
+      <span class="src-line">      <span class="src-ln"> 145</span> <span class="src-hl"> * - <span class="src-cls">Compaction</span>&#x27;s generateSummary (<span class="src-kw">for</span> summarization)</span></span>
+      <span class="src-line">      <span class="src-ln"> 146</span> <span class="src-hl"> * - <span class="src-cls">Custom</span> extensions and tools</span></span>
+      <span class="src-line">      <span class="src-ln"> 147</span> <span class="src-hl"> */</span></span>
+      <span class="src-line">      <span class="src-ln"> 148</span> <span class="src-hl"><span class="src-kw">export</span> <span class="src-kw">function</span> convertToLlm(messages: AgentMessage[]): <span class="src-cls">Message</span>[] {</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">coding-agent 的生产 convertToLlm 实现</span><span class="lang-en-only">production convertToLlm in coding-agent</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 149</span> <span class="src-hl">	<span class="src-kw">return</span> messages</span></span>
+      <span class="src-line">      <span class="src-ln"> 150</span> <span class="src-hl">		.map((m): <span class="src-cls">Message</span> | <span class="src-kw">undefined</span> =&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln"> 151</span> <span class="src-hl">			<span class="src-kw">switch</span> (m.role) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 152</span> <span class="src-hl">				<span class="src-kw">case</span> &quot;bashExecution&quot;:</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">switch(m.role)：custom / bashExecution / branchSummary 在此折叠</span><span class="lang-en-only">switch(m.role): custom/bash/branch fold here</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 153</span> <span class="src-hl">					<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Skip</span> messages excluded <span class="src-kw">from</span> context (!! prefix)</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 154</span> <span class="src-hl">					<span class="src-kw">if</span> (m.excludeFromContext) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 155</span> <span class="src-hl">						<span class="src-kw">return</span> <span class="src-kw">undefined</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 156</span> <span class="src-hl">					}</span></span>
+      <span class="src-line">      <span class="src-ln"> 157</span> <span class="src-hl">					<span class="src-kw">return</span> {</span></span>
+      <span class="src-line">      <span class="src-ln"> 158</span> <span class="src-hl">						role: &quot;user&quot;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 159</span> <span class="src-hl">						content: [{ <span class="src-kw">type</span>: &quot;text&quot;, text: bashExecutionToText(m) }],</span></span>
+      <span class="src-line">      <span class="src-ln"> 160</span> <span class="src-hl">						timestamp: m.timestamp,</span></span>
+      <span class="src-line">      <span class="src-ln"> 161</span> <span class="src-hl">					};</span></span>
+      <span class="src-line">      <span class="src-ln"> 162</span> <span class="src-hl">				<span class="src-kw">case</span> &quot;custom&quot;: {</span></span>
+      <span class="src-line">      <span class="src-ln"> 163</span> <span class="src-hl">					<span class="src-kw">const</span> content = <span class="src-kw">typeof</span> m.content === &quot;string&quot; ? [{ <span class="src-kw">type</span>: &quot;text&quot; as <span class="src-kw">const</span>, text: m.content }] : m.content;</span></span>
+      <span class="src-line">      <span class="src-ln"> 164</span> <span class="src-hl">					<span class="src-kw">return</span> {</span></span>
+      <span class="src-line">      <span class="src-ln"> 165</span> <span class="src-hl">						role: &quot;user&quot;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 166</span> <span class="src-hl">						content,</span></span>
+      <span class="src-line">      <span class="src-ln"> 167</span> <span class="src-hl">						timestamp: m.timestamp,</span></span>
+      <span class="src-line">      <span class="src-ln"> 168</span> <span class="src-hl">					};</span></span>
+      <span class="src-line">      <span class="src-ln"> 169</span> <span class="src-hl">				}</span></span>
+      <span class="src-line">      <span class="src-ln"> 170</span> <span class="src-hl">				<span class="src-kw">case</span> &quot;branchSummary&quot;:</span></span>
+      <span class="src-line">      <span class="src-ln"> 171</span> <span class="src-hl">					<span class="src-kw">return</span> {</span></span>
+      <span class="src-line">      <span class="src-ln"> 172</span> <span class="src-hl">						role: &quot;user&quot;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 173</span> <span class="src-hl">						content: [{ <span class="src-kw">type</span>: &quot;text&quot; as <span class="src-kw">const</span>, text: BRANCH_SUMMARY_PREFIX + m.summary + BRANCH_SUMMARY_SUFFIX }],</span></span>
+      <span class="src-line">      <span class="src-ln"> 174</span> <span class="src-hl">						timestamp: m.timestamp,</span></span>
+      <span class="src-line">      <span class="src-ln"> 175</span> <span class="src-hl">					};</span></span>
+      <span class="src-line">      <span class="src-ln"> 176</span> <span class="src-hl">				<span class="src-kw">case</span> &quot;compactionSummary&quot;:</span></span>
+      <span class="src-line">      <span class="src-ln"> 177</span> <span class="src-hl">					<span class="src-kw">return</span> {</span></span>
+      <span class="src-line">      <span class="src-ln"> 178</span> <span class="src-hl">						role: &quot;user&quot;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 179</span> <span class="src-hl">						content: [</span></span>
+      <span class="src-line">      <span class="src-ln"> 180</span> <span class="src-hl">							{ <span class="src-kw">type</span>: &quot;text&quot; as <span class="src-kw">const</span>, text: COMPACTION_SUMMARY_PREFIX + m.summary + COMPACTION_SUMMARY_SUFFIX },</span></span>
+      <span class="src-line">      <span class="src-ln"> 181</span> <span class="src-hl">						],</span></span>
+      <span class="src-line">      <span class="src-ln"> 182</span> <span class="src-hl">						timestamp: m.timestamp,</span></span>
+      <span class="src-line">      <span class="src-ln"> 183</span> <span class="src-hl">					};</span></span>
+      <span class="src-line">      <span class="src-ln"> 184</span> <span class="src-hl">				<span class="src-kw">case</span> &quot;user&quot;:</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">user/assistant/toolResult 原样透传——主线三角色</span><span class="lang-en-only">user/assistant/toolResult pass through — through-line trio</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 185</span> <span class="src-hl">				<span class="src-kw">case</span> &quot;assistant&quot;:</span></span>
+      <span class="src-line">      <span class="src-ln"> 186</span> <span class="src-hl">				<span class="src-kw">case</span> &quot;toolResult&quot;:</span></span>
+      <span class="src-line">      <span class="src-ln"> 187</span> <span class="src-hl">					<span class="src-kw">return</span> m;</span></span>
+      <span class="src-line">      <span class="src-ln"> 188</span> <span class="src-hl">				default:</span></span>
+      <span class="src-line">      <span class="src-ln"> 189</span> <span class="src-hl">					<span class=<span class="src-str">"src-comment"</span>>// biome-ignore lint/correctness/noSwitchDeclarations: fine</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 190</span> <span class="src-hl">					<span class="src-kw">const</span> _exhaustiveCheck: never = m;</span></span>
+      <span class="src-line">      <span class="src-ln"> 191</span> <span class="src-hl">					<span class="src-kw">return</span> <span class="src-kw">undefined</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 192</span> <span class="src-hl">			}</span></span>
+      <span class="src-line">      <span class="src-ln"> 193</span> <span class="src-hl">		})</span></span>
+      <span class="src-line">      <span class="src-ln"> 194</span> <span class="src-hl">		.filter((m) =&gt; m !== <span class="src-kw">undefined</span>);</span></span>
+      <span class="src-line">      <span class="src-ln"> 195</span> <span class="src-hl">}</span></span>
+    </div>
+
+    <div class="trace-steps"><div class="ts-label"><span class="lang-zh-only">主线 prompt 消息投影时间线</span><span class="lang-en-only">Through-line message projection timeline</span></div>    <table class="cmp">
+      <thead><tr><th>#</th><th>location</th><th>主线时刻 / through-line moment</th></tr></thead>
+      <tbody>
+      <tr><td>1</td><td><code>AgentSession.prompt()</code></td><td>user AgentMessage: «读取 README.md，用一句话告…»</td></tr>
+      <tr><td>2</td><td><code>context.messages[]</code></td><td>canonical transcript 追加 user</td></tr>
+      <tr><td>3</td><td><code>transformContext?</code></td><td>compaction 可能在此剪枝旧消息</td></tr>
+      <tr><td>4</td><td><code>convertToLlm()</code></td><td>→ [{role:user, content:…}] 送 pi-ai</td></tr>
+      <tr><td>5</td><td>turn-1 assistant</td><td>toolUse(read) 仍在 AgentMessage 形状</td></tr>
+      <tr><td>6</td><td>toolResult</td><td>read README 内容 · role=toolResult</td></tr>
+      <tr><td>7</td><td>turn-2 convert</td><td>user+assistant+toolResult → Message[]</td></tr>
+      <tr><td>8</td><td>turn-2 assistant</td><td>stopReason=stop · 最终回答</td></tr>
+      </tbody>
+    </table></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
+        <span class="src-tag">stream</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 281</span> <span class="src-hl"><span class="src-kw">async</span> <span class="src-kw">function</span> streamAssistantResponse(</span></span>
+      <span class="src-line">      <span class="src-ln"> 282</span> <span class="src-hl">	context: <span class="src-cls">AgentContext</span>,</span></span>
+      <span class="src-line">      <span class="src-ln"> 283</span> <span class="src-hl">	config: <span class="src-cls">AgentLoopConfig</span>,</span></span>
+      <span class="src-line">      <span class="src-ln"> 284</span> <span class="src-hl">	signal: <span class="src-cls">AbortSignal</span> | <span class="src-kw">undefined</span>,</span></span>
+      <span class="src-line">      <span class="src-ln"> 285</span> <span class="src-hl">	emit: <span class="src-cls">AgentEventSink</span>,</span></span>
+      <span class="src-line">      <span class="src-ln"> 286</span> <span class="src-hl">	streamFunction: <span class="src-cls">StreamFn</span>,</span></span>
+      <span class="src-line">      <span class="src-ln"> 287</span> <span class="src-hl">): <span class="src-cls">Promise</span>&lt;<span class="src-cls">AssistantMessage</span>&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln"> 288</span> <span class="src-hl">	<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Apply</span> context transform <span class="src-kw">if</span> configured (AgentMessage[] → AgentMessage[])</span></span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">transformContext 边界：仍是 AgentMessage[]</span><span class="lang-en-only">transformContext boundary: still AgentMessage[]</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 289</span> <span class="src-hl">	<span class="src-kw">let</span> messages = context.messages;</span></span>
+      <span class="src-line">      <span class="src-ln"> 290</span> <span class="src-hl">	<span class="src-kw">if</span> (config.transformContext) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 291</span> <span class="src-hl">		messages = <span class="src-kw">await</span> config.transformContext(messages, signal);</span></span>
+      <span class="src-line">      <span class="src-ln"> 292</span> <span class="src-hl">	}</span></span>
+      <span class="src-line">      <span class="src-ln"> 293</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 294</span> <span class="src-hl">	<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Convert</span> to <span class="src-cls">LLM</span>-compatible messages (AgentMessage[] → <span class="src-cls">Message</span>[])</span></span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">★ 唯一 convert 调用点</span><span class="lang-en-only">★ sole convert call site</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 295</span> <span class="src-hl">	<span class="src-kw">const</span> llmMessages = <span class="src-kw">await</span> config.convertToLlm(messages);</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">llmMessages 进入 streamFunction</span><span class="lang-en-only">llmMessages enters streamFunction</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 296</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 297</span> <span class="src-hl">	<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Build</span> <span class="src-cls">LLM</span> context</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 298</span> <span class="src-hl">	<span class="src-kw">const</span> llmContext: <span class="src-cls">Context</span> = {</span></span>
+      <span class="src-line">      <span class="src-ln"> 299</span> <span class="src-hl">		systemPrompt: context.systemPrompt,</span></span>
+      <span class="src-line">      <span class="src-ln"> 300</span> <span class="src-hl">		messages: llmMessages,</span></span>
+      <span class="src-line">      <span class="src-ln"> 301</span> <span class="src-hl">		tools: context.tools,</span></span>
+      <span class="src-line">      <span class="src-ln"> 302</span> <span class="src-hl">	};</span></span>
+      <span class="src-line">      <span class="src-ln"> 303</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 304</span> <span class="src-hl">	<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Resolve</span> <span class="src-cls">API</span> key (important <span class="src-kw">for</span> expiring tokens)</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 305</span> <span class="src-hl">	<span class="src-kw">const</span> resolvedApiKey =</span></span>
+      <span class="src-line">      <span class="src-ln"> 306</span> <span class="src-hl">		(config.getApiKey ? <span class="src-kw">await</span> config.getApiKey(config.model.provider) : <span class="src-kw">undefined</span>) || config.apiKey;</span></span>
+      <span class="src-line">      <span class="src-ln"> 307</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 308</span> <span class="src-hl">	<span class="src-kw">const</span> response = <span class="src-kw">await</span> streamFunction(config.model, llmContext, {</span></span>
+      <span class="src-line">      <span class="src-ln"> 309</span> <span class="src-hl">		...config,</span></span>
+      <span class="src-line">      <span class="src-ln"> 310</span> <span class="src-hl">		apiKey: resolvedApiKey,</span></span>
+      <span class="src-line">      <span class="src-ln"> 311</span> <span class="src-hl">		signal,</span></span>
+      <span class="src-line">      <span class="src-ln"> 312</span> <span class="src-hl">	});</span></span>
+    </div>
+
+    <div class="lang-zh-only"><p>注意 <code>streamAssistantResponse</code> 注释原文：「This is where AgentMessage[] gets transformed to Message[] for the LLM.」——读 pi-mono 时搜索这句话，比搜索 <code>convertToLlm</code> 更快定位心脏。主线 prompt 第一次 convert 发生在 turn-1 model stream 前；第二次在 turn-2（tool result 已入 context）前。</p></div>
+    <div class="lang-en-only"><p>Note <code>streamAssistantResponse</code> comment: «This is where AgentMessage[] gets transformed to Message[] for the LLM.» Search this phrase in pi-mono to locate the heart faster than <code>convertToLlm</code>. First convert before turn-1; second before turn-2 after tool result enters context.</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/types.ts</span>
+        <span class="src-tag">agentmsg</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 318</span> <span class="src-hl">}</span></span>
+      <span class="src-line">      <span class="src-ln"> 319</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 320</span> <span class="src-hl">/**</span></span>
+      <span class="src-line">      <span class="src-ln"> 321</span> <span class="src-hl"> * AgentMessage: <span class="src-cls">Union</span> of <span class="src-cls">LLM</span> messages + custom messages.</span></span>
+      <span class="src-line">      <span class="src-ln"> 322</span> <span class="src-hl"> * <span class="src-cls">This</span> abstraction allows apps to add custom message types <span class="src-kw">while</span> maintaining</span></span>
+      <span class="src-line">      <span class="src-ln"> 323</span> <span class="src-hl"> * <span class="src-kw">type</span> safety and compatibility with the base <span class="src-cls">LLM</span> messages.</span></span>
+      <span class="src-line">      <span class="src-ln"> 324</span> <span class="src-hl"> */</span></span>
+      <span class="src-line">      <span class="src-ln"> 325</span> <span class="src-hl"><span class="src-kw">export</span> <span class="src-kw">type</span> AgentMessage = <span class="src-cls">Message</span> | <span class="src-cls">CustomAgentMessages</span>[keyof <span class="src-cls">CustomAgentMessages</span>];</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">AgentMessage = Message | CustomAgentMessages 合并</span><span class="lang-en-only">AgentMessage = Message | CustomAgentMessages merge</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 326</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 327</span> <span class="src-hl">/**</span></span>
+      <span class="src-line">      <span class="src-ln"> 328</span> <span class="src-hl"> * <span class="src-cls">Public</span> agent state.</span></span>
+      <span class="src-line">      <span class="src-ln"> 329</span> <span class="src-hl"> *</span></span>
+      <span class="src-line">      <span class="src-ln"> 330</span> <span class="src-hl"> * <span class=<span class="src-str">"src-str"</span>>`tools`</span> and <span class=<span class="src-str">"src-str"</span>>`messages`</span> use accessor properties so implementations can copy</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/types.ts</span>
+        <span class="src-tag">events-type</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 421</span> <span class="src-hl">/**</span></span>
+      <span class="src-line">      <span class="src-ln"> 422</span> <span class="src-hl"> * <span class="src-cls">Events</span> emitted by the <span class="src-cls">Agent</span> <span class="src-kw">for</span> <span class="src-cls">UI</span> updates.</span></span>
+      <span class="src-line">      <span class="src-ln"> 423</span> <span class="src-hl"> *</span></span>
+      <span class="src-line">      <span class="src-ln"> 424</span> <span class="src-hl"> * <span class=<span class="src-str">"src-str"</span>>`agent_end`</span> is the last event emitted <span class="src-kw">for</span> a run, but awaited <span class=<span class="src-str">"src-str"</span>>`<span class="src-cls">Agent</span>.subscribe()`</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 425</span> <span class="src-hl"> * listeners <span class="src-kw">for</span> that event are still part of run settlement. <span class="src-cls">The</span> agent becomes</span></span>
+      <span class="src-line">      <span class="src-ln"> 426</span> <span class="src-hl"> * idle only after those listeners finish.</span></span>
+      <span class="src-line">      <span class="src-ln"> 427</span> <span class="src-hl"> */</span></span>
+      <span class="src-line">      <span class="src-ln"> 428</span> <span class="src-hl"><span class="src-kw">export</span> <span class="src-kw">type</span> <span class="src-cls">AgentEvent</span> =</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">AgentEvent：message_* 事件携带 AgentMessage 快照</span><span class="lang-en-only">AgentEvent: message_* carries AgentMessage snapshot</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 429</span> <span class="src-hl">	<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Agent</span> lifecycle</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 430</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;agent_start&quot; }</span></span>
+      <span class="src-line">      <span class="src-ln"> 431</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;agent_end&quot;; messages: AgentMessage[] }</span></span>
+      <span class="src-line">      <span class="src-ln"> 432</span> <span class="src-hl">	<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Turn</span> lifecycle - a turn is one assistant response + any tool calls/results</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 433</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;turn_start&quot; }</span></span>
+      <span class="src-line">      <span class="src-ln"> 434</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;turn_end&quot;; message: AgentMessage; toolResults: <span class="src-cls">ToolResultMessage</span>[] }</span></span>
+      <span class="src-line">      <span class="src-ln"> 435</span> <span class="src-hl">	<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Message</span> lifecycle - emitted <span class="src-kw">for</span> user, assistant, and toolResult messages</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 436</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;message_start&quot;; message: AgentMessage }</span></span>
+      <span class="src-line">      <span class="src-ln"> 437</span> <span class="src-hl">	<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Only</span> emitted <span class="src-kw">for</span> assistant messages during streaming</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 438</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;message_update&quot;; message: AgentMessage; assistantMessageEvent: <span class="src-cls">AssistantMessageEvent</span> }</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">message_update 仅 assistant 流式阶段</span><span class="lang-en-only">message_update only during assistant streaming</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 439</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;message_end&quot;; message: AgentMessage }</span></span>
+      <span class="src-line">      <span class="src-ln"> 440</span> <span class="src-hl">	<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Tool</span> execution lifecycle</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 441</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;tool_execution_start&quot;; toolCallId: string; toolName: string; args: any }</span></span>
+      <span class="src-line">      <span class="src-ln"> 442</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;tool_execution_update&quot;; toolCallId: string; toolName: string; args: any; partialResult: any }</span></span>
+      <span class="src-line">      <span class="src-ln"> 443</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;tool_execution_end&quot;; toolCallId: string; toolName: string; result: any; isError: boolean };</span></span>
+    </div>
+
+    <div class="note copper">
+      <span class="lang-zh-only">练习：在 pi-textbook checkpoint 03 给 transcript 加一条 <code>role:custom</code> 消息，观察 convertToLlm 是否过滤、JSONL 是否仍完整保存。</span>
+      <span class="lang-en-only">Exercise: in textbook cp03 add a <code>role:custom</code> message; observe convertToLlm filter vs JSONL full save.</span>
+    </div>
+
+    </div>
+
     <div class="depth-zone" data-chapter="C09"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C09.4+</span><span class="lang-en-only">Deep dive · C09.4+</span></div>
 
     <h4 class="sub2 depth-sec"><span class="sec-num">C09.4</span> <span class="lang-zh-only">主线 prompt 如何穿过此模块</span><span class="lang-en-only">through-line crossing</span></h4>
@@ -4530,6 +4813,260 @@
       <cite>Field Note · 10</cite>
     </blockquote>
 
+    <div class="trace-walk">
+      <div class="tw-head">
+        <span class="tw-tag">SOURCE TRACE · C10</span>
+        <span class="lang-zh-only">runLoop 双环：主线 prompt 两圈 model stream 完整源码 trace</span>
+        <span class="lang-en-only">runLoop twin loops: full source trace for two model streams</span>
+      </div>
+
+    <div class="lang-zh-only"><p><code>runLoop</code>（<code>agent-loop.ts:155</code>）是 Pi 与 Claude Code 最大架构差异所在：不是「一次 completion」，而是<strong>外环 follow-up × 内环 tool batch</strong>。主线 prompt 固定走两圈内环迭代（turn-1 toolUse + turn-2 stop），外环通常只转一圈。</p></div>
+    <div class="lang-en-only"><p><code>runLoop</code> (<code>agent-loop.ts:155</code>) is Pi's biggest architectural difference from Claude Code: not one completion but <strong>outer follow-up × inner tool batch</strong>. Through-line prompt runs two inner iterations (turn-1 toolUse + turn-2 stop); outer loop usually one revolution.</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
+        <span class="src-tag">runloop</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 155</span> <span class="src-hl"><span class="src-kw">async</span> <span class="src-kw">function</span> runLoop(</span></span>
+      <span class="src-line">      <span class="src-ln"> 156</span> <span class="src-hl">	initialContext: <span class="src-cls">AgentContext</span>,</span></span>
+      <span class="src-line">      <span class="src-ln"> 157</span> <span class="src-hl">	newMessages: AgentMessage[],</span></span>
+      <span class="src-line">      <span class="src-ln"> 158</span> <span class="src-hl">	initialConfig: <span class="src-cls">AgentLoopConfig</span>,</span></span>
+      <span class="src-line">      <span class="src-ln"> 159</span> <span class="src-hl">	signal: <span class="src-cls">AbortSignal</span> | <span class="src-kw">undefined</span>,</span></span>
+      <span class="src-line">      <span class="src-ln"> 160</span> <span class="src-hl">	emit: <span class="src-cls">AgentEventSink</span>,</span></span>
+      <span class="src-line">      <span class="src-ln"> 161</span> <span class="src-hl">	streamFunction: <span class="src-cls">StreamFn</span>,</span></span>
+      <span class="src-line">      <span class="src-ln"> 162</span> <span class="src-hl">): <span class="src-cls">Promise</span>&lt;void&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln"> 163</span> <span class="src-hl">	<span class="src-kw">let</span> currentContext = initialContext;</span></span>
+      <span class="src-line">      <span class="src-ln"> 164</span> <span class="src-hl">	<span class="src-kw">let</span> config = initialConfig;</span></span>
+      <span class="src-line">      <span class="src-ln"> 165</span> <span class="src-hl">	<span class="src-kw">let</span> firstTurn = <span class="src-kw">true</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 166</span> <span class="src-hl">	<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Check</span> <span class="src-kw">for</span> steering messages at start (user may have typed <span class="src-kw">while</span> waiting)</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 167</span> <span class="src-hl">	<span class="src-kw">let</span> pendingMessages: AgentMessage[] = (<span class="src-kw">await</span> config.getSteeringMessages?.()) || [];</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">启动时先 drain steering 队列</span><span class="lang-en-only">drain steering queue at start</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 168</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 169</span> <span class="src-hl">	<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Outer</span> loop: continues when queued follow-up messages arrive after agent would stop</span></span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">外环：follow-up 到达时 agent 本可停止却继续</span><span class="lang-en-only">outer: continue when follow-up arrives</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 170</span> <span class="src-hl">	<span class="src-kw">while</span> (<span class="src-kw">true</span>) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 171</span> <span class="src-hl">		<span class="src-kw">let</span> hasMoreToolCalls = <span class="src-kw">true</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 172</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 173</span> <span class="src-hl">		<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Inner</span> loop: process tool calls and steering messages</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 174</span> <span class="src-hl">		<span class="src-kw">while</span> (hasMoreToolCalls || pendingMessages.length &gt; 0) {</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">内环条件：还有 tool 或 pending steering</span><span class="lang-en-only">inner: more tools or pending steering</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 175</span> <span class="src-hl">			<span class="src-kw">if</span> (!firstTurn) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 176</span> <span class="src-hl">				<span class="src-kw">await</span> emit({ <span class="src-kw">type</span>: &quot;turn_start&quot; });</span></span>
+      <span class="src-line">      <span class="src-ln"> 177</span> <span class="src-hl">			} <span class="src-kw">else</span> {</span></span>
+      <span class="src-line">      <span class="src-ln"> 178</span> <span class="src-hl">				firstTurn = <span class="src-kw">false</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 179</span> <span class="src-hl">			}</span></span>
+      <span class="src-line">      <span class="src-ln"> 180</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 181</span> <span class="src-hl">			<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Process</span> pending messages (inject before next assistant response)</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 182</span> <span class="src-hl">			<span class="src-kw">if</span> (pendingMessages.length &gt; 0) {</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">steering 注入：message_start/end 无 streaming</span><span class="lang-en-only">steering inject: message_start/end, no streaming</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 183</span> <span class="src-hl">				<span class="src-kw">for</span> (<span class="src-kw">const</span> message of pendingMessages) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 184</span> <span class="src-hl">					<span class="src-kw">await</span> emit({ <span class="src-kw">type</span>: &quot;message_start&quot;, message });</span></span>
+      <span class="src-line">      <span class="src-ln"> 185</span> <span class="src-hl">					<span class="src-kw">await</span> emit({ <span class="src-kw">type</span>: &quot;message_end&quot;, message });</span></span>
+      <span class="src-line">      <span class="src-ln"> 186</span> <span class="src-hl">					currentContext.messages.push(message);</span></span>
+      <span class="src-line">      <span class="src-ln"> 187</span> <span class="src-hl">					newMessages.push(message);</span></span>
+      <span class="src-line">      <span class="src-ln"> 188</span> <span class="src-hl">				}</span></span>
+      <span class="src-line">      <span class="src-ln"> 189</span> <span class="src-hl">				pendingMessages = [];</span></span>
+      <span class="src-line">      <span class="src-ln"> 190</span> <span class="src-hl">			}</span></span>
+      <span class="src-line">      <span class="src-ln"> 191</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 192</span> <span class="src-hl">			<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Stream</span> assistant response</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 193</span> <span class="src-hl">			<span class="src-kw">const</span> message = <span class="src-kw">await</span> streamAssistantResponse(currentContext, config, signal, emit, streamFunction);</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">★ streamAssistantResponse：每圈内环一次 model</span><span class="lang-en-only">★ streamAssistantResponse: one model per inner round</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 194</span> <span class="src-hl">			newMessages.push(message);</span></span>
+      <span class="src-line">      <span class="src-ln"> 195</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 196</span> <span class="src-hl">			<span class="src-kw">if</span> (message.stopReason === &quot;error&quot; || message.stopReason === &quot;aborted&quot;) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 197</span> <span class="src-hl">				<span class="src-kw">await</span> emit({ <span class="src-kw">type</span>: &quot;turn_end&quot;, message, toolResults: [] });</span></span>
+      <span class="src-line">      <span class="src-ln"> 198</span> <span class="src-hl">				<span class="src-kw">await</span> emit({ <span class="src-kw">type</span>: &quot;agent_end&quot;, messages: newMessages });</span></span>
+      <span class="src-line">      <span class="src-ln"> 199</span> <span class="src-hl">				<span class="src-kw">return</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 200</span> <span class="src-hl">			}</span></span>
+      <span class="src-line">      <span class="src-ln"> 201</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 202</span> <span class="src-hl">			<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Check</span> <span class="src-kw">for</span> tool calls</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 203</span> <span class="src-hl">			<span class="src-kw">const</span> toolCalls = message.content.filter((c) =&gt; c.<span class="src-kw">type</span> === &quot;toolCall&quot;);</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">从 assistant content 提取 toolCall</span><span class="lang-en-only">extract toolCall from assistant content</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 204</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 205</span> <span class="src-hl">			<span class="src-kw">const</span> toolResults: <span class="src-cls">ToolResultMessage</span>[] = [];</span></span>
+      <span class="src-line">      <span class="src-ln"> 206</span> <span class="src-hl">			hasMoreToolCalls = <span class="src-kw">false</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 207</span> <span class="src-hl">			<span class="src-kw">if</span> (toolCalls.length &gt; 0) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 208</span> <span class="src-hl">				<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">A</span> &quot;length&quot; stop means the output was cut off by the token limit, so</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 209</span> <span class="src-hl">				<span class=<span class="src-str">"src-comment"</span>>// every tool call in the message may carry truncated arguments. <span class="src-cls">Fail</span></span></span></span>
+      <span class="src-line">      <span class="src-ln"> 210</span> <span class="src-hl">				<span class=<span class="src-str">"src-comment"</span>>// them all instead of executing potentially borked calls.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 211</span> <span class="src-hl">				<span class="src-kw">const</span> executedToolBatch =</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">stopReason=length → 批量 fail tool，不执行</span><span class="lang-en-only">stopReason=length → fail all tools, don't execute</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 212</span> <span class="src-hl">					message.stopReason === &quot;length&quot;</span></span>
+      <span class="src-line">      <span class="src-ln"> 213</span> <span class="src-hl">						? <span class="src-kw">await</span> failToolCallsFromTruncatedMessage(toolCalls, emit)</span></span>
+      <span class="src-line">      <span class="src-ln"> 214</span> <span class="src-hl">						: <span class="src-kw">await</span> executeToolCalls(currentContext, message, config, signal, emit);</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">★ executeToolCalls：read README 在此</span><span class="lang-en-only">★ executeToolCalls: read README here</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 215</span> <span class="src-hl">				toolResults.push(...executedToolBatch.messages);</span></span>
+      <span class="src-line">      <span class="src-ln"> 216</span> <span class="src-hl">				hasMoreToolCalls = !executedToolBatch.terminate;</span></span>
+      <span class="src-line">      <span class="src-ln"> 217</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 218</span> <span class="src-hl">				<span class="src-kw">for</span> (<span class="src-kw">const</span> result of toolResults) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 219</span> <span class="src-hl">					currentContext.messages.push(result);</span></span>
+      <span class="src-line">      <span class="src-ln"> 220</span> <span class="src-hl">					newMessages.push(result);</span></span>
+      <span class="src-line">      <span class="src-ln"> 221</span> <span class="src-hl">				}</span></span>
+      <span class="src-line">      <span class="src-ln"> 222</span> <span class="src-hl">			}</span></span>
+      <span class="src-line">      <span class="src-ln"> 223</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 224</span> <span class="src-hl">			<span class="src-kw">await</span> emit({ <span class="src-kw">type</span>: &quot;turn_end&quot;, message, toolResults });</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">turn_end：TUI 可在此刷新 tool 卡片</span><span class="lang-en-only">turn_end: TUI refreshes tool cards</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 225</span> <span class="src-hl"></span></span>
+    </div>
+
+    <div class="trace-steps"><div class="ts-label"><span class="lang-zh-only">主线 prompt · runLoop 状态机</span><span class="lang-en-only">Through-line prompt · runLoop state machine</span></div>    <table class="cmp">
+      <thead><tr><th>#</th><th>location</th><th>主线时刻 / through-line moment</th></tr></thead>
+      <tbody>
+      <tr><td>T0</td><td>outer iter=1, inner iter=1</td><td>pending=[] · stream turn-1</td></tr>
+      <tr><td>T1</td><td>inner iter=1 end</td><td>stopReason=toolUse · toolCalls=[read]</td></tr>
+      <tr><td>T2</td><td>executeToolCalls</td><td>tool_execution_* · README content</td></tr>
+      <tr><td>T3</td><td>inner iter=2</td><td>context+=toolResult · stream turn-2</td></tr>
+      <tr><td>T4</td><td>inner iter=2 end</td><td>stopReason=stop · 最终回答</td></tr>
+      <tr><td>T5</td><td>inner exit</td><td>hasMoreToolCalls=false · pending=[]</td></tr>
+      <tr><td>T6</td><td>outer check follow-up</td><td>无 follow-up → break</td></tr>
+      <tr><td>T7</td><td>agent_end</td><td>return newMessages[]</td></tr>
+      </tbody>
+    </table></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
+        <span class="src-tag">stream-emit</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 314</span> <span class="src-hl">	<span class="src-kw">let</span> partialMessage: <span class="src-cls">AssistantMessage</span> | <span class="src-kw">null</span> = <span class="src-kw">null</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 315</span> <span class="src-hl">	<span class="src-kw">let</span> addedPartial = <span class="src-kw">false</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 316</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 317</span> <span class="src-hl">	<span class="src-kw">for</span> <span class="src-kw">await</span> (<span class="src-kw">const</span> event of response) {</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">消费 pi-ai EventStream</span><span class="lang-en-only">consume pi-ai EventStream</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 318</span> <span class="src-hl">		<span class="src-kw">switch</span> (event.<span class="src-kw">type</span>) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 319</span> <span class="src-hl">			<span class="src-kw">case</span> &quot;start&quot;:</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">start → message_start(partial)</span><span class="lang-en-only">start → message_start(partial)</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 320</span> <span class="src-hl">				partialMessage = event.partial;</span></span>
+      <span class="src-line">      <span class="src-ln"> 321</span> <span class="src-hl">				context.messages.push(partialMessage);</span></span>
+      <span class="src-line">      <span class="src-ln"> 322</span> <span class="src-hl">				addedPartial = <span class="src-kw">true</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 323</span> <span class="src-hl">				<span class="src-kw">await</span> emit({ <span class="src-kw">type</span>: &quot;message_start&quot;, message: { ...partialMessage } });</span></span>
+      <span class="src-line">      <span class="src-ln"> 324</span> <span class="src-hl">				<span class="src-kw">break</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 325</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 326</span> <span class="src-hl">			<span class="src-kw">case</span> &quot;text_start&quot;:</span></span>
+      <span class="src-line">      <span class="src-ln"> 327</span> <span class="src-hl">			<span class="src-kw">case</span> &quot;text_delta&quot;:</span></span>
+      <span class="src-line">      <span class="src-ln"> 328</span> <span class="src-hl">			<span class="src-kw">case</span> &quot;text_end&quot;:</span></span>
+      <span class="src-line">      <span class="src-ln"> 329</span> <span class="src-hl">			<span class="src-kw">case</span> &quot;thinking_start&quot;:</span></span>
+      <span class="src-line">      <span class="src-ln"> 330</span> <span class="src-hl">			<span class="src-kw">case</span> &quot;thinking_delta&quot;:</span></span>
+      <span class="src-line">      <span class="src-ln"> 331</span> <span class="src-hl">			<span class="src-kw">case</span> &quot;thinking_end&quot;:</span></span>
+      <span class="src-line">      <span class="src-ln"> 332</span> <span class="src-hl">			<span class="src-kw">case</span> &quot;toolcall_start&quot;:</span></span>
+      <span class="src-line">      <span class="src-ln"> 333</span> <span class="src-hl">			<span class="src-kw">case</span> &quot;toolcall_delta&quot;:</span></span>
+      <span class="src-line">      <span class="src-ln"> 334</span> <span class="src-hl">			<span class="src-kw">case</span> &quot;toolcall_end&quot;:</span></span>
+      <span class="src-line">      <span class="src-ln"> 335</span> <span class="src-hl">				<span class="src-kw">if</span> (partialMessage) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 336</span> <span class="src-hl">					partialMessage = event.partial;</span></span>
+      <span class="src-line">      <span class="src-ln"> 337</span> <span class="src-hl">					context.messages[context.messages.length - 1] = partialMessage;</span></span>
+      <span class="src-line">      <span class="src-ln"> 338</span> <span class="src-hl">					<span class="src-kw">await</span> emit({</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">★ message_update：每个 text/toolcall delta</span><span class="lang-en-only">★ message_update: each text/toolcall delta</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 339</span> <span class="src-hl">						<span class="src-kw">type</span>: &quot;message_update&quot;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 340</span> <span class="src-hl">						assistantMessageEvent: event,</span></span>
+      <span class="src-line">      <span class="src-ln"> 341</span> <span class="src-hl">						message: { ...partialMessage },</span></span>
+      <span class="src-line">      <span class="src-ln"> 342</span> <span class="src-hl">					});</span></span>
+      <span class="src-line">      <span class="src-ln"> 343</span> <span class="src-hl">				}</span></span>
+      <span class="src-line">      <span class="src-ln"> 344</span> <span class="src-hl">				<span class="src-kw">break</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 345</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 346</span> <span class="src-hl">			<span class="src-kw">case</span> &quot;done&quot;:</span></span>
+      <span class="src-line">      <span class="src-ln"> 347</span> <span class="src-hl">			<span class="src-kw">case</span> &quot;error&quot;: {</span></span>
+      <span class="src-line">      <span class="src-ln"> 348</span> <span class="src-hl">				<span class="src-kw">const</span> finalMessage = <span class="src-kw">await</span> response.result();</span></span>
+      <span class="src-line">      <span class="src-ln"> 349</span> <span class="src-hl">				<span class="src-kw">if</span> (addedPartial) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 350</span> <span class="src-hl">					context.messages[context.messages.length - 1] = finalMessage;</span></span>
+      <span class="src-line">      <span class="src-ln"> 351</span> <span class="src-hl">				} <span class="src-kw">else</span> {</span></span>
+      <span class="src-line">      <span class="src-ln"> 352</span> <span class="src-hl">					context.messages.push(finalMessage);</span></span>
+      <span class="src-line">      <span class="src-ln"> 353</span> <span class="src-hl">				}</span></span>
+      <span class="src-line">      <span class="src-ln"> 354</span> <span class="src-hl">				<span class="src-kw">if</span> (!addedPartial) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 355</span> <span class="src-hl">					<span class="src-kw">await</span> emit({ <span class="src-kw">type</span>: &quot;message_start&quot;, message: { ...finalMessage } });</span></span>
+      <span class="src-line">      <span class="src-ln"> 356</span> <span class="src-hl">				}</span></span>
+      <span class="src-line">      <span class="src-ln"> 357</span> <span class="src-hl">				<span class="src-kw">await</span> emit({ <span class="src-kw">type</span>: &quot;message_end&quot;, message: finalMessage });</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">done → message_end(final)</span><span class="lang-en-only">done → message_end(final)</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 358</span> <span class="src-hl">				<span class="src-kw">return</span> finalMessage;</span></span>
+      <span class="src-line">      <span class="src-ln"> 359</span> <span class="src-hl">			}</span></span>
+      <span class="src-line">      <span class="src-ln"> 360</span> <span class="src-hl">		}</span></span>
+    </div>
+
+    <div class="lang-zh-only"><p>内环第二次迭代时，<code>currentContext.messages</code> 已含：user prompt、turn-1 assistant(toolUse)、toolResult(README)。<code>convertToLlm</code> 把 toolResult 折叠成 provider 特定 tool_result 块——Anthropic 与 OpenAI 形状不同，但 agent-loop 不感知，这是 pi-ai adapter 的职责（C14）。</p></div>
+    <div class="lang-en-only"><p>Second inner iteration: <code>currentContext.messages</code> has user, turn-1 assistant(toolUse), toolResult(README). <code>convertToLlm</code> folds toolResult to provider-specific blocks — agent-loop doesn't care, pi-ai adapter's job (C14).</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
+        <span class="src-tag">outer-exit</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 247</span> <span class="src-hl">			<span class="src-kw">if</span> (</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">shouldStopAfterTurn：扩展可强制提前 agent_end</span><span class="lang-en-only">shouldStopAfterTurn: extensions can force early agent_end</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 248</span> <span class="src-hl">				<span class="src-kw">await</span> config.shouldStopAfterTurn?.({</span></span>
+      <span class="src-line">      <span class="src-ln"> 249</span> <span class="src-hl">					message,</span></span>
+      <span class="src-line">      <span class="src-ln"> 250</span> <span class="src-hl">					toolResults,</span></span>
+      <span class="src-line">      <span class="src-ln"> 251</span> <span class="src-hl">					context: currentContext,</span></span>
+      <span class="src-line">      <span class="src-ln"> 252</span> <span class="src-hl">					newMessages,</span></span>
+      <span class="src-line">      <span class="src-ln"> 253</span> <span class="src-hl">				})</span></span>
+      <span class="src-line">      <span class="src-ln"> 254</span> <span class="src-hl">			) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 255</span> <span class="src-hl">				<span class="src-kw">await</span> emit({ <span class="src-kw">type</span>: &quot;agent_end&quot;, messages: newMessages });</span></span>
+      <span class="src-line">      <span class="src-ln"> 256</span> <span class="src-hl">				<span class="src-kw">return</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 257</span> <span class="src-hl">			}</span></span>
+      <span class="src-line">      <span class="src-ln"> 258</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 259</span> <span class="src-hl">			pendingMessages = (<span class="src-kw">await</span> config.getSteeringMessages?.()) || [];</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">内环结束后再次 poll steering</span><span class="lang-en-only">poll steering again after inner loop</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 260</span> <span class="src-hl">		}</span></span>
+      <span class="src-line">      <span class="src-ln"> 261</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 262</span> <span class="src-hl">		<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Agent</span> would stop here. <span class="src-cls">Check</span> <span class="src-kw">for</span> follow-up messages.</span></span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">外环 follow-up 检查点</span><span class="lang-en-only">outer follow-up checkpoint</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 263</span> <span class="src-hl">		<span class="src-kw">const</span> followUpMessages = (<span class="src-kw">await</span> config.getFollowUpMessages?.()) || [];</span></span>
+      <span class="src-line">      <span class="src-ln"> 264</span> <span class="src-hl">		<span class="src-kw">if</span> (followUpMessages.length &gt; 0) {</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">有 follow-up → pendingMessages → continue 外环</span><span class="lang-en-only">follow-up → pendingMessages → continue outer</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 265</span> <span class="src-hl">			<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Set</span> as pending so inner loop processes them</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 266</span> <span class="src-hl">			pendingMessages = followUpMessages;</span></span>
+      <span class="src-line">      <span class="src-ln"> 267</span> <span class="src-hl">			<span class="src-kw">continue</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 268</span> <span class="src-hl">		}</span></span>
+      <span class="src-line">      <span class="src-ln"> 269</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 270</span> <span class="src-hl">		<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">No</span> more messages, exit</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 271</span> <span class="src-hl">		<span class="src-kw">break</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 272</span> <span class="src-hl">	}</span></span>
+      <span class="src-line">      <span class="src-ln"> 273</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 274</span> <span class="src-hl">	<span class="src-kw">await</span> emit({ <span class="src-kw">type</span>: &quot;agent_end&quot;, messages: newMessages });</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">无消息 → agent_end</span><span class="lang-en-only">no messages → agent_end</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 275</span> <span class="src-hl">}</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
+        <span class="src-tag">length-fail</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 381</span> <span class="src-hl"><span class="src-kw">async</span> <span class="src-kw">function</span> failToolCallsFromTruncatedMessage(</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">length 截断时拒绝执行所有 tool call</span><span class="lang-en-only">length truncation rejects all tool calls</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 382</span> <span class="src-hl">	toolCalls: <span class="src-cls">AgentToolCall</span>[],</span></span>
+      <span class="src-line">      <span class="src-ln"> 383</span> <span class="src-hl">	emit: <span class="src-cls">AgentEventSink</span>,</span></span>
+      <span class="src-line">      <span class="src-ln"> 384</span> <span class="src-hl">): <span class="src-cls">Promise</span>&lt;<span class="src-cls">ExecutedToolCallBatch</span>&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln"> 385</span> <span class="src-hl">	<span class="src-kw">const</span> messages: <span class="src-cls">ToolResultMessage</span>[] = [];</span></span>
+      <span class="src-line">      <span class="src-ln"> 386</span> <span class="src-hl">	<span class="src-kw">for</span> (<span class="src-kw">const</span> toolCall of toolCalls) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 387</span> <span class="src-hl">		<span class="src-kw">await</span> emit({</span></span>
+      <span class="src-line">      <span class="src-ln"> 388</span> <span class="src-hl">			<span class="src-kw">type</span>: &quot;tool_execution_start&quot;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 389</span> <span class="src-hl">			toolCallId: toolCall.id,</span></span>
+      <span class="src-line">      <span class="src-ln"> 390</span> <span class="src-hl">			toolName: toolCall.name,</span></span>
+      <span class="src-line">      <span class="src-ln"> 391</span> <span class="src-hl">			args: toolCall.arguments,</span></span>
+      <span class="src-line">      <span class="src-ln"> 392</span> <span class="src-hl">		});</span></span>
+      <span class="src-line">      <span class="src-ln"> 393</span> <span class="src-hl">		<span class="src-kw">const</span> finalized: <span class="src-cls">FinalizedToolCallOutcome</span> = {</span></span>
+      <span class="src-line">      <span class="src-ln"> 394</span> <span class="src-hl">			toolCall,</span></span>
+      <span class="src-line">      <span class="src-ln"> 395</span> <span class="src-hl">			result: createErrorToolResult(</span></span>
+      <span class="src-line">      <span class="src-ln"> 396</span> <span class="src-hl">				<span class=<span class="src-str">"src-str"</span>>`<span class="src-cls">Tool</span> call &quot;${toolCall.name}&quot; was not executed: the response hit the output token limit, so its arguments may be truncated. <span class="src-cls">Re</span>-issue the tool call with complete arguments.`</span>,</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">错误 tool result 文案：要求模型重新发起完整参数</span><span class="lang-en-only">error tool result: ask model to re-issue full args</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 397</span> <span class="src-hl">			),</span></span>
+      <span class="src-line">      <span class="src-ln"> 398</span> <span class="src-hl">			isError: <span class="src-kw">true</span>,</span></span>
+      <span class="src-line">      <span class="src-ln"> 399</span> <span class="src-hl">		};</span></span>
+      <span class="src-line">      <span class="src-ln"> 400</span> <span class="src-hl">		<span class="src-kw">await</span> emitToolExecutionEnd(finalized, emit);</span></span>
+      <span class="src-line">      <span class="src-ln"> 401</span> <span class="src-hl">		<span class="src-kw">const</span> toolResultMessage = createToolResultMessage(finalized);</span></span>
+      <span class="src-line">      <span class="src-ln"> 402</span> <span class="src-hl">		<span class="src-kw">await</span> emitToolResultMessage(toolResultMessage, emit);</span></span>
+      <span class="src-line">      <span class="src-ln"> 403</span> <span class="src-hl">		messages.push(toolResultMessage);</span></span>
+      <span class="src-line">      <span class="src-ln"> 404</span> <span class="src-hl">	}</span></span>
+      <span class="src-line">      <span class="src-ln"> 405</span> <span class="src-hl">	<span class="src-kw">return</span> { messages, terminate: <span class="src-kw">false</span> };</span></span>
+    </div>
+
+    <div class="note copper">
+      <span class="lang-zh-only">对照 pi-textbook cp07 <code>agent-loop.test.ts</code>：搜索 <code>two turn</code> 或 <code>toolUse</code>，测试里的 event 序列应与 --verbose stderr 同构。</span>
+      <span class="lang-en-only">Cross-read textbook cp07 <code>agent-loop.test.ts</code>: search <code>two turn</code> or <code>toolUse</code>; test event sequence should match --verbose stderr.</span>
+    </div>
+
+    </div>
+
     <div class="src-stack">
       <div class="src-h">
         <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
@@ -4770,6 +5307,173 @@
     <div class="note copper">
       <span class="lang-zh-only">📘 <strong>pi-textbook checkpoint 09</strong>：Stateful Agent（<code>stateful-agent</code>）· 生产映射：<code>packages/agent/src/agent.ts</code></span>
       <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 09</strong>: Stateful Agent (<code>stateful-agent</code>) · production: <code>packages/agent/src/agent.ts</code></span>
+    </div>
+
+    <div class="trace-walk">
+      <div class="tw-head">
+        <span class="tw-tag">SOURCE TRACE · C11</span>
+        <span class="lang-zh-only">Steering / Follow-up 双队列源码 trace</span>
+        <span class="lang-en-only">Steering / Follow-up dual-queue source trace</span>
+      </div>
+
+    <div class="lang-zh-only"><p>Steering 与 Follow-up 不是 UI 花活——它们在类型系统里是 <code>AgentLoopConfig</code> 的两个可选钩子：<code>getSteeringMessages</code> 与 <code>getFollowUpMessages</code>。AgentSession 维护 <code>_steeringMessages</code> / <code>_followUpMessages</code> 字符串队列，在 config 工厂里桥接到 agent-loop。</p></div>
+    <div class="lang-en-only"><p>Steering and follow-up aren't UI gimmicks — they're optional hooks on <code>AgentLoopConfig</code>: <code>getSteeringMessages</code> and <code>getFollowUpMessages</code>. AgentSession maintains string queues bridged to agent-loop via config factory.</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/types.ts</span>
+        <span class="src-tag">config-hooks</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 230</span> <span class="src-hl">		context: <span class="src-cls">PrepareNextTurnContext</span>,</span></span>
+      <span class="src-line">      <span class="src-ln"> 231</span> <span class="src-hl">	) =&gt; <span class="src-cls">AgentLoopTurnUpdate</span> | <span class="src-kw">undefined</span> | <span class="src-cls">Promise</span>&lt;<span class="src-cls">AgentLoopTurnUpdate</span> | <span class="src-kw">undefined</span>&gt;;</span></span>
+      <span class="src-line">      <span class="src-ln"> 232</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 233</span> <span class="src-hl">	/**</span></span>
+      <span class="src-line">      <span class="src-ln"> 234</span> <span class="src-hl">	 * <span class="src-cls">Returns</span> steering messages to inject into the conversation mid-run.</span></span>
+      <span class="src-line">      <span class="src-ln"> 235</span> <span class="src-hl">	 *</span></span>
+      <span class="src-line">      <span class="src-ln"> 236</span> <span class="src-hl">	 * <span class="src-cls">Called</span> after the current assistant turn finishes executing its tool calls, unless <span class=<span class="src-str">"src-str"</span>>`shouldStopAfterTurn`</span> exits first.</span></span>
+      <span class="src-line">      <span class="src-ln"> 237</span> <span class="src-hl">	 * <span class="src-cls">If</span> messages are returned, they are added to the context before the next <span class="src-cls">LLM</span> call.</span></span>
+      <span class="src-line">      <span class="src-ln"> 238</span> <span class="src-hl">	 * <span class="src-cls">Tool</span> calls <span class="src-kw">from</span> the current assistant message are not skipped.</span></span>
+      <span class="src-line">      <span class="src-ln"> 239</span> <span class="src-hl">	 *</span></span>
+      <span class="src-line">      <span class="src-ln"> 240</span> <span class="src-hl">	 * <span class="src-cls">Use</span> this <span class="src-kw">for</span> &quot;steering&quot; the agent <span class="src-kw">while</span> it&#x27;s working.</span></span>
+      <span class="src-line">      <span class="src-ln"> 241</span> <span class="src-hl">	 *</span></span>
+      <span class="src-line">      <span class="src-ln"> 242</span> <span class="src-hl">	 * <span class="src-cls">Contract</span>: must not <span class="src-kw">throw</span> or reject. <span class="src-cls">Return</span> [] when no steering messages are available.</span></span>
+      <span class="src-line">      <span class="src-ln"> 243</span> <span class="src-hl">	 */</span></span>
+      <span class="src-line">      <span class="src-ln"> 244</span> <span class="src-hl">	getSteeringMessages?: () =&gt; <span class="src-cls">Promise</span>&lt;AgentMessage[]&gt;;</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">getSteeringMessages：内环每轮前 poll</span><span class="lang-en-only">getSteeringMessages: poll before each inner round</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 245</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 246</span> <span class="src-hl">	/**</span></span>
+      <span class="src-line">      <span class="src-ln"> 247</span> <span class="src-hl">	 * <span class="src-cls">Returns</span> follow-up messages to process after the agent would otherwise stop.</span></span>
+      <span class="src-line">      <span class="src-ln"> 248</span> <span class="src-hl">	 *</span></span>
+      <span class="src-line">      <span class="src-ln"> 249</span> <span class="src-hl">	 * <span class="src-cls">Called</span> when the agent has no more tool calls and no steering messages.</span></span>
+      <span class="src-line">      <span class="src-ln"> 250</span> <span class="src-hl">	 * <span class="src-cls">If</span> messages are returned, they&#x27;re added to the context and the agent</span></span>
+      <span class="src-line">      <span class="src-ln"> 251</span> <span class="src-hl">	 * continues with another turn.</span></span>
+      <span class="src-line">      <span class="src-ln"> 252</span> <span class="src-hl">	 *</span></span>
+      <span class="src-line">      <span class="src-ln"> 253</span> <span class="src-hl">	 * <span class="src-cls">Use</span> this <span class="src-kw">for</span> follow-up messages that should wait until the agent finishes.</span></span>
+      <span class="src-line">      <span class="src-ln"> 254</span> <span class="src-hl">	 *</span></span>
+      <span class="src-line">      <span class="src-ln"> 255</span> <span class="src-hl">	 * <span class="src-cls">Contract</span>: must not <span class="src-kw">throw</span> or reject. <span class="src-cls">Return</span> [] when no follow-up messages are available.</span></span>
+      <span class="src-line">      <span class="src-ln"> 256</span> <span class="src-hl">	 */</span></span>
+      <span class="src-line">      <span class="src-ln"> 257</span> <span class="src-hl">	getFollowUpMessages?: () =&gt; <span class="src-cls">Promise</span>&lt;AgentMessage[]&gt;;</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">getFollowUpMessages：外环 would-stop 时 poll</span><span class="lang-en-only">getFollowUpMessages: poll at outer would-stop</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 258</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 259</span> <span class="src-hl">	/**</span></span>
+      <span class="src-line">      <span class="src-ln"> 260</span> <span class="src-hl">	 * <span class="src-cls">Tool</span> execution mode.</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
+        <span class="src-tag">inject</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 166</span> <span class="src-hl">	<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Check</span> <span class="src-kw">for</span> steering messages at start (user may have typed <span class="src-kw">while</span> waiting)</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 167</span> <span class="src-hl">	<span class="src-kw">let</span> pendingMessages: AgentMessage[] = (<span class="src-kw">await</span> config.getSteeringMessages?.()) || [];</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">循环开头：await getSteeringMessages</span><span class="lang-en-only">loop start: await getSteeringMessages</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 168</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 169</span> <span class="src-hl">	<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Outer</span> loop: continues when queued follow-up messages arrive after agent would stop</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 170</span> <span class="src-hl">	<span class="src-kw">while</span> (<span class="src-kw">true</span>) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 171</span> <span class="src-hl">		<span class="src-kw">let</span> hasMoreToolCalls = <span class="src-kw">true</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 172</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 173</span> <span class="src-hl">		<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Inner</span> loop: process tool calls and steering messages</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 174</span> <span class="src-hl">		<span class="src-kw">while</span> (hasMoreToolCalls || pendingMessages.length &gt; 0) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 175</span> <span class="src-hl">			<span class="src-kw">if</span> (!firstTurn) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 176</span> <span class="src-hl">				<span class="src-kw">await</span> emit({ <span class="src-kw">type</span>: &quot;turn_start&quot; });</span></span>
+      <span class="src-line">      <span class="src-ln"> 177</span> <span class="src-hl">			} <span class="src-kw">else</span> {</span></span>
+      <span class="src-line">      <span class="src-ln"> 178</span> <span class="src-hl">				firstTurn = <span class="src-kw">false</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 179</span> <span class="src-hl">			}</span></span>
+      <span class="src-line">      <span class="src-ln"> 180</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 181</span> <span class="src-hl">			<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Process</span> pending messages (inject before next assistant response)</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 182</span> <span class="src-hl">			<span class="src-kw">if</span> (pendingMessages.length &gt; 0) {</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">pending 非空：逐条 push 到 context，无 LLM</span><span class="lang-en-only">pending non-empty: push to context, no LLM</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 183</span> <span class="src-hl">				<span class="src-kw">for</span> (<span class="src-kw">const</span> message of pendingMessages) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 184</span> <span class="src-hl">					<span class="src-kw">await</span> emit({ <span class="src-kw">type</span>: &quot;message_start&quot;, message });</span></span>
+      <span class="src-line">      <span class="src-ln"> 185</span> <span class="src-hl">					<span class="src-kw">await</span> emit({ <span class="src-kw">type</span>: &quot;message_end&quot;, message });</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">message_end 后立即进入 streamAssistantResponse</span><span class="lang-en-only">message_end then streamAssistantResponse</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 186</span> <span class="src-hl">					currentContext.messages.push(message);</span></span>
+      <span class="src-line">      <span class="src-ln"> 187</span> <span class="src-hl">					newMessages.push(message);</span></span>
+      <span class="src-line">      <span class="src-ln"> 188</span> <span class="src-hl">				}</span></span>
+      <span class="src-line">      <span class="src-ln"> 189</span> <span class="src-hl">				pendingMessages = [];</span></span>
+      <span class="src-line">      <span class="src-ln"> 190</span> <span class="src-hl">			}</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
+        <span class="src-tag">followup</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 258</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 259</span> <span class="src-hl">			pendingMessages = (<span class="src-kw">await</span> config.getSteeringMessages?.()) || [];</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">内环结束后再 poll steering</span><span class="lang-en-only">poll steering after inner loop</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 260</span> <span class="src-hl">		}</span></span>
+      <span class="src-line">      <span class="src-ln"> 261</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 262</span> <span class="src-hl">		<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Agent</span> would stop here. <span class="src-cls">Check</span> <span class="src-kw">for</span> follow-up messages.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 263</span> <span class="src-hl">		<span class="src-kw">const</span> followUpMessages = (<span class="src-kw">await</span> config.getFollowUpMessages?.()) || [];</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">★ follow-up：外环唯一重启条件</span><span class="lang-en-only">★ follow-up: sole outer restart condition</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 264</span> <span class="src-hl">		<span class="src-kw">if</span> (followUpMessages.length &gt; 0) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 265</span> <span class="src-hl">			<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Set</span> as pending so inner loop processes them</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 266</span> <span class="src-hl">			pendingMessages = followUpMessages;</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">follow-up 变成 pending，continue 外环</span><span class="lang-en-only">follow-up becomes pending, continue outer</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 267</span> <span class="src-hl">			<span class="src-kw">continue</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 268</span> <span class="src-hl">		}</span></span>
+    </div>
+
+    <div class="trace-steps"><div class="ts-label"><span class="lang-zh-only">Case：read 中途 steering「先 ls」</span><span class="lang-en-only">Case: steer «ls first» mid-read</span></div>    <table class="cmp">
+      <thead><tr><th>#</th><th>location</th><th>主线时刻 / through-line moment</th></tr></thead>
+      <tbody>
+      <tr><td>1</td><td>turn-1 toolUse(read)</td><td>模型已决定读 README</td></tr>
+      <tr><td>2</td><td>executeTool 前</td><td>getSteeringMessages 返回 user「先 ls」</td></tr>
+      <tr><td>3</td><td>pending 注入</td><td>context += steer user · 无 model</td></tr>
+      <tr><td>4</td><td>stream turn-1b</td><td>模型可能改调 bash/ls</td></tr>
+      <tr><td>5</td><td>队列 UI</td><td>AgentSession splice steering 队列</td></tr>
+      </tbody>
+    </table></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/agent-session.ts</span>
+        <span class="src-tag">session-queue</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 620</span> <span class="src-hl">	/** <span class="src-cls">Internal</span> handler <span class="src-kw">for</span> agent events - shared by subscribe and reconnect */</span></span>
+      <span class="src-line">      <span class="src-ln"> 621</span> <span class="src-hl">	private _handleAgentEvent = <span class="src-kw">async</span> (event: <span class="src-cls">AgentEvent</span>): <span class="src-cls">Promise</span>&lt;void&gt; =&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln"> 622</span> <span class="src-hl">		<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">When</span> a user message starts, check <span class="src-kw">if</span> it&#x27;s <span class="src-kw">from</span> either queue and remove it <span class="src-cls">BEFORE</span> emitting</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 623</span> <span class="src-hl">		<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">This</span> ensures the <span class="src-cls">UI</span> sees the updated queue state</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 624</span> <span class="src-hl">		<span class="src-kw">if</span> (event.<span class="src-kw">type</span> === &quot;message_start&quot; &amp;&amp; event.message.role === &quot;user&quot;) {</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">message_start(user) 时从队列移除</span><span class="lang-en-only">on message_start(user) remove from queue</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 625</span> <span class="src-hl">			this._overflowRecoveryAttempted = <span class="src-kw">false</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 626</span> <span class="src-hl">			<span class="src-kw">const</span> messageText = contentText(event.message.content, &quot;&quot;);</span></span>
+      <span class="src-line">      <span class="src-ln"> 627</span> <span class="src-hl">			<span class="src-kw">if</span> (messageText) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 628</span> <span class="src-hl">				<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Check</span> steering queue first</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 629</span> <span class="src-hl">				<span class="src-kw">const</span> steeringIndex = this._steeringMessages.indexOf(messageText);</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">先匹配 steering 队列</span><span class="lang-en-only">match steering queue first</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 630</span> <span class="src-hl">				<span class="src-kw">if</span> (steeringIndex !== -1) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 631</span> <span class="src-hl">					this._steeringMessages.splice(steeringIndex, 1);</span></span>
+      <span class="src-line">      <span class="src-ln"> 632</span> <span class="src-hl">					this._emitQueueUpdate();</span></span>
+      <span class="src-line">      <span class="src-ln"> 633</span> <span class="src-hl">				} <span class="src-kw">else</span> {</span></span>
+      <span class="src-line">      <span class="src-ln"> 634</span> <span class="src-hl">					<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Check</span> follow-up queue</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 635</span> <span class="src-hl">					<span class="src-kw">const</span> followUpIndex = this._followUpMessages.indexOf(messageText);</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">再匹配 follow-up 队列</span><span class="lang-en-only">then follow-up queue</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 636</span> <span class="src-hl">					<span class="src-kw">if</span> (followUpIndex !== -1) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 637</span> <span class="src-hl">						this._followUpMessages.splice(followUpIndex, 1);</span></span>
+      <span class="src-line">      <span class="src-ln"> 638</span> <span class="src-hl">						this._emitQueueUpdate();</span></span>
+      <span class="src-line">      <span class="src-ln"> 639</span> <span class="src-hl">					}</span></span>
+      <span class="src-line">      <span class="src-ln"> 640</span> <span class="src-hl">				}</span></span>
+      <span class="src-line">      <span class="src-ln"> 641</span> <span class="src-hl">			}</span></span>
+      <span class="src-line">      <span class="src-ln"> 642</span> <span class="src-hl">		}</span></span>
+      <span class="src-line">      <span class="src-ln"> 643</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 644</span> <span class="src-hl">		<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Emit</span> to extensions first</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 645</span> <span class="src-hl">		<span class="src-kw">await</span> this._emitExtensionEvent(event);</span></span>
+      <span class="src-line">      <span class="src-ln"> 646</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 647</span> <span class="src-hl">		<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Notify</span> all listeners</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 648</span> <span class="src-hl">		this._emit(event.<span class="src-kw">type</span> === &quot;agent_end&quot; ? { ...event, willRetry: this._willRetryAfterAgentEnd(event) } : event);</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">_emit 给 TUI 监听器</span><span class="lang-en-only">_emit to TUI listeners</span></span></span>
+    </div>
+
+    <div class="lang-zh-only"><p>关键时序：<code>_handleAgentEvent</code> 在 <code>message_start(user)</code> 时<strong>先于 emit</strong> 修改队列状态——保证 TUI 看到 steering 消息时侧边栏队列已更新。这是「事件驱动 UI」与「轮询队列」的接缝，也是 fork Pi 时最容易漏掉的细节。</p></div>
+    <div class="lang-en-only"><p>Key timing: <code>_handleAgentEvent</code> mutates queue <strong>before emit</strong> on <code>message_start(user)</code> — TUI sees updated sidebar when steering message appears. Seam between event-driven UI and queue polling; easy to miss when forking Pi.</p></div>
+
+    <div class="note copper">
+      <span class="lang-zh-only">实验：interactive 模式下模型 toolUse(read) 后立刻输入 steering，观察 inner loop 是否多一轮 model stream。</span>
+      <span class="lang-en-only">Experiment: after toolUse(read) in interactive mode, steer immediately; observe extra inner model round.</span>
+    </div>
+
     </div>
 
     <div class="depth-zone" data-chapter="C11"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C11.4+</span><span class="lang-en-only">Deep dive · C11.4+</span></div>
@@ -5030,6 +5734,241 @@
       <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 08</strong>: Coding Tools (<code>coding-tools</code>) · production: <code>packages/coding-agent/src/core/tools/index.ts</code></span>
     </div>
 
+    <div class="trace-walk">
+      <div class="tw-head">
+        <span class="tw-tag">SOURCE TRACE · C12</span>
+        <span class="lang-zh-only">read README 工具管线 · 从 toolUse 到 toolResult</span>
+        <span class="lang-en-only">read README tool pipeline · toolUse to toolResult</span>
+      </div>
+
+    <div class="lang-zh-only"><p>主线 prompt 的第一次 tool call 几乎总是 <code>read({"path":"README.md"})</code>。<code>executeToolCalls</code> 根据 <code>toolExecution</code> 配置和 per-tool <code>executionMode</code> 选择并行或串行；read 默认并行安全。</p></div>
+    <div class="lang-en-only"><p>Through-line's first tool call is usually <code>read({"path":"README.md"})</code>. <code>executeToolCalls</code> picks parallel vs sequential from <code>toolExecution</code> config and per-tool <code>executionMode</code>; read is parallel-safe by default.</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
+        <span class="src-tag">dispatch</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 411</span> <span class="src-hl"><span class="src-kw">async</span> <span class="src-kw">function</span> executeToolCalls(</span></span>
+      <span class="src-line">      <span class="src-ln"> 412</span> <span class="src-hl">	currentContext: <span class="src-cls">AgentContext</span>,</span></span>
+      <span class="src-line">      <span class="src-ln"> 413</span> <span class="src-hl">	assistantMessage: <span class="src-cls">AssistantMessage</span>,</span></span>
+      <span class="src-line">      <span class="src-ln"> 414</span> <span class="src-hl">	config: <span class="src-cls">AgentLoopConfig</span>,</span></span>
+      <span class="src-line">      <span class="src-ln"> 415</span> <span class="src-hl">	signal: <span class="src-cls">AbortSignal</span> | <span class="src-kw">undefined</span>,</span></span>
+      <span class="src-line">      <span class="src-ln"> 416</span> <span class="src-hl">	emit: <span class="src-cls">AgentEventSink</span>,</span></span>
+      <span class="src-line">      <span class="src-ln"> 417</span> <span class="src-hl">): <span class="src-cls">Promise</span>&lt;<span class="src-cls">ExecutedToolCallBatch</span>&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln"> 418</span> <span class="src-hl">	<span class="src-kw">const</span> toolCalls = assistantMessage.content.filter((c) =&gt; c.<span class="src-kw">type</span> === &quot;toolCall&quot;);</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">从 assistant content filter toolCall</span><span class="lang-en-only">filter toolCall from assistant content</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 419</span> <span class="src-hl">	<span class="src-kw">const</span> hasSequentialToolCall = toolCalls.some(</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">任一 tool executionMode=sequential → 串行</span><span class="lang-en-only">any tool sequential → sequential path</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 420</span> <span class="src-hl">		(tc) =&gt; currentContext.tools?.find((t) =&gt; t.name === tc.name)?.executionMode === &quot;sequential&quot;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 421</span> <span class="src-hl">	);</span></span>
+      <span class="src-line">      <span class="src-ln"> 422</span> <span class="src-hl">	<span class="src-kw">if</span> (config.toolExecution === &quot;sequential&quot; || hasSequentialToolCall) {</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">config.toolExecution 全局覆盖</span><span class="lang-en-only">config.toolExecution global override</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 423</span> <span class="src-hl">		<span class="src-kw">return</span> executeToolCallsSequential(currentContext, assistantMessage, toolCalls, config, signal, emit);</span></span>
+      <span class="src-line">      <span class="src-ln"> 424</span> <span class="src-hl">	}</span></span>
+      <span class="src-line">      <span class="src-ln"> 425</span> <span class="src-hl">	<span class="src-kw">return</span> executeToolCallsParallel(currentContext, assistantMessage, toolCalls, config, signal, emit);</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">read 单 call 时 parallel/sequential 等价</span><span class="lang-en-only">single read: parallel≈sequential</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 426</span> <span class="src-hl">}</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
+        <span class="src-tag">sequential</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 433</span> <span class="src-hl"><span class="src-kw">async</span> <span class="src-kw">function</span> executeToolCallsSequential(</span></span>
+      <span class="src-line">      <span class="src-ln"> 434</span> <span class="src-hl">	currentContext: <span class="src-cls">AgentContext</span>,</span></span>
+      <span class="src-line">      <span class="src-ln"> 435</span> <span class="src-hl">	assistantMessage: <span class="src-cls">AssistantMessage</span>,</span></span>
+      <span class="src-line">      <span class="src-ln"> 436</span> <span class="src-hl">	toolCalls: <span class="src-cls">AgentToolCall</span>[],</span></span>
+      <span class="src-line">      <span class="src-ln"> 437</span> <span class="src-hl">	config: <span class="src-cls">AgentLoopConfig</span>,</span></span>
+      <span class="src-line">      <span class="src-ln"> 438</span> <span class="src-hl">	signal: <span class="src-cls">AbortSignal</span> | <span class="src-kw">undefined</span>,</span></span>
+      <span class="src-line">      <span class="src-ln"> 439</span> <span class="src-hl">	emit: <span class="src-cls">AgentEventSink</span>,</span></span>
+      <span class="src-line">      <span class="src-ln"> 440</span> <span class="src-hl">): <span class="src-cls">Promise</span>&lt;<span class="src-cls">ExecutedToolCallBatch</span>&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln"> 441</span> <span class="src-hl">	<span class="src-kw">const</span> finalizedCalls: <span class="src-cls">FinalizedToolCallOutcome</span>[] = [];</span></span>
+      <span class="src-line">      <span class="src-ln"> 442</span> <span class="src-hl">	<span class="src-kw">const</span> messages: <span class="src-cls">ToolResultMessage</span>[] = [];</span></span>
+      <span class="src-line">      <span class="src-ln"> 443</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 444</span> <span class="src-hl">	<span class="src-kw">for</span> (<span class="src-kw">const</span> toolCall of toolCalls) {</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">逐 toolCall：tool_execution_start</span><span class="lang-en-only">per toolCall: tool_execution_start</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 445</span> <span class="src-hl">		<span class="src-kw">await</span> emit({</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-ln"> 446</span> <span class="src-hl">			<span class="src-kw">type</span>: &quot;tool_execution_start&quot;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 447</span> <span class="src-hl">			toolCallId: toolCall.id,</span></span>
+      <span class="src-line">      <span class="src-ln"> 448</span> <span class="src-hl">			toolName: toolCall.name,</span></span>
+      <span class="src-line">      <span class="src-ln"> 449</span> <span class="src-hl">			args: toolCall.arguments,</span></span>
+      <span class="src-line">      <span class="src-ln"> 450</span> <span class="src-hl">		});</span></span>
+      <span class="src-line">      <span class="src-ln"> 451</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 452</span> <span class="src-hl">		<span class="src-kw">const</span> preparation = <span class="src-kw">await</span> prepareToolCall(currentContext, assistantMessage, toolCall, config, signal);</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">prepareToolCall：参数校验 + 扩展 hook</span><span class="lang-en-only">prepareToolCall: validate + extension hook</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 453</span> <span class="src-hl">		<span class="src-kw">let</span> finalized: <span class="src-cls">FinalizedToolCallOutcome</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 454</span> <span class="src-hl">		<span class="src-kw">if</span> (preparation.kind === &quot;immediate&quot;) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 455</span> <span class="src-hl">			finalized = {</span></span>
+      <span class="src-line">      <span class="src-ln"> 456</span> <span class="src-hl">				toolCall,</span></span>
+      <span class="src-line">      <span class="src-ln"> 457</span> <span class="src-hl">				result: preparation.result,</span></span>
+      <span class="src-line">      <span class="src-ln"> 458</span> <span class="src-hl">				isError: preparation.isError,</span></span>
+      <span class="src-line">      <span class="src-ln"> 459</span> <span class="src-hl">			};</span></span>
+      <span class="src-line">      <span class="src-ln"> 460</span> <span class="src-hl">		} <span class="src-kw">else</span> {</span></span>
+      <span class="src-line">      <span class="src-ln"> 461</span> <span class="src-hl">			<span class="src-kw">const</span> executed = <span class="src-kw">await</span> executePreparedToolCall(preparation, signal, emit);</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">executePreparedToolCall：真正执行 read</span><span class="lang-en-only">executePreparedToolCall: actually run read</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 462</span> <span class="src-hl">			finalized = <span class="src-kw">await</span> finalizeExecutedToolCall(</span></span>
+      <span class="src-line">      <span class="src-ln"> 463</span> <span class="src-hl">				currentContext,</span></span>
+      <span class="src-line">      <span class="src-ln"> 464</span> <span class="src-hl">				assistantMessage,</span></span>
+      <span class="src-line">      <span class="src-ln"> 465</span> <span class="src-hl">				preparation,</span></span>
+      <span class="src-line">      <span class="src-ln"> 466</span> <span class="src-hl">				executed,</span></span>
+      <span class="src-line">      <span class="src-ln"> 467</span> <span class="src-hl">				config,</span></span>
+      <span class="src-line">      <span class="src-ln"> 468</span> <span class="src-hl">				signal,</span></span>
+      <span class="src-line">      <span class="src-ln"> 469</span> <span class="src-hl">			);</span></span>
+      <span class="src-line">      <span class="src-ln"> 470</span> <span class="src-hl">		}</span></span>
+      <span class="src-line">      <span class="src-ln"> 471</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 472</span> <span class="src-hl">		<span class="src-kw">await</span> emitToolExecutionEnd(finalized, emit);</span></span>
+      <span class="src-line">      <span class="src-ln"> 473</span> <span class="src-hl">		<span class="src-kw">const</span> toolResultMessage = createToolResultMessage(finalized);</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">createToolResultMessage → message_start/end</span><span class="lang-en-only">createToolResultMessage → message_start/end</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 474</span> <span class="src-hl">		<span class="src-kw">await</span> emitToolResultMessage(toolResultMessage, emit);</span></span>
+      <span class="src-line">      <span class="src-ln"> 475</span> <span class="src-hl">		finalizedCalls.push(finalized);</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/tools/read.ts</span>
+        <span class="src-tag">read-exec</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 209</span> <span class="src-hl"><span class="src-kw">export</span> <span class="src-kw">function</span> createReadToolDefinition(</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">createReadToolDefinition：schema + execute</span><span class="lang-en-only">createReadToolDefinition: schema + execute</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 210</span> <span class="src-hl">	cwd: string,</span></span>
+      <span class="src-line">      <span class="src-ln"> 211</span> <span class="src-hl">	options?: <span class="src-cls">ReadToolOptions</span>,</span></span>
+      <span class="src-line">      <span class="src-ln"> 212</span> <span class="src-hl">): <span class="src-cls">ToolDefinition</span>&lt;<span class="src-kw">typeof</span> readSchema, <span class="src-cls">ReadToolDetails</span> | <span class="src-kw">undefined</span>&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln"> 213</span> <span class="src-hl">	<span class="src-kw">const</span> autoResizeImages = options?.autoResizeImages ?? <span class="src-kw">true</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 214</span> <span class="src-hl">	<span class="src-kw">const</span> ops = options?.operations ?? defaultReadOperations;</span></span>
+      <span class="src-line">      <span class="src-ln"> 215</span> <span class="src-hl">	<span class="src-kw">return</span> {</span></span>
+      <span class="src-line">      <span class="src-ln"> 216</span> <span class="src-hl">		name: &quot;read&quot;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 217</span> <span class="src-hl">		label: &quot;read&quot;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 218</span> <span class="src-hl">		description: <span class=<span class="src-str">"src-str"</span>>`<span class="src-cls">Read</span> the contents of a file. <span class="src-cls">Supports</span> text files and images (jpg, png, gif, webp, bmp). <span class="src-cls">Images</span> are sent as attachments. <span class="src-cls">For</span> text files, output is truncated to ${DEFAULT_MAX_LINES} lines or ${DEFAULT_MAX_BYTES / 1024}<span class="src-cls">KB</span> (whichever is hit first). <span class="src-cls">Use</span> offset/limit <span class="src-kw">for</span> large files. <span class="src-cls">When</span> you need the full file, <span class="src-kw">continue</span> with offset until complete.`</span>,</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">DEFAULT_MAX_LINES / MAX_BYTES 截断说明在 description</span><span class="lang-en-only">truncation limits in description</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 219</span> <span class="src-hl">		promptSnippet: readToolSystemPromptContribution.snippet,</span></span>
+      <span class="src-line">      <span class="src-ln"> 220</span> <span class="src-hl">		promptGuidelines: [...readToolSystemPromptContribution.guidelines],</span></span>
+      <span class="src-line">      <span class="src-ln"> 221</span> <span class="src-hl">		parameters: readSchema,</span></span>
+      <span class="src-line">      <span class="src-ln"> 222</span> <span class="src-hl">		constrainedSampling: getExperimentalToolSampling(),</span></span>
+      <span class="src-line">      <span class="src-ln"> 223</span> <span class="src-hl">		<span class="src-kw">async</span> execute(</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">execute 入口：Promise + AbortSignal</span><span class="lang-en-only">execute entry: Promise + AbortSignal</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 224</span> <span class="src-hl">			_toolCallId,</span></span>
+      <span class="src-line">      <span class="src-ln"> 225</span> <span class="src-hl">			{ path, offset, limit }: { path: string; offset?: number; limit?: number },</span></span>
+      <span class="src-line">      <span class="src-ln"> 226</span> <span class="src-hl">			signal?: <span class="src-cls">AbortSignal</span>,</span></span>
+      <span class="src-line">      <span class="src-ln"> 227</span> <span class="src-hl">			_onUpdate?,</span></span>
+      <span class="src-line">      <span class="src-ln"> 228</span> <span class="src-hl">			ctx?,</span></span>
+      <span class="src-line">      <span class="src-ln"> 229</span> <span class="src-hl">		) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 230</span> <span class="src-hl">			<span class="src-kw">return</span> <span class="src-kw">new</span> <span class="src-cls">Promise</span>&lt;{ content: (<span class="src-cls">TextContent</span> | <span class="src-cls">ImageContent</span>)[]; details: <span class="src-cls">ReadToolDetails</span> | <span class="src-kw">undefined</span> }&gt;(</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/tools/read.ts</span>
+        <span class="src-tag">read-body</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 243</span> <span class="src-hl">					(<span class="src-kw">async</span> () =&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln"> 244</span> <span class="src-hl">						try {</span></span>
+      <span class="src-line">      <span class="src-ln"> 245</span> <span class="src-hl">							<span class="src-kw">const</span> absolutePath = <span class="src-kw">await</span> resolveReadPathAsync(path, cwd);</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">resolveReadPathAsync：cwd 相对 → 绝对</span><span class="lang-en-only">resolveReadPathAsync: cwd-relative → absolute</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 246</span> <span class="src-hl">							<span class="src-kw">if</span> (aborted) <span class="src-kw">return</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 247</span> <span class="src-hl">							<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Check</span> <span class="src-kw">if</span> file exists and is readable.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 248</span> <span class="src-hl">							<span class="src-kw">await</span> ops.access(absolutePath);</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">fs access 检查可读</span><span class="lang-en-only">fs access readability check</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 249</span> <span class="src-hl">							<span class="src-kw">if</span> (aborted) <span class="src-kw">return</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 250</span> <span class="src-hl">							<span class="src-kw">const</span> mimeType = ops.detectImageMimeType ? <span class="src-kw">await</span> ops.detectImageMimeType(absolutePath) : <span class="src-kw">undefined</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 251</span> <span class="src-hl">							<span class="src-kw">let</span> content: (<span class="src-cls">TextContent</span> | <span class="src-cls">ImageContent</span>)[];</span></span>
+      <span class="src-line">      <span class="src-ln"> 252</span> <span class="src-hl">							<span class="src-kw">let</span> details: <span class="src-cls">ReadToolDetails</span> | <span class="src-kw">undefined</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 253</span> <span class="src-hl">							<span class="src-kw">const</span> nonVisionImageNote = getNonVisionImageNote(ctx?.model);</span></span>
+      <span class="src-line">      <span class="src-ln"> 254</span> <span class="src-hl">							<span class="src-kw">if</span> (mimeType) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 255</span> <span class="src-hl">								<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Read</span> image as binary.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 256</span> <span class="src-hl">								<span class="src-kw">const</span> buffer = <span class="src-kw">await</span> ops.readFile(absolutePath);</span></span>
+      <span class="src-line">      <span class="src-ln"> 257</span> <span class="src-hl">								<span class="src-kw">const</span> processed = <span class="src-kw">await</span> processImage(buffer, mimeType, { autoResizeImages });</span></span>
+      <span class="src-line">      <span class="src-ln"> 258</span> <span class="src-hl">								<span class="src-kw">if</span> (!processed.ok) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 259</span> <span class="src-hl">									<span class="src-kw">let</span> textNote = <span class=<span class="src-str">"src-str"</span>>`<span class="src-cls">Read</span> image file [${mimeType}]\n${processed.message}`</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 260</span> <span class="src-hl">									<span class="src-kw">if</span> (nonVisionImageNote) textNote += <span class=<span class="src-str">"src-str"</span>>`\n${nonVisionImageNote}`</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 261</span> <span class="src-hl">									content = [{ <span class="src-kw">type</span>: &quot;text&quot;, text: textNote }];</span></span>
+      <span class="src-line">      <span class="src-ln"> 262</span> <span class="src-hl">								} <span class="src-kw">else</span> {</span></span>
+      <span class="src-line">      <span class="src-ln"> 263</span> <span class="src-hl">									<span class="src-kw">let</span> textNote = <span class=<span class="src-str">"src-str"</span>>`<span class="src-cls">Read</span> image file [${processed.mimeType}]`</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 264</span> <span class="src-hl">									<span class="src-kw">if</span> (processed.hints.length &gt; 0) textNote += <span class=<span class="src-str">"src-str"</span>>`\n${processed.hints.join(&quot;\n&quot;)}`</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 265</span> <span class="src-hl">									<span class="src-kw">if</span> (nonVisionImageNote) textNote += <span class=<span class="src-str">"src-str"</span>>`\n${nonVisionImageNote}`</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 266</span> <span class="src-hl">									content = [</span></span>
+      <span class="src-line">      <span class="src-ln"> 267</span> <span class="src-hl">										{ <span class="src-kw">type</span>: &quot;text&quot;, text: textNote },</span></span>
+      <span class="src-line">      <span class="src-ln"> 268</span> <span class="src-hl">										{ <span class="src-kw">type</span>: &quot;image&quot;, data: processed.data, mimeType: processed.mimeType },</span></span>
+      <span class="src-line">      <span class="src-ln"> 269</span> <span class="src-hl">									];</span></span>
+      <span class="src-line">      <span class="src-ln"> 270</span> <span class="src-hl">								}</span></span>
+      <span class="src-line">      <span class="src-ln"> 271</span> <span class="src-hl">							} <span class="src-kw">else</span> {</span></span>
+      <span class="src-line">      <span class="src-ln"> 272</span> <span class="src-hl">								<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Read</span> text content.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 273</span> <span class="src-hl">								<span class="src-kw">const</span> buffer = <span class="src-kw">await</span> ops.readFile(absolutePath);</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">文本分支：buffer.toString utf-8</span><span class="lang-en-only">text branch: buffer.toString utf-8</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 274</span> <span class="src-hl">								<span class="src-kw">const</span> textContent = buffer.toString(&quot;utf-8&quot;);</span></span>
+      <span class="src-line">      <span class="src-ln"> 275</span> <span class="src-hl">								<span class="src-kw">const</span> allLines = textContent.split(&quot;\n&quot;);</span></span>
+      <span class="src-line">      <span class="src-ln"> 276</span> <span class="src-hl">								<span class="src-kw">const</span> totalFileLines = allLines.length;</span></span>
+      <span class="src-line">      <span class="src-ln"> 277</span> <span class="src-hl">								<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Apply</span> offset <span class="src-kw">if</span> specified. <span class="src-cls">Convert</span> <span class="src-kw">from</span> 1-indexed input to 0-indexed array access.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 278</span> <span class="src-hl">								<span class="src-kw">const</span> startLine = offset ? <span class="src-cls">Math</span>.max(0, offset - 1) : 0;</span></span>
+      <span class="src-line">      <span class="src-ln"> 279</span> <span class="src-hl">								<span class="src-kw">const</span> startLineDisplay = startLine + 1;</span></span>
+      <span class="src-line">      <span class="src-ln"> 280</span> <span class="src-hl">								<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Check</span> <span class="src-kw">if</span> offset is out of bounds.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 281</span> <span class="src-hl">								<span class="src-kw">if</span> (startLine &gt;= allLines.length) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 282</span> <span class="src-hl">									<span class="src-kw">throw</span> <span class="src-kw">new</span> <span class="src-cls">Error</span>(<span class=<span class="src-str">"src-str"</span>>`<span class="src-cls">Offset</span> ${offset} is beyond end of file (${allLines.length} lines total)`</span>);</span></span>
+      <span class="src-line">      <span class="src-ln"> 283</span> <span class="src-hl">								}</span></span>
+      <span class="src-line">      <span class="src-ln"> 284</span> <span class="src-hl">								<span class="src-kw">let</span> selectedContent: string;</span></span>
+      <span class="src-line">      <span class="src-ln"> 285</span> <span class="src-hl">								<span class="src-kw">let</span> userLimitedLines: number | <span class="src-kw">undefined</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 286</span> <span class="src-hl">								<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">If</span> limit is specified by the user, honor it first. <span class="src-cls">Otherwise</span> truncateHead decides.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 287</span> <span class="src-hl">								<span class="src-kw">if</span> (limit !== <span class="src-kw">undefined</span>) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 288</span> <span class="src-hl">									<span class="src-kw">const</span> endLine = <span class="src-cls">Math</span>.min(startLine + limit, allLines.length);</span></span>
+      <span class="src-line">      <span class="src-ln"> 289</span> <span class="src-hl">									selectedContent = allLines.slice(startLine, endLine).join(&quot;\n&quot;);</span></span>
+      <span class="src-line">      <span class="src-ln"> 290</span> <span class="src-hl">									userLimitedLines = endLine - startLine;</span></span>
+      <span class="src-line">      <span class="src-ln"> 291</span> <span class="src-hl">								} <span class="src-kw">else</span> {</span></span>
+      <span class="src-line">      <span class="src-ln"> 292</span> <span class="src-hl">									selectedContent = allLines.slice(startLine).join(&quot;\n&quot;);</span></span>
+      <span class="src-line">      <span class="src-ln"> 293</span> <span class="src-hl">								}</span></span>
+      <span class="src-line">      <span class="src-ln"> 294</span> <span class="src-hl">								<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Apply</span> truncation, respecting both line and byte limits.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 295</span> <span class="src-hl">								<span class="src-kw">const</span> truncation = truncateHead(selectedContent);</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">★ truncateHead：超长按行/字节截断</span><span class="lang-en-only">★ truncateHead: line/byte truncation</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 296</span> <span class="src-hl">								<span class="src-kw">let</span> outputText: string;</span></span>
+      <span class="src-line">      <span class="src-ln"> 297</span> <span class="src-hl">								<span class="src-kw">if</span> (truncation.firstLineExceedsLimit) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 298</span> <span class="src-hl">									<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">First</span> line alone exceeds the byte limit. <span class="src-cls">Point</span> the model at a bash fallback.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 299</span> <span class="src-hl">									<span class="src-kw">const</span> firstLineSize = formatSize(<span class="src-cls">Buffer</span>.byteLength(allLines[startLine], &quot;utf-8&quot;));</span></span>
+      <span class="src-line">      <span class="src-ln"> 300</span> <span class="src-hl">									outputText = <span class=<span class="src-str">"src-str"</span>>`[<span class="src-cls">Line</span> ${startLineDisplay} is ${firstLineSize}, exceeds ${formatSize(DEFAULT_MAX_BYTES)} limit. <span class="src-cls">Use</span> bash: sed -n &#x27;${startLineDisplay}p&#x27; ${path} | head -c ${DEFAULT_MAX_BYTES}]`</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 301</span> <span class="src-hl">									details = { truncation };</span></span>
+      <span class="src-line">      <span class="src-ln"> 302</span> <span class="src-hl">								} <span class="src-kw">else</span> <span class="src-kw">if</span> (truncation.truncated) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 303</span> <span class="src-hl">									<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Truncation</span> occurred. <span class="src-cls">Build</span> an actionable continuation notice.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 304</span> <span class="src-hl">									<span class="src-kw">const</span> endLineDisplay = startLineDisplay + truncation.outputLines - 1;</span></span>
+      <span class="src-line">      <span class="src-ln"> 305</span> <span class="src-hl">									<span class="src-kw">const</span> nextOffset = endLineDisplay + 1;</span></span>
+      <span class="src-line">      <span class="src-ln"> 306</span> <span class="src-hl">									outputText = truncation.content;</span></span>
+      <span class="src-line">      <span class="src-ln"> 307</span> <span class="src-hl">									<span class="src-kw">if</span> (truncation.truncatedBy === &quot;lines&quot;) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 308</span> <span class="src-hl">										outputText += <span class=<span class="src-str">"src-str"</span>>`\n\n[<span class="src-cls">Showing</span> lines ${startLineDisplay}-${endLineDisplay} of ${totalFileLines}. <span class="src-cls">Use</span> offset=${nextOffset} to <span class="src-kw">continue</span>.]`</span>;</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">截断提示：offset=N 继续读</span><span class="lang-en-only">truncation hint: offset=N to continue</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 309</span> <span class="src-hl">									} <span class="src-kw">else</span> {</span></span>
+      <span class="src-line">      <span class="src-ln"> 310</span> <span class="src-hl">										outputText += <span class=<span class="src-str">"src-str"</span>>`\n\n[<span class="src-cls">Showing</span> lines ${startLineDisplay}-${endLineDisplay} of ${totalFileLines} (${formatSize(DEFAULT_MAX_BYTES)} limit). <span class="src-cls">Use</span> offset=${nextOffset} to <span class="src-kw">continue</span>.]`</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 311</span> <span class="src-hl">									}</span></span>
+      <span class="src-line">      <span class="src-ln"> 312</span> <span class="src-hl">									details = { truncation };</span></span>
+      <span class="src-line">      <span class="src-ln"> 313</span> <span class="src-hl">								} <span class="src-kw">else</span> <span class="src-kw">if</span> (userLimitedLines !== <span class="src-kw">undefined</span> &amp;&amp; startLine + userLimitedLines &lt; allLines.length) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 314</span> <span class="src-hl">									<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">User</span>-specified limit stopped early, but the file still has more content.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 315</span> <span class="src-hl">									<span class="src-kw">const</span> remaining = allLines.length - (startLine + userLimitedLines);</span></span>
+      <span class="src-line">      <span class="src-ln"> 316</span> <span class="src-hl">									<span class="src-kw">const</span> nextOffset = startLine + userLimitedLines + 1;</span></span>
+      <span class="src-line">      <span class="src-ln"> 317</span> <span class="src-hl">									outputText = <span class=<span class="src-str">"src-str"</span>>`${truncation.content}\n\n[${remaining} more lines in file. <span class="src-cls">Use</span> offset=${nextOffset} to <span class="src-kw">continue</span>.]`</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 318</span> <span class="src-hl">								} <span class="src-kw">else</span> {</span></span>
+      <span class="src-line">      <span class="src-ln"> 319</span> <span class="src-hl">									<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">No</span> truncation and no remaining user-limited content.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 320</span> <span class="src-hl">									outputText = truncation.content;</span></span>
+      <span class="src-line">      <span class="src-ln"> 321</span> <span class="src-hl">								}</span></span>
+      <span class="src-line">      <span class="src-ln"> 322</span> <span class="src-hl">								content = [{ <span class="src-kw">type</span>: &quot;text&quot;, text: outputText }];</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">返回 TextContent[] 给 agent-loop</span><span class="lang-en-only">return TextContent[] to agent-loop</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 323</span> <span class="src-hl">							}</span></span>
+    </div>
+
+    <div class="trace-steps"><div class="ts-label"><span class="lang-zh-only">read(README.md) 逐步</span><span class="lang-en-only">read(README.md) step by step</span></div>    <table class="cmp">
+      <thead><tr><th>#</th><th>location</th><th>主线时刻 / through-line moment</th></tr></thead>
+      <tbody>
+      <tr><td>1</td><td>validateToolArguments</td><td>{"path":"README.md"}</td></tr>
+      <tr><td>2</td><td>resolveReadPathAsync</td><td>cwd/README.md → absolute</td></tr>
+      <tr><td>3</td><td>fsReadFile</td><td>UTF-8 buffer</td></tr>
+      <tr><td>4</td><td>truncateHead</td><td>≤2000 lines / 256KB</td></tr>
+      <tr><td>5</td><td>tool_execution_end</td><td>isError=false</td></tr>
+      <tr><td>6</td><td>AgentMessage</td><td>role=toolResult · toolCallId=call_1</td></tr>
+      <tr><td>7</td><td>inner loop iter 2</td><td>context.messages += result</td></tr>
+      </tbody>
+    </table></div>
+
+    <div class="lang-zh-only"><p>若 README 超大，<code>truncateHead</code> 会在 tool result 末尾附加 <code>[Showing lines … Use offset=N to continue.]</code>——模型在 turn-2 可能只读到文件头部。主线 prompt「一句话概括」通常不需要全文；这是 Pi 故意用截断换上下文窗口的设计取舍。</p></div>
+    <div class="lang-en-only"><p>If README is huge, <code>truncateHead</code> appends continuation hints — turn-2 model may only see the head. Through-line «one sentence summary» rarely needs full file; truncation trades context window for completeness.</p></div>
+
+    </div>
+
     <div class="depth-zone" data-chapter="C12"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C12.4+</span><span class="lang-en-only">Deep dive · C12.4+</span></div>
 
     <h4 class="sub2 depth-sec"><span class="sec-num">C12.4</span> <span class="lang-zh-only">主线 prompt 如何穿过此模块</span><span class="lang-en-only">through-line crossing</span></h4>
@@ -5261,6 +6200,262 @@
     <div class="note copper">
       <span class="lang-zh-only">📘 <strong>pi-textbook checkpoint 02</strong>：EventStream（<code>event-stream.ts</code>）· 生产映射：<code>packages/ai/src/utils/event-stream.ts</code></span>
       <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 02</strong>: EventStream (<code>event-stream.ts</code>) · production: <code>packages/ai/src/utils/event-stream.ts</code></span>
+    </div>
+
+    <div class="trace-walk">
+      <div class="tw-head">
+        <span class="tw-tag">SOURCE TRACE · C13</span>
+        <span class="lang-zh-only">AgentEvent 总线：主线一轮完整事件序列</span>
+        <span class="lang-en-only">AgentEvent bus: full event sequence for one through-line turn</span>
+      </div>
+
+    <div class="lang-zh-only"><p><code>AgentEvent</code> 是 agent-core 与 coding-agent/TUI 的<strong>唯一契约</strong>。agent-loop 只 call <code>emit(event)</code>；AgentSession 订阅后 fan-out 到 JSONL、TUI、ExtensionRunner。主线 prompt 一轮大约产生 25–40 个事件（含 message_update delta）。</p></div>
+    <div class="lang-en-only"><p><code>AgentEvent</code> is the <strong>sole contract</strong> between agent-core and coding-agent/TUI. agent-loop only <code>emit(event)</code>; AgentSession fans out to JSONL, TUI, ExtensionRunner. One through-line turn emits ~25–40 events (including message_update deltas).</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/types.ts</span>
+        <span class="src-tag">event-union</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 421</span> <span class="src-hl">/**</span></span>
+      <span class="src-line">      <span class="src-ln"> 422</span> <span class="src-hl"> * <span class="src-cls">Events</span> emitted by the <span class="src-cls">Agent</span> <span class="src-kw">for</span> <span class="src-cls">UI</span> updates.</span></span>
+      <span class="src-line">      <span class="src-ln"> 423</span> <span class="src-hl"> *</span></span>
+      <span class="src-line">      <span class="src-ln"> 424</span> <span class="src-hl"> * <span class=<span class="src-str">"src-str"</span>>`agent_end`</span> is the last event emitted <span class="src-kw">for</span> a run, but awaited <span class=<span class="src-str">"src-str"</span>>`<span class="src-cls">Agent</span>.subscribe()`</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 425</span> <span class="src-hl"> * listeners <span class="src-kw">for</span> that event are still part of run settlement. <span class="src-cls">The</span> agent becomes</span></span>
+      <span class="src-line">      <span class="src-ln"> 426</span> <span class="src-hl"> * idle only after those listeners finish.</span></span>
+      <span class="src-line">      <span class="src-ln"> 427</span> <span class="src-hl"> */</span></span>
+      <span class="src-line">      <span class="src-ln"> 428</span> <span class="src-hl"><span class="src-kw">export</span> <span class="src-kw">type</span> <span class="src-cls">AgentEvent</span> =</span></span>
+      <span class="src-line">      <span class="src-ln"> 429</span> <span class="src-hl">	<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Agent</span> lifecycle</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 430</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;agent_start&quot; }</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">agent_start / agent_end 包裹整次 runLoop</span><span class="lang-en-only">agent_start/agent_end wrap runLoop</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 431</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;agent_end&quot;; messages: AgentMessage[] }</span></span>
+      <span class="src-line">      <span class="src-ln"> 432</span> <span class="src-hl">	<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Turn</span> lifecycle - a turn is one assistant response + any tool calls/results</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 433</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;turn_start&quot; }</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">turn_start / turn_end 包裹每圈 model+tools</span><span class="lang-en-only">turn_start/turn_end wrap each model+tools round</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 434</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;turn_end&quot;; message: AgentMessage; toolResults: <span class="src-cls">ToolResultMessage</span>[] }</span></span>
+      <span class="src-line">      <span class="src-ln"> 435</span> <span class="src-hl">	<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Message</span> lifecycle - emitted <span class="src-kw">for</span> user, assistant, and toolResult messages</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 436</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;message_start&quot;; message: AgentMessage }</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">message_start/end：user/assistant/toolResult 共用</span><span class="lang-en-only">message_start/end: shared by user/assistant/toolResult</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 437</span> <span class="src-hl">	<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Only</span> emitted <span class="src-kw">for</span> assistant messages during streaming</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 438</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;message_update&quot;; message: AgentMessage; assistantMessageEvent: <span class="src-cls">AssistantMessageEvent</span> }</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">★ message_update：仅 assistant 流式</span><span class="lang-en-only">★ message_update: assistant streaming only</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 439</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;message_end&quot;; message: AgentMessage }</span></span>
+      <span class="src-line">      <span class="src-ln"> 440</span> <span class="src-hl">	<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Tool</span> execution lifecycle</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 441</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;tool_execution_start&quot;; toolCallId: string; toolName: string; args: any }</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">tool_execution_*：read 生命周期</span><span class="lang-en-only">tool_execution_*: read lifecycle</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 442</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;tool_execution_update&quot;; toolCallId: string; toolName: string; args: any; partialResult: any }</span></span>
+      <span class="src-line">      <span class="src-ln"> 443</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;tool_execution_end&quot;; toolCallId: string; toolName: string; result: any; isError: boolean };</span></span>
+    </div>
+
+    <div class="trace-steps"><div class="ts-label"><span class="lang-zh-only">主线 prompt 事件序列（简化）</span><span class="lang-en-only">Through-line event sequence (simplified)</span></div>    <table class="cmp">
+      <thead><tr><th>#</th><th>location</th><th>主线时刻 / through-line moment</th></tr></thead>
+      <tbody>
+      <tr><td>1</td><td>agent_start</td><td>runLoop 进入</td></tr>
+      <tr><td>2</td><td>turn_start</td><td>turn-1 开始</td></tr>
+      <tr><td>3</td><td>message_start</td><td>user prompt</td></tr>
+      <tr><td>4</td><td>message_end</td><td>user 定稿 → JSONL append</td></tr>
+      <tr><td>5</td><td>message_start</td><td>assistant partial</td></tr>
+      <tr><td>6</td><td>message_update×N</td><td>toolcall_delta 组装 read(args)</td></tr>
+      <tr><td>7</td><td>message_end</td><td>stopReason=toolUse</td></tr>
+      <tr><td>8</td><td>tool_execution_start</td><td>read · call_1</td></tr>
+      <tr><td>9</td><td>tool_execution_end</td><td>README 内容</td></tr>
+      <tr><td>10</td><td>message_start/end</td><td>toolResult 消息</td></tr>
+      <tr><td>11</td><td>turn_end</td><td>turn-1 完成</td></tr>
+      <tr><td>12</td><td>turn_start</td><td>turn-2</td></tr>
+      <tr><td>13</td><td>message_update×M</td><td>text_delta 最终回答</td></tr>
+      <tr><td>14</td><td>message_end</td><td>stopReason=stop</td></tr>
+      <tr><td>15</td><td>turn_end</td><td>turn-2 完成</td></tr>
+      <tr><td>16</td><td>agent_end</td><td>newMessages 返回</td></tr>
+      </tbody>
+    </table></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
+        <span class="src-tag">emit-loop</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 326</span> <span class="src-hl">			<span class="src-kw">case</span> &quot;text_start&quot;:</span></span>
+      <span class="src-line">      <span class="src-ln"> 327</span> <span class="src-hl">			<span class="src-kw">case</span> &quot;text_delta&quot;:</span></span>
+      <span class="src-line">      <span class="src-ln"> 328</span> <span class="src-hl">			<span class="src-kw">case</span> &quot;text_end&quot;:</span></span>
+      <span class="src-line">      <span class="src-ln"> 329</span> <span class="src-hl">			<span class="src-kw">case</span> &quot;thinking_start&quot;:</span></span>
+      <span class="src-line">      <span class="src-ln"> 330</span> <span class="src-hl">			<span class="src-kw">case</span> &quot;thinking_delta&quot;:</span></span>
+      <span class="src-line">      <span class="src-ln"> 331</span> <span class="src-hl">			<span class="src-kw">case</span> &quot;thinking_end&quot;:</span></span>
+      <span class="src-line">      <span class="src-ln"> 332</span> <span class="src-hl">			<span class="src-kw">case</span> &quot;toolcall_start&quot;:</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">toolcall_delta → message_update</span><span class="lang-en-only">toolcall_delta → message_update</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 333</span> <span class="src-hl">			<span class="src-kw">case</span> &quot;toolcall_delta&quot;:</span></span>
+      <span class="src-line">      <span class="src-ln"> 334</span> <span class="src-hl">			<span class="src-kw">case</span> &quot;toolcall_end&quot;:</span></span>
+      <span class="src-line">      <span class="src-ln"> 335</span> <span class="src-hl">				<span class="src-kw">if</span> (partialMessage) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 336</span> <span class="src-hl">					partialMessage = event.partial;</span></span>
+      <span class="src-line">      <span class="src-ln"> 337</span> <span class="src-hl">					context.messages[context.messages.length - 1] = partialMessage;</span></span>
+      <span class="src-line">      <span class="src-ln"> 338</span> <span class="src-hl">					<span class="src-kw">await</span> emit({</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">emit 携带 assistantMessageEvent 原样</span><span class="lang-en-only">emit carries assistantMessageEvent as-is</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 339</span> <span class="src-hl">						<span class="src-kw">type</span>: &quot;message_update&quot;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 340</span> <span class="src-hl">						assistantMessageEvent: event,</span></span>
+      <span class="src-line">      <span class="src-ln"> 341</span> <span class="src-hl">						message: { ...partialMessage },</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">TUI 靠 message 快照差分渲染</span><span class="lang-en-only">TUI diffs from message snapshot</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 342</span> <span class="src-hl">					});</span></span>
+      <span class="src-line">      <span class="src-ln"> 343</span> <span class="src-hl">				}</span></span>
+      <span class="src-line">      <span class="src-ln"> 344</span> <span class="src-hl">				<span class="src-kw">break</span>;</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/agent-session.ts</span>
+        <span class="src-tag">session-persist</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 644</span> <span class="src-hl">		<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Emit</span> to extensions first</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 645</span> <span class="src-hl">		<span class="src-kw">await</span> this._emitExtensionEvent(event);</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">扩展先收到事件（可改写 message_end）</span><span class="lang-en-only">extensions receive first (can rewrite message_end)</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 646</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 647</span> <span class="src-hl">		<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Notify</span> all listeners</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 648</span> <span class="src-hl">		this._emit(event.<span class="src-kw">type</span> === &quot;agent_end&quot; ? { ...event, willRetry: this._willRetryAfterAgentEnd(event) } : event);</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">fan-out 到 session 监听器</span><span class="lang-en-only">fan-out to session listeners</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 649</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 650</span> <span class="src-hl">		<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Handle</span> session persistence</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 651</span> <span class="src-hl">		<span class="src-kw">if</span> (event.<span class="src-kw">type</span> === &quot;message_end&quot;) {</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">★ message_end → SessionManager.appendMessage</span><span class="lang-en-only">★ message_end → SessionManager.appendMessage</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 652</span> <span class="src-hl">			<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Check</span> <span class="src-kw">if</span> this is a custom message <span class="src-kw">from</span> extensions</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 653</span> <span class="src-hl">			<span class="src-kw">if</span> (event.message.role === &quot;custom&quot;) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 654</span> <span class="src-hl">				<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Persist</span> as <span class="src-cls">CustomMessageEntry</span></span></span></span>
+      <span class="src-line">      <span class="src-ln"> 655</span> <span class="src-hl">				this.sessionManager.appendCustomMessageEntry(</span></span>
+      <span class="src-line">      <span class="src-ln"> 656</span> <span class="src-hl">					event.message.customType,</span></span>
+      <span class="src-line">      <span class="src-ln"> 657</span> <span class="src-hl">					event.message.content,</span></span>
+      <span class="src-line">      <span class="src-ln"> 658</span> <span class="src-hl">					event.message.display,</span></span>
+      <span class="src-line">      <span class="src-ln"> 659</span> <span class="src-hl">					event.message.details,</span></span>
+      <span class="src-line">      <span class="src-ln"> 660</span> <span class="src-hl">				);</span></span>
+      <span class="src-line">      <span class="src-ln"> 661</span> <span class="src-hl">			} <span class="src-kw">else</span> <span class="src-kw">if</span> (</span></span>
+      <span class="src-line">      <span class="src-ln"> 662</span> <span class="src-hl">				event.message.role === &quot;user&quot; ||</span></span>
+      <span class="src-line">      <span class="src-ln"> 663</span> <span class="src-hl">				event.message.role === &quot;assistant&quot; ||</span></span>
+      <span class="src-line">      <span class="src-ln"> 664</span> <span class="src-hl">				event.message.role === &quot;toolResult&quot;</span></span>
+      <span class="src-line">      <span class="src-ln"> 665</span> <span class="src-hl">			) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 666</span> <span class="src-hl">				<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Regular</span> <span class="src-cls">LLM</span> message - persist as <span class="src-cls">SessionMessageEntry</span></span></span></span>
+      <span class="src-line">      <span class="src-ln"> 667</span> <span class="src-hl">				this.sessionManager.appendMessage(event.message);</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">user/assistant/toolResult 写 JSONL</span><span class="lang-en-only">user/assistant/toolResult to JSONL</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 668</span> <span class="src-hl">			}</span></span>
+      <span class="src-line">      <span class="src-ln"> 669</span> <span class="src-hl">			<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Other</span> message types (bashExecution, compactionSummary, branchSummary) are persisted elsewhere</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 670</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 671</span> <span class="src-hl">			<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Track</span> assistant message <span class="src-kw">for</span> auto-compaction (checked on agent_end)</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 672</span> <span class="src-hl">			<span class="src-kw">if</span> (event.message.role === &quot;assistant&quot;) {</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">assistant message_end 触发 compaction 检查标记</span><span class="lang-en-only">assistant message_end sets compaction check flag</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 673</span> <span class="src-hl">				this._lastAssistantMessage = event.message;</span></span>
+      <span class="src-line">      <span class="src-ln"> 674</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 675</span> <span class="src-hl">				<span class="src-kw">const</span> assistantMsg = event.message as <span class="src-cls">AssistantMessage</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 676</span> <span class="src-hl">				<span class="src-kw">if</span> (assistantMsg.stopReason !== &quot;error&quot; &amp;&amp; assistantMsg.stopReason !== &quot;length&quot;) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 677</span> <span class="src-hl">					this._overflowRecoveryAttempted = <span class="src-kw">false</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 678</span> <span class="src-hl">				}</span></span>
+      <span class="src-line">      <span class="src-ln"> 679</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 680</span> <span class="src-hl">				<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Reset</span> retry counter immediately on successful assistant response</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 681</span> <span class="src-hl">				<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">This</span> prevents accumulation across multiple <span class="src-cls">LLM</span> calls within a turn</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 682</span> <span class="src-hl">				<span class="src-kw">if</span> (assistantMsg.stopReason !== &quot;error&quot; &amp;&amp; this._retryAttempt &gt; 0) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 683</span> <span class="src-hl">					this._emit({</span></span>
+      <span class="src-line">      <span class="src-ln"> 684</span> <span class="src-hl">						<span class="src-kw">type</span>: &quot;auto_retry_end&quot;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 685</span> <span class="src-hl">						success: <span class="src-kw">true</span>,</span></span>
+      <span class="src-line">      <span class="src-ln"> 686</span> <span class="src-hl">						attempt: this._retryAttempt,</span></span>
+      <span class="src-line">      <span class="src-ln"> 687</span> <span class="src-hl">					});</span></span>
+      <span class="src-line">      <span class="src-ln"> 688</span> <span class="src-hl">					this._retryAttempt = 0;</span></span>
+      <span class="src-line">      <span class="src-ln"> 689</span> <span class="src-hl">				}</span></span>
+      <span class="src-line">      <span class="src-ln"> 690</span> <span class="src-hl">			}</span></span>
+    </div>
+
+    <div class="lang-zh-only"><p>「message_update 驱动 TUI，message_end 驱动 JSONL」——不是两条管道，而是<strong>同一 emit 的两个订阅者消费不同阶段</strong>。TUI 在 update 时重绘；SessionManager 只在 end 时落盘，避免每个 delta 写一行 JSONL。</p></div>
+    <div class="lang-en-only"><p>«message_update drives TUI, message_end drives JSONL» — not two pipes but <strong>two subscribers to same emit at different stages</strong>. TUI redraws on update; SessionManager persists only on end, avoiding per-delta JSONL lines.</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/agent-session.ts</span>
+        <span class="src-tag">extension-fanout</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 738</span> <span class="src-hl">	private <span class="src-kw">async</span> _emitExtensionEvent(event: <span class="src-cls">AgentEvent</span>): <span class="src-cls">Promise</span>&lt;void&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln"> 739</span> <span class="src-hl">		<span class="src-kw">if</span> (event.<span class="src-kw">type</span> === &quot;agent_start&quot;) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 740</span> <span class="src-hl">			this._turnIndex = 0;</span></span>
+      <span class="src-line">      <span class="src-ln"> 741</span> <span class="src-hl">			<span class="src-kw">await</span> this._extensionRunner.emit({ <span class="src-kw">type</span>: &quot;agent_start&quot; });</span></span>
+      <span class="src-line">      <span class="src-ln"> 742</span> <span class="src-hl">		} <span class="src-kw">else</span> <span class="src-kw">if</span> (event.<span class="src-kw">type</span> === &quot;agent_end&quot;) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 743</span> <span class="src-hl">			<span class="src-kw">await</span> this._extensionRunner.emit({ <span class="src-kw">type</span>: &quot;agent_end&quot;, messages: event.messages });</span></span>
+      <span class="src-line">      <span class="src-ln"> 744</span> <span class="src-hl">		} <span class="src-kw">else</span> <span class="src-kw">if</span> (event.<span class="src-kw">type</span> === &quot;turn_start&quot;) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 745</span> <span class="src-hl">			<span class="src-kw">const</span> extensionEvent: <span class="src-cls">TurnStartEvent</span> = {</span></span>
+      <span class="src-line">      <span class="src-ln"> 746</span> <span class="src-hl">				<span class="src-kw">type</span>: &quot;turn_start&quot;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 747</span> <span class="src-hl">				turnIndex: this._turnIndex,</span></span>
+      <span class="src-line">      <span class="src-ln"> 748</span> <span class="src-hl">				timestamp: <span class="src-cls">Date</span>.now(),</span></span>
+      <span class="src-line">      <span class="src-ln"> 749</span> <span class="src-hl">			};</span></span>
+      <span class="src-line">      <span class="src-ln"> 750</span> <span class="src-hl">			<span class="src-kw">await</span> this._extensionRunner.emit(extensionEvent);</span></span>
+      <span class="src-line">      <span class="src-ln"> 751</span> <span class="src-hl">		} <span class="src-kw">else</span> <span class="src-kw">if</span> (event.<span class="src-kw">type</span> === &quot;turn_end&quot;) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 752</span> <span class="src-hl">			<span class="src-kw">const</span> extensionEvent: <span class="src-cls">TurnEndEvent</span> = {</span></span>
+      <span class="src-line">      <span class="src-ln"> 753</span> <span class="src-hl">				<span class="src-kw">type</span>: &quot;turn_end&quot;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 754</span> <span class="src-hl">				turnIndex: this._turnIndex,</span></span>
+      <span class="src-line">      <span class="src-ln"> 755</span> <span class="src-hl">				message: event.message,</span></span>
+      <span class="src-line">      <span class="src-ln"> 756</span> <span class="src-hl">				toolResults: event.toolResults,</span></span>
+      <span class="src-line">      <span class="src-ln"> 757</span> <span class="src-hl">			};</span></span>
+      <span class="src-line">      <span class="src-ln"> 758</span> <span class="src-hl">			<span class="src-kw">await</span> this._extensionRunner.emit(extensionEvent);</span></span>
+      <span class="src-line">      <span class="src-ln"> 759</span> <span class="src-hl">			this._turnIndex++;</span></span>
+      <span class="src-line">      <span class="src-ln"> 760</span> <span class="src-hl">		} <span class="src-kw">else</span> <span class="src-kw">if</span> (event.<span class="src-kw">type</span> === &quot;message_start&quot;) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 761</span> <span class="src-hl">			<span class="src-kw">const</span> extensionEvent: <span class="src-cls">MessageStartEvent</span> = {</span></span>
+      <span class="src-line">      <span class="src-ln"> 762</span> <span class="src-hl">				<span class="src-kw">type</span>: &quot;message_start&quot;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 763</span> <span class="src-hl">				message: event.message,</span></span>
+      <span class="src-line">      <span class="src-ln"> 764</span> <span class="src-hl">			};</span></span>
+      <span class="src-line">      <span class="src-ln"> 765</span> <span class="src-hl">			<span class="src-kw">await</span> this._extensionRunner.emit(extensionEvent);</span></span>
+      <span class="src-line">      <span class="src-ln"> 766</span> <span class="src-hl">		} <span class="src-kw">else</span> <span class="src-kw">if</span> (event.<span class="src-kw">type</span> === &quot;message_update&quot;) {</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">message_update → ExtensionRunner</span><span class="lang-en-only">message_update → ExtensionRunner</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 767</span> <span class="src-hl">			<span class="src-kw">const</span> extensionEvent: <span class="src-cls">MessageUpdateEvent</span> = {</span></span>
+      <span class="src-line">      <span class="src-ln"> 768</span> <span class="src-hl">				<span class="src-kw">type</span>: &quot;message_update&quot;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 769</span> <span class="src-hl">				message: event.message,</span></span>
+      <span class="src-line">      <span class="src-ln"> 770</span> <span class="src-hl">				assistantMessageEvent: event.assistantMessageEvent,</span></span>
+      <span class="src-line">      <span class="src-ln"> 771</span> <span class="src-hl">			};</span></span>
+      <span class="src-line">      <span class="src-ln"> 772</span> <span class="src-hl">			<span class="src-kw">await</span> this._extensionRunner.emit(extensionEvent);</span></span>
+      <span class="src-line">      <span class="src-ln"> 773</span> <span class="src-hl">		} <span class="src-kw">else</span> <span class="src-kw">if</span> (event.<span class="src-kw">type</span> === &quot;message_end&quot;) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 774</span> <span class="src-hl">			<span class="src-kw">const</span> extensionEvent: <span class="src-cls">MessageEndEvent</span> = {</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">message_end → emitMessageEnd 可替换消息</span><span class="lang-en-only">message_end → emitMessageEnd can replace message</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 775</span> <span class="src-hl">				<span class="src-kw">type</span>: &quot;message_end&quot;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 776</span> <span class="src-hl">				message: event.message,</span></span>
+      <span class="src-line">      <span class="src-ln"> 777</span> <span class="src-hl">			};</span></span>
+      <span class="src-line">      <span class="src-ln"> 778</span> <span class="src-hl">			<span class="src-kw">const</span> replacement = <span class="src-kw">await</span> this._extensionRunner.emitMessageEnd(extensionEvent);</span></span>
+      <span class="src-line">      <span class="src-ln"> 779</span> <span class="src-hl">			<span class="src-kw">if</span> (replacement) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 780</span> <span class="src-hl">				<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Untyped</span> extension handlers can <span class="src-kw">return</span> messages with <span class="src-kw">null</span>/missing content;</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 781</span> <span class="src-hl">				<span class=<span class="src-str">"src-comment"</span>>// normalize so it never enters agent state or session history.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 782</span> <span class="src-hl">				<span class="src-kw">const</span> normalized =</span></span>
+      <span class="src-line">      <span class="src-ln"> 783</span> <span class="src-hl">					(replacement.role === &quot;user&quot; ||</span></span>
+      <span class="src-line">      <span class="src-ln"> 784</span> <span class="src-hl">						replacement.role === &quot;assistant&quot; ||</span></span>
+      <span class="src-line">      <span class="src-ln"> 785</span> <span class="src-hl">						replacement.role === &quot;toolResult&quot; ||</span></span>
+      <span class="src-line">      <span class="src-ln"> 786</span> <span class="src-hl">						replacement.role === &quot;custom&quot;) &amp;&amp;</span></span>
+      <span class="src-line">      <span class="src-ln"> 787</span> <span class="src-hl">					replacement.content == <span class="src-kw">null</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 788</span> <span class="src-hl">						? ({ ...replacement, content: [] } as AgentMessage)</span></span>
+      <span class="src-line">      <span class="src-ln"> 789</span> <span class="src-hl">						: replacement;</span></span>
+      <span class="src-line">      <span class="src-ln"> 790</span> <span class="src-hl">				this._replaceMessageInPlace(event.message, normalized);</span></span>
+      <span class="src-line">      <span class="src-ln"> 791</span> <span class="src-hl">			}</span></span>
+      <span class="src-line">      <span class="src-ln"> 792</span> <span class="src-hl">		} <span class="src-kw">else</span> <span class="src-kw">if</span> (event.<span class="src-kw">type</span> === &quot;tool_execution_start&quot;) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 793</span> <span class="src-hl">			<span class="src-kw">const</span> extensionEvent: <span class="src-cls">ToolExecutionStartEvent</span> = {</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">tool_execution_start 扩展可见</span><span class="lang-en-only">tool_execution_start visible to extensions</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 794</span> <span class="src-hl">				<span class="src-kw">type</span>: &quot;tool_execution_start&quot;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 795</span> <span class="src-hl">				toolCallId: event.toolCallId,</span></span>
+      <span class="src-line">      <span class="src-ln"> 796</span> <span class="src-hl">				toolName: event.toolName,</span></span>
+      <span class="src-line">      <span class="src-ln"> 797</span> <span class="src-hl">				args: event.args,</span></span>
+      <span class="src-line">      <span class="src-ln"> 798</span> <span class="src-hl">			};</span></span>
+      <span class="src-line">      <span class="src-ln"> 799</span> <span class="src-hl">			<span class="src-kw">await</span> this._extensionRunner.emit(extensionEvent);</span></span>
+      <span class="src-line">      <span class="src-ln"> 800</span> <span class="src-hl">		} <span class="src-kw">else</span> <span class="src-kw">if</span> (event.<span class="src-kw">type</span> === &quot;tool_execution_update&quot;) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 801</span> <span class="src-hl">			<span class="src-kw">const</span> extensionEvent: <span class="src-cls">ToolExecutionUpdateEvent</span> = {</span></span>
+      <span class="src-line">      <span class="src-ln"> 802</span> <span class="src-hl">				<span class="src-kw">type</span>: &quot;tool_execution_update&quot;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 803</span> <span class="src-hl">				toolCallId: event.toolCallId,</span></span>
+      <span class="src-line">      <span class="src-ln"> 804</span> <span class="src-hl">				toolName: event.toolName,</span></span>
+      <span class="src-line">      <span class="src-ln"> 805</span> <span class="src-hl">				args: event.args,</span></span>
+      <span class="src-line">      <span class="src-ln"> 806</span> <span class="src-hl">				partialResult: event.partialResult,</span></span>
+      <span class="src-line">      <span class="src-ln"> 807</span> <span class="src-hl">			};</span></span>
+      <span class="src-line">      <span class="src-ln"> 808</span> <span class="src-hl">			<span class="src-kw">await</span> this._extensionRunner.emit(extensionEvent);</span></span>
+      <span class="src-line">      <span class="src-ln"> 809</span> <span class="src-hl">		} <span class="src-kw">else</span> <span class="src-kw">if</span> (event.<span class="src-kw">type</span> === &quot;tool_execution_end&quot;) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 810</span> <span class="src-hl">			<span class="src-kw">const</span> extensionEvent: <span class="src-cls">ToolExecutionEndEvent</span> = {</span></span>
+      <span class="src-line">      <span class="src-ln"> 811</span> <span class="src-hl">				<span class="src-kw">type</span>: &quot;tool_execution_end&quot;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 812</span> <span class="src-hl">				toolCallId: event.toolCallId,</span></span>
+      <span class="src-line">      <span class="src-ln"> 813</span> <span class="src-hl">				toolName: event.toolName,</span></span>
+      <span class="src-line">      <span class="src-ln"> 814</span> <span class="src-hl">				result: event.result,</span></span>
+      <span class="src-line">      <span class="src-ln"> 815</span> <span class="src-hl">				isError: event.isError,</span></span>
+      <span class="src-line">      <span class="src-ln"> 816</span> <span class="src-hl">			};</span></span>
+      <span class="src-line">      <span class="src-ln"> 817</span> <span class="src-hl">			<span class="src-kw">await</span> this._extensionRunner.emit(extensionEvent);</span></span>
+      <span class="src-line">      <span class="src-ln"> 818</span> <span class="src-hl">		}</span></span>
+    </div>
+
+    <div class="note copper">
+      <span class="lang-zh-only">用 <code>pi --verbose 2&gt;events.log</code> 跑主线 prompt，<code>grep message_update events.log | wc -l</code> 应与 TUI 刷新次数同量级。</span>
+      <span class="lang-en-only">Run <code>pi --verbose 2&gt;events.log</code> on through-line; <code>grep message_update events.log | wc -l</code> should match TUI refresh magnitude.</span>
+    </div>
+
     </div>
 
     <div class="depth-zone" data-chapter="C13"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C13.4+</span><span class="lang-en-only">Deep dive · C13.4+</span></div>

--- a/public/immersive/pi-agent/index.html
+++ b/public/immersive/pi-agent/index.html
@@ -798,6 +798,70 @@
     .lang-toggle { right: 16px; font-size: 11px; }
   }
 
+  .formula {
+    background: var(--ink); color: var(--bg);
+    padding: 32px; margin: 32px 0;
+    font-family: var(--mono); font-size: 14px; line-height: 1.9;
+    border-radius: 4px; position: relative;
+  }
+  .formula .ftitle {
+    font-family: var(--sans); font-size: 11px;
+    letter-spacing: 0.22em; text-transform: uppercase;
+    margin-bottom: 16px; color: var(--rule);
+  }
+  .formula .cond { display: block; margin: 4px 0; }
+  .formula .cond::before { content: "▸"; color: var(--accent-soft); margin-right: 12px; }
+  .formula .out {
+    margin-top: 16px; padding-top: 16px;
+    border-top: 1px solid #2c2f36; color: var(--accent-soft);
+  }
+  .formula .term { color: #fcd34d; font-weight: 700; }
+  .formula .term-cu { color: #d1855a; font-weight: 700; }
+  .ladder {
+    background: var(--paper); border: 1px solid var(--rule);
+    border-radius: 4px; padding: 22px 24px; margin: 8px 0 24px;
+  }
+  .ladder .ld-row {
+    display: grid; grid-template-columns: 36px 1fr;
+    align-items: center; gap: 14px;
+    padding: 10px 0; border-bottom: 1px dashed var(--rule);
+  }
+  .ladder .ld-row:last-child { border-bottom: none; }
+  .ladder .ld-num {
+    font-family: var(--mono); font-size: 22px; color: var(--accent);
+    font-weight: 700; line-height: 1;
+  }
+  .ladder .ld-row:nth-child(2) .ld-num { color: #3873a3; }
+  .ladder .ld-row:nth-child(3) .ld-num { color: #6285a8; }
+  .ladder .ld-row:nth-child(4) .ld-num { color: #8090a8; }
+  .ladder .ld-name {
+    font-family: var(--serif); font-size: 15px; font-weight: 700; color: var(--ink);
+  }
+  body.lang-en .ladder .ld-name { font-family: var(--serif-en); }
+  .ladder .ld-desc {
+    font-family: var(--sans); font-size: 12px; color: var(--ink-mute);
+    margin-top: 2px;
+  }
+  .pi-fig { width: 100%; overflow-x: auto; }
+  .pi-fig.wide svg { min-width: 720px; }
+  .pi-svg { width: 100%; height: auto; display: block; }
+  .pi-svg .svg-label {
+    font-family: var(--mono); font-size: 10px; letter-spacing: 0.14em;
+    text-transform: uppercase; fill: var(--ink-mute);
+  }
+  .pi-svg .svg-body { font-family: var(--sans); font-size: 12px; fill: var(--ink); }
+  .pi-svg .svg-mute { font-family: var(--sans); font-size: 10.5px; fill: #767c87; }
+  .pi-svg .svg-micro { font-family: var(--mono); font-size: 9px; fill: var(--ink-soft); }
+  .pi-svg .svg-tiny { font-family: var(--mono); font-size: 10px; fill: var(--ink); }
+  .pi-svg .svg-mono { font-family: var(--mono); font-size: 11px; fill: var(--ink-soft); }
+  .pi-svg .svg-box { fill: #faf6ed; stroke: #c7c4ba; stroke-width: 1.5; }
+  .pi-svg .svg-box.accent { fill: #e8f0f8; stroke: #1f5c8c; }
+  .pi-svg .svg-box.copper { fill: #f5ebe0; stroke: #b35a1f; }
+  .pi-svg .svg-box.gpu { fill: #efe8f5; stroke: #6b3aa3; }
+  .pi-svg .svg-box.asm { fill: #e8f2ec; stroke: #2d6a4f; }
+  .pi-svg .svg-box.paper { fill: #f3efe6; stroke: #c7c4ba; }
+  .pi-svg .svg-box.muted { fill: #ebe5d8; stroke: #c7c4ba; }
+  .pi-svg .svg-arrow { stroke: #1f5c8c; stroke-width: 1.5; marker-end: url(#pi-arr); }
   .toc-group[data-phase="heart"] { border-left-color: var(--accent); background: linear-gradient(135deg, rgba(31,92,140,0.04) 0%, var(--paper) 60%); }
   .toc-group[data-phase="llm"] { border-left-color: var(--gpu); background: linear-gradient(135deg, rgba(107,58,163,0.05) 0%, var(--paper) 60%); }
   .toc-group[data-phase="tui"] { border-left-color: var(--asm); background: linear-gradient(135deg, rgba(45,106,79,0.04) 0%, var(--paper) 60%); }
@@ -825,6 +889,10 @@
   .milestone-table td.owner-model { color: var(--accent); }
   .milestone-table td.owner-loop { color: var(--gpu); }
   .milestone-table td.owner-tool { color: var(--asm); }
+  .milestone-table .owner-user { color: var(--copper); }
+  .milestone-table .owner-model { color: var(--accent); }
+  .milestone-table .owner-loop { color: var(--gpu); }
+  .milestone-table .owner-tool { color: var(--asm); }
   .case-study {
     margin: 22px 0; padding: 18px 20px;
     background: var(--paper-2); border: 1px solid var(--rule);
@@ -1326,11 +1394,45 @@
     </div>
 
     <figure>
-      <div class="figbox"><div class="fig-placeholder">diagram</div></div>
+      <div class="figbox"><div class="pi-fig"><svg viewBox="0 0 720 280" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true" class="pi-svg">
+  <defs>
+    <marker id="pi-arr" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 Z" fill="#1f5c8c"/>
+    </marker>
+  </defs>
+  <defs>
+    <linearGradient id="g-spec" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#767c87"/>
+      <stop offset="50%" stop-color="#1f5c8c"/>
+      <stop offset="100%" stop-color="#2d6a4f"/>
+    </linearGradient>
+  </defs>
+  <text x="24" y="28" class="svg-label">SEALED PRODUCT</text>
+  <text x="620" y="28" text-anchor="end" class="svg-label">OPEN HARNESS</text>
+  <rect x="24" y="40" width="672" height="10" rx="5" fill="url(#g-spec)" opacity="0.85"/>
+  <circle cx="120" cy="45" r="14" fill="#faf6ed" stroke="#767c87" stroke-width="2"/>
+  <text x="120" y="49" text-anchor="middle" class="svg-tiny">CC</text>
+  <circle cx="280" cy="45" r="14" fill="#faf6ed" stroke="#767c87" stroke-width="2"/>
+  <text x="280" y="49" text-anchor="middle" class="svg-tiny">Cur</text>
+  <circle cx="560" cy="45" r="18" fill="#1f5c8c" stroke="#15171c" stroke-width="2"/>
+  <text x="560" y="50" text-anchor="middle" fill="#faf6ed" class="svg-tiny" font-weight="700">Pi</text>
+  <rect x="40" y="80" width="200" height="56" rx="4" class="svg-box muted"/>
+  <text x="140" y="104" text-anchor="middle" class="svg-body">MCP · Sub-agents</text>
+  <text x="140" y="122" text-anchor="middle" class="svg-mute">baked in</text>
+  <rect x="260" y="80" width="200" height="56" rx="4" class="svg-box muted"/>
+  <text x="360" y="104" text-anchor="middle" class="svg-body">IDE · Cloud sync</text>
+  <text x="360" y="122" text-anchor="middle" class="svg-mute">editor lock-in</text>
+  <rect x="480" y="72" width="200" height="72" rx="4" class="svg-box accent"/>
+  <text x="580" y="100" text-anchor="middle" class="svg-body">JSONL tree</text>
+  <text x="580" y="118" text-anchor="middle" class="svg-body">TS extensions</text>
+  <text x="580" y="136" text-anchor="middle" class="svg-mute">agent-loop.ts readable</text>
+  <path d="M140 136 L140 168 L580 168 L580 144" fill="none" class="svg-arrow"/>
+  <text x="360" y="190" text-anchor="middle" class="svg-mute">Pi trades features for observability</text>
+</svg></div></div>
       <figcaption>
         <span class="figid">FIG</span>
-        <span class="lang-zh-only">Harness vs Product 光谱：密封体验在左，可组合层在右，Pi 落在右侧但保持终端原生。</span>
-        <span class="lang-en-only">Harness vs product spectrum: sealed UX left, composable layers right; Pi stays terminal-native.</span>
+        <span class="lang-zh-only">Harness vs Product 光谱：密封产品在左，可组合 harness 在右；Pi 落在终端原生、JSONL 可读的一侧。</span>
+        <span class="lang-en-only">Harness vs product spectrum: sealed products left, composable harness right; Pi sits on the terminal-native, JSONL-readable side.</span>
       </figcaption>
     </figure>
 
@@ -1352,121 +1454,16 @@
     <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
       <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
       <tbody>
-      <tr><td>00</td><td>一次 README 读取的七个里程碑</td><td>prologue.ts</td><td>packages/coding-agent/src/main.ts · packages/agent/src/agent-loop.ts</td></tr>
-      <tr><td>13</td><td>Composition Root</td><td>composition-root</td><td>packages/coding-agent/src/core/agent-session.ts · sdk.ts</td></tr>
+      <tr><td>cp 00</td><td>一次 README 读取的七个里程碑</td><td><code>prologue.ts</code></td><td><code>packages/coding-agent/src/main.ts · packages/agent/src/agent-loop.ts</code></td></tr>
+      <tr><td>cp 13</td><td>Composition Root</td><td><code>composition-root</code></td><td><code>packages/coding-agent/src/core/agent-session.ts · sdk.ts</code></td></tr>
       </tbody>
     </table>
 
     <div class="case-study">
       <div class="cs-tag">CASE STUDY</div>
-      <h4 class="sub2"><span class="lang-zh-only">从 Claude Code 迁移到 Pi</span><span class="lang-en-only">Migrating mental model from Claude Code to Pi</span></h4>
-      <div class="lang-zh-only"><p>Claude Code 用户习惯「一条命令搞定」；Pi 用户需要理解 AgentSession 和 JSONL。迁移的第一步是跑通 pi-textbook checkpoint 00 的七里程碑。</p></div>
-      <div class="lang-en-only"><p>Claude Code users expect one command does all; Pi users need AgentSession and JSONL. First migration step: run pi-textbook checkpoint 00 seven milestones.</p></div>
-    </div>
-
-    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
-
-    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">Pi 是产品吗？</span><span class="lang-en-only">Is Pi a product?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>不是。Pi 是 harness——你 fork 后自己成为产品作者。</p></div><div class="lang-en-only"><p>No. Pi is a harness — you fork and become the product author.</p></div></div></details>
-
-    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">为什么终端原生？</span><span class="lang-en-only">Why terminal-native?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>Mario 的背景是游戏引擎和 CLI 工具；终端是最高带宽的开发者接口。</p></div><div class="lang-en-only"><p>Mario's background is game engines and CLI tools; terminal is highest-bandwidth dev interface.</p></div></div></details>
-
-    <h3 class="sub"><span class="lang-zh-only">附录 · Harness 不是 Product 深度 trace</span><span class="lang-en-only">Appendix · deep trace for Harness is not a product</span></h3>
-
-    <div class="lang-zh-only"><p>本章 (01) 属于 Phase「引子」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
-    <div class="lang-en-only"><p>Chapter (01) belongs to Phase «Prologue». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
-
-    <table class="cmp">
-      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
-      <tbody>
-      <tr><td>1</td><td>概念层</td><td>harness vs product 定位</td></tr>
-      <tr><td>2</td><td>—</td><td>checkpoint 2</td></tr>
-      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
-      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
-      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
-      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
-      </tbody>
-    </table>
-
-    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/sdk.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// harness 入口契约</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 01 · Harness 不是 Product</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 01 · Harness 不是 Product</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 01 · Harness 不是 Product</span></span>
-    </div>
-
-    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
-
-    <div class="lang-zh-only"><p><strong>AgentMessage</strong> — agent-core 内部消息 IR</p></div>
-    <div class="lang-en-only"><p><strong>AgentMessage</strong> — agent-core internal message IR</p></div>
-
-    <div class="lang-zh-only"><p><strong>StreamFn</strong> — 可注入的模型流函数</p></div>
-    <div class="lang-en-only"><p><strong>StreamFn</strong> — injectable model stream function</p></div>
-
-    <div class="lang-zh-only"><p><strong>leafId</strong> — JSONL 会话树当前叶</p></div>
-    <div class="lang-en-only"><p><strong>leafId</strong> — JSONL session tree current leaf</p></div>
-
-    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
-
-    <div class="note">
-      <span class="lang-zh-only">[01.1] 在 Harness 不是 Product 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[01.1] At Harness is not a product stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[01.2] 在 Harness 不是 Product 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[01.2] At Harness is not a product stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[01.3] 在 Harness 不是 Product 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[01.3] At Harness is not a product stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[01.4] 在 Harness 不是 Product 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[01.4] At Harness is not a product stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[01.5] 在 Harness 不是 Product 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[01.5] At Harness is not a product stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[01.6] 在 Harness 不是 Product 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[01.6] At Harness is not a product stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[01.7] 在 Harness 不是 Product 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[01.7] At Harness is not a product stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[01.8] 在 Harness 不是 Product 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[01.8] At Harness is not a product stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
+      <h4 class="sub2"><span class="lang-zh-only">从 Claude Code 迁移到 Pi</span><span class="lang-en-only">Migrating from Claude Code to Pi</span></h4>
+      <div class="lang-zh-only"><p>Claude Code 把编排藏在产品里；Pi 把编排写在 agent-loop.ts。迁移的第一步不是换 CLI，而是跑通 pi-textbook checkpoint 00 的七里程碑，建立事件心智模型。</p></div>
+      <div class="lang-en-only"><p>Claude Code hides orchestration in the product; Pi writes it in agent-loop.ts. Migration starts not with a new CLI but checkpoint 00's seven milestones — building an event mental model.</p></div>
     </div>
   </section>
 
@@ -1486,96 +1483,232 @@
 
     <table class="cmp milestone-table"><thead><tr><th>#</th><th>type</th><th>owner</th><th>detail</th></tr></thead><tbody><tr><td>01</td><td>user_message</td><td class="owner-user">user</td><td>读取 README.md，用一句话告诉我…</td></tr><tr><td>02</td><td>model_start</td><td class="owner-model">model</td><td>turn=1</td></tr><tr><td>03</td><td>assistant_message</td><td class="owner-model">model</td><td>stopReason=toolUse · call_1</td></tr><tr><td>04</td><td>tool_start</td><td class="owner-loop">loop</td><td>read(call_1)</td></tr><tr><td>05</td><td>tool_result</td><td class="owner-tool">tool</td><td>README fixture</td></tr><tr><td>06</td><td>model_start</td><td class="owner-model">model</td><td>turn=2</td></tr><tr><td>07</td><td>assistant_message</td><td class="owner-model">model</td><td>stopReason=stop</td></tr></tbody></table>
 
+    <figure>
+      <div class="figbox"><div class="pi-fig"><svg viewBox="0 0 720 260" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true" class="pi-svg">
+  <defs>
+    <marker id="pi-arr" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 Z" fill="#1f5c8c"/>
+    </marker>
+  </defs>
+  <line x1="70" y1="120" x2="650" y2="120" stroke="#c7c4ba" stroke-width="2"/>
+  
+  <circle cx="48" cy="120" r="22" fill="#b35a1f" opacity="0.15" stroke="#b35a1f" stroke-width="2"/>
+  <text x="48" y="116" text-anchor="middle" class="svg-tiny" fill="#b35a1f" font-weight="700">01</text>
+  <text x="48" y="130" text-anchor="middle" class="svg-micro">user_mes</text>
+  <text x="48" y="158" text-anchor="middle" class="svg-mute">user</text>
+  <circle cx="148" cy="120" r="22" fill="#1f5c8c" opacity="0.15" stroke="#1f5c8c" stroke-width="2"/>
+  <text x="148" y="116" text-anchor="middle" class="svg-tiny" fill="#1f5c8c" font-weight="700">02</text>
+  <text x="148" y="130" text-anchor="middle" class="svg-micro">model_st</text>
+  <text x="148" y="158" text-anchor="middle" class="svg-mute">model</text>
+  <circle cx="248" cy="120" r="22" fill="#1f5c8c" opacity="0.15" stroke="#1f5c8c" stroke-width="2"/>
+  <text x="248" y="116" text-anchor="middle" class="svg-tiny" fill="#1f5c8c" font-weight="700">03</text>
+  <text x="248" y="130" text-anchor="middle" class="svg-micro">assistan</text>
+  <text x="248" y="158" text-anchor="middle" class="svg-mute">model</text>
+  <circle cx="348" cy="120" r="22" fill="#6b3aa3" opacity="0.15" stroke="#6b3aa3" stroke-width="2"/>
+  <text x="348" y="116" text-anchor="middle" class="svg-tiny" fill="#6b3aa3" font-weight="700">04</text>
+  <text x="348" y="130" text-anchor="middle" class="svg-micro">tool_sta</text>
+  <text x="348" y="158" text-anchor="middle" class="svg-mute">loop</text>
+  <circle cx="448" cy="120" r="22" fill="#2d6a4f" opacity="0.15" stroke="#2d6a4f" stroke-width="2"/>
+  <text x="448" y="116" text-anchor="middle" class="svg-tiny" fill="#2d6a4f" font-weight="700">05</text>
+  <text x="448" y="130" text-anchor="middle" class="svg-micro">tool_res</text>
+  <text x="448" y="158" text-anchor="middle" class="svg-mute">tool</text>
+  <circle cx="548" cy="120" r="22" fill="#1f5c8c" opacity="0.15" stroke="#1f5c8c" stroke-width="2"/>
+  <text x="548" y="116" text-anchor="middle" class="svg-tiny" fill="#1f5c8c" font-weight="700">06</text>
+  <text x="548" y="130" text-anchor="middle" class="svg-micro">model_st</text>
+  <text x="548" y="158" text-anchor="middle" class="svg-mute">model</text>
+  <circle cx="648" cy="120" r="22" fill="#1f5c8c" opacity="0.15" stroke="#1f5c8c" stroke-width="2"/>
+  <text x="648" y="116" text-anchor="middle" class="svg-tiny" fill="#1f5c8c" font-weight="700">07</text>
+  <text x="648" y="130" text-anchor="middle" class="svg-micro">assistan</text>
+  <text x="648" y="158" text-anchor="middle" class="svg-mute">model</text>
+  <text x="48" y="52" class="svg-label">pi-textbook checkpoint 00 · README read trace</text>
+  <rect x="230" y="190" width="260" height="58" rx="4" class="svg-box paper"/>
+  <text x="360" y="212" text-anchor="middle" class="svg-body">toolCallId = call_1</text>
+  <text x="360" y="232" text-anchor="middle" class="svg-mute">request (03) ↔ result (05) must pair</text>
+</svg></div></div>
+      <figcaption>
+        <span class="figid">FIG</span>
+        <span class="lang-zh-only">七个里程碑：owner 分工——user 定目标，model 推理，loop 调度，tool 返回环境事实。</span>
+        <span class="lang-en-only">Seven milestones: owner roles — user sets goal, model reasons, loop dispatches, tool returns environment facts.</span>
+      </figcaption>
+    </figure>
+
     <h3 class="sub"><span class="lang-zh-only">22 站全景（前 22 站）</span><span class="lang-en-only">22-station panorama (first 22)</span></h3>
 
+    <figure>
+      <div class="figbox"><div class="pi-fig wide"><svg viewBox="0 0 720 250" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true" class="pi-svg">
+  <defs>
+    <marker id="pi-arr" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 Z" fill="#1f5c8c"/>
+    </marker>
+  </defs>
+  <text x="24" y="28" class="svg-label">22 stations · grouped by phase (C02 map)</text>
+  <rect x="24" y="70" width="148" height="88" rx="4" fill="#767c87" opacity="0.08" stroke="#767c87" stroke-width="1.5"/><text x="98.0" y="58" text-anchor="middle" class="svg-label" fill="#767c87">入口</text><rect x="42" y="98" width="22" height="44" rx="2" fill="#faf6ed" stroke="#767c87" stroke-width="1"/><text x="53" y="126" text-anchor="middle" class="svg-micro">CLI</text><rect x="70" y="98" width="22" height="44" rx="2" fill="#faf6ed" stroke="#767c87" stroke-width="1"/><text x="81" y="126" text-anchor="middle" class="svg-micro">main</text><rect x="98" y="98" width="22" height="44" rx="2" fill="#faf6ed" stroke="#767c87" stroke-width="1"/><text x="109" y="126" text-anchor="middle" class="svg-micro">Session</text><rect x="126" y="98" width="22" height="44" rx="2" fill="#faf6ed" stroke="#767c87" stroke-width="1"/><text x="137" y="126" text-anchor="middle" class="svg-micro">AGENTS</text><rect x="188" y="70" width="148" height="88" rx="4" fill="#1f5c8c" opacity="0.08" stroke="#1f5c8c" stroke-width="1.5"/><text x="262.0" y="58" text-anchor="middle" class="svg-label" fill="#1f5c8c">心脏</text><rect x="206" y="98" width="22" height="44" rx="2" fill="#faf6ed" stroke="#1f5c8c" stroke-width="1"/><text x="217" y="126" text-anchor="middle" class="svg-micro">loop</text><rect x="234" y="98" width="22" height="44" rx="2" fill="#faf6ed" stroke="#1f5c8c" stroke-width="1"/><text x="245" y="126" text-anchor="middle" class="svg-micro">stream</text><rect x="262" y="98" width="22" height="44" rx="2" fill="#faf6ed" stroke="#1f5c8c" stroke-width="1"/><text x="273" y="126" text-anchor="middle" class="svg-micro">tool</text><rect x="290" y="98" width="22" height="44" rx="2" fill="#faf6ed" stroke="#1f5c8c" stroke-width="1"/><text x="301" y="126" text-anchor="middle" class="svg-micro">event</text><rect x="352" y="70" width="120" height="88" rx="4" fill="#6b3aa3" opacity="0.08" stroke="#6b3aa3" stroke-width="1.5"/><text x="412.0" y="58" text-anchor="middle" class="svg-label" fill="#6b3aa3">LLM</text><rect x="370" y="98" width="22" height="44" rx="2" fill="#faf6ed" stroke="#6b3aa3" stroke-width="1"/><text x="381" y="126" text-anchor="middle" class="svg-micro">provider</text><rect x="398" y="98" width="22" height="44" rx="2" fill="#faf6ed" stroke="#6b3aa3" stroke-width="1"/><text x="409" y="126" text-anchor="middle" class="svg-micro">delta</text><rect x="426" y="98" width="22" height="44" rx="2" fill="#faf6ed" stroke="#6b3aa3" stroke-width="1"/><text x="437" y="126" text-anchor="middle" class="svg-micro">auth</text><rect x="488" y="70" width="92" height="88" rx="4" fill="#2d6a4f" opacity="0.08" stroke="#2d6a4f" stroke-width="1.5"/><text x="534.0" y="58" text-anchor="middle" class="svg-label" fill="#2d6a4f">终端</text><rect x="506" y="98" width="22" height="44" rx="2" fill="#faf6ed" stroke="#2d6a4f" stroke-width="1"/><text x="517" y="126" text-anchor="middle" class="svg-micro">TUI</text><rect x="534" y="98" width="22" height="44" rx="2" fill="#faf6ed" stroke="#2d6a4f" stroke-width="1"/><text x="545" y="126" text-anchor="middle" class="svg-micro">Editor</text><rect x="596" y="70" width="92" height="88" rx="4" fill="#b35a1f" opacity="0.08" stroke="#b35a1f" stroke-width="1.5"/><text x="642.0" y="58" text-anchor="middle" class="svg-label" fill="#b35a1f">持久化</text><rect x="614" y="98" width="22" height="44" rx="2" fill="#faf6ed" stroke="#b35a1f" stroke-width="1"/><text x="625" y="126" text-anchor="middle" class="svg-micro">JSONL</text><rect x="642" y="98" width="22" height="44" rx="2" fill="#faf6ed" stroke="#b35a1f" stroke-width="1"/><text x="653" y="126" text-anchor="middle" class="svg-micro">compact</text>
+  <path d="M 60 200 L 660 200" stroke="#c7c4ba" stroke-dasharray="4 3"/>
+  <text x="360" y="230" text-anchor="middle" class="svg-mute">Enter → JSONL on disk · one user message</text>
+</svg></div></div>
+      <figcaption>
+        <span class="figid">FIG</span>
+        <span class="lang-zh-only">22 站按 Phase 分组：入口四站、心脏四站、LLM 三站、终端两站、持久化两站——持住这张地图读完全文。</span>
+        <span class="lang-en-only">22 stations by phase: intake 4, heart 4, LLM 3, terminal 2, persistence 2 — hold this map through the article.</span>
+      </figcaption>
+    </figure>
+
+    <h4 class="sub2"><span class="lang-zh-only">逐站清单</span><span class="lang-en-only">Station-by-station list</span></h4>
+
     <div class="ladder">
-      <div class="ladder-step">
-        <div class="ladder-num">01</div>
-        <div class="ladder-body"><span class="lang-zh-only">CLI 解析 argv</span><span class="lang-en-only">cli.ts parses argv</span></div>
+      <div class="ld-row">
+        <div class="ld-num">01</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">CLI 解析 argv</span><span class="lang-en-only">cli.ts parses argv</span></div>
+
+        </div>
       </div>
-      <div class="ladder-step">
-        <div class="ladder-num">02</div>
-        <div class="ladder-body"><span class="lang-zh-only">main 启动</span><span class="lang-en-only">main.ts boot</span></div>
+      <div class="ld-row">
+        <div class="ld-num">02</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">main 启动</span><span class="lang-en-only">main.ts boot</span></div>
+
+        </div>
       </div>
-      <div class="ladder-step">
-        <div class="ladder-num">03</div>
-        <div class="ladder-body"><span class="lang-zh-only">createAgentSession</span><span class="lang-en-only">session factory</span></div>
+      <div class="ld-row">
+        <div class="ld-num">03</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">createAgentSession</span><span class="lang-en-only">session factory</span></div>
+
+        </div>
       </div>
-      <div class="ladder-step">
-        <div class="ladder-num">04</div>
-        <div class="ladder-body"><span class="lang-zh-only">ResourceLoader AGENTS.md</span><span class="lang-en-only">context stack</span></div>
+      <div class="ld-row">
+        <div class="ld-num">04</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">ResourceLoader AGENTS.md</span><span class="lang-en-only">context stack</span></div>
+
+        </div>
       </div>
-      <div class="ladder-step">
-        <div class="ladder-num">05</div>
-        <div class="ladder-body"><span class="lang-zh-only">user message 入队</span><span class="lang-en-only">prompt queued</span></div>
+      <div class="ld-row">
+        <div class="ld-num">05</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">user message 入队</span><span class="lang-en-only">prompt queued</span></div>
+
+        </div>
       </div>
-      <div class="ladder-step">
-        <div class="ladder-num">06</div>
-        <div class="ladder-body"><span class="lang-zh-only">agent_start 事件</span><span class="lang-en-only">agent_start event</span></div>
+      <div class="ld-row">
+        <div class="ld-num">06</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">agent_start 事件</span><span class="lang-en-only">agent_start event</span></div>
+
+        </div>
       </div>
-      <div class="ladder-step">
-        <div class="ladder-num">07</div>
-        <div class="ladder-body"><span class="lang-zh-only">turn_start</span><span class="lang-en-only">turn_start</span></div>
+      <div class="ld-row">
+        <div class="ld-num">07</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">turn_start</span><span class="lang-en-only">turn_start</span></div>
+
+        </div>
       </div>
-      <div class="ladder-step">
-        <div class="ladder-num">08</div>
-        <div class="ladder-body"><span class="lang-zh-only">convertToLlm</span><span class="lang-en-only">AgentMessage → Message[]</span></div>
+      <div class="ld-row">
+        <div class="ld-num">08</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">convertToLlm</span><span class="lang-en-only">AgentMessage → Message[]</span></div>
+
+        </div>
       </div>
-      <div class="ladder-step">
-        <div class="ladder-num">09</div>
-        <div class="ladder-body"><span class="lang-zh-only">streamSimple</span><span class="lang-en-only">pi-ai stream</span></div>
+      <div class="ld-row">
+        <div class="ld-num">09</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">streamSimple</span><span class="lang-en-only">pi-ai stream</span></div>
+
+        </div>
       </div>
-      <div class="ladder-step">
-        <div class="ladder-num">10</div>
-        <div class="ladder-body"><span class="lang-zh-only">text_delta</span><span class="lang-en-only">token streaming</span></div>
+      <div class="ld-row">
+        <div class="ld-num">10</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">text_delta</span><span class="lang-en-only">token streaming</span></div>
+
+        </div>
       </div>
-      <div class="ladder-step">
-        <div class="ladder-num">11</div>
-        <div class="ladder-body"><span class="lang-zh-only">toolcall_delta</span><span class="lang-en-only">tool call assembly</span></div>
+      <div class="ld-row">
+        <div class="ld-num">11</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">toolcall_delta</span><span class="lang-en-only">tool call assembly</span></div>
+
+        </div>
       </div>
-      <div class="ladder-step">
-        <div class="ladder-num">12</div>
-        <div class="ladder-body"><span class="lang-zh-only">assistant stopReason=toolUse</span><span class="lang-en-only">read tool requested</span></div>
+      <div class="ld-row">
+        <div class="ld-num">12</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">assistant stopReason=toolUse</span><span class="lang-en-only">read tool requested</span></div>
+
+        </div>
       </div>
-      <div class="ladder-step">
-        <div class="ladder-num">13</div>
-        <div class="ladder-body"><span class="lang-zh-only">executeTool parallel/seq</span><span class="lang-en-only">tool dispatch</span></div>
+      <div class="ld-row">
+        <div class="ld-num">13</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">executeTool parallel/seq</span><span class="lang-en-only">tool dispatch</span></div>
+
+        </div>
       </div>
-      <div class="ladder-step">
-        <div class="ladder-num">14</div>
-        <div class="ladder-body"><span class="lang-zh-only">read README.md</span><span class="lang-en-only">filesystem I/O</span></div>
+      <div class="ld-row">
+        <div class="ld-num">14</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">read README.md</span><span class="lang-en-only">filesystem I/O</span></div>
+
+        </div>
       </div>
-      <div class="ladder-step">
-        <div class="ladder-num">15</div>
-        <div class="ladder-body"><span class="lang-zh-only">tool_result 消息</span><span class="lang-en-only">tool result message</span></div>
+      <div class="ld-row">
+        <div class="ld-num">15</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">tool_result 消息</span><span class="lang-en-only">tool result message</span></div>
+
+        </div>
       </div>
-      <div class="ladder-step">
-        <div class="ladder-num">16</div>
-        <div class="ladder-body"><span class="lang-zh-only">第二次 streamSimple</span><span class="lang-en-only">turn 2 model call</span></div>
+      <div class="ld-row">
+        <div class="ld-num">16</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">第二次 streamSimple</span><span class="lang-en-only">turn 2 model call</span></div>
+
+        </div>
       </div>
-      <div class="ladder-step">
-        <div class="ladder-num">17</div>
-        <div class="ladder-body"><span class="lang-zh-only">最终 assistant stop</span><span class="lang-en-only">final answer</span></div>
+      <div class="ld-row">
+        <div class="ld-num">17</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">最终 assistant stop</span><span class="lang-en-only">final answer</span></div>
+
+        </div>
       </div>
-      <div class="ladder-step">
-        <div class="ladder-num">18</div>
-        <div class="ladder-body"><span class="lang-zh-only">message_end 事件</span><span class="lang-en-only">message_end</span></div>
+      <div class="ld-row">
+        <div class="ld-num">18</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">message_end 事件</span><span class="lang-en-only">message_end</span></div>
+
+        </div>
       </div>
-      <div class="ladder-step">
-        <div class="ladder-num">19</div>
-        <div class="ladder-body"><span class="lang-zh-only">SessionManager.append</span><span class="lang-en-only">JSONL write</span></div>
+      <div class="ld-row">
+        <div class="ld-num">19</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">SessionManager.append</span><span class="lang-en-only">JSONL write</span></div>
+
+        </div>
       </div>
-      <div class="ladder-step">
-        <div class="ladder-num">20</div>
-        <div class="ladder-body"><span class="lang-zh-only">TUI message_update</span><span class="lang-en-only">diff render</span></div>
+      <div class="ld-row">
+        <div class="ld-num">20</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">TUI message_update</span><span class="lang-en-only">diff render</span></div>
+
+        </div>
       </div>
-      <div class="ladder-step">
-        <div class="ladder-num">21</div>
-        <div class="ladder-body"><span class="lang-zh-only">ExtensionRunner hooks</span><span class="lang-en-only">extension events</span></div>
+      <div class="ld-row">
+        <div class="ld-num">21</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">ExtensionRunner hooks</span><span class="lang-en-only">extension events</span></div>
+
+        </div>
       </div>
-      <div class="ladder-step">
-        <div class="ladder-num">22</div>
-        <div class="ladder-body"><span class="lang-zh-only">compaction 检查</span><span class="lang-en-only">context check</span></div>
+      <div class="ld-row">
+        <div class="ld-num">22</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">compaction 检查</span><span class="lang-en-only">context check</span></div>
+
+        </div>
       </div>
     </div>
 
@@ -1593,6 +1726,20 @@
     </div>
       </div>
       <figcaption><span class="figid">EVT</span><span class="lang-zh-only">AgentEvent 流 · 主线 prompt</span><span class="lang-en-only">AgentEvent stream · through-line prompt</span></figcaption>
+    </figure>
+
+    <figure>
+      <div class="figbox"><div class="pi-fig wide"><svg viewBox="0 0 720 400" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true" class="pi-svg">
+  <defs>
+    <marker id="pi-arr" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 Z" fill="#1f5c8c"/>
+    </marker>
+  </defs><text x="24" y="22" class="svg-label">AgentEvent swimlane · README through-line</text><text x="24" y="56" class="svg-micro" fill="#b35a1f">user</text><line x1="70" y1="52" x2="700" y2="52" stroke="#ebe5d8"/><text x="24" y="156" class="svg-micro" fill="#1f5c8c">model</text><line x1="70" y1="152" x2="700" y2="152" stroke="#ebe5d8"/><text x="24" y="256" class="svg-micro" fill="#6b3aa3">loop</text><line x1="70" y1="252" x2="700" y2="252" stroke="#ebe5d8"/><text x="24" y="356" class="svg-micro" fill="#2d6a4f">tool</text><line x1="70" y1="352" x2="700" y2="352" stroke="#ebe5d8"/><rect x="90" y="40" width="56" height="24" rx="2" fill="#faf6ed" stroke="#c7c4ba"/><text x="118" y="56" text-anchor="middle" class="svg-micro">user_messa</text><rect x="160" y="140" width="56" height="24" rx="2" fill="#faf6ed" stroke="#c7c4ba"/><text x="188" y="156" text-anchor="middle" class="svg-micro">model_star</text><rect x="230" y="140" width="56" height="24" rx="2" fill="#faf6ed" stroke="#c7c4ba"/><text x="258" y="156" text-anchor="middle" class="svg-micro">assistant </text><rect x="300" y="240" width="56" height="24" rx="2" fill="#faf6ed" stroke="#c7c4ba"/><text x="328" y="256" text-anchor="middle" class="svg-micro">tool_start</text><rect x="370" y="340" width="56" height="24" rx="2" fill="#faf6ed" stroke="#c7c4ba"/><text x="398" y="356" text-anchor="middle" class="svg-micro">tool_resul</text><rect x="440" y="140" width="56" height="24" rx="2" fill="#faf6ed" stroke="#c7c4ba"/><text x="468" y="156" text-anchor="middle" class="svg-micro">model_star</text><rect x="510" y="140" width="56" height="24" rx="2" fill="#faf6ed" stroke="#c7c4ba"/><text x="538" y="156" text-anchor="middle" class="svg-micro">assistant </text></svg></div></div>
+      <figcaption>
+        <span class="figid">FIG</span>
+        <span class="lang-zh-only">事件泳道图：同一主线在 user/model/loop/tool 四条泳道上的时序。</span>
+        <span class="lang-en-only">Event swimlane: through-line timing across user/model/loop/tool lanes.</span>
+      </figcaption>
     </figure>
 
     <div class="stage-purpose">
@@ -1638,241 +1785,6 @@
     <div class="note">
       <span class="lang-zh-only">本章 (02) 在主线 prompt「从回车到 JSONL 的全景图」路径上负责：<strong>一条消息的 22 站</strong>。回到 C02 的 22 站地图定位这一章。</span>
       <span class="lang-en-only">Chapter (02) on the through-line path handles: <strong>22 stations for one message</strong>. Return to C02's 22-station map to locate this chapter.</span>
-    </div>
-
-    <table class="cmp">
-      <thead><tr><th>owner</th><th>职责</th><th>主线例子</th></tr></thead>
-      <tbody>
-      <tr><td>user</td><td>发起目标</td><td>读取 README.md…</td></tr>
-      <tr><td>model</td><td>推理与 toolUse 决策</td><td>turn=1 toolUse read</td></tr>
-      <tr><td>loop</td><td>调度与顺序</td><td>tool_start call_1</td></tr>
-      <tr><td>tool</td><td>环境 I/O</td><td>README fixture 返回</td></tr>
-      </tbody>
-    </table>
-
-    <h3 class="sub"><span class="lang-zh-only">AgentEvent 完整目录</span><span class="lang-en-only">Full AgentEvent catalog</span></h3>    <table class="cmp">
-      <thead><tr><th>事件</th><th>中文</th><th>主线关联</th></tr></thead>
-      <tbody>
-      <tr><td><code>agent_start</code></td><td>循环开始</td><td>AgentSession 订阅</td></tr>
-      <tr><td><code>agent_end</code></td><td>循环结束</td><td>返回 messages[]</td></tr>
-      <tr><td><code>turn_start</code></td><td>新 turn</td><td>可能含 steering</td></tr>
-      <tr><td><code>turn_end</code></td><td>turn 结束</td><td>附带 toolResults</td></tr>
-      <tr><td><code>message_start</code></td><td>消息开始</td><td>user/assistant/tool</td></tr>
-      <tr><td><code>message_update</code></td><td>流式更新</td><td>text_delta/toolcall_delta</td></tr>
-      <tr><td><code>message_end</code></td><td>消息结束</td><td>触发 JSONL 写入</td></tr>
-      <tr><td><code>tool_execution_start</code></td><td>工具开始</td><td>read/write/bash</td></tr>
-      <tr><td><code>tool_execution_update</code></td><td>工具进度</td><td>bash 流式输出</td></tr>
-      <tr><td><code>tool_execution_end</code></td><td>工具结束</td><td>结果截断</td></tr>
-      </tbody>
-    </table>
-
-    <div class="note">
-      <span class="lang-zh-only">站 01：在完整 26 章路线图中，前 22 站覆盖从 CLI 到 compaction 检查的主线；站 1 的详细实现见对应章节。</span>
-      <span class="lang-en-only">Station 01: in the full 26-chapter route, the first 22 stations cover CLI through compaction check; see matching chapter for station 1 implementation.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">站 02：在完整 26 章路线图中，前 22 站覆盖从 CLI 到 compaction 检查的主线；站 2 的详细实现见对应章节。</span>
-      <span class="lang-en-only">Station 02: in the full 26-chapter route, the first 22 stations cover CLI through compaction check; see matching chapter for station 2 implementation.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">站 03：在完整 26 章路线图中，前 22 站覆盖从 CLI 到 compaction 检查的主线；站 3 的详细实现见对应章节。</span>
-      <span class="lang-en-only">Station 03: in the full 26-chapter route, the first 22 stations cover CLI through compaction check; see matching chapter for station 3 implementation.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">站 04：在完整 26 章路线图中，前 22 站覆盖从 CLI 到 compaction 检查的主线；站 4 的详细实现见对应章节。</span>
-      <span class="lang-en-only">Station 04: in the full 26-chapter route, the first 22 stations cover CLI through compaction check; see matching chapter for station 4 implementation.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">站 05：在完整 26 章路线图中，前 22 站覆盖从 CLI 到 compaction 检查的主线；站 5 的详细实现见对应章节。</span>
-      <span class="lang-en-only">Station 05: in the full 26-chapter route, the first 22 stations cover CLI through compaction check; see matching chapter for station 5 implementation.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">站 06：在完整 26 章路线图中，前 22 站覆盖从 CLI 到 compaction 检查的主线；站 6 的详细实现见对应章节。</span>
-      <span class="lang-en-only">Station 06: in the full 26-chapter route, the first 22 stations cover CLI through compaction check; see matching chapter for station 6 implementation.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">站 07：在完整 26 章路线图中，前 22 站覆盖从 CLI 到 compaction 检查的主线；站 7 的详细实现见对应章节。</span>
-      <span class="lang-en-only">Station 07: in the full 26-chapter route, the first 22 stations cover CLI through compaction check; see matching chapter for station 7 implementation.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">站 08：在完整 26 章路线图中，前 22 站覆盖从 CLI 到 compaction 检查的主线；站 8 的详细实现见对应章节。</span>
-      <span class="lang-en-only">Station 08: in the full 26-chapter route, the first 22 stations cover CLI through compaction check; see matching chapter for station 8 implementation.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">站 09：在完整 26 章路线图中，前 22 站覆盖从 CLI 到 compaction 检查的主线；站 9 的详细实现见对应章节。</span>
-      <span class="lang-en-only">Station 09: in the full 26-chapter route, the first 22 stations cover CLI through compaction check; see matching chapter for station 9 implementation.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">站 10：在完整 26 章路线图中，前 22 站覆盖从 CLI 到 compaction 检查的主线；站 10 的详细实现见对应章节。</span>
-      <span class="lang-en-only">Station 10: in the full 26-chapter route, the first 22 stations cover CLI through compaction check; see matching chapter for station 10 implementation.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">站 11：在完整 26 章路线图中，前 22 站覆盖从 CLI 到 compaction 检查的主线；站 11 的详细实现见对应章节。</span>
-      <span class="lang-en-only">Station 11: in the full 26-chapter route, the first 22 stations cover CLI through compaction check; see matching chapter for station 11 implementation.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">站 12：在完整 26 章路线图中，前 22 站覆盖从 CLI 到 compaction 检查的主线；站 12 的详细实现见对应章节。</span>
-      <span class="lang-en-only">Station 12: in the full 26-chapter route, the first 22 stations cover CLI through compaction check; see matching chapter for station 12 implementation.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">站 13：在完整 26 章路线图中，前 22 站覆盖从 CLI 到 compaction 检查的主线；站 13 的详细实现见对应章节。</span>
-      <span class="lang-en-only">Station 13: in the full 26-chapter route, the first 22 stations cover CLI through compaction check; see matching chapter for station 13 implementation.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">站 14：在完整 26 章路线图中，前 22 站覆盖从 CLI 到 compaction 检查的主线；站 14 的详细实现见对应章节。</span>
-      <span class="lang-en-only">Station 14: in the full 26-chapter route, the first 22 stations cover CLI through compaction check; see matching chapter for station 14 implementation.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">站 15：在完整 26 章路线图中，前 22 站覆盖从 CLI 到 compaction 检查的主线；站 15 的详细实现见对应章节。</span>
-      <span class="lang-en-only">Station 15: in the full 26-chapter route, the first 22 stations cover CLI through compaction check; see matching chapter for station 15 implementation.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">站 16：在完整 26 章路线图中，前 22 站覆盖从 CLI 到 compaction 检查的主线；站 16 的详细实现见对应章节。</span>
-      <span class="lang-en-only">Station 16: in the full 26-chapter route, the first 22 stations cover CLI through compaction check; see matching chapter for station 16 implementation.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">站 17：在完整 26 章路线图中，前 22 站覆盖从 CLI 到 compaction 检查的主线；站 17 的详细实现见对应章节。</span>
-      <span class="lang-en-only">Station 17: in the full 26-chapter route, the first 22 stations cover CLI through compaction check; see matching chapter for station 17 implementation.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">站 18：在完整 26 章路线图中，前 22 站覆盖从 CLI 到 compaction 检查的主线；站 18 的详细实现见对应章节。</span>
-      <span class="lang-en-only">Station 18: in the full 26-chapter route, the first 22 stations cover CLI through compaction check; see matching chapter for station 18 implementation.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">站 19：在完整 26 章路线图中，前 22 站覆盖从 CLI 到 compaction 检查的主线；站 19 的详细实现见对应章节。</span>
-      <span class="lang-en-only">Station 19: in the full 26-chapter route, the first 22 stations cover CLI through compaction check; see matching chapter for station 19 implementation.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">站 20：在完整 26 章路线图中，前 22 站覆盖从 CLI 到 compaction 检查的主线；站 20 的详细实现见对应章节。</span>
-      <span class="lang-en-only">Station 20: in the full 26-chapter route, the first 22 stations cover CLI through compaction check; see matching chapter for station 20 implementation.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">站 21：在完整 26 章路线图中，前 22 站覆盖从 CLI 到 compaction 检查的主线；站 21 的详细实现见对应章节。</span>
-      <span class="lang-en-only">Station 21: in the full 26-chapter route, the first 22 stations cover CLI through compaction check; see matching chapter for station 21 implementation.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">站 22：在完整 26 章路线图中，前 22 站覆盖从 CLI 到 compaction 检查的主线；站 22 的详细实现见对应章节。</span>
-      <span class="lang-en-only">Station 22: in the full 26-chapter route, the first 22 stations cover CLI through compaction check; see matching chapter for station 22 implementation.</span>
-    </div>
-
-    <h3 class="sub"><span class="lang-zh-only">附录 · 一条消息的 22 站 深度 trace</span><span class="lang-en-only">Appendix · deep trace for 22 stations for one message</span></h3>
-
-    <div class="lang-zh-only"><p>本章 (02) 属于 Phase「引子」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
-    <div class="lang-en-only"><p>Chapter (02) belongs to Phase «Prologue». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
-
-    <table class="cmp">
-      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
-      <tbody>
-      <tr><td>1</td><td>user</td><td>prompt 入队</td></tr>
-      <tr><td>2</td><td>loop</td><td>agent_start</td></tr>
-      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
-      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
-      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
-      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
-      </tbody>
-    </table>
-
-    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// default trace</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 02 · 一条消息的 22 站</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 02 · 一条消息的 22 站</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 02 · 一条消息的 22 站</span></span>
-    </div>
-
-    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
-
-    <div class="lang-zh-only"><p><strong>AgentMessage</strong> — agent-core 内部消息 IR</p></div>
-    <div class="lang-en-only"><p><strong>AgentMessage</strong> — agent-core internal message IR</p></div>
-
-    <div class="lang-zh-only"><p><strong>StreamFn</strong> — 可注入的模型流函数</p></div>
-    <div class="lang-en-only"><p><strong>StreamFn</strong> — injectable model stream function</p></div>
-
-    <div class="lang-zh-only"><p><strong>leafId</strong> — JSONL 会话树当前叶</p></div>
-    <div class="lang-en-only"><p><strong>leafId</strong> — JSONL session tree current leaf</p></div>
-
-    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
-
-    <div class="note">
-      <span class="lang-zh-only">[02.1] 在 一条消息的 22 站 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[02.1] At 22 stations for one message stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[02.2] 在 一条消息的 22 站 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[02.2] At 22 stations for one message stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[02.3] 在 一条消息的 22 站 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[02.3] At 22 stations for one message stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[02.4] 在 一条消息的 22 站 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[02.4] At 22 stations for one message stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[02.5] 在 一条消息的 22 站 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[02.5] At 22 stations for one message stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[02.6] 在 一条消息的 22 站 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[02.6] At 22 stations for one message stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[02.7] 在 一条消息的 22 站 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[02.7] At 22 stations for one message stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[02.8] 在 一条消息的 22 站 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[02.8] At 22 stations for one message stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
     </div>
   </section>
 
@@ -1956,153 +1868,69 @@
     </div>
 
     <figure>
-      <div class="figbox"><div class="fig-placeholder">diagram</div></div>
+      <div class="figbox"><div class="pi-fig"><svg viewBox="0 0 720 300" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true" class="pi-svg">
+  <defs>
+    <marker id="pi-arr" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 Z" fill="#1f5c8c"/>
+    </marker>
+  </defs>
+  <text x="24" y="18" class="svg-label">pi-mono six-layer cake · dependency flows downward</text>
+  
+  <rect x="120" y="28" width="480" height="36" rx="3" fill="#1f5c8c" opacity="0.12" stroke="#1f5c8c" stroke-width="1.5"/>
+  <text x="140" y="44" class="svg-tiny" fill="#1f5c8c" font-weight="700">L6</text>
+  <text x="180" y="44" class="svg-body">coding-agent</text>
+  <text x="180" y="58" class="svg-mute">CLI · AgentSession · tools</text>
+  <rect x="120" y="70" width="480" height="36" rx="3" fill="#3873a3" opacity="0.12" stroke="#3873a3" stroke-width="1.5"/>
+  <text x="140" y="86" class="svg-tiny" fill="#3873a3" font-weight="700">L5</text>
+  <text x="180" y="86" class="svg-body">agent-core</text>
+  <text x="180" y="100" class="svg-mute">agentLoop · AgentMessage</text>
+  <rect x="120" y="112" width="480" height="36" rx="3" fill="#6b3aa3" opacity="0.12" stroke="#6b3aa3" stroke-width="1.5"/>
+  <text x="140" y="128" class="svg-tiny" fill="#6b3aa3" font-weight="700">L4</text>
+  <text x="180" y="128" class="svg-body">pi-ai</text>
+  <text x="180" y="142" class="svg-mute">Models · streamSimple</text>
+  <rect x="120" y="154" width="480" height="36" rx="3" fill="#2d6a4f" opacity="0.12" stroke="#2d6a4f" stroke-width="1.5"/>
+  <text x="140" y="170" class="svg-tiny" fill="#2d6a4f" font-weight="700">L3</text>
+  <text x="180" y="170" class="svg-body">pi-tui</text>
+  <text x="180" y="184" class="svg-mute">diff render · Editor</text>
+  <rect x="120" y="196" width="480" height="36" rx="3" fill="#b35a1f" opacity="0.12" stroke="#b35a1f" stroke-width="1.5"/>
+  <text x="140" y="212" class="svg-tiny" fill="#b35a1f" font-weight="700">L2</text>
+  <text x="180" y="212" class="svg-body">protocol</text>
+  <text x="180" y="226" class="svg-mute">JSONL RPC frames</text>
+  <rect x="120" y="238" width="480" height="36" rx="3" fill="#767c87" opacity="0.12" stroke="#767c87" stroke-width="1.5"/>
+  <text x="140" y="254" class="svg-tiny" fill="#767c87" font-weight="700">L1</text>
+  <text x="180" y="254" class="svg-body">server</text>
+  <text x="180" y="268" class="svg-mute">CBOR remote</text>
+  <path d="M360 250 L360 268" stroke="#1f5c8c" marker-end="url(#arr)"/>
+  <text x="360" y="285" text-anchor="middle" class="svg-mute">through-line prompt enters at L6</text>
+</svg></div></div>
       <figcaption>
         <span class="figid">FIG</span>
-        <span class="lang-zh-only">pi-mono 六包依赖图：coding-agent 在顶层组装，agent-core 是心脏，pi-ai 是 LLM 边界。</span>
-        <span class="lang-en-only">pi-mono six-package dependency graph: coding-agent composes at top, agent-core is the heart, pi-ai is the LLM boundary.</span>
+        <span class="lang-zh-only">六层蛋糕：coding-agent 组装下层；agent-core 不 import pi-ai/compat，由宿主注入 StreamFn。</span>
+        <span class="lang-en-only">Six-layer cake: coding-agent composes below; agent-core does not import pi-ai/compat — host injects StreamFn.</span>
+      </figcaption>
+    </figure>
+
+    <figure>
+      <div class="figbox"><div class="pi-fig"><svg viewBox="0 0 720 270" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true" class="pi-svg">
+  <defs>
+    <marker id="pi-arr" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 Z" fill="#1f5c8c"/>
+    </marker>
+  </defs>
+  <text x="24" y="24" class="svg-label">pi-textbook · 15 checkpoints → production pi-mono</text>
+  <text x="48" y="44" class="svg-micro" fill="#1f5c8c">cp 00</text><text x="100" y="44" class="svg-body">Prologue</text><line x1="90" y1="40" x2="680" y2="40" stroke="#ebe5d8"/><text x="48" y="76" class="svg-micro" fill="#1f5c8c">cp 03</text><text x="100" y="76" class="svg-body">Message IR</text><line x1="90" y1="72" x2="680" y2="72" stroke="#ebe5d8"/><text x="48" y="108" class="svg-micro" fill="#1f5c8c">cp 07</text><text x="100" y="108" class="svg-body">Agent Loop</text><line x1="90" y1="104" x2="680" y2="104" stroke="#ebe5d8"/><text x="48" y="140" class="svg-micro" fill="#1f5c8c">cp 10</text><text x="100" y="140" class="svg-body">Session Tree</text><line x1="90" y1="136" x2="680" y2="136" stroke="#ebe5d8"/><text x="48" y="172" class="svg-micro" fill="#1f5c8c">cp 11</text><text x="100" y="172" class="svg-body">Compaction</text><line x1="90" y1="168" x2="680" y2="168" stroke="#ebe5d8"/><text x="48" y="204" class="svg-micro" fill="#1f5c8c">cp 14</text><text x="100" y="204" class="svg-body">Eval</text><line x1="90" y1="200" x2="680" y2="200" stroke="#ebe5d8"/>
+  <text x="360" y="250" text-anchor="middle" class="svg-mute">each checkpoint = one testable abstraction layer</text>
+</svg></div></div>
+      <figcaption>
+        <span class="figid">FIG</span>
+        <span class="lang-zh-only">pi-textbook 15 checkpoint 与生产代码的映射关系（节选）。</span>
+        <span class="lang-en-only">pi-textbook 15 checkpoints mapped to production code (excerpt).</span>
       </figcaption>
     </figure>
 
     <div class="note">
       <span class="lang-zh-only">本章 (03) 在主线 prompt「Mario Zechner 与 earendil-works」路径上负责：<strong>pi-mono 家谱</strong>。回到 C02 的 22 站地图定位这一章。</span>
       <span class="lang-en-only">Chapter (03) on the through-line path handles: <strong>The pi-mono family tree</strong>. Return to C02's 22-station map to locate this chapter.</span>
-    </div>
-
-    <table class="cmp">
-      <thead><tr><th>路径</th><th>说明</th></tr></thead>
-      <tbody>
-      <tr><td><code>packages/agent/</code></td><td>agent-core 包</td></tr>
-      <tr><td><code>packages/ai/</code></td><td>pi-ai 包</td></tr>
-      <tr><td><code>packages/tui/</code></td><td>终端 UI 包</td></tr>
-      <tr><td><code>packages/coding-agent/</code></td><td>CLI 与组装</td></tr>
-      </tbody>
-    </table>
-
-    <h3 class="sub"><span class="lang-zh-only">pi-mono 家谱 · 实现清单</span><span class="lang-en-only">The pi-mono family tree · implementation checklist</span></h3>
-
-    <div class="note">
-      <span class="lang-zh-only">1. 定位生产文件：packages/agent/src/agent-loop.ts</span>
-      <span class="lang-en-only">1. Locate production file: packages/agent/src/agent-loop.ts</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">2. 对照 pi-textbook 同主题 checkpoint</span>
-      <span class="lang-en-only">2. Cross-read matching pi-textbook checkpoint</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">3. 用 --verbose 观察 AgentEvent</span>
-      <span class="lang-en-only">3. Observe AgentEvents with --verbose</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">4. 检查 JSONL 会话文件对应 entry</span>
-      <span class="lang-en-only">4. Inspect matching JSONL session entry</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">5. 阅读 packages/*/test/ 下相关测试</span>
-      <span class="lang-en-only">5. Read related tests under packages/*/test/</span>
-    </div>
-
-    <h3 class="sub"><span class="lang-zh-only">附录 · pi-mono 家谱 深度 trace</span><span class="lang-en-only">Appendix · deep trace for The pi-mono family tree</span></h3>
-
-    <div class="lang-zh-only"><p>本章 (03) 属于 Phase「背景」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
-    <div class="lang-en-only"><p>Chapter (03) belongs to Phase «Background». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
-
-    <table class="cmp">
-      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
-      <tbody>
-      <tr><td>1</td><td>pi-mono 家谱</td><td>Mario Zechner 与 earendil-works</td></tr>
-      <tr><td>2</td><td>—</td><td>checkpoint 2</td></tr>
-      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
-      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
-      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
-      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
-      </tbody>
-    </table>
-
-    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// default trace</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 03 · pi-mono 家谱</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 03 · pi-mono 家谱</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 03 · pi-mono 家谱</span></span>
-    </div>
-
-    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
-
-    <div class="lang-zh-only"><p><strong>AgentMessage</strong> — agent-core 内部消息 IR</p></div>
-    <div class="lang-en-only"><p><strong>AgentMessage</strong> — agent-core internal message IR</p></div>
-
-    <div class="lang-zh-only"><p><strong>StreamFn</strong> — 可注入的模型流函数</p></div>
-    <div class="lang-en-only"><p><strong>StreamFn</strong> — injectable model stream function</p></div>
-
-    <div class="lang-zh-only"><p><strong>leafId</strong> — JSONL 会话树当前叶</p></div>
-    <div class="lang-en-only"><p><strong>leafId</strong> — JSONL session tree current leaf</p></div>
-
-    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
-
-    <div class="note">
-      <span class="lang-zh-only">[03.1] 在 pi-mono 家谱 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[03.1] At The pi-mono family tree stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[03.2] 在 pi-mono 家谱 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[03.2] At The pi-mono family tree stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[03.3] 在 pi-mono 家谱 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[03.3] At The pi-mono family tree stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[03.4] 在 pi-mono 家谱 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[03.4] At The pi-mono family tree stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[03.5] 在 pi-mono 家谱 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[03.5] At The pi-mono family tree stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[03.6] 在 pi-mono 家谱 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[03.6] At The pi-mono family tree stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[03.7] 在 pi-mono 家谱 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[03.7] At The pi-mono family tree stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[03.8] 在 pi-mono 家谱 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[03.8] At The pi-mono family tree stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
     </div>
   </section>
 
@@ -2117,30 +1945,91 @@
 
     <h3 class="sub"><span class="lang-zh-only">六层蛋糕</span><span class="lang-en-only">Six-layer cake</span></h3>
 
+    <figure>
+      <div class="figbox"><div class="pi-fig"><svg viewBox="0 0 720 300" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true" class="pi-svg">
+  <defs>
+    <marker id="pi-arr" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 Z" fill="#1f5c8c"/>
+    </marker>
+  </defs>
+  <text x="24" y="18" class="svg-label">pi-mono six-layer cake · dependency flows downward</text>
+  
+  <rect x="120" y="28" width="480" height="36" rx="3" fill="#1f5c8c" opacity="0.12" stroke="#1f5c8c" stroke-width="1.5"/>
+  <text x="140" y="44" class="svg-tiny" fill="#1f5c8c" font-weight="700">L6</text>
+  <text x="180" y="44" class="svg-body">coding-agent</text>
+  <text x="180" y="58" class="svg-mute">CLI · AgentSession · tools</text>
+  <rect x="120" y="70" width="480" height="36" rx="3" fill="#3873a3" opacity="0.12" stroke="#3873a3" stroke-width="1.5"/>
+  <text x="140" y="86" class="svg-tiny" fill="#3873a3" font-weight="700">L5</text>
+  <text x="180" y="86" class="svg-body">agent-core</text>
+  <text x="180" y="100" class="svg-mute">agentLoop · AgentMessage</text>
+  <rect x="120" y="112" width="480" height="36" rx="3" fill="#6b3aa3" opacity="0.12" stroke="#6b3aa3" stroke-width="1.5"/>
+  <text x="140" y="128" class="svg-tiny" fill="#6b3aa3" font-weight="700">L4</text>
+  <text x="180" y="128" class="svg-body">pi-ai</text>
+  <text x="180" y="142" class="svg-mute">Models · streamSimple</text>
+  <rect x="120" y="154" width="480" height="36" rx="3" fill="#2d6a4f" opacity="0.12" stroke="#2d6a4f" stroke-width="1.5"/>
+  <text x="140" y="170" class="svg-tiny" fill="#2d6a4f" font-weight="700">L3</text>
+  <text x="180" y="170" class="svg-body">pi-tui</text>
+  <text x="180" y="184" class="svg-mute">diff render · Editor</text>
+  <rect x="120" y="196" width="480" height="36" rx="3" fill="#b35a1f" opacity="0.12" stroke="#b35a1f" stroke-width="1.5"/>
+  <text x="140" y="212" class="svg-tiny" fill="#b35a1f" font-weight="700">L2</text>
+  <text x="180" y="212" class="svg-body">protocol</text>
+  <text x="180" y="226" class="svg-mute">JSONL RPC frames</text>
+  <rect x="120" y="238" width="480" height="36" rx="3" fill="#767c87" opacity="0.12" stroke="#767c87" stroke-width="1.5"/>
+  <text x="140" y="254" class="svg-tiny" fill="#767c87" font-weight="700">L1</text>
+  <text x="180" y="254" class="svg-body">server</text>
+  <text x="180" y="268" class="svg-mute">CBOR remote</text>
+  <path d="M360 250 L360 268" stroke="#1f5c8c" marker-end="url(#arr)"/>
+  <text x="360" y="285" text-anchor="middle" class="svg-mute">through-line prompt enters at L6</text>
+</svg></div></div>
+      <figcaption>
+        <span class="figid">FIG</span>
+        <span class="lang-zh-only">六层蛋糕：coding-agent 组装下层；agent-core 不 import pi-ai/compat，由宿主注入 StreamFn。</span>
+        <span class="lang-en-only">Six-layer cake: coding-agent composes below; agent-core does not import pi-ai/compat — host injects StreamFn.</span>
+      </figcaption>
+    </figure>
+
     <div class="ladder">
-      <div class="ladder-step">
-        <div class="ladder-num">01</div>
-        <div class="ladder-body"><span class="lang-zh-only">L6 · coding-agent</span><span class="lang-en-only">L6 · coding-agent — CLI · AgentSession · tools · extensions</span></div>
+      <div class="ld-row">
+        <div class="ld-num">01</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">L6 · coding-agent</span><span class="lang-en-only">L6 · coding-agent — CLI · AgentSession · tools · extensions</span></div>
+
+        </div>
       </div>
-      <div class="ladder-step">
-        <div class="ladder-num">02</div>
-        <div class="ladder-body"><span class="lang-zh-only">L5 · agent-core</span><span class="lang-en-only">L5 · agent-core — agentLoop · AgentMessage · events</span></div>
+      <div class="ld-row">
+        <div class="ld-num">02</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">L5 · agent-core</span><span class="lang-en-only">L5 · agent-core — agentLoop · AgentMessage · events</span></div>
+
+        </div>
       </div>
-      <div class="ladder-step">
-        <div class="ladder-num">03</div>
-        <div class="ladder-body"><span class="lang-zh-only">L4 · pi-ai</span><span class="lang-en-only">L4 · pi-ai — Models · streamSimple · providers</span></div>
+      <div class="ld-row">
+        <div class="ld-num">03</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">L4 · pi-ai</span><span class="lang-en-only">L4 · pi-ai — Models · streamSimple · providers</span></div>
+
+        </div>
       </div>
-      <div class="ladder-step">
-        <div class="ladder-num">04</div>
-        <div class="ladder-body"><span class="lang-zh-only">L3 · pi-tui</span><span class="lang-en-only">L3 · pi-tui — TUI · Editor · Markdown · diff</span></div>
+      <div class="ld-row">
+        <div class="ld-num">04</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">L3 · pi-tui</span><span class="lang-en-only">L3 · pi-tui — TUI · Editor · Markdown · diff</span></div>
+
+        </div>
       </div>
-      <div class="ladder-step">
-        <div class="ladder-num">05</div>
-        <div class="ladder-body"><span class="lang-zh-only">L2 · protocol</span><span class="lang-en-only">L2 · protocol — JSONL RPC 帧</span></div>
+      <div class="ld-row">
+        <div class="ld-num">05</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">L2 · protocol</span><span class="lang-en-only">L2 · protocol — JSONL RPC 帧</span></div>
+
+        </div>
       </div>
-      <div class="ladder-step">
-        <div class="ladder-num">06</div>
-        <div class="ladder-body"><span class="lang-zh-only">L1 · server</span><span class="lang-en-only">L1 · server — 远程会话</span></div>
+      <div class="ld-row">
+        <div class="ld-num">06</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">L1 · server</span><span class="lang-en-only">L1 · server — 远程会话</span></div>
+
+        </div>
       </div>
     </div>
 
@@ -2197,142 +2086,6 @@
       <span class="lang-zh-only">本章 (04) 在主线 prompt「agent-core · ai · tui · coding-agent」路径上负责：<strong>六层蛋糕</strong>。回到 C02 的 22 站地图定位这一章。</span>
       <span class="lang-en-only">Chapter (04) on the through-line path handles: <strong>The six-layer cake</strong>. Return to C02's 22-station map to locate this chapter.</span>
     </div>
-
-    <table class="cmp">
-      <thead><tr><th>路径</th><th>说明</th></tr></thead>
-      <tbody>
-      <tr><td><code>packages/agent/</code></td><td>agent-core 包</td></tr>
-      <tr><td><code>packages/ai/</code></td><td>pi-ai 包</td></tr>
-      <tr><td><code>packages/tui/</code></td><td>终端 UI 包</td></tr>
-      <tr><td><code>packages/coding-agent/</code></td><td>CLI 与组装</td></tr>
-      </tbody>
-    </table>
-
-    <h3 class="sub"><span class="lang-zh-only">六层蛋糕 · 实现清单</span><span class="lang-en-only">The six-layer cake · implementation checklist</span></h3>
-
-    <div class="note">
-      <span class="lang-zh-only">1. 定位生产文件：packages/agent/src/agent-loop.ts</span>
-      <span class="lang-en-only">1. Locate production file: packages/agent/src/agent-loop.ts</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">2. 对照 pi-textbook 同主题 checkpoint</span>
-      <span class="lang-en-only">2. Cross-read matching pi-textbook checkpoint</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">3. 用 --verbose 观察 AgentEvent</span>
-      <span class="lang-en-only">3. Observe AgentEvents with --verbose</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">4. 检查 JSONL 会话文件对应 entry</span>
-      <span class="lang-en-only">4. Inspect matching JSONL session entry</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">5. 阅读 packages/*/test/ 下相关测试</span>
-      <span class="lang-en-only">5. Read related tests under packages/*/test/</span>
-    </div>
-
-    <h3 class="sub"><span class="lang-zh-only">附录 · 六层蛋糕 深度 trace</span><span class="lang-en-only">Appendix · deep trace for The six-layer cake</span></h3>
-
-    <div class="lang-zh-only"><p>本章 (04) 属于 Phase「背景」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
-    <div class="lang-en-only"><p>Chapter (04) belongs to Phase «Background». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
-
-    <table class="cmp">
-      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
-      <tbody>
-      <tr><td>1</td><td>六层蛋糕</td><td>agent-core · ai · tui · coding-agent</td></tr>
-      <tr><td>2</td><td>—</td><td>checkpoint 2</td></tr>
-      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
-      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
-      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
-      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
-      </tbody>
-    </table>
-
-    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// default trace</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 04 · 六层蛋糕</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 04 · 六层蛋糕</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 04 · 六层蛋糕</span></span>
-    </div>
-
-    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
-
-    <div class="lang-zh-only"><p><strong>AgentMessage</strong> — agent-core 内部消息 IR</p></div>
-    <div class="lang-en-only"><p><strong>AgentMessage</strong> — agent-core internal message IR</p></div>
-
-    <div class="lang-zh-only"><p><strong>StreamFn</strong> — 可注入的模型流函数</p></div>
-    <div class="lang-en-only"><p><strong>StreamFn</strong> — injectable model stream function</p></div>
-
-    <div class="lang-zh-only"><p><strong>leafId</strong> — JSONL 会话树当前叶</p></div>
-    <div class="lang-en-only"><p><strong>leafId</strong> — JSONL session tree current leaf</p></div>
-
-    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
-
-    <div class="note">
-      <span class="lang-zh-only">[04.1] 在 六层蛋糕 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[04.1] At The six-layer cake stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[04.2] 在 六层蛋糕 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[04.2] At The six-layer cake stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[04.3] 在 六层蛋糕 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[04.3] At The six-layer cake stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[04.4] 在 六层蛋糕 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[04.4] At The six-layer cake stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[04.5] 在 六层蛋糕 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[04.5] At The six-layer cake stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[04.6] 在 六层蛋糕 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[04.6] At The six-layer cake stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[04.7] 在 六层蛋糕 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[04.7] At The six-layer cake stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[04.8] 在 六层蛋糕 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[04.8] At The six-layer cake stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
   </section>
 
   <section class="chap" id="c5">
@@ -2380,142 +2133,6 @@
       <span class="lang-zh-only">本章 (05) 在主线 prompt「No MCP · No sub-agents · No plan mode」路径上负责：<strong>故意不做的功能</strong>。回到 C02 的 22 站地图定位这一章。</span>
       <span class="lang-en-only">Chapter (05) on the through-line path handles: <strong>Intentionally missing features</strong>. Return to C02's 22-station map to locate this chapter.</span>
     </div>
-
-    <table class="cmp">
-      <thead><tr><th>路径</th><th>说明</th></tr></thead>
-      <tbody>
-      <tr><td><code>packages/agent/</code></td><td>agent-core 包</td></tr>
-      <tr><td><code>packages/ai/</code></td><td>pi-ai 包</td></tr>
-      <tr><td><code>packages/tui/</code></td><td>终端 UI 包</td></tr>
-      <tr><td><code>packages/coding-agent/</code></td><td>CLI 与组装</td></tr>
-      </tbody>
-    </table>
-
-    <h3 class="sub"><span class="lang-zh-only">故意不做的功能 · 实现清单</span><span class="lang-en-only">Intentionally missing features · implementation checklist</span></h3>
-
-    <div class="note">
-      <span class="lang-zh-only">1. 定位生产文件：packages/agent/src/agent-loop.ts</span>
-      <span class="lang-en-only">1. Locate production file: packages/agent/src/agent-loop.ts</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">2. 对照 pi-textbook 同主题 checkpoint</span>
-      <span class="lang-en-only">2. Cross-read matching pi-textbook checkpoint</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">3. 用 --verbose 观察 AgentEvent</span>
-      <span class="lang-en-only">3. Observe AgentEvents with --verbose</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">4. 检查 JSONL 会话文件对应 entry</span>
-      <span class="lang-en-only">4. Inspect matching JSONL session entry</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">5. 阅读 packages/*/test/ 下相关测试</span>
-      <span class="lang-en-only">5. Read related tests under packages/*/test/</span>
-    </div>
-
-    <h3 class="sub"><span class="lang-zh-only">附录 · 故意不做的功能 深度 trace</span><span class="lang-en-only">Appendix · deep trace for Intentionally missing features</span></h3>
-
-    <div class="lang-zh-only"><p>本章 (05) 属于 Phase「背景」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
-    <div class="lang-en-only"><p>Chapter (05) belongs to Phase «Background». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
-
-    <table class="cmp">
-      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
-      <tbody>
-      <tr><td>1</td><td>故意不做的功能</td><td>No MCP · No sub-agents · No plan mode</td></tr>
-      <tr><td>2</td><td>—</td><td>checkpoint 2</td></tr>
-      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
-      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
-      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
-      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
-      </tbody>
-    </table>
-
-    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// default trace</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 05 · 故意不做的功能</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 05 · 故意不做的功能</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 05 · 故意不做的功能</span></span>
-    </div>
-
-    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
-
-    <div class="lang-zh-only"><p><strong>AgentMessage</strong> — agent-core 内部消息 IR</p></div>
-    <div class="lang-en-only"><p><strong>AgentMessage</strong> — agent-core internal message IR</p></div>
-
-    <div class="lang-zh-only"><p><strong>StreamFn</strong> — 可注入的模型流函数</p></div>
-    <div class="lang-en-only"><p><strong>StreamFn</strong> — injectable model stream function</p></div>
-
-    <div class="lang-zh-only"><p><strong>leafId</strong> — JSONL 会话树当前叶</p></div>
-    <div class="lang-en-only"><p><strong>leafId</strong> — JSONL session tree current leaf</p></div>
-
-    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
-
-    <div class="note">
-      <span class="lang-zh-only">[05.1] 在 故意不做的功能 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[05.1] At Intentionally missing features stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[05.2] 在 故意不做的功能 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[05.2] At Intentionally missing features stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[05.3] 在 故意不做的功能 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[05.3] At Intentionally missing features stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[05.4] 在 故意不做的功能 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[05.4] At Intentionally missing features stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[05.5] 在 故意不做的功能 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[05.5] At Intentionally missing features stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[05.6] 在 故意不做的功能 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[05.6] At Intentionally missing features stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[05.7] 在 故意不做的功能 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[05.7] At Intentionally missing features stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[05.8] 在 故意不做的功能 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[05.8] At Intentionally missing features stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
   </section>
 
   <section class="chap" id="c6">
@@ -2528,21 +2145,33 @@
     <div class="lang-en-only"><p>You type <code>pi</code> or <code>npx @earendil-works/coding-agent</code>; boot chain parses argv in <code>cli.ts</code>, <code>main.ts</code> picks interactive/print/rpc mode, then <code>createAgentSession()</code>.</p></div>
 
     <div class="ladder">
-      <div class="ladder-step">
-        <div class="ladder-num">01</div>
-        <div class="ladder-body"><span class="lang-zh-only">cli.ts</span><span class="lang-en-only">argv · --model · --mode rpc</span></div>
+      <div class="ld-row">
+        <div class="ld-num">01</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">cli.ts</span><span class="lang-en-only">argv · --model · --mode rpc</span></div>
+
+        </div>
       </div>
-      <div class="ladder-step">
-        <div class="ladder-num">02</div>
-        <div class="ladder-body"><span class="lang-zh-only">main.ts</span><span class="lang-en-only">mode dispatch · theme · keybindings</span></div>
+      <div class="ld-row">
+        <div class="ld-num">02</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">main.ts</span><span class="lang-en-only">mode dispatch · theme · keybindings</span></div>
+
+        </div>
       </div>
-      <div class="ladder-step">
-        <div class="ladder-num">03</div>
-        <div class="ladder-body"><span class="lang-zh-only">createAgentSession</span><span class="lang-en-only">AgentSession + ExtensionRunner</span></div>
+      <div class="ld-row">
+        <div class="ld-num">03</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">createAgentSession</span><span class="lang-en-only">AgentSession + ExtensionRunner</span></div>
+
+        </div>
       </div>
-      <div class="ladder-step">
-        <div class="ladder-num">04</div>
-        <div class="ladder-body"><span class="lang-zh-only">interactive mode</span><span class="lang-en-only">TUI loop · Editor</span></div>
+      <div class="ld-row">
+        <div class="ld-num">04</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">interactive mode</span><span class="lang-en-only">TUI loop · Editor</span></div>
+
+        </div>
       </div>
     </div>
 
@@ -2604,151 +2233,6 @@
       <span class="src-line"><span class="src-comment">// Through-line: cli.ts → main.ts → createAgentSession</span></span>
       <span class="src-line"><span class="src-comment">// Phase: 入口 / Intake</span></span>
       <span class="src-line"><span class="src-kw">await</span> <span class="src-fn">traceTurn</span>({ <span class="src-arg">prompt</span>: <span class="src-str">"README.md"</span> });</span>
-    </div>
-
-    <table class="cmp">
-      <thead><tr><th>路径</th><th>说明</th></tr></thead>
-      <tbody>
-      <tr><td><code>packages/coding-agent/src/cli.ts</code></td><td>CLI 入口</td></tr>
-      <tr><td><code>packages/coding-agent/src/main.ts</code></td><td>模式分发</td></tr>
-      <tr><td><code>packages/coding-agent/src/core/agent-session.ts</code></td><td>中枢调度</td></tr>
-      <tr><td><code>packages/coding-agent/src/core/resource-loader.ts</code></td><td>AGENTS.md 栈</td></tr>
-      </tbody>
-    </table>
-
-    <h3 class="sub"><span class="lang-zh-only">CLI 启动链 · 实现清单</span><span class="lang-en-only">CLI boot chain · implementation checklist</span></h3>
-
-    <div class="note">
-      <span class="lang-zh-only">1. 定位生产文件：packages/agent/src/agent-loop.ts</span>
-      <span class="lang-en-only">1. Locate production file: packages/agent/src/agent-loop.ts</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">2. 对照 pi-textbook 同主题 checkpoint</span>
-      <span class="lang-en-only">2. Cross-read matching pi-textbook checkpoint</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">3. 用 --verbose 观察 AgentEvent</span>
-      <span class="lang-en-only">3. Observe AgentEvents with --verbose</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">4. 检查 JSONL 会话文件对应 entry</span>
-      <span class="lang-en-only">4. Inspect matching JSONL session entry</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">5. 阅读 packages/*/test/ 下相关测试</span>
-      <span class="lang-en-only">5. Read related tests under packages/*/test/</span>
-    </div>
-
-    <h3 class="sub"><span class="lang-zh-only">附录 · CLI 启动链 深度 trace</span><span class="lang-en-only">Appendix · deep trace for CLI boot chain</span></h3>
-
-    <div class="lang-zh-only"><p>本章 (06) 属于 Phase「入口」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
-    <div class="lang-en-only"><p>Chapter (06) belongs to Phase «Intake». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
-
-    <table class="cmp">
-      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
-      <tbody>
-      <tr><td>1</td><td>cli.ts</td><td>argv 解析</td></tr>
-      <tr><td>2</td><td>main.ts</td><td>mode=interactive</td></tr>
-      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
-      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
-      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
-      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
-      </tbody>
-    </table>
-
-    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/cli.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// CLI</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 06 · CLI 启动链</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/main.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// main</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 06 · CLI 启动链</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 06 · CLI 启动链</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 06 · CLI 启动链</span></span>
-    </div>
-
-    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
-
-    <div class="lang-zh-only"><p><strong>AgentMessage</strong> — agent-core 内部消息 IR</p></div>
-    <div class="lang-en-only"><p><strong>AgentMessage</strong> — agent-core internal message IR</p></div>
-
-    <div class="lang-zh-only"><p><strong>StreamFn</strong> — 可注入的模型流函数</p></div>
-    <div class="lang-en-only"><p><strong>StreamFn</strong> — injectable model stream function</p></div>
-
-    <div class="lang-zh-only"><p><strong>leafId</strong> — JSONL 会话树当前叶</p></div>
-    <div class="lang-en-only"><p><strong>leafId</strong> — JSONL session tree current leaf</p></div>
-
-    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
-
-    <div class="note">
-      <span class="lang-zh-only">[06.1] 在 CLI 启动链 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[06.1] At CLI boot chain stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[06.2] 在 CLI 启动链 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[06.2] At CLI boot chain stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[06.3] 在 CLI 启动链 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[06.3] At CLI boot chain stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[06.4] 在 CLI 启动链 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[06.4] At CLI boot chain stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[06.5] 在 CLI 启动链 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[06.5] At CLI boot chain stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[06.6] 在 CLI 启动链 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[06.6] At CLI boot chain stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[06.7] 在 CLI 启动链 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[06.7] At CLI boot chain stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[06.8] 在 CLI 启动链 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[06.8] At CLI boot chain stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
     </div>
   </section>
 
@@ -2848,121 +2332,22 @@
         <span class="src-tag">walkthrough</span>
       </div>
       <span class="src-line"><span class="src-ln">  1</span> <span class="src-hl">async prompt(text: string)</span></span>
-      <span class="src-line"><span class="src-comment">     // 用户主线入口 / user through-line entry</span></span>
+      <span class="src-line"><span class="src-comment">     // 用户主线入口 / through-line entry</span></span>
       <span class="src-line"><span class="src-ln">  2</span> <span class="src-hl">const userMsg = createUserMessage(text)</span></span>
-      <span class="src-line"><span class="src-comment">     // 构造 AgentMessage / construct AgentMessage</span></span>
-      <span class="src-line"><span class="src-ln">  3</span> <span class="src-hl">const stream = agentLoop([userMsg], ctx, config, signal, streamFn)</span></span>
+      <span class="src-line"><span class="src-comment">     // 构造 AgentMessage / build AgentMessage</span></span>
+      <span class="src-line"><span class="src-ln">  3</span> <span class="src-hl">agentLoop([userMsg], ctx, config, signal, streamFn)</span></span>
       <span class="src-line"><span class="src-comment">     // 委托 agent-core / delegate to agent-core</span></span>
       <span class="src-line"><span class="src-ln">  4</span> <span class="src-hl">for await (const event of stream)</span></span>
-      <span class="src-line"><span class="src-comment">     // 事件泵 / event pump</span></span>
-      <span class="src-line"><span class="src-ln">  5</span> <span class="src-hl">await this.sessionManager.append(event)</span></span>
-      <span class="src-line"><span class="src-comment">     // 持久化 / persist</span></span>
-      <span class="src-line"><span class="src-ln">  6</span> <span class="src-hl">this.extensionRunner.emit(event)</span></span>
-      <span class="src-line"><span class="src-comment">     // 扩展广播 / extension broadcast</span></span>
+      <span class="src-line"><span class="src-comment">     // 事件泵 → JSONL + TUI / event pump → JSONL + TUI</span></span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
-
-    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">AgentSession vs agentLoop？</span><span class="lang-en-only">AgentSession vs agentLoop?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>Session 有状态+I/O；Loop 纯编排。</p></div><div class="lang-en-only"><p>Session has state+I/O; Loop is pure orchestration.</p></div></div></details>
-
-    <h3 class="sub"><span class="lang-zh-only">附录 · AgentSession 编排 深度 trace</span><span class="lang-en-only">Appendix · deep trace for AgentSession orchestration</span></h3>
-
-    <div class="lang-zh-only"><p>本章 (07) 属于 Phase「入口」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
-    <div class="lang-en-only"><p>Chapter (07) belongs to Phase «Intake». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
-
-    <table class="cmp">
-      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
+    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+      <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
       <tbody>
-      <tr><td>1</td><td>AgentSession</td><td>prompt()</td></tr>
-      <tr><td>2</td><td>agentLoop</td><td>订阅</td></tr>
-      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
-      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
-      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
-      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
+      <tr><td>cp 09</td><td>Stateful Agent</td><td><code>stateful-agent</code></td><td><code>packages/agent/src/agent.ts</code></td></tr>
+      <tr><td>cp 13</td><td>Composition Root</td><td><code>composition-root</code></td><td><code>packages/coding-agent/src/core/agent-session.ts · sdk.ts</code></td></tr>
       </tbody>
     </table>
-
-    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/agent-session.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// AgentSession</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 07 · AgentSession 编排</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 07 · AgentSession 编排</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 07 · AgentSession 编排</span></span>
-    </div>
-
-    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
-
-    <div class="lang-zh-only"><p><strong>AgentMessage</strong> — agent-core 内部消息 IR</p></div>
-    <div class="lang-en-only"><p><strong>AgentMessage</strong> — agent-core internal message IR</p></div>
-
-    <div class="lang-zh-only"><p><strong>StreamFn</strong> — 可注入的模型流函数</p></div>
-    <div class="lang-en-only"><p><strong>StreamFn</strong> — injectable model stream function</p></div>
-
-    <div class="lang-zh-only"><p><strong>leafId</strong> — JSONL 会话树当前叶</p></div>
-    <div class="lang-en-only"><p><strong>leafId</strong> — JSONL session tree current leaf</p></div>
-
-    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
-
-    <div class="note">
-      <span class="lang-zh-only">[07.1] 在 AgentSession 编排 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[07.1] At AgentSession orchestration stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[07.2] 在 AgentSession 编排 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[07.2] At AgentSession orchestration stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[07.3] 在 AgentSession 编排 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[07.3] At AgentSession orchestration stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[07.4] 在 AgentSession 编排 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[07.4] At AgentSession orchestration stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[07.5] 在 AgentSession 编排 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[07.5] At AgentSession orchestration stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[07.6] 在 AgentSession 编排 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[07.6] At AgentSession orchestration stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[07.7] 在 AgentSession 编排 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[07.7] At AgentSession orchestration stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[07.8] 在 AgentSession 编排 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[07.8] At AgentSession orchestration stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
   </section>
 
   <section class="chap" id="c8">
@@ -2975,21 +2360,33 @@
     <div class="lang-en-only"><p>Before the through-line prompt reaches the model, <code>ResourceLoader</code> <strong>stacks</strong> instruction files from <code>~/.pi/AGENTS.md</code> to project root into system context.</p></div>
 
     <div class="ladder">
-      <div class="ladder-step">
-        <div class="ladder-num">01</div>
-        <div class="ladder-body"><span class="lang-zh-only">~/.pi/AGENTS.md</span><span class="lang-en-only">全局 harness 指令</span></div>
+      <div class="ld-row">
+        <div class="ld-num">01</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">~/.pi/AGENTS.md</span><span class="lang-en-only">全局 harness 指令</span></div>
+
+        </div>
       </div>
-      <div class="ladder-step">
-        <div class="ladder-num">02</div>
-        <div class="ladder-body"><span class="lang-zh-only">~/.pi/PROJECT.md</span><span class="lang-en-only">用户级项目偏好</span></div>
+      <div class="ld-row">
+        <div class="ld-num">02</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">~/.pi/PROJECT.md</span><span class="lang-en-only">用户级项目偏好</span></div>
+
+        </div>
       </div>
-      <div class="ladder-step">
-        <div class="ladder-num">03</div>
-        <div class="ladder-body"><span class="lang-zh-only">./AGENTS.md</span><span class="lang-en-only">仓库级规则</span></div>
+      <div class="ld-row">
+        <div class="ld-num">03</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">./AGENTS.md</span><span class="lang-en-only">仓库级规则</span></div>
+
+        </div>
       </div>
-      <div class="ladder-step">
-        <div class="ladder-num">04</div>
-        <div class="ladder-body"><span class="lang-zh-only">./subdir/AGENTS.md</span><span class="lang-en-only">子目录覆盖（若存在）</span></div>
+      <div class="ld-row">
+        <div class="ld-num">04</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">./subdir/AGENTS.md</span><span class="lang-en-only">子目录覆盖（若存在）</span></div>
+
+        </div>
       </div>
     </div>
 
@@ -3032,154 +2429,6 @@
     <div class="note">
       <span class="lang-zh-only">本章 (08) 在主线 prompt「从 ~/.pi 到项目根的指令叠加」路径上负责：<strong>AGENTS.md 上下文栈</strong>。回到 C02 的 22 站地图定位这一章。</span>
       <span class="lang-en-only">Chapter (08) on the through-line path handles: <strong>The AGENTS.md context stack</strong>. Return to C02's 22-station map to locate this chapter.</span>
-    </div>
-
-    <table class="cmp">
-      <thead><tr><th>路径</th><th>说明</th></tr></thead>
-      <tbody>
-      <tr><td><code>packages/coding-agent/src/cli.ts</code></td><td>CLI 入口</td></tr>
-      <tr><td><code>packages/coding-agent/src/main.ts</code></td><td>模式分发</td></tr>
-      <tr><td><code>packages/coding-agent/src/core/agent-session.ts</code></td><td>中枢调度</td></tr>
-      <tr><td><code>packages/coding-agent/src/core/resource-loader.ts</code></td><td>AGENTS.md 栈</td></tr>
-      </tbody>
-    </table>
-
-    <h3 class="sub"><span class="lang-zh-only">AGENTS.md 上下文栈 · 实现清单</span><span class="lang-en-only">The AGENTS.md context stack · implementation checklist</span></h3>
-
-    <div class="note">
-      <span class="lang-zh-only">1. 定位生产文件：packages/agent/src/agent-loop.ts</span>
-      <span class="lang-en-only">1. Locate production file: packages/agent/src/agent-loop.ts</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">2. 对照 pi-textbook 同主题 checkpoint</span>
-      <span class="lang-en-only">2. Cross-read matching pi-textbook checkpoint</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">3. 用 --verbose 观察 AgentEvent</span>
-      <span class="lang-en-only">3. Observe AgentEvents with --verbose</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">4. 检查 JSONL 会话文件对应 entry</span>
-      <span class="lang-en-only">4. Inspect matching JSONL session entry</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">5. 阅读 packages/*/test/ 下相关测试</span>
-      <span class="lang-en-only">5. Read related tests under packages/*/test/</span>
-    </div>
-
-    <h3 class="sub"><span class="lang-zh-only">Coding Tools 目录</span><span class="lang-en-only">Coding tools catalog</span></h3>    <table class="cmp">
-      <thead><tr><th>Tool</th><th>名称</th><th>实现要点</th></tr></thead>
-      <tbody>
-      <tr><td>read</td><td>读取文件</td><td>UTF-8 · 二进制检测 · 路径解析</td></tr>
-      <tr><td>write</td><td>写入文件</td><td>创建/覆盖 · 权限检查</td></tr>
-      <tr><td>edit</td><td>编辑文件</td><td>search/replace 块</td></tr>
-      <tr><td>bash</td><td>执行 shell</td><td>cwd 继承 · 超时 · 输出截断</td></tr>
-      <tr><td>glob</td><td>文件匹配</td><td>ripgrep 风格</td></tr>
-      <tr><td>grep</td><td>内容搜索</td><td>正则 · 上下文行</td></tr>
-      </tbody>
-    </table>
-
-    <h3 class="sub"><span class="lang-zh-only">附录 · AGENTS.md 上下文栈 深度 trace</span><span class="lang-en-only">Appendix · deep trace for The AGENTS.md context stack</span></h3>
-
-    <div class="lang-zh-only"><p>本章 (08) 属于 Phase「入口」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
-    <div class="lang-en-only"><p>Chapter (08) belongs to Phase «Intake». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
-
-    <table class="cmp">
-      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
-      <tbody>
-      <tr><td>1</td><td>AGENTS.md 上下文栈</td><td>从 ~/.pi 到项目根的指令叠加</td></tr>
-      <tr><td>2</td><td>—</td><td>checkpoint 2</td></tr>
-      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
-      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
-      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
-      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
-      </tbody>
-    </table>
-
-    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// default trace</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 08 · AGENTS.md 上下文栈</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 08 · AGENTS.md 上下文栈</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 08 · AGENTS.md 上下文栈</span></span>
-    </div>
-
-    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
-
-    <div class="lang-zh-only"><p><strong>AgentMessage</strong> — agent-core 内部消息 IR</p></div>
-    <div class="lang-en-only"><p><strong>AgentMessage</strong> — agent-core internal message IR</p></div>
-
-    <div class="lang-zh-only"><p><strong>StreamFn</strong> — 可注入的模型流函数</p></div>
-    <div class="lang-en-only"><p><strong>StreamFn</strong> — injectable model stream function</p></div>
-
-    <div class="lang-zh-only"><p><strong>leafId</strong> — JSONL 会话树当前叶</p></div>
-    <div class="lang-en-only"><p><strong>leafId</strong> — JSONL session tree current leaf</p></div>
-
-    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
-
-    <div class="note">
-      <span class="lang-zh-only">[08.1] 在 AGENTS.md 上下文栈 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[08.1] At The AGENTS.md context stack stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[08.2] 在 AGENTS.md 上下文栈 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[08.2] At The AGENTS.md context stack stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[08.3] 在 AGENTS.md 上下文栈 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[08.3] At The AGENTS.md context stack stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[08.4] 在 AGENTS.md 上下文栈 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[08.4] At The AGENTS.md context stack stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[08.5] 在 AGENTS.md 上下文栈 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[08.5] At The AGENTS.md context stack stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[08.6] 在 AGENTS.md 上下文栈 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[08.6] At The AGENTS.md context stack stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[08.7] 在 AGENTS.md 上下文栈 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[08.7] At The AGENTS.md context stack stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[08.8] 在 AGENTS.md 上下文栈 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[08.8] At The AGENTS.md context stack stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
     </div>
   </section>
 
@@ -3232,6 +2481,40 @@
       <div class="out"><span class="lang-zh-only">主线 prompt 在三层各出现一次</span><span class="lang-en-only">Through-line prompt appears once per layer</span></div>
     </div>
 
+    <figure>
+      <div class="figbox"><div class="pi-fig"><svg viewBox="0 0 720 230" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true" class="pi-svg">
+  <defs>
+    <marker id="pi-arr" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 Z" fill="#1f5c8c"/>
+    </marker>
+  </defs>
+  <rect x="40" y="50" width="180" height="160" rx="4" class="svg-box accent"/>
+  <text x="130" y="78" text-anchor="middle" class="svg-label">CANONICAL</text>
+  <text x="130" y="110" text-anchor="middle" class="svg-body">AgentMessage[]</text>
+  <text x="130" y="130" text-anchor="middle" class="svg-mute">JSONL transcript</text>
+  <text x="130" y="150" text-anchor="middle" class="svg-mute">user · assistant</text>
+  <text x="130" y="168" text-anchor="middle" class="svg-mute">toolResult · custom</text>
+  <rect x="270" y="50" width="180" height="160" rx="4" class="svg-box copper"/>
+  <text x="360" y="78" text-anchor="middle" class="svg-label">LLM PROJECTION</text>
+  <text x="360" y="110" text-anchor="middle" class="svg-body">Message[]</text>
+  <text x="360" y="130" text-anchor="middle" class="svg-mute">convertToLlm()</text>
+  <text x="360" y="150" text-anchor="middle" class="svg-mute">streamSimple boundary</text>
+  <rect x="500" y="50" width="180" height="160" rx="4" class="svg-box gpu"/>
+  <text x="590" y="78" text-anchor="middle" class="svg-label">TUI PROJECTION</text>
+  <text x="590" y="110" text-anchor="middle" class="svg-body">Rendered cells</text>
+  <text x="590" y="130" text-anchor="middle" class="svg-mute">Markdown · tool cards</text>
+  <path d="M220 130 L270 130" class="svg-arrow"/>
+  <path d="M450 130 L500 130" class="svg-arrow"/>
+  <text x="245" y="122" class="svg-micro">convert</text>
+  <text x="475" y="122" class="svg-micro">render</text>
+</svg></div></div>
+      <figcaption>
+        <span class="figid">FIG</span>
+        <span class="lang-zh-only">三层投影：transcript 是唯一真相源；LLM 与 TUI 各取所需字段。</span>
+        <span class="lang-en-only">Three projections: transcript is single source of truth; LLM and TUI each take needed fields.</span>
+      </figcaption>
+    </figure>
+
     <div class="note copper">
       <span class="lang-zh-only">📘 <strong>pi-textbook checkpoint 03</strong>：Message IR（<code>types.ts</code>）· 生产映射：<code>packages/agent/src/types.ts · packages/coding-agent/src/core/messages.ts</code></span>
       <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 03</strong>: Message IR (<code>types.ts</code>) · production: <code>packages/agent/src/types.ts · packages/coding-agent/src/core/messages.ts</code></span>
@@ -3240,160 +2523,6 @@
     <div class="note">
       <span class="lang-zh-only">本章 (09) 在主线 prompt「AgentMessage ≠ Message」路径上负责：<strong>两层消息模型</strong>。回到 C02 的 22 站地图定位这一章。</span>
       <span class="lang-en-only">Chapter (09) on the through-line path handles: <strong>Two-layer message model</strong>. Return to C02's 22-station map to locate this chapter.</span>
-    </div>
-
-    <table class="cmp">
-      <thead><tr><th>路径</th><th>说明</th></tr></thead>
-      <tbody>
-      <tr><td><code>packages/agent/src/agent-loop.ts</code></td><td>runLoop 双环</td></tr>
-      <tr><td><code>packages/agent/src/types.ts</code></td><td>AgentMessage / AgentEvent</td></tr>
-      <tr><td><code>packages/coding-agent/src/core/tools/</code></td><td>coding tools</td></tr>
-      </tbody>
-    </table>
-
-    <h3 class="sub"><span class="lang-zh-only">两层消息模型 · 实现清单</span><span class="lang-en-only">Two-layer message model · implementation checklist</span></h3>
-
-    <div class="note">
-      <span class="lang-zh-only">1. 定位生产文件：packages/agent/src/agent-loop.ts</span>
-      <span class="lang-en-only">1. Locate production file: packages/agent/src/agent-loop.ts</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">2. 对照 pi-textbook 同主题 checkpoint</span>
-      <span class="lang-en-only">2. Cross-read matching pi-textbook checkpoint</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">3. 用 --verbose 观察 AgentEvent</span>
-      <span class="lang-en-only">3. Observe AgentEvents with --verbose</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">4. 检查 JSONL 会话文件对应 entry</span>
-      <span class="lang-en-only">4. Inspect matching JSONL session entry</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">5. 阅读 packages/*/test/ 下相关测试</span>
-      <span class="lang-en-only">5. Read related tests under packages/*/test/</span>
-    </div>
-
-    <h3 class="sub"><span class="lang-zh-only">AgentEvent 完整目录</span><span class="lang-en-only">Full AgentEvent catalog</span></h3>    <table class="cmp">
-      <thead><tr><th>事件</th><th>中文</th><th>主线关联</th></tr></thead>
-      <tbody>
-      <tr><td><code>agent_start</code></td><td>循环开始</td><td>AgentSession 订阅</td></tr>
-      <tr><td><code>agent_end</code></td><td>循环结束</td><td>返回 messages[]</td></tr>
-      <tr><td><code>turn_start</code></td><td>新 turn</td><td>可能含 steering</td></tr>
-      <tr><td><code>turn_end</code></td><td>turn 结束</td><td>附带 toolResults</td></tr>
-      <tr><td><code>message_start</code></td><td>消息开始</td><td>user/assistant/tool</td></tr>
-      <tr><td><code>message_update</code></td><td>流式更新</td><td>text_delta/toolcall_delta</td></tr>
-      <tr><td><code>message_end</code></td><td>消息结束</td><td>触发 JSONL 写入</td></tr>
-      <tr><td><code>tool_execution_start</code></td><td>工具开始</td><td>read/write/bash</td></tr>
-      <tr><td><code>tool_execution_update</code></td><td>工具进度</td><td>bash 流式输出</td></tr>
-      <tr><td><code>tool_execution_end</code></td><td>工具结束</td><td>结果截断</td></tr>
-      </tbody>
-    </table>
-
-    <h3 class="sub"><span class="lang-zh-only">附录 · 两层消息模型 深度 trace</span><span class="lang-en-only">Appendix · deep trace for Two-layer message model</span></h3>
-
-    <div class="lang-zh-only"><p>本章 (09) 属于 Phase「心脏」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
-    <div class="lang-en-only"><p>Chapter (09) belongs to Phase «Heart». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
-
-    <table class="cmp">
-      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
-      <tbody>
-      <tr><td>1</td><td>两层消息模型</td><td>AgentMessage ≠ Message</td></tr>
-      <tr><td>2</td><td>—</td><td>checkpoint 2</td></tr>
-      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
-      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
-      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
-      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
-      </tbody>
-    </table>
-
-    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/types.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// AgentMessage</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 09 · 两层消息模型</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/messages.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// convertToLlm</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 09 · 两层消息模型</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 09 · 两层消息模型</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 09 · 两层消息模型</span></span>
-    </div>
-
-    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
-
-    <div class="lang-zh-only"><p><strong>convertToLlm</strong> — AgentMessage → Message[] 投影</p></div>
-    <div class="lang-en-only"><p><strong>convertToLlm</strong> — AgentMessage → Message[] projection</p></div>
-
-    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
-
-    <div class="note">
-      <span class="lang-zh-only">[09.1] 在 两层消息模型 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[09.1] At Two-layer message model stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[09.2] 在 两层消息模型 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[09.2] At Two-layer message model stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[09.3] 在 两层消息模型 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[09.3] At Two-layer message model stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[09.4] 在 两层消息模型 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[09.4] At Two-layer message model stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[09.5] 在 两层消息模型 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[09.5] At Two-layer message model stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[09.6] 在 两层消息模型 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[09.6] At Two-layer message model stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[09.7] 在 两层消息模型 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[09.7] At Two-layer message model stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[09.8] 在 两层消息模型 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[09.8] At Two-layer message model stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
     </div>
   </section>
 
@@ -3422,18 +2551,59 @@
 
     <h3 class="sub"><span class="lang-zh-only">主线 prompt 的两圈 model stream</span><span class="lang-en-only">Two model streams for through-line prompt</span></h3>
 
+    <figure>
+      <div class="figbox"><div class="pi-fig"><svg viewBox="0 0 720 250" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true" class="pi-svg">
+  <defs>
+    <marker id="pi-arr" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 Z" fill="#1f5c8c"/>
+    </marker>
+  </defs>
+  <rect x="30" y="40" width="660" height="200" rx="6" fill="none" stroke="#1f5c8c" stroke-width="2" stroke-dasharray="8 4"/>
+  <text x="50" y="64" class="svg-label" fill="#1f5c8c">OUTER LOOP · follow-up queue</text>
+  <rect x="60" y="80" width="600" height="140" rx="4" fill="none" stroke="#b35a1f" stroke-width="2"/>
+  <text x="80" y="104" class="svg-label" fill="#b35a1f">INNER LOOP · tools + steering</text>
+  <rect x="100" y="120" width="120" height="44" rx="3" class="svg-box accent"/>
+  <text x="160" y="148" text-anchor="middle" class="svg-body">stream</text>
+  <path d="M220 142 L250 142" class="svg-arrow"/>
+  <rect x="250" y="120" width="100" height="44" rx="3" class="svg-box copper"/>
+  <text x="300" y="148" text-anchor="middle" class="svg-body">toolUse?</text>
+  <path d="M350 142 L380 142" class="svg-arrow"/>
+  <rect x="380" y="120" width="100" height="44" rx="3" class="svg-box asm"/>
+  <text x="430" y="148" text-anchor="middle" class="svg-body">execute</text>
+  <path d="M480 142 L510 142" class="svg-arrow"/>
+  <rect x="510" y="120" width="120" height="44" rx="3" class="svg-box accent"/>
+  <text x="570" y="148" text-anchor="middle" class="svg-body">stream again</text>
+  <path d="M570 164 L570 188 L120 188 L120 164" fill="none" stroke="#b35a1f" stroke-dasharray="4 3"/>
+  <text x="360" y="210" text-anchor="middle" class="svg-mute">README prompt: 2× stream · 1× read tool</text>
+</svg></div></div>
+      <figcaption>
+        <span class="figid">FIG</span>
+        <span class="lang-zh-only">runLoop 双环：外环处理 follow-up；内环处理 tool batch 与 steering 注入。</span>
+        <span class="lang-en-only">runLoop twin loops: outer handles follow-up; inner handles tool batch and steering injection.</span>
+      </figcaption>
+    </figure>
+
     <div class="ladder">
-      <div class="ladder-step">
-        <div class="ladder-num">01</div>
-        <div class="ladder-body"><span class="lang-zh-only">Turn 1</span><span class="lang-en-only">user → assistant(toolUse: read)</span></div>
+      <div class="ld-row">
+        <div class="ld-num">01</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">Turn 1</span><span class="lang-en-only">user → assistant(toolUse: read)</span></div>
+
+        </div>
       </div>
-      <div class="ladder-step">
-        <div class="ladder-num">02</div>
-        <div class="ladder-body"><span class="lang-zh-only">Tool batch</span><span class="lang-en-only">executeTool(read) → toolResult</span></div>
+      <div class="ld-row">
+        <div class="ld-num">02</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">Tool batch</span><span class="lang-en-only">executeTool(read) → toolResult</span></div>
+
+        </div>
       </div>
-      <div class="ladder-step">
-        <div class="ladder-num">03</div>
-        <div class="ladder-body"><span class="lang-zh-only">Turn 2</span><span class="lang-en-only">context+result → assistant(stop)</span></div>
+      <div class="ld-row">
+        <div class="ld-num">03</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">Turn 2</span><span class="lang-en-only">context+result → assistant(stop)</span></div>
+
+        </div>
       </div>
     </div>
 
@@ -3509,128 +2679,16 @@
       <span class="src-line"><span class="src-comment">     // 内环：tool+steer / inner: tool+steer</span></span>
       <span class="src-line"><span class="src-ln">  3</span> <span class="src-hl">await streamAssistantResponse(...)</span></span>
       <span class="src-line"><span class="src-comment">     // 调 LLM / call LLM</span></span>
-      <span class="src-line"><span class="src-ln">  4</span> <span class="src-hl">if (message.stopReason === 'toolUse')</span></span>
-      <span class="src-line"><span class="src-comment">     // 需要工具 / needs tools</span></span>
-      <span class="src-line"><span class="src-ln">  5</span> <span class="src-hl">await executeToolCalls(...)</span></span>
+      <span class="src-line"><span class="src-ln">  4</span> <span class="src-hl">await executeToolCalls(...)</span></span>
       <span class="src-line"><span class="src-comment">     // 执行 read 等 / execute read etc</span></span>
     </div>
 
     <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
       <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
       <tbody>
-      <tr><td>07</td><td>Agent Loop</td><td>agent-loop.ts</td><td>packages/agent/src/agent-loop.ts</td></tr>
-      <tr><td>09</td><td>Stateful Agent</td><td>stateful-agent</td><td>packages/agent/src/agent.ts</td></tr>
+      <tr><td>cp 07</td><td>Agent Loop</td><td><code>agent-loop.ts</code></td><td><code>packages/agent/src/agent-loop.ts</code></td></tr>
       </tbody>
     </table>
-
-    <h3 class="sub"><span class="lang-zh-only">AgentEvent 完整目录</span><span class="lang-en-only">Full AgentEvent catalog</span></h3>    <table class="cmp">
-      <thead><tr><th>事件</th><th>中文</th><th>主线关联</th></tr></thead>
-      <tbody>
-      <tr><td><code>agent_start</code></td><td>循环开始</td><td>AgentSession 订阅</td></tr>
-      <tr><td><code>agent_end</code></td><td>循环结束</td><td>返回 messages[]</td></tr>
-      <tr><td><code>turn_start</code></td><td>新 turn</td><td>可能含 steering</td></tr>
-      <tr><td><code>turn_end</code></td><td>turn 结束</td><td>附带 toolResults</td></tr>
-      <tr><td><code>message_start</code></td><td>消息开始</td><td>user/assistant/tool</td></tr>
-      <tr><td><code>message_update</code></td><td>流式更新</td><td>text_delta/toolcall_delta</td></tr>
-      <tr><td><code>message_end</code></td><td>消息结束</td><td>触发 JSONL 写入</td></tr>
-      <tr><td><code>tool_execution_start</code></td><td>工具开始</td><td>read/write/bash</td></tr>
-      <tr><td><code>tool_execution_update</code></td><td>工具进度</td><td>bash 流式输出</td></tr>
-      <tr><td><code>tool_execution_end</code></td><td>工具结束</td><td>结果截断</td></tr>
-      </tbody>
-    </table>
-
-    <h3 class="sub"><span class="lang-zh-only">附录 · runLoop 双环 深度 trace</span><span class="lang-en-only">Appendix · deep trace for The runLoop twin loops</span></h3>
-
-    <div class="lang-zh-only"><p>本章 (10) 属于 Phase「心脏」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
-    <div class="lang-en-only"><p>Chapter (10) belongs to Phase «Heart». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
-
-    <table class="cmp">
-      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
-      <tbody>
-      <tr><td>1</td><td>runLoop</td><td>外环启动</td></tr>
-      <tr><td>2</td><td>inner</td><td>streamAssistantResponse</td></tr>
-      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
-      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
-      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
-      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
-      </tbody>
-    </table>
-
-    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// runLoop</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 10 · runLoop 双环</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 10 · runLoop 双环</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 10 · runLoop 双环</span></span>
-    </div>
-
-    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
-
-    <div class="lang-zh-only"><p><strong>runLoop</strong> — 外环 follow-up + 内环 tool</p></div>
-    <div class="lang-en-only"><p><strong>runLoop</strong> — outer follow-up + inner tool loop</p></div>
-
-    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
-
-    <div class="note">
-      <span class="lang-zh-only">[10.1] 在 runLoop 双环 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[10.1] At The runLoop twin loops stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[10.2] 在 runLoop 双环 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[10.2] At The runLoop twin loops stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[10.3] 在 runLoop 双环 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[10.3] At The runLoop twin loops stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[10.4] 在 runLoop 双环 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[10.4] At The runLoop twin loops stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[10.5] 在 runLoop 双环 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[10.5] At The runLoop twin loops stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[10.6] 在 runLoop 双环 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[10.6] At The runLoop twin loops stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[10.7] 在 runLoop 双环 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[10.7] At The runLoop twin loops stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[10.8] 在 runLoop 双环 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[10.8] At The runLoop twin loops stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
   </section>
 
   <section class="chap" id="c11">
@@ -3676,151 +2734,6 @@
       <span class="lang-zh-only">本章 (11) 在主线 prompt「运行中插队与结束后续」路径上负责：<strong>Steering 与 Follow-up</strong>。回到 C02 的 22 站地图定位这一章。</span>
       <span class="lang-en-only">Chapter (11) on the through-line path handles: <strong>Steering and follow-up</strong>. Return to C02's 22-station map to locate this chapter.</span>
     </div>
-
-    <table class="cmp">
-      <thead><tr><th>路径</th><th>说明</th></tr></thead>
-      <tbody>
-      <tr><td><code>packages/agent/src/agent-loop.ts</code></td><td>runLoop 双环</td></tr>
-      <tr><td><code>packages/agent/src/types.ts</code></td><td>AgentMessage / AgentEvent</td></tr>
-      <tr><td><code>packages/coding-agent/src/core/tools/</code></td><td>coding tools</td></tr>
-      </tbody>
-    </table>
-
-    <h3 class="sub"><span class="lang-zh-only">Steering 与 Follow-up · 实现清单</span><span class="lang-en-only">Steering and follow-up · implementation checklist</span></h3>
-
-    <div class="note">
-      <span class="lang-zh-only">1. 定位生产文件：packages/agent/src/agent-loop.ts</span>
-      <span class="lang-en-only">1. Locate production file: packages/agent/src/agent-loop.ts</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">2. 对照 pi-textbook 同主题 checkpoint</span>
-      <span class="lang-en-only">2. Cross-read matching pi-textbook checkpoint</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">3. 用 --verbose 观察 AgentEvent</span>
-      <span class="lang-en-only">3. Observe AgentEvents with --verbose</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">4. 检查 JSONL 会话文件对应 entry</span>
-      <span class="lang-en-only">4. Inspect matching JSONL session entry</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">5. 阅读 packages/*/test/ 下相关测试</span>
-      <span class="lang-en-only">5. Read related tests under packages/*/test/</span>
-    </div>
-
-    <h3 class="sub"><span class="lang-zh-only">AgentEvent 完整目录</span><span class="lang-en-only">Full AgentEvent catalog</span></h3>    <table class="cmp">
-      <thead><tr><th>事件</th><th>中文</th><th>主线关联</th></tr></thead>
-      <tbody>
-      <tr><td><code>agent_start</code></td><td>循环开始</td><td>AgentSession 订阅</td></tr>
-      <tr><td><code>agent_end</code></td><td>循环结束</td><td>返回 messages[]</td></tr>
-      <tr><td><code>turn_start</code></td><td>新 turn</td><td>可能含 steering</td></tr>
-      <tr><td><code>turn_end</code></td><td>turn 结束</td><td>附带 toolResults</td></tr>
-      <tr><td><code>message_start</code></td><td>消息开始</td><td>user/assistant/tool</td></tr>
-      <tr><td><code>message_update</code></td><td>流式更新</td><td>text_delta/toolcall_delta</td></tr>
-      <tr><td><code>message_end</code></td><td>消息结束</td><td>触发 JSONL 写入</td></tr>
-      <tr><td><code>tool_execution_start</code></td><td>工具开始</td><td>read/write/bash</td></tr>
-      <tr><td><code>tool_execution_update</code></td><td>工具进度</td><td>bash 流式输出</td></tr>
-      <tr><td><code>tool_execution_end</code></td><td>工具结束</td><td>结果截断</td></tr>
-      </tbody>
-    </table>
-
-    <h3 class="sub"><span class="lang-zh-only">附录 · Steering 与 Follow-up 深度 trace</span><span class="lang-en-only">Appendix · deep trace for Steering and follow-up</span></h3>
-
-    <div class="lang-zh-only"><p>本章 (11) 属于 Phase「心脏」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
-    <div class="lang-en-only"><p>Chapter (11) belongs to Phase «Heart». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
-
-    <table class="cmp">
-      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
-      <tbody>
-      <tr><td>1</td><td>Steering 与 Follow-up</td><td>运行中插队与结束后续</td></tr>
-      <tr><td>2</td><td>—</td><td>checkpoint 2</td></tr>
-      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
-      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
-      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
-      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
-      </tbody>
-    </table>
-
-    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// default trace</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 11 · Steering 与 Follow-up</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 11 · Steering 与 Follow-up</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 11 · Steering 与 Follow-up</span></span>
-    </div>
-
-    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
-
-    <div class="lang-zh-only"><p><strong>steering</strong> — 运行中插队消息</p></div>
-    <div class="lang-en-only"><p><strong>steering</strong> — mid-run injected messages</p></div>
-
-    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
-
-    <div class="note">
-      <span class="lang-zh-only">[11.1] 在 Steering 与 Follow-up 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[11.1] At Steering and follow-up stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[11.2] 在 Steering 与 Follow-up 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[11.2] At Steering and follow-up stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[11.3] 在 Steering 与 Follow-up 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[11.3] At Steering and follow-up stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[11.4] 在 Steering 与 Follow-up 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[11.4] At Steering and follow-up stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[11.5] 在 Steering 与 Follow-up 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[11.5] At Steering and follow-up stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[11.6] 在 Steering 与 Follow-up 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[11.6] At Steering and follow-up stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[11.7] 在 Steering 与 Follow-up 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[11.7] At Steering and follow-up stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[11.8] 在 Steering 与 Follow-up 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[11.8] At Steering and follow-up stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
   </section>
 
   <section class="chap" id="c12">
@@ -3861,25 +2774,40 @@
     <h3 class="sub"><span class="lang-zh-only">read README 的完整路径</span><span class="lang-en-only">Full path of read README</span></h3>
 
     <div class="ladder">
-      <div class="ladder-step">
-        <div class="ladder-num">01</div>
-        <div class="ladder-body"><span class="lang-zh-only">validateToolArguments</span><span class="lang-en-only">{ "path": "README.md" }</span></div>
+      <div class="ld-row">
+        <div class="ld-num">01</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">validateToolArguments</span><span class="lang-en-only">{ "path": "README.md" }</span></div>
+
+        </div>
       </div>
-      <div class="ladder-step">
-        <div class="ladder-num">02</div>
-        <div class="ladder-body"><span class="lang-zh-only">resolvePath(cwd)</span><span class="lang-en-only">绝对路径</span></div>
+      <div class="ld-row">
+        <div class="ld-num">02</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">resolvePath(cwd)</span><span class="lang-en-only">绝对路径</span></div>
+
+        </div>
       </div>
-      <div class="ladder-step">
-        <div class="ladder-num">03</div>
-        <div class="ladder-body"><span class="lang-zh-only">readFileSync</span><span class="lang-en-only">UTF-8 内容</span></div>
+      <div class="ld-row">
+        <div class="ld-num">03</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">readFileSync</span><span class="lang-en-only">UTF-8 内容</span></div>
+
+        </div>
       </div>
-      <div class="ladder-step">
-        <div class="ladder-num">04</div>
-        <div class="ladder-body"><span class="lang-zh-only">truncate if needed</span><span class="lang-en-only">默认 max length</span></div>
+      <div class="ld-row">
+        <div class="ld-num">04</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">truncate if needed</span><span class="lang-en-only">默认 max length</span></div>
+
+        </div>
       </div>
-      <div class="ladder-step">
-        <div class="ladder-num">05</div>
-        <div class="ladder-body"><span class="lang-zh-only">toolResult AgentMessage</span><span class="lang-en-only">toolCallId=call_1</span></div>
+      <div class="ld-row">
+        <div class="ld-num">05</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">toolResult AgentMessage</span><span class="lang-en-only">toolCallId=call_1</span></div>
+
+        </div>
       </div>
     </div>
 
@@ -3906,169 +2834,6 @@
       <span class="src-line"><span class="src-comment">// Through-line: parallel vs sequential · length 截断</span></span>
       <span class="src-line"><span class="src-comment">// Phase: 心脏 / Heart</span></span>
       <span class="src-line"><span class="src-kw">await</span> <span class="src-fn">traceTurn</span>({ <span class="src-arg">prompt</span>: <span class="src-str">"README.md"</span> });</span>
-    </div>
-
-    <table class="cmp">
-      <thead><tr><th>路径</th><th>说明</th></tr></thead>
-      <tbody>
-      <tr><td><code>packages/agent/src/agent-loop.ts</code></td><td>runLoop 双环</td></tr>
-      <tr><td><code>packages/agent/src/types.ts</code></td><td>AgentMessage / AgentEvent</td></tr>
-      <tr><td><code>packages/coding-agent/src/core/tools/</code></td><td>coding tools</td></tr>
-      </tbody>
-    </table>
-
-    <h3 class="sub"><span class="lang-zh-only">Tool 执行管线 · 实现清单</span><span class="lang-en-only">Tool execution pipeline · implementation checklist</span></h3>
-
-    <div class="note">
-      <span class="lang-zh-only">1. 定位生产文件：packages/agent/src/agent-loop.ts</span>
-      <span class="lang-en-only">1. Locate production file: packages/agent/src/agent-loop.ts</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">2. 对照 pi-textbook 同主题 checkpoint</span>
-      <span class="lang-en-only">2. Cross-read matching pi-textbook checkpoint</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">3. 用 --verbose 观察 AgentEvent</span>
-      <span class="lang-en-only">3. Observe AgentEvents with --verbose</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">4. 检查 JSONL 会话文件对应 entry</span>
-      <span class="lang-en-only">4. Inspect matching JSONL session entry</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">5. 阅读 packages/*/test/ 下相关测试</span>
-      <span class="lang-en-only">5. Read related tests under packages/*/test/</span>
-    </div>
-
-    <h3 class="sub"><span class="lang-zh-only">AgentEvent 完整目录</span><span class="lang-en-only">Full AgentEvent catalog</span></h3>    <table class="cmp">
-      <thead><tr><th>事件</th><th>中文</th><th>主线关联</th></tr></thead>
-      <tbody>
-      <tr><td><code>agent_start</code></td><td>循环开始</td><td>AgentSession 订阅</td></tr>
-      <tr><td><code>agent_end</code></td><td>循环结束</td><td>返回 messages[]</td></tr>
-      <tr><td><code>turn_start</code></td><td>新 turn</td><td>可能含 steering</td></tr>
-      <tr><td><code>turn_end</code></td><td>turn 结束</td><td>附带 toolResults</td></tr>
-      <tr><td><code>message_start</code></td><td>消息开始</td><td>user/assistant/tool</td></tr>
-      <tr><td><code>message_update</code></td><td>流式更新</td><td>text_delta/toolcall_delta</td></tr>
-      <tr><td><code>message_end</code></td><td>消息结束</td><td>触发 JSONL 写入</td></tr>
-      <tr><td><code>tool_execution_start</code></td><td>工具开始</td><td>read/write/bash</td></tr>
-      <tr><td><code>tool_execution_update</code></td><td>工具进度</td><td>bash 流式输出</td></tr>
-      <tr><td><code>tool_execution_end</code></td><td>工具结束</td><td>结果截断</td></tr>
-      </tbody>
-    </table>
-
-    <h3 class="sub"><span class="lang-zh-only">Coding Tools 目录</span><span class="lang-en-only">Coding tools catalog</span></h3>    <table class="cmp">
-      <thead><tr><th>Tool</th><th>名称</th><th>实现要点</th></tr></thead>
-      <tbody>
-      <tr><td>read</td><td>读取文件</td><td>UTF-8 · 二进制检测 · 路径解析</td></tr>
-      <tr><td>write</td><td>写入文件</td><td>创建/覆盖 · 权限检查</td></tr>
-      <tr><td>edit</td><td>编辑文件</td><td>search/replace 块</td></tr>
-      <tr><td>bash</td><td>执行 shell</td><td>cwd 继承 · 超时 · 输出截断</td></tr>
-      <tr><td>glob</td><td>文件匹配</td><td>ripgrep 风格</td></tr>
-      <tr><td>grep</td><td>内容搜索</td><td>正则 · 上下文行</td></tr>
-      </tbody>
-    </table>
-
-    <h3 class="sub"><span class="lang-zh-only">附录 · Tool 执行管线 深度 trace</span><span class="lang-en-only">Appendix · deep trace for Tool execution pipeline</span></h3>
-
-    <div class="lang-zh-only"><p>本章 (12) 属于 Phase「心脏」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
-    <div class="lang-en-only"><p>Chapter (12) belongs to Phase «Heart». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
-
-    <table class="cmp">
-      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
-      <tbody>
-      <tr><td>1</td><td>toolUse</td><td>read call_1</td></tr>
-      <tr><td>2</td><td>executeTool</td><td>README 内容</td></tr>
-      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
-      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
-      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
-      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
-      </tbody>
-    </table>
-
-    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// default trace</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 12 · Tool 执行管线</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 12 · Tool 执行管线</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 12 · Tool 执行管线</span></span>
-    </div>
-
-    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
-
-    <div class="lang-zh-only"><p><strong>AgentMessage</strong> — agent-core 内部消息 IR</p></div>
-    <div class="lang-en-only"><p><strong>AgentMessage</strong> — agent-core internal message IR</p></div>
-
-    <div class="lang-zh-only"><p><strong>StreamFn</strong> — 可注入的模型流函数</p></div>
-    <div class="lang-en-only"><p><strong>StreamFn</strong> — injectable model stream function</p></div>
-
-    <div class="lang-zh-only"><p><strong>leafId</strong> — JSONL 会话树当前叶</p></div>
-    <div class="lang-en-only"><p><strong>leafId</strong> — JSONL session tree current leaf</p></div>
-
-    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
-
-    <div class="note">
-      <span class="lang-zh-only">[12.1] 在 Tool 执行管线 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[12.1] At Tool execution pipeline stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[12.2] 在 Tool 执行管线 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[12.2] At Tool execution pipeline stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[12.3] 在 Tool 执行管线 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[12.3] At Tool execution pipeline stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[12.4] 在 Tool 执行管线 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[12.4] At Tool execution pipeline stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[12.5] 在 Tool 执行管线 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[12.5] At Tool execution pipeline stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[12.6] 在 Tool 执行管线 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[12.6] At Tool execution pipeline stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[12.7] 在 Tool 执行管线 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[12.7] At Tool execution pipeline stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[12.8] 在 Tool 执行管线 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[12.8] At Tool execution pipeline stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
     </div>
   </section>
 
@@ -4112,6 +2877,20 @@
     <div class="lang-zh-only"><p>简化版：agent_start → turn_start → message_start(user) → message_end(user) → message_update×N → message_end(assistant) → tool_execution_* → message_update×M → message_end(assistant) → turn_end → agent_end。</p></div>
     <div class="lang-en-only"><p>Simplified: agent_start → turn_start → message_start(user) → … → agent_end.</p></div>
 
+    <figure>
+      <div class="figbox"><div class="pi-fig wide"><svg viewBox="0 0 720 400" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true" class="pi-svg">
+  <defs>
+    <marker id="pi-arr" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 Z" fill="#1f5c8c"/>
+    </marker>
+  </defs><text x="24" y="22" class="svg-label">AgentEvent swimlane · README through-line</text><text x="24" y="56" class="svg-micro" fill="#b35a1f">user</text><line x1="70" y1="52" x2="700" y2="52" stroke="#ebe5d8"/><text x="24" y="156" class="svg-micro" fill="#1f5c8c">model</text><line x1="70" y1="152" x2="700" y2="152" stroke="#ebe5d8"/><text x="24" y="256" class="svg-micro" fill="#6b3aa3">loop</text><line x1="70" y1="252" x2="700" y2="252" stroke="#ebe5d8"/><text x="24" y="356" class="svg-micro" fill="#2d6a4f">tool</text><line x1="70" y1="352" x2="700" y2="352" stroke="#ebe5d8"/><rect x="90" y="40" width="56" height="24" rx="2" fill="#faf6ed" stroke="#c7c4ba"/><text x="118" y="56" text-anchor="middle" class="svg-micro">user_messa</text><rect x="160" y="140" width="56" height="24" rx="2" fill="#faf6ed" stroke="#c7c4ba"/><text x="188" y="156" text-anchor="middle" class="svg-micro">model_star</text><rect x="230" y="140" width="56" height="24" rx="2" fill="#faf6ed" stroke="#c7c4ba"/><text x="258" y="156" text-anchor="middle" class="svg-micro">assistant </text><rect x="300" y="240" width="56" height="24" rx="2" fill="#faf6ed" stroke="#c7c4ba"/><text x="328" y="256" text-anchor="middle" class="svg-micro">tool_start</text><rect x="370" y="340" width="56" height="24" rx="2" fill="#faf6ed" stroke="#c7c4ba"/><text x="398" y="356" text-anchor="middle" class="svg-micro">tool_resul</text><rect x="440" y="140" width="56" height="24" rx="2" fill="#faf6ed" stroke="#c7c4ba"/><text x="468" y="156" text-anchor="middle" class="svg-micro">model_star</text><rect x="510" y="140" width="56" height="24" rx="2" fill="#faf6ed" stroke="#c7c4ba"/><text x="538" y="156" text-anchor="middle" class="svg-micro">assistant </text></svg></div></div>
+      <figcaption>
+        <span class="figid">FIG</span>
+        <span class="lang-zh-only">事件泳道图：同一主线在 user/model/loop/tool 四条泳道上的时序。</span>
+        <span class="lang-en-only">Event swimlane: through-line timing across user/model/loop/tool lanes.</span>
+      </figcaption>
+    </figure>
+
     <div class="note copper">
       <span class="lang-zh-only">📘 <strong>pi-textbook checkpoint 01</strong>：TypeScript 生存集（<code>events.ts</code>）· 生产映射：<code></code></span>
       <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 01</strong>: TypeScript 生存集 (<code>events.ts</code>) · production: <code></code></span>
@@ -4125,157 +2904,6 @@
     <div class="note">
       <span class="lang-zh-only">本章 (13) 在主线 prompt「message_update 如何驱动 TUI」路径上负责：<strong>事件总线</strong>。回到 C02 的 22 站地图定位这一章。</span>
       <span class="lang-en-only">Chapter (13) on the through-line path handles: <strong>The event bus</strong>. Return to C02's 22-station map to locate this chapter.</span>
-    </div>
-
-    <table class="cmp">
-      <thead><tr><th>路径</th><th>说明</th></tr></thead>
-      <tbody>
-      <tr><td><code>packages/agent/src/agent-loop.ts</code></td><td>runLoop 双环</td></tr>
-      <tr><td><code>packages/agent/src/types.ts</code></td><td>AgentMessage / AgentEvent</td></tr>
-      <tr><td><code>packages/coding-agent/src/core/tools/</code></td><td>coding tools</td></tr>
-      </tbody>
-    </table>
-
-    <h3 class="sub"><span class="lang-zh-only">事件总线 · 实现清单</span><span class="lang-en-only">The event bus · implementation checklist</span></h3>
-
-    <div class="note">
-      <span class="lang-zh-only">1. 定位生产文件：packages/agent/src/agent-loop.ts</span>
-      <span class="lang-en-only">1. Locate production file: packages/agent/src/agent-loop.ts</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">2. 对照 pi-textbook 同主题 checkpoint</span>
-      <span class="lang-en-only">2. Cross-read matching pi-textbook checkpoint</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">3. 用 --verbose 观察 AgentEvent</span>
-      <span class="lang-en-only">3. Observe AgentEvents with --verbose</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">4. 检查 JSONL 会话文件对应 entry</span>
-      <span class="lang-en-only">4. Inspect matching JSONL session entry</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">5. 阅读 packages/*/test/ 下相关测试</span>
-      <span class="lang-en-only">5. Read related tests under packages/*/test/</span>
-    </div>
-
-    <h3 class="sub"><span class="lang-zh-only">AgentEvent 完整目录</span><span class="lang-en-only">Full AgentEvent catalog</span></h3>    <table class="cmp">
-      <thead><tr><th>事件</th><th>中文</th><th>主线关联</th></tr></thead>
-      <tbody>
-      <tr><td><code>agent_start</code></td><td>循环开始</td><td>AgentSession 订阅</td></tr>
-      <tr><td><code>agent_end</code></td><td>循环结束</td><td>返回 messages[]</td></tr>
-      <tr><td><code>turn_start</code></td><td>新 turn</td><td>可能含 steering</td></tr>
-      <tr><td><code>turn_end</code></td><td>turn 结束</td><td>附带 toolResults</td></tr>
-      <tr><td><code>message_start</code></td><td>消息开始</td><td>user/assistant/tool</td></tr>
-      <tr><td><code>message_update</code></td><td>流式更新</td><td>text_delta/toolcall_delta</td></tr>
-      <tr><td><code>message_end</code></td><td>消息结束</td><td>触发 JSONL 写入</td></tr>
-      <tr><td><code>tool_execution_start</code></td><td>工具开始</td><td>read/write/bash</td></tr>
-      <tr><td><code>tool_execution_update</code></td><td>工具进度</td><td>bash 流式输出</td></tr>
-      <tr><td><code>tool_execution_end</code></td><td>工具结束</td><td>结果截断</td></tr>
-      </tbody>
-    </table>
-
-    <h3 class="sub"><span class="lang-zh-only">附录 · 事件总线 深度 trace</span><span class="lang-en-only">Appendix · deep trace for The event bus</span></h3>
-
-    <div class="lang-zh-only"><p>本章 (13) 属于 Phase「心脏」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
-    <div class="lang-en-only"><p>Chapter (13) belongs to Phase «Heart». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
-
-    <table class="cmp">
-      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
-      <tbody>
-      <tr><td>1</td><td>事件总线</td><td>message_update 如何驱动 TUI</td></tr>
-      <tr><td>2</td><td>—</td><td>checkpoint 2</td></tr>
-      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
-      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
-      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
-      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
-      </tbody>
-    </table>
-
-    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// default trace</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 13 · 事件总线</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 13 · 事件总线</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 13 · 事件总线</span></span>
-    </div>
-
-    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
-
-    <div class="lang-zh-only"><p><strong>AgentMessage</strong> — agent-core 内部消息 IR</p></div>
-    <div class="lang-en-only"><p><strong>AgentMessage</strong> — agent-core internal message IR</p></div>
-
-    <div class="lang-zh-only"><p><strong>StreamFn</strong> — 可注入的模型流函数</p></div>
-    <div class="lang-en-only"><p><strong>StreamFn</strong> — injectable model stream function</p></div>
-
-    <div class="lang-zh-only"><p><strong>leafId</strong> — JSONL 会话树当前叶</p></div>
-    <div class="lang-en-only"><p><strong>leafId</strong> — JSONL session tree current leaf</p></div>
-
-    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
-
-    <div class="note">
-      <span class="lang-zh-only">[13.1] 在 事件总线 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[13.1] At The event bus stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[13.2] 在 事件总线 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[13.2] At The event bus stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[13.3] 在 事件总线 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[13.3] At The event bus stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[13.4] 在 事件总线 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[13.4] At The event bus stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[13.5] 在 事件总线 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[13.5] At The event bus stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[13.6] 在 事件总线 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[13.6] At The event bus stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[13.7] 在 事件总线 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[13.7] At The event bus stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[13.8] 在 事件总线 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[13.8] At The event bus stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
     </div>
   </section>
 
@@ -4332,154 +2960,6 @@
       <span class="src-line"><span class="src-comment">// Phase: LLM / LLM</span></span>
       <span class="src-line"><span class="src-kw">await</span> <span class="src-fn">traceTurn</span>({ <span class="src-arg">prompt</span>: <span class="src-str">"README.md"</span> });</span>
     </div>
-
-    <table class="cmp">
-      <thead><tr><th>路径</th><th>说明</th></tr></thead>
-      <tbody>
-      <tr><td><code>packages/ai/src/stream.ts</code></td><td>streamSimple</td></tr>
-      <tr><td><code>packages/ai/src/utils/event-stream.ts</code></td><td>EventStream</td></tr>
-      <tr><td><code>packages/ai/src/models.ts</code></td><td>模型目录</td></tr>
-      <tr><td><code>packages/ai/src/api/</code></td><td>provider adapters</td></tr>
-      </tbody>
-    </table>
-
-    <h3 class="sub"><span class="lang-zh-only">pi-ai 提供商抽象 · 实现清单</span><span class="lang-en-only">pi-ai provider abstraction · implementation checklist</span></h3>
-
-    <div class="note">
-      <span class="lang-zh-only">1. 定位生产文件：packages/agent/src/agent-loop.ts</span>
-      <span class="lang-en-only">1. Locate production file: packages/agent/src/agent-loop.ts</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">2. 对照 pi-textbook 同主题 checkpoint</span>
-      <span class="lang-en-only">2. Cross-read matching pi-textbook checkpoint</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">3. 用 --verbose 观察 AgentEvent</span>
-      <span class="lang-en-only">3. Observe AgentEvents with --verbose</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">4. 检查 JSONL 会话文件对应 entry</span>
-      <span class="lang-en-only">4. Inspect matching JSONL session entry</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">5. 阅读 packages/*/test/ 下相关测试</span>
-      <span class="lang-en-only">5. Read related tests under packages/*/test/</span>
-    </div>
-
-    <h3 class="sub"><span class="lang-zh-only">pi-ai 流事件目录</span><span class="lang-en-only">pi-ai stream event catalog</span></h3>    <table class="cmp">
-      <thead><tr><th>事件</th><th>名称</th><th>说明</th></tr></thead>
-      <tbody>
-      <tr><td>start</td><td>流开始</td><td>model id · usage 初始化</td></tr>
-      <tr><td>text_delta</td><td>文本增量</td><td>TUI 逐字显示</td></tr>
-      <tr><td>toolcall_delta</td><td>工具调用增量</td><td>JSON 参数组装</td></tr>
-      <tr><td>thinking_delta</td><td>思考增量</td><td>reasoning 模型</td></tr>
-      <tr><td>done</td><td>流结束</td><td>stopReason 确定</td></tr>
-      <tr><td>error</td><td>流错误</td><td>重试判定</td></tr>
-      </tbody>
-    </table>
-
-    <h3 class="sub"><span class="lang-zh-only">附录 · pi-ai 提供商抽象 深度 trace</span><span class="lang-en-only">Appendix · deep trace for pi-ai provider abstraction</span></h3>
-
-    <div class="lang-zh-only"><p>本章 (14) 属于 Phase「LLM」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
-    <div class="lang-en-only"><p>Chapter (14) belongs to Phase «LLM». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
-
-    <table class="cmp">
-      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
-      <tbody>
-      <tr><td>1</td><td>streamSimple</td><td>SSE 连接</td></tr>
-      <tr><td>2</td><td>EventStream</td><td>delta 推送</td></tr>
-      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
-      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
-      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
-      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
-      </tbody>
-    </table>
-
-    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/ai/src/stream.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// streamSimple</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 14 · pi-ai 提供商抽象</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 14 · pi-ai 提供商抽象</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 14 · pi-ai 提供商抽象</span></span>
-    </div>
-
-    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
-
-    <div class="lang-zh-only"><p><strong>AgentMessage</strong> — agent-core 内部消息 IR</p></div>
-    <div class="lang-en-only"><p><strong>AgentMessage</strong> — agent-core internal message IR</p></div>
-
-    <div class="lang-zh-only"><p><strong>StreamFn</strong> — 可注入的模型流函数</p></div>
-    <div class="lang-en-only"><p><strong>StreamFn</strong> — injectable model stream function</p></div>
-
-    <div class="lang-zh-only"><p><strong>leafId</strong> — JSONL 会话树当前叶</p></div>
-    <div class="lang-en-only"><p><strong>leafId</strong> — JSONL session tree current leaf</p></div>
-
-    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
-
-    <div class="note">
-      <span class="lang-zh-only">[14.1] 在 pi-ai 提供商抽象 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[14.1] At pi-ai provider abstraction stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[14.2] 在 pi-ai 提供商抽象 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[14.2] At pi-ai provider abstraction stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[14.3] 在 pi-ai 提供商抽象 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[14.3] At pi-ai provider abstraction stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[14.4] 在 pi-ai 提供商抽象 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[14.4] At pi-ai provider abstraction stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[14.5] 在 pi-ai 提供商抽象 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[14.5] At pi-ai provider abstraction stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[14.6] 在 pi-ai 提供商抽象 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[14.6] At pi-ai provider abstraction stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[14.7] 在 pi-ai 提供商抽象 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[14.7] At pi-ai provider abstraction stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[14.8] 在 pi-ai 提供商抽象 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[14.8] At pi-ai provider abstraction stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
   </section>
 
   <section class="chap" id="c15">
@@ -4520,154 +3000,6 @@
       <span class="lang-zh-only">本章 (15) 在主线 prompt「text_delta · toolcall_delta · done」路径上负责：<strong>流式 EventStream</strong>。回到 C02 的 22 站地图定位这一章。</span>
       <span class="lang-en-only">Chapter (15) on the through-line path handles: <strong>Streaming EventStream</strong>. Return to C02's 22-station map to locate this chapter.</span>
     </div>
-
-    <table class="cmp">
-      <thead><tr><th>路径</th><th>说明</th></tr></thead>
-      <tbody>
-      <tr><td><code>packages/ai/src/stream.ts</code></td><td>streamSimple</td></tr>
-      <tr><td><code>packages/ai/src/utils/event-stream.ts</code></td><td>EventStream</td></tr>
-      <tr><td><code>packages/ai/src/models.ts</code></td><td>模型目录</td></tr>
-      <tr><td><code>packages/ai/src/api/</code></td><td>provider adapters</td></tr>
-      </tbody>
-    </table>
-
-    <h3 class="sub"><span class="lang-zh-only">流式 EventStream · 实现清单</span><span class="lang-en-only">Streaming EventStream · implementation checklist</span></h3>
-
-    <div class="note">
-      <span class="lang-zh-only">1. 定位生产文件：packages/agent/src/agent-loop.ts</span>
-      <span class="lang-en-only">1. Locate production file: packages/agent/src/agent-loop.ts</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">2. 对照 pi-textbook 同主题 checkpoint</span>
-      <span class="lang-en-only">2. Cross-read matching pi-textbook checkpoint</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">3. 用 --verbose 观察 AgentEvent</span>
-      <span class="lang-en-only">3. Observe AgentEvents with --verbose</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">4. 检查 JSONL 会话文件对应 entry</span>
-      <span class="lang-en-only">4. Inspect matching JSONL session entry</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">5. 阅读 packages/*/test/ 下相关测试</span>
-      <span class="lang-en-only">5. Read related tests under packages/*/test/</span>
-    </div>
-
-    <h3 class="sub"><span class="lang-zh-only">pi-ai 流事件目录</span><span class="lang-en-only">pi-ai stream event catalog</span></h3>    <table class="cmp">
-      <thead><tr><th>事件</th><th>名称</th><th>说明</th></tr></thead>
-      <tbody>
-      <tr><td>start</td><td>流开始</td><td>model id · usage 初始化</td></tr>
-      <tr><td>text_delta</td><td>文本增量</td><td>TUI 逐字显示</td></tr>
-      <tr><td>toolcall_delta</td><td>工具调用增量</td><td>JSON 参数组装</td></tr>
-      <tr><td>thinking_delta</td><td>思考增量</td><td>reasoning 模型</td></tr>
-      <tr><td>done</td><td>流结束</td><td>stopReason 确定</td></tr>
-      <tr><td>error</td><td>流错误</td><td>重试判定</td></tr>
-      </tbody>
-    </table>
-
-    <h3 class="sub"><span class="lang-zh-only">附录 · 流式 EventStream 深度 trace</span><span class="lang-en-only">Appendix · deep trace for Streaming EventStream</span></h3>
-
-    <div class="lang-zh-only"><p>本章 (15) 属于 Phase「LLM」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
-    <div class="lang-en-only"><p>Chapter (15) belongs to Phase «LLM». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
-
-    <table class="cmp">
-      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
-      <tbody>
-      <tr><td>1</td><td>流式 EventStream</td><td>text_delta · toolcall_delta · done</td></tr>
-      <tr><td>2</td><td>—</td><td>checkpoint 2</td></tr>
-      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
-      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
-      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
-      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
-      </tbody>
-    </table>
-
-    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// default trace</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 15 · 流式 EventStream</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 15 · 流式 EventStream</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 15 · 流式 EventStream</span></span>
-    </div>
-
-    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
-
-    <div class="lang-zh-only"><p><strong>AgentMessage</strong> — agent-core 内部消息 IR</p></div>
-    <div class="lang-en-only"><p><strong>AgentMessage</strong> — agent-core internal message IR</p></div>
-
-    <div class="lang-zh-only"><p><strong>StreamFn</strong> — 可注入的模型流函数</p></div>
-    <div class="lang-en-only"><p><strong>StreamFn</strong> — injectable model stream function</p></div>
-
-    <div class="lang-zh-only"><p><strong>leafId</strong> — JSONL 会话树当前叶</p></div>
-    <div class="lang-en-only"><p><strong>leafId</strong> — JSONL session tree current leaf</p></div>
-
-    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
-
-    <div class="note">
-      <span class="lang-zh-only">[15.1] 在 流式 EventStream 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[15.1] At Streaming EventStream stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[15.2] 在 流式 EventStream 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[15.2] At Streaming EventStream stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[15.3] 在 流式 EventStream 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[15.3] At Streaming EventStream stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[15.4] 在 流式 EventStream 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[15.4] At Streaming EventStream stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[15.5] 在 流式 EventStream 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[15.5] At Streaming EventStream stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[15.6] 在 流式 EventStream 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[15.6] At Streaming EventStream stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[15.7] 在 流式 EventStream 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[15.7] At Streaming EventStream stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[15.8] 在 流式 EventStream 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[15.8] At Streaming EventStream stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
   </section>
 
   <section class="chap" id="c16">
@@ -4706,154 +3038,6 @@
       <span class="lang-zh-only">本章 (16) 在主线 prompt「40+ providers · OAuth · models.generated.ts」路径上负责：<strong>认证与模型目录</strong>。回到 C02 的 22 站地图定位这一章。</span>
       <span class="lang-en-only">Chapter (16) on the through-line path handles: <strong>Auth and model catalog</strong>. Return to C02's 22-station map to locate this chapter.</span>
     </div>
-
-    <table class="cmp">
-      <thead><tr><th>路径</th><th>说明</th></tr></thead>
-      <tbody>
-      <tr><td><code>packages/ai/src/stream.ts</code></td><td>streamSimple</td></tr>
-      <tr><td><code>packages/ai/src/utils/event-stream.ts</code></td><td>EventStream</td></tr>
-      <tr><td><code>packages/ai/src/models.ts</code></td><td>模型目录</td></tr>
-      <tr><td><code>packages/ai/src/api/</code></td><td>provider adapters</td></tr>
-      </tbody>
-    </table>
-
-    <h3 class="sub"><span class="lang-zh-only">认证与模型目录 · 实现清单</span><span class="lang-en-only">Auth and model catalog · implementation checklist</span></h3>
-
-    <div class="note">
-      <span class="lang-zh-only">1. 定位生产文件：packages/agent/src/agent-loop.ts</span>
-      <span class="lang-en-only">1. Locate production file: packages/agent/src/agent-loop.ts</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">2. 对照 pi-textbook 同主题 checkpoint</span>
-      <span class="lang-en-only">2. Cross-read matching pi-textbook checkpoint</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">3. 用 --verbose 观察 AgentEvent</span>
-      <span class="lang-en-only">3. Observe AgentEvents with --verbose</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">4. 检查 JSONL 会话文件对应 entry</span>
-      <span class="lang-en-only">4. Inspect matching JSONL session entry</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">5. 阅读 packages/*/test/ 下相关测试</span>
-      <span class="lang-en-only">5. Read related tests under packages/*/test/</span>
-    </div>
-
-    <h3 class="sub"><span class="lang-zh-only">pi-ai 流事件目录</span><span class="lang-en-only">pi-ai stream event catalog</span></h3>    <table class="cmp">
-      <thead><tr><th>事件</th><th>名称</th><th>说明</th></tr></thead>
-      <tbody>
-      <tr><td>start</td><td>流开始</td><td>model id · usage 初始化</td></tr>
-      <tr><td>text_delta</td><td>文本增量</td><td>TUI 逐字显示</td></tr>
-      <tr><td>toolcall_delta</td><td>工具调用增量</td><td>JSON 参数组装</td></tr>
-      <tr><td>thinking_delta</td><td>思考增量</td><td>reasoning 模型</td></tr>
-      <tr><td>done</td><td>流结束</td><td>stopReason 确定</td></tr>
-      <tr><td>error</td><td>流错误</td><td>重试判定</td></tr>
-      </tbody>
-    </table>
-
-    <h3 class="sub"><span class="lang-zh-only">附录 · 认证与模型目录 深度 trace</span><span class="lang-en-only">Appendix · deep trace for Auth and model catalog</span></h3>
-
-    <div class="lang-zh-only"><p>本章 (16) 属于 Phase「LLM」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
-    <div class="lang-en-only"><p>Chapter (16) belongs to Phase «LLM». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
-
-    <table class="cmp">
-      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
-      <tbody>
-      <tr><td>1</td><td>认证与模型目录</td><td>40+ providers · OAuth · models.generated.ts</td></tr>
-      <tr><td>2</td><td>—</td><td>checkpoint 2</td></tr>
-      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
-      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
-      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
-      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
-      </tbody>
-    </table>
-
-    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// default trace</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 16 · 认证与模型目录</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 16 · 认证与模型目录</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 16 · 认证与模型目录</span></span>
-    </div>
-
-    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
-
-    <div class="lang-zh-only"><p><strong>AgentMessage</strong> — agent-core 内部消息 IR</p></div>
-    <div class="lang-en-only"><p><strong>AgentMessage</strong> — agent-core internal message IR</p></div>
-
-    <div class="lang-zh-only"><p><strong>StreamFn</strong> — 可注入的模型流函数</p></div>
-    <div class="lang-en-only"><p><strong>StreamFn</strong> — injectable model stream function</p></div>
-
-    <div class="lang-zh-only"><p><strong>leafId</strong> — JSONL 会话树当前叶</p></div>
-    <div class="lang-en-only"><p><strong>leafId</strong> — JSONL session tree current leaf</p></div>
-
-    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
-
-    <div class="note">
-      <span class="lang-zh-only">[16.1] 在 认证与模型目录 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[16.1] At Auth and model catalog stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[16.2] 在 认证与模型目录 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[16.2] At Auth and model catalog stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[16.3] 在 认证与模型目录 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[16.3] At Auth and model catalog stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[16.4] 在 认证与模型目录 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[16.4] At Auth and model catalog stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[16.5] 在 认证与模型目录 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[16.5] At Auth and model catalog stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[16.6] 在 认证与模型目录 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[16.6] At Auth and model catalog stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[16.7] 在 认证与模型目录 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[16.7] At Auth and model catalog stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[16.8] 在 认证与模型目录 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[16.8] At Auth and model catalog stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
   </section>
 
   <section class="chap" id="c17">
@@ -4888,144 +3072,41 @@
     <div class="lang-zh-only"><p>AgentSession 把 message_update 交给 interactive mode → TUI 组件树 → Markdown 增量解析 → 终端 write。</p></div>
     <div class="lang-en-only"><p>AgentSession hands message_update to interactive mode → TUI component tree → incremental Markdown → terminal write.</p></div>
 
+    <figure>
+      <div class="figbox"><div class="pi-fig"><svg viewBox="0 0 720 240" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true" class="pi-svg">
+  <defs>
+    <marker id="pi-arr" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 Z" fill="#1f5c8c"/>
+    </marker>
+  </defs>
+  <text x="180" y="28" text-anchor="middle" class="svg-label">FULL REFRESH</text>
+  <text x="540" y="28" text-anchor="middle" class="svg-label">CSI 2026 DIFF</text>
+  <rect x="40" y="40" width="280" height="160" rx="4" class="svg-box muted"/>
+  <rect x="60" y="60" width="240" height="14" fill="#ebe5d8"/>
+  <rect x="60" y="78" width="240" height="14" fill="#ebe5d8"/>
+  <rect x="60" y="96" width="240" height="14" fill="#ebe5d8"/>
+  <rect x="60" y="114" width="240" height="14" fill="#ebe5d8"/>
+  <rect x="60" y="132" width="240" height="14" fill="#ebe5d8"/>
+  <text x="180" y="185" text-anchor="middle" class="svg-mute">O(screen) · flicker</text>
+  <rect x="400" y="40" width="280" height="160" rx="4" class="svg-box accent"/>
+  <rect x="420" y="60" width="240" height="14" fill="#faf6ed" opacity="0.4"/>
+  <rect x="420" y="78" width="240" height="14" fill="#faf6ed" opacity="0.4"/>
+  <rect x="420" y="96" width="240" height="14" fill="#c9dceb" stroke="#1f5c8c"/>
+  <rect x="420" y="114" width="240" height="14" fill="#faf6ed" opacity="0.4"/>
+  <rect x="420" y="132" width="240" height="14" fill="#faf6ed" opacity="0.4"/>
+  <text x="540" y="185" text-anchor="middle" class="svg-mute">O(changed lines) · stable stream</text>
+  <text x="540" y="220" text-anchor="middle" class="svg-body">firstChanged → lastChanged only</text>
+</svg></div></div>
+      <figcaption>
+        <span class="figid">FIG</span>
+        <span class="lang-zh-only">TUI 差分渲染：只重绘变更行区间，流式 token 不触发全屏闪烁。</span>
+        <span class="lang-en-only">TUI differential render: redraw only changed line range; streaming tokens avoid full-screen flicker.</span>
+      </figcaption>
+    </figure>
+
     <div class="note">
       <span class="lang-zh-only">本章 (17) 在主线 prompt「CSI 2026 · firstChanged → lastChanged」路径上负责：<strong>差分渲染 TUI</strong>。回到 C02 的 22 站地图定位这一章。</span>
       <span class="lang-en-only">Chapter (17) on the through-line path handles: <strong>Differential-render TUI</strong>. Return to C02's 22-station map to locate this chapter.</span>
-    </div>
-
-    <table class="cmp">
-      <thead><tr><th>路径</th><th>说明</th></tr></thead>
-      <tbody>
-      <tr><td><code>packages/tui/src/tui.ts</code></td><td>差分渲染</td></tr>
-      <tr><td><code>packages/tui/src/components/editor.ts</code></td><td>输入编辑器</td></tr>
-      <tr><td><code>packages/tui/src/components/markdown.ts</code></td><td>Markdown 渲染</td></tr>
-      </tbody>
-    </table>
-
-    <h3 class="sub"><span class="lang-zh-only">差分渲染 TUI · 实现清单</span><span class="lang-en-only">Differential-render TUI · implementation checklist</span></h3>
-
-    <div class="note">
-      <span class="lang-zh-only">1. 定位生产文件：packages/agent/src/agent-loop.ts</span>
-      <span class="lang-en-only">1. Locate production file: packages/agent/src/agent-loop.ts</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">2. 对照 pi-textbook 同主题 checkpoint</span>
-      <span class="lang-en-only">2. Cross-read matching pi-textbook checkpoint</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">3. 用 --verbose 观察 AgentEvent</span>
-      <span class="lang-en-only">3. Observe AgentEvents with --verbose</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">4. 检查 JSONL 会话文件对应 entry</span>
-      <span class="lang-en-only">4. Inspect matching JSONL session entry</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">5. 阅读 packages/*/test/ 下相关测试</span>
-      <span class="lang-en-only">5. Read related tests under packages/*/test/</span>
-    </div>
-
-    <h3 class="sub"><span class="lang-zh-only">附录 · 差分渲染 TUI 深度 trace</span><span class="lang-en-only">Appendix · deep trace for Differential-render TUI</span></h3>
-
-    <div class="lang-zh-only"><p>本章 (17) 属于 Phase「终端」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
-    <div class="lang-en-only"><p>Chapter (17) belongs to Phase «Terminal». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
-
-    <table class="cmp">
-      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
-      <tbody>
-      <tr><td>1</td><td>message_update</td><td>TUI 收到</td></tr>
-      <tr><td>2</td><td>tui.ts</td><td>CSI 2026 差分</td></tr>
-      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
-      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
-      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
-      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
-      </tbody>
-    </table>
-
-    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/tui/src/tui.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// diff render</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 17 · 差分渲染 TUI</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 17 · 差分渲染 TUI</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 17 · 差分渲染 TUI</span></span>
-    </div>
-
-    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
-
-    <div class="lang-zh-only"><p><strong>AgentMessage</strong> — agent-core 内部消息 IR</p></div>
-    <div class="lang-en-only"><p><strong>AgentMessage</strong> — agent-core internal message IR</p></div>
-
-    <div class="lang-zh-only"><p><strong>StreamFn</strong> — 可注入的模型流函数</p></div>
-    <div class="lang-en-only"><p><strong>StreamFn</strong> — injectable model stream function</p></div>
-
-    <div class="lang-zh-only"><p><strong>leafId</strong> — JSONL 会话树当前叶</p></div>
-    <div class="lang-en-only"><p><strong>leafId</strong> — JSONL session tree current leaf</p></div>
-
-    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
-
-    <div class="note">
-      <span class="lang-zh-only">[17.1] 在 差分渲染 TUI 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[17.1] At Differential-render TUI stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[17.2] 在 差分渲染 TUI 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[17.2] At Differential-render TUI stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[17.3] 在 差分渲染 TUI 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[17.3] At Differential-render TUI stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[17.4] 在 差分渲染 TUI 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[17.4] At Differential-render TUI stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[17.5] 在 差分渲染 TUI 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[17.5] At Differential-render TUI stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[17.6] 在 差分渲染 TUI 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[17.6] At Differential-render TUI stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[17.7] 在 差分渲染 TUI 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[17.7] At Differential-render TUI stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[17.8] 在 差分渲染 TUI 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[17.8] At Differential-render TUI stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
     </div>
   </section>
 
@@ -5065,141 +3146,6 @@
       <span class="lang-zh-only">本章 (18) 在主线 prompt「Editor · Markdown · tool renderers」路径上负责：<strong>Interactive Mode</strong>。回到 C02 的 22 站地图定位这一章。</span>
       <span class="lang-en-only">Chapter (18) on the through-line path handles: <strong>Interactive mode</strong>. Return to C02's 22-station map to locate this chapter.</span>
     </div>
-
-    <table class="cmp">
-      <thead><tr><th>路径</th><th>说明</th></tr></thead>
-      <tbody>
-      <tr><td><code>packages/tui/src/tui.ts</code></td><td>差分渲染</td></tr>
-      <tr><td><code>packages/tui/src/components/editor.ts</code></td><td>输入编辑器</td></tr>
-      <tr><td><code>packages/tui/src/components/markdown.ts</code></td><td>Markdown 渲染</td></tr>
-      </tbody>
-    </table>
-
-    <h3 class="sub"><span class="lang-zh-only">Interactive Mode · 实现清单</span><span class="lang-en-only">Interactive mode · implementation checklist</span></h3>
-
-    <div class="note">
-      <span class="lang-zh-only">1. 定位生产文件：packages/agent/src/agent-loop.ts</span>
-      <span class="lang-en-only">1. Locate production file: packages/agent/src/agent-loop.ts</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">2. 对照 pi-textbook 同主题 checkpoint</span>
-      <span class="lang-en-only">2. Cross-read matching pi-textbook checkpoint</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">3. 用 --verbose 观察 AgentEvent</span>
-      <span class="lang-en-only">3. Observe AgentEvents with --verbose</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">4. 检查 JSONL 会话文件对应 entry</span>
-      <span class="lang-en-only">4. Inspect matching JSONL session entry</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">5. 阅读 packages/*/test/ 下相关测试</span>
-      <span class="lang-en-only">5. Read related tests under packages/*/test/</span>
-    </div>
-
-    <h3 class="sub"><span class="lang-zh-only">附录 · Interactive Mode 深度 trace</span><span class="lang-en-only">Appendix · deep trace for Interactive mode</span></h3>
-
-    <div class="lang-zh-only"><p>本章 (18) 属于 Phase「终端」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
-    <div class="lang-en-only"><p>Chapter (18) belongs to Phase «Terminal». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
-
-    <table class="cmp">
-      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
-      <tbody>
-      <tr><td>1</td><td>Interactive Mode</td><td>Editor · Markdown · tool renderers</td></tr>
-      <tr><td>2</td><td>—</td><td>checkpoint 2</td></tr>
-      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
-      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
-      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
-      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
-      </tbody>
-    </table>
-
-    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// default trace</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 18 · Interactive Mode</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 18 · Interactive Mode</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 18 · Interactive Mode</span></span>
-    </div>
-
-    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
-
-    <div class="lang-zh-only"><p><strong>AgentMessage</strong> — agent-core 内部消息 IR</p></div>
-    <div class="lang-en-only"><p><strong>AgentMessage</strong> — agent-core internal message IR</p></div>
-
-    <div class="lang-zh-only"><p><strong>StreamFn</strong> — 可注入的模型流函数</p></div>
-    <div class="lang-en-only"><p><strong>StreamFn</strong> — injectable model stream function</p></div>
-
-    <div class="lang-zh-only"><p><strong>leafId</strong> — JSONL 会话树当前叶</p></div>
-    <div class="lang-en-only"><p><strong>leafId</strong> — JSONL session tree current leaf</p></div>
-
-    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
-
-    <div class="note">
-      <span class="lang-zh-only">[18.1] 在 Interactive Mode 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[18.1] At Interactive mode stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[18.2] 在 Interactive Mode 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[18.2] At Interactive mode stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[18.3] 在 Interactive Mode 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[18.3] At Interactive mode stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[18.4] 在 Interactive Mode 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[18.4] At Interactive mode stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[18.5] 在 Interactive Mode 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[18.5] At Interactive mode stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[18.6] 在 Interactive Mode 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[18.6] At Interactive mode stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[18.7] 在 Interactive Mode 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[18.7] At Interactive mode stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[18.8] 在 Interactive Mode 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[18.8] At Interactive mode stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
   </section>
 
   <section class="chap" id="c19">
@@ -5231,6 +3177,37 @@
       </tbody>
     </table>
 
+    <figure>
+      <div class="figbox"><div class="pi-fig"><svg viewBox="0 0 720 220" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true" class="pi-svg">
+  <defs>
+    <marker id="pi-arr" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 Z" fill="#1f5c8c"/>
+    </marker>
+  </defs>
+  <rect x="280" y="20" width="160" height="44" rx="4" class="svg-box accent"/>
+  <text x="360" y="48" text-anchor="middle" class="svg-body">AgentSession</text>
+  <line x1="360" y1="64" x2="360" y2="88" stroke="#c7c4ba"/>
+  <rect x="240" y="88" width="240" height="36" rx="3" class="svg-box copper"/>
+  <text x="360" y="110" text-anchor="middle" class="svg-body">ExtensionRunner</text>
+  <line x1="120" y1="124" x2="600" y2="124" stroke="#c7c4ba"/>
+  <rect x="60" y="140" width="110" height="56" rx="3" class="svg-box paper"/>
+  <text x="115" y="172" text-anchor="middle" class="svg-micro">session_start</text>
+  <rect x="190" y="140" width="110" height="56" rx="3" class="svg-box paper"/>
+  <text x="245" y="172" text-anchor="middle" class="svg-micro">tool_call</text>
+  <rect x="320" y="140" width="110" height="56" rx="3" class="svg-box paper"/>
+  <text x="375" y="172" text-anchor="middle" class="svg-micro">before_compact</text>
+  <rect x="450" y="140" width="110" height="56" rx="3" class="svg-box paper"/>
+  <text x="505" y="172" text-anchor="middle" class="svg-micro">registerTool</text>
+  <rect x="580" y="140" width="110" height="56" rx="3" class="svg-box paper"/>
+  <text x="635" y="172" text-anchor="middle" class="svg-micro">message_update</text>
+</svg></div></div>
+      <figcaption>
+        <span class="figid">FIG</span>
+        <span class="lang-zh-only">Extension 钩子：ExtensionRunner 在 AgentSession 生命周期注入，无需 MCP 同进程协议。</span>
+        <span class="lang-en-only">Extension hooks: ExtensionRunner injects at AgentSession lifecycle — no MCP same-process protocol.</span>
+      </figcaption>
+    </figure>
+
     <div class="note copper">
       <span class="lang-zh-only">📘 <strong>pi-textbook checkpoint 12</strong>：Resources + Extensions（<code>resources-extensions</code>）· 生产映射：<code>packages/coding-agent/src/core/extensions/ · resource-loader.ts</code></span>
       <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 12</strong>: Resources + Extensions (<code>resources-extensions</code>) · production: <code>packages/coding-agent/src/core/extensions/ · resource-loader.ts</code></span>
@@ -5239,140 +3216,6 @@
     <div class="note">
       <span class="lang-zh-only">本章 (19) 在主线 prompt「registerTool · registerCommand · events」路径上负责：<strong>Extension API 面</strong>。回到 C02 的 22 站地图定位这一章。</span>
       <span class="lang-en-only">Chapter (19) on the through-line path handles: <strong>Extension API surface</strong>. Return to C02's 22-station map to locate this chapter.</span>
-    </div>
-
-    <table class="cmp">
-      <thead><tr><th>路径</th><th>说明</th></tr></thead>
-      <tbody>
-      <tr><td><code>packages/coding-agent/src/core/extensions/</code></td><td>Extension API</td></tr>
-      <tr><td><code>packages/coding-agent/src/core/extensions/runner.ts</code></td><td>ExtensionRunner</td></tr>
-      </tbody>
-    </table>
-
-    <h3 class="sub"><span class="lang-zh-only">Extension API 面 · 实现清单</span><span class="lang-en-only">Extension API surface · implementation checklist</span></h3>
-
-    <div class="note">
-      <span class="lang-zh-only">1. 定位生产文件：packages/agent/src/agent-loop.ts</span>
-      <span class="lang-en-only">1. Locate production file: packages/agent/src/agent-loop.ts</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">2. 对照 pi-textbook 同主题 checkpoint</span>
-      <span class="lang-en-only">2. Cross-read matching pi-textbook checkpoint</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">3. 用 --verbose 观察 AgentEvent</span>
-      <span class="lang-en-only">3. Observe AgentEvents with --verbose</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">4. 检查 JSONL 会话文件对应 entry</span>
-      <span class="lang-en-only">4. Inspect matching JSONL session entry</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">5. 阅读 packages/*/test/ 下相关测试</span>
-      <span class="lang-en-only">5. Read related tests under packages/*/test/</span>
-    </div>
-
-    <h3 class="sub"><span class="lang-zh-only">附录 · Extension API 面 深度 trace</span><span class="lang-en-only">Appendix · deep trace for Extension API surface</span></h3>
-
-    <div class="lang-zh-only"><p>本章 (19) 属于 Phase「扩展」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
-    <div class="lang-en-only"><p>Chapter (19) belongs to Phase «Extensions». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
-
-    <table class="cmp">
-      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
-      <tbody>
-      <tr><td>1</td><td>Extension API 面</td><td>registerTool · registerCommand · events</td></tr>
-      <tr><td>2</td><td>—</td><td>checkpoint 2</td></tr>
-      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
-      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
-      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
-      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
-      </tbody>
-    </table>
-
-    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/extensions/types.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// Extension API</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 19 · Extension API 面</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 19 · Extension API 面</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 19 · Extension API 面</span></span>
-    </div>
-
-    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
-
-    <div class="lang-zh-only"><p><strong>AgentMessage</strong> — agent-core 内部消息 IR</p></div>
-    <div class="lang-en-only"><p><strong>AgentMessage</strong> — agent-core internal message IR</p></div>
-
-    <div class="lang-zh-only"><p><strong>StreamFn</strong> — 可注入的模型流函数</p></div>
-    <div class="lang-en-only"><p><strong>StreamFn</strong> — injectable model stream function</p></div>
-
-    <div class="lang-zh-only"><p><strong>leafId</strong> — JSONL 会话树当前叶</p></div>
-    <div class="lang-en-only"><p><strong>leafId</strong> — JSONL session tree current leaf</p></div>
-
-    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
-
-    <div class="note">
-      <span class="lang-zh-only">[19.1] 在 Extension API 面 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[19.1] At Extension API surface stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[19.2] 在 Extension API 面 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[19.2] At Extension API surface stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[19.3] 在 Extension API 面 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[19.3] At Extension API surface stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[19.4] 在 Extension API 面 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[19.4] At Extension API surface stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[19.5] 在 Extension API 面 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[19.5] At Extension API surface stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[19.6] 在 Extension API 面 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[19.6] At Extension API surface stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[19.7] 在 Extension API 面 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[19.7] At Extension API surface stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[19.8] 在 Extension API 面 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[19.8] At Extension API surface stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
     </div>
   </section>
 
@@ -5409,140 +3252,6 @@
       <span class="lang-zh-only">本章 (20) 在主线 prompt「jiti 加载 · 事件合并 · hook 注入」路径上负责：<strong>ExtensionRunner</strong>。回到 C02 的 22 站地图定位这一章。</span>
       <span class="lang-en-only">Chapter (20) on the through-line path handles: <strong>ExtensionRunner</strong>. Return to C02's 22-station map to locate this chapter.</span>
     </div>
-
-    <table class="cmp">
-      <thead><tr><th>路径</th><th>说明</th></tr></thead>
-      <tbody>
-      <tr><td><code>packages/coding-agent/src/core/extensions/</code></td><td>Extension API</td></tr>
-      <tr><td><code>packages/coding-agent/src/core/extensions/runner.ts</code></td><td>ExtensionRunner</td></tr>
-      </tbody>
-    </table>
-
-    <h3 class="sub"><span class="lang-zh-only">ExtensionRunner · 实现清单</span><span class="lang-en-only">ExtensionRunner · implementation checklist</span></h3>
-
-    <div class="note">
-      <span class="lang-zh-only">1. 定位生产文件：packages/agent/src/agent-loop.ts</span>
-      <span class="lang-en-only">1. Locate production file: packages/agent/src/agent-loop.ts</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">2. 对照 pi-textbook 同主题 checkpoint</span>
-      <span class="lang-en-only">2. Cross-read matching pi-textbook checkpoint</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">3. 用 --verbose 观察 AgentEvent</span>
-      <span class="lang-en-only">3. Observe AgentEvents with --verbose</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">4. 检查 JSONL 会话文件对应 entry</span>
-      <span class="lang-en-only">4. Inspect matching JSONL session entry</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">5. 阅读 packages/*/test/ 下相关测试</span>
-      <span class="lang-en-only">5. Read related tests under packages/*/test/</span>
-    </div>
-
-    <h3 class="sub"><span class="lang-zh-only">附录 · ExtensionRunner 深度 trace</span><span class="lang-en-only">Appendix · deep trace for ExtensionRunner</span></h3>
-
-    <div class="lang-zh-only"><p>本章 (20) 属于 Phase「扩展」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
-    <div class="lang-en-only"><p>Chapter (20) belongs to Phase «Extensions». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
-
-    <table class="cmp">
-      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
-      <tbody>
-      <tr><td>1</td><td>ExtensionRunner</td><td>jiti 加载 · 事件合并 · hook 注入</td></tr>
-      <tr><td>2</td><td>—</td><td>checkpoint 2</td></tr>
-      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
-      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
-      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
-      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
-      </tbody>
-    </table>
-
-    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// default trace</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 20 · ExtensionRunner</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 20 · ExtensionRunner</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 20 · ExtensionRunner</span></span>
-    </div>
-
-    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
-
-    <div class="lang-zh-only"><p><strong>AgentMessage</strong> — agent-core 内部消息 IR</p></div>
-    <div class="lang-en-only"><p><strong>AgentMessage</strong> — agent-core internal message IR</p></div>
-
-    <div class="lang-zh-only"><p><strong>StreamFn</strong> — 可注入的模型流函数</p></div>
-    <div class="lang-en-only"><p><strong>StreamFn</strong> — injectable model stream function</p></div>
-
-    <div class="lang-zh-only"><p><strong>leafId</strong> — JSONL 会话树当前叶</p></div>
-    <div class="lang-en-only"><p><strong>leafId</strong> — JSONL session tree current leaf</p></div>
-
-    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
-
-    <div class="note">
-      <span class="lang-zh-only">[20.1] 在 ExtensionRunner 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[20.1] At ExtensionRunner stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[20.2] 在 ExtensionRunner 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[20.2] At ExtensionRunner stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[20.3] 在 ExtensionRunner 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[20.3] At ExtensionRunner stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[20.4] 在 ExtensionRunner 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[20.4] At ExtensionRunner stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[20.5] 在 ExtensionRunner 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[20.5] At ExtensionRunner stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[20.6] 在 ExtensionRunner 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[20.6] At ExtensionRunner stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[20.7] 在 ExtensionRunner 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[20.7] At ExtensionRunner stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[20.8] 在 ExtensionRunner 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[20.8] At ExtensionRunner stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
   </section>
 
   <section class="chap" id="c21">
@@ -5572,140 +3281,6 @@
       <span class="lang-zh-only">本章 (21) 在主线 prompt「npm · git · 可分享的 harness 能力」路径上负责：<strong>Pi Packages</strong>。回到 C02 的 22 站地图定位这一章。</span>
       <span class="lang-en-only">Chapter (21) on the through-line path handles: <strong>Pi packages</strong>. Return to C02's 22-station map to locate this chapter.</span>
     </div>
-
-    <table class="cmp">
-      <thead><tr><th>路径</th><th>说明</th></tr></thead>
-      <tbody>
-      <tr><td><code>packages/coding-agent/src/core/extensions/</code></td><td>Extension API</td></tr>
-      <tr><td><code>packages/coding-agent/src/core/extensions/runner.ts</code></td><td>ExtensionRunner</td></tr>
-      </tbody>
-    </table>
-
-    <h3 class="sub"><span class="lang-zh-only">Pi Packages · 实现清单</span><span class="lang-en-only">Pi packages · implementation checklist</span></h3>
-
-    <div class="note">
-      <span class="lang-zh-only">1. 定位生产文件：packages/agent/src/agent-loop.ts</span>
-      <span class="lang-en-only">1. Locate production file: packages/agent/src/agent-loop.ts</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">2. 对照 pi-textbook 同主题 checkpoint</span>
-      <span class="lang-en-only">2. Cross-read matching pi-textbook checkpoint</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">3. 用 --verbose 观察 AgentEvent</span>
-      <span class="lang-en-only">3. Observe AgentEvents with --verbose</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">4. 检查 JSONL 会话文件对应 entry</span>
-      <span class="lang-en-only">4. Inspect matching JSONL session entry</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">5. 阅读 packages/*/test/ 下相关测试</span>
-      <span class="lang-en-only">5. Read related tests under packages/*/test/</span>
-    </div>
-
-    <h3 class="sub"><span class="lang-zh-only">附录 · Pi Packages 深度 trace</span><span class="lang-en-only">Appendix · deep trace for Pi packages</span></h3>
-
-    <div class="lang-zh-only"><p>本章 (21) 属于 Phase「扩展」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
-    <div class="lang-en-only"><p>Chapter (21) belongs to Phase «Extensions». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
-
-    <table class="cmp">
-      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
-      <tbody>
-      <tr><td>1</td><td>Pi Packages</td><td>npm · git · 可分享的 harness 能力</td></tr>
-      <tr><td>2</td><td>—</td><td>checkpoint 2</td></tr>
-      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
-      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
-      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
-      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
-      </tbody>
-    </table>
-
-    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// default trace</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 21 · Pi Packages</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 21 · Pi Packages</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 21 · Pi Packages</span></span>
-    </div>
-
-    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
-
-    <div class="lang-zh-only"><p><strong>AgentMessage</strong> — agent-core 内部消息 IR</p></div>
-    <div class="lang-en-only"><p><strong>AgentMessage</strong> — agent-core internal message IR</p></div>
-
-    <div class="lang-zh-only"><p><strong>StreamFn</strong> — 可注入的模型流函数</p></div>
-    <div class="lang-en-only"><p><strong>StreamFn</strong> — injectable model stream function</p></div>
-
-    <div class="lang-zh-only"><p><strong>leafId</strong> — JSONL 会话树当前叶</p></div>
-    <div class="lang-en-only"><p><strong>leafId</strong> — JSONL session tree current leaf</p></div>
-
-    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
-
-    <div class="note">
-      <span class="lang-zh-only">[21.1] 在 Pi Packages 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[21.1] At Pi packages stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[21.2] 在 Pi Packages 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[21.2] At Pi packages stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[21.3] 在 Pi Packages 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[21.3] At Pi packages stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[21.4] 在 Pi Packages 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[21.4] At Pi packages stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[21.5] 在 Pi Packages 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[21.5] At Pi packages stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[21.6] 在 Pi Packages 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[21.6] At Pi packages stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[21.7] 在 Pi Packages 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[21.7] At Pi packages stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[21.8] 在 Pi Packages 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[21.8] At Pi packages stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
   </section>
 
   <section class="chap" id="c22">
@@ -5718,18 +3293,33 @@
     <div class="lang-en-only"><p>Each session is a JSONL file: <code>parentId</code> chain forms tree, <code>leafId</code> points to current leaf, <code>fork</code> creates child with <code>parentSession</code>.</p></div>
 
     <figure>
-      <div class="figbox"><div class="session-tree">
-      <div>session <code>sess_root</code></div>
-      <div class="st-node">├─ user: 「读取 README.md…」 <code>id=u1</code></div>
-      <div class="st-node">├─ assistant: toolUse read <code>id=a1</code></div>
-      <div class="st-node">├─ toolResult: README fixture <code>id=t1</code></div>
-      <div class="st-node st-leaf">└─ assistant: stop · 最终回答 <code>id=a2</code> ← leafId</div>
-      <div class="st-node" style="margin-top:12px;border-left-color:var(--copper)">fork → session <code>sess_branch</code> (parentSession=sess_root)</div>
-    </div></div>
+      <div class="figbox"><div class="pi-fig"><svg viewBox="0 0 720 270" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true" class="pi-svg">
+  <defs>
+    <marker id="pi-arr" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 Z" fill="#1f5c8c"/>
+    </marker>
+  </defs>
+  <circle cx="360" cy="36" r="8" fill="#b35a1f"/>
+  <text x="360" y="58" text-anchor="middle" class="svg-body">u-1 · user prompt</text>
+  <line x1="360" y1="44" x2="280" y2="88" stroke="#c7c4ba"/>
+  <line x1="360" y1="44" x2="480" y2="88" stroke="#c7c4ba"/>
+  <rect x="220" y="88" width="120" height="36" rx="3" class="svg-box accent"/>
+  <text x="280" y="110" text-anchor="middle" class="svg-micro">a-read · toolUse</text>
+  <rect x="420" y="88" width="120" height="36" rx="3" class="svg-box muted"/>
+  <text x="480" y="110" text-anchor="middle" class="svg-micro">a-alt · sibling</text>
+  <line x1="280" y1="124" x2="280" y2="148" stroke="#c7c4ba"/>
+  <rect x="220" y="148" width="120" height="36" rx="3" class="svg-box asm"/>
+  <text x="280" y="170" text-anchor="middle" class="svg-micro">r-read · toolResult</text>
+  <line x1="280" y1="184" x2="280" y2="208" stroke="#c7c4ba"/>
+  <rect x="220" y="208" width="120" height="36" rx="3" class="svg-box accent"/>
+  <text x="280" y="230" text-anchor="middle" class="svg-micro">a-final · stop</text>
+  <text x="520" y="170" class="svg-mute">pathTo(leaf) →</text>
+  <text x="520" y="188" class="svg-mute">u-1→a-read→r-read→a-final</text>
+</svg></div></div>
       <figcaption>
         <span class="figid">FIG</span>
-        <span class="lang-zh-only">JSONL 会话树：parentId 链 + leafId 指针 + fork 分支</span>
-        <span class="lang-en-only">JSONL session tree: parentId chain + leafId pointer + fork branch</span>
+        <span class="lang-zh-only">JSONL 会话树：parentId 构成有向树；sibling 分支不覆盖旧路径；leafId 选择 active path。</span>
+        <span class="lang-en-only">JSONL session tree: parentId forms directed tree; sibling branches don't overwrite; leafId selects active path.</span>
       </figcaption>
     </figure>
 
@@ -5806,107 +3396,17 @@
       <span class="src-line"><span class="src-ln">  2</span> <span class="src-hl">parentId: string | null</span></span>
       <span class="src-line"><span class="src-comment">     // 树边 / tree edge</span></span>
       <span class="src-line"><span class="src-ln">  3</span> <span class="src-hl">fork(fromEntryId)</span></span>
-      <span class="src-line"><span class="src-comment">     // 创建分支会话 / create branch session</span></span>
+      <span class="src-line"><span class="src-comment">     // 创建分支会话 / branch session</span></span>
       <span class="src-line"><span class="src-ln">  4</span> <span class="src-hl">getLeafId()</span></span>
-      <span class="src-line"><span class="src-comment">     // 当前叶指针 / current leaf pointer</span></span>
+      <span class="src-line"><span class="src-comment">     // 当前叶指针 / current leaf</span></span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
-
-    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">JSONL 为什么不用 SQLite？</span><span class="lang-en-only">Why JSONL not SQLite?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>可 git diff、可手工编辑、可流式 tail；SQLite 留给扩展 artifact。</p></div><div class="lang-en-only"><p>git diffable, hand-editable, streamable tail; SQLite for extension artifacts.</p></div></div></details>
-
-    <h3 class="sub"><span class="lang-zh-only">附录 · JSONL 会话树 深度 trace</span><span class="lang-en-only">Appendix · deep trace for JSONL session tree</span></h3>
-
-    <div class="lang-zh-only"><p>本章 (22) 属于 Phase「持久化」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
-    <div class="lang-en-only"><p>Chapter (22) belongs to Phase «Persistence». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
-
-    <table class="cmp">
-      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
+    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+      <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
       <tbody>
-      <tr><td>1</td><td>SessionManager</td><td>append</td></tr>
-      <tr><td>2</td><td>JSONL</td><td>parentId 写入</td></tr>
-      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
-      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
-      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
-      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
+      <tr><td>cp 10</td><td>Session Tree</td><td><code>session.ts</code></td><td><code>packages/coding-agent/src/core/session-manager.ts</code></td></tr>
       </tbody>
     </table>
-
-    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/session-manager.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// SessionManager</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 22 · JSONL 会话树</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 22 · JSONL 会话树</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 22 · JSONL 会话树</span></span>
-    </div>
-
-    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
-
-    <div class="lang-zh-only"><p><strong>parentId</strong> — JSONL 树边指向父 entry</p></div>
-    <div class="lang-en-only"><p><strong>parentId</strong> — JSONL tree edge to parent entry</p></div>
-
-    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
-
-    <div class="note">
-      <span class="lang-zh-only">[22.1] 在 JSONL 会话树 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[22.1] At JSONL session tree stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[22.2] 在 JSONL 会话树 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[22.2] At JSONL session tree stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[22.3] 在 JSONL 会话树 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[22.3] At JSONL session tree stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[22.4] 在 JSONL 会话树 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[22.4] At JSONL session tree stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[22.5] 在 JSONL 会话树 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[22.5] At JSONL session tree stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[22.6] 在 JSONL 会话树 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[22.6] At JSONL session tree stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[22.7] 在 JSONL 会话树 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[22.7] At JSONL session tree stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[22.8] 在 JSONL 会话树 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[22.8] At JSONL session tree stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
   </section>
 
   <section class="chap" id="c23">
@@ -5947,6 +3447,33 @@
     <div class="lang-zh-only"><p>agent-loop 不管 token 数；AgentSession 在 turn_end 检查 shouldCompact；扩展可在 before_compact 注入结构化摘要。</p></div>
     <div class="lang-en-only"><p>agent-loop ignores token count; AgentSession checks shouldCompact at turn_end; extensions inject structured summary in before_compact.</p></div>
 
+    <figure>
+      <div class="figbox"><div class="pi-fig"><svg viewBox="0 0 720 260" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true" class="pi-svg">
+  <defs>
+    <marker id="pi-arr" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 Z" fill="#1f5c8c"/>
+    </marker>
+  </defs>
+  <text x="24" y="24" class="svg-label">HISTORY (JSONL) — never deleted</text>
+  <rect x="24" y="36" width="672" height="48" rx="3" class="svg-box paper"/>
+  <text x="40" y="58" class="svg-mono">u1 · a1 · u2 · a2 · u3 · calls · r-read · r-test · a3 · ...</text>
+  <text x="40" y="74" class="svg-mute">full append-only log on disk</text>
+  <text x="24" y="110" class="svg-label">CONTEXT (model window) — rebuilt per request</text>
+  <rect x="24" y="122" width="200" height="48" rx="3" fill="#ebe5d8" stroke="#c7c4ba"/>
+  <text x="124" y="152" text-anchor="middle" class="svg-mute">dropped · summarized</text>
+  <rect x="240" y="122" width="456" height="48" rx="3" class="svg-box accent"/>
+  <text x="260" y="152" class="svg-body">compaction summary + recent suffix (full tool interactions)</text>
+  <path d="M360 170 L360 200" class="svg-arrow"/>
+  <rect x="200" y="200" width="320" height="40" rx="3" class="svg-box asm"/>
+  <text x="360" y="226" text-anchor="middle" class="svg-body">streamSimple(context) · token budget enforced</text>
+</svg></div></div>
+      <figcaption>
+        <span class="figid">FIG</span>
+        <span class="lang-zh-only">Compaction：历史完整保留在 JSONL；发给模型的 context 按 token 预算重建，早期事实以摘要补回。</span>
+        <span class="lang-en-only">Compaction: history stays complete in JSONL; model context rebuilt under token budget with summary for early facts.</span>
+      </figcaption>
+    </figure>
+
     <div class="note copper">
       <span class="lang-zh-only">📘 <strong>pi-textbook checkpoint 11</strong>：Context Compaction（<code>context.ts</code>）· 生产映射：<code>packages/coding-agent/src/core/compaction/</code></span>
       <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 11</strong>: Context Compaction (<code>context.ts</code>) · production: <code>packages/coding-agent/src/core/compaction/</code></span>
@@ -5957,133 +3484,12 @@
       <span class="lang-en-only">Chapter (23) on the through-line path handles: <strong>Compaction and harness</strong>. Return to C02's 22-station map to locate this chapter.</span>
     </div>
 
-    <table class="cmp">
-      <thead><tr><th>路径</th><th>说明</th></tr></thead>
+    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+      <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
       <tbody>
-      <tr><td><code>packages/coding-agent/src/core/session-manager.ts</code></td><td>JSONL 会话树</td></tr>
-      <tr><td><code>packages/coding-agent/src/core/compaction/</code></td><td>上下文压缩</td></tr>
+      <tr><td>cp 11</td><td>Context Compaction</td><td><code>context.ts</code></td><td><code>packages/coding-agent/src/core/compaction/</code></td></tr>
       </tbody>
     </table>
-
-    <h3 class="sub"><span class="lang-zh-only">Compaction 与 Harness · 实现清单</span><span class="lang-en-only">Compaction and harness · implementation checklist</span></h3>
-
-    <div class="note">
-      <span class="lang-zh-only">1. 定位生产文件：packages/agent/src/agent-loop.ts</span>
-      <span class="lang-en-only">1. Locate production file: packages/agent/src/agent-loop.ts</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">2. 对照 pi-textbook 同主题 checkpoint</span>
-      <span class="lang-en-only">2. Cross-read matching pi-textbook checkpoint</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">3. 用 --verbose 观察 AgentEvent</span>
-      <span class="lang-en-only">3. Observe AgentEvents with --verbose</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">4. 检查 JSONL 会话文件对应 entry</span>
-      <span class="lang-en-only">4. Inspect matching JSONL session entry</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">5. 阅读 packages/*/test/ 下相关测试</span>
-      <span class="lang-en-only">5. Read related tests under packages/*/test/</span>
-    </div>
-
-    <h3 class="sub"><span class="lang-zh-only">附录 · Compaction 与 Harness 深度 trace</span><span class="lang-en-only">Appendix · deep trace for Compaction and harness</span></h3>
-
-    <div class="lang-zh-only"><p>本章 (23) 属于 Phase「持久化」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
-    <div class="lang-en-only"><p>Chapter (23) belongs to Phase «Persistence». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
-
-    <table class="cmp">
-      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
-      <tbody>
-      <tr><td>1</td><td>Compaction 与 Harness</td><td>上下文压缩 · SQLite lanes</td></tr>
-      <tr><td>2</td><td>—</td><td>checkpoint 2</td></tr>
-      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
-      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
-      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
-      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
-      </tbody>
-    </table>
-
-    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/compaction/index.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// compaction</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 23 · Compaction 与 Harness</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 23 · Compaction 与 Harness</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 23 · Compaction 与 Harness</span></span>
-    </div>
-
-    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
-
-    <div class="lang-zh-only"><p><strong>compaction</strong> — 历史保留·上下文重建</p></div>
-    <div class="lang-en-only"><p><strong>compaction</strong> — history kept · context rebuilt</p></div>
-
-    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
-
-    <div class="note">
-      <span class="lang-zh-only">[23.1] 在 Compaction 与 Harness 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[23.1] At Compaction and harness stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[23.2] 在 Compaction 与 Harness 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[23.2] At Compaction and harness stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[23.3] 在 Compaction 与 Harness 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[23.3] At Compaction and harness stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[23.4] 在 Compaction 与 Harness 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[23.4] At Compaction and harness stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[23.5] 在 Compaction 与 Harness 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[23.5] At Compaction and harness stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[23.6] 在 Compaction 与 Harness 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[23.6] At Compaction and harness stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[23.7] 在 Compaction 与 Harness 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[23.7] At Compaction and harness stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[23.8] 在 Compaction 与 Harness 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[23.8] At Compaction and harness stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
   </section>
 
   <section class="chap" id="c24">
@@ -6134,105 +3540,6 @@
       <tr><td>OAuth 40+ 模型</td><td>△</td><td>△</td><td>✓</td></tr>
       </tbody>
     </table>
-
-    <h3 class="sub"><span class="lang-zh-only">附录 · 对比 Claude Code / Cursor 深度 trace</span><span class="lang-en-only">Appendix · deep trace for vs Claude Code / Cursor</span></h3>
-
-    <div class="lang-zh-only"><p>本章 (24) 属于 Phase「全景」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
-    <div class="lang-en-only"><p>Chapter (24) belongs to Phase «Landscape». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
-
-    <table class="cmp">
-      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
-      <tbody>
-      <tr><td>1</td><td>对比 Claude Code / Cursor</td><td>minimal harness 的设计取舍</td></tr>
-      <tr><td>2</td><td>—</td><td>checkpoint 2</td></tr>
-      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
-      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
-      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
-      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
-      </tbody>
-    </table>
-
-    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// default trace</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 24 · 对比 Claude Code / Cursor</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 24 · 对比 Claude Code / Cursor</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 24 · 对比 Claude Code / Cursor</span></span>
-    </div>
-
-    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
-
-    <div class="lang-zh-only"><p><strong>AgentMessage</strong> — agent-core 内部消息 IR</p></div>
-    <div class="lang-en-only"><p><strong>AgentMessage</strong> — agent-core internal message IR</p></div>
-
-    <div class="lang-zh-only"><p><strong>StreamFn</strong> — 可注入的模型流函数</p></div>
-    <div class="lang-en-only"><p><strong>StreamFn</strong> — injectable model stream function</p></div>
-
-    <div class="lang-zh-only"><p><strong>leafId</strong> — JSONL 会话树当前叶</p></div>
-    <div class="lang-en-only"><p><strong>leafId</strong> — JSONL session tree current leaf</p></div>
-
-    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
-
-    <div class="note">
-      <span class="lang-zh-only">[24.1] 在 对比 Claude Code / Cursor 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[24.1] At vs Claude Code / Cursor stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[24.2] 在 对比 Claude Code / Cursor 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[24.2] At vs Claude Code / Cursor stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[24.3] 在 对比 Claude Code / Cursor 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[24.3] At vs Claude Code / Cursor stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[24.4] 在 对比 Claude Code / Cursor 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[24.4] At vs Claude Code / Cursor stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[24.5] 在 对比 Claude Code / Cursor 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[24.5] At vs Claude Code / Cursor stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[24.6] 在 对比 Claude Code / Cursor 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[24.6] At vs Claude Code / Cursor stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[24.7] 在 对比 Claude Code / Cursor 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[24.7] At vs Claude Code / Cursor stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[24.8] 在 对比 Claude Code / Cursor 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[24.8] At vs Claude Code / Cursor stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
   </section>
 
   <section class="chap" id="c25">
@@ -6266,140 +3573,6 @@
       <span class="lang-zh-only">本章 (25) 在主线 prompt「JSONL 进程协议 · CBOR 远程会话」路径上负责：<strong>RPC 与 pi-server</strong>。回到 C02 的 22 站地图定位这一章。</span>
       <span class="lang-en-only">Chapter (25) on the through-line path handles: <strong>RPC and pi-server</strong>. Return to C02's 22-station map to locate this chapter.</span>
     </div>
-
-    <table class="cmp">
-      <thead><tr><th>路径</th><th>说明</th></tr></thead>
-      <tbody>
-      <tr><td><code>packages/coding-agent/src/modes/rpc/</code></td><td>RPC 模式</td></tr>
-      <tr><td><code>packages/protocol/</code></td><td>JSONL 协议</td></tr>
-      </tbody>
-    </table>
-
-    <h3 class="sub"><span class="lang-zh-only">RPC 与 pi-server · 实现清单</span><span class="lang-en-only">RPC and pi-server · implementation checklist</span></h3>
-
-    <div class="note">
-      <span class="lang-zh-only">1. 定位生产文件：packages/agent/src/agent-loop.ts</span>
-      <span class="lang-en-only">1. Locate production file: packages/agent/src/agent-loop.ts</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">2. 对照 pi-textbook 同主题 checkpoint</span>
-      <span class="lang-en-only">2. Cross-read matching pi-textbook checkpoint</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">3. 用 --verbose 观察 AgentEvent</span>
-      <span class="lang-en-only">3. Observe AgentEvents with --verbose</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">4. 检查 JSONL 会话文件对应 entry</span>
-      <span class="lang-en-only">4. Inspect matching JSONL session entry</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">5. 阅读 packages/*/test/ 下相关测试</span>
-      <span class="lang-en-only">5. Read related tests under packages/*/test/</span>
-    </div>
-
-    <h3 class="sub"><span class="lang-zh-only">附录 · RPC 与 pi-server 深度 trace</span><span class="lang-en-only">Appendix · deep trace for RPC and pi-server</span></h3>
-
-    <div class="lang-zh-only"><p>本章 (25) 属于 Phase「全景」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
-    <div class="lang-en-only"><p>Chapter (25) belongs to Phase «Landscape». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
-
-    <table class="cmp">
-      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
-      <tbody>
-      <tr><td>1</td><td>RPC 与 pi-server</td><td>JSONL 进程协议 · CBOR 远程会话</td></tr>
-      <tr><td>2</td><td>—</td><td>checkpoint 2</td></tr>
-      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
-      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
-      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
-      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
-      </tbody>
-    </table>
-
-    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// default trace</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 25 · RPC 与 pi-server</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 25 · RPC 与 pi-server</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 25 · RPC 与 pi-server</span></span>
-    </div>
-
-    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
-
-    <div class="lang-zh-only"><p><strong>AgentMessage</strong> — agent-core 内部消息 IR</p></div>
-    <div class="lang-en-only"><p><strong>AgentMessage</strong> — agent-core internal message IR</p></div>
-
-    <div class="lang-zh-only"><p><strong>StreamFn</strong> — 可注入的模型流函数</p></div>
-    <div class="lang-en-only"><p><strong>StreamFn</strong> — injectable model stream function</p></div>
-
-    <div class="lang-zh-only"><p><strong>leafId</strong> — JSONL 会话树当前叶</p></div>
-    <div class="lang-en-only"><p><strong>leafId</strong> — JSONL session tree current leaf</p></div>
-
-    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
-
-    <div class="note">
-      <span class="lang-zh-only">[25.1] 在 RPC 与 pi-server 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[25.1] At RPC and pi-server stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[25.2] 在 RPC 与 pi-server 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[25.2] At RPC and pi-server stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[25.3] 在 RPC 与 pi-server 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[25.3] At RPC and pi-server stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[25.4] 在 RPC 与 pi-server 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[25.4] At RPC and pi-server stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[25.5] 在 RPC 与 pi-server 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[25.5] At RPC and pi-server stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[25.6] 在 RPC 与 pi-server 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[25.6] At RPC and pi-server stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[25.7] 在 RPC 与 pi-server 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[25.7] At RPC and pi-server stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[25.8] 在 RPC 与 pi-server 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[25.8] At RPC and pi-server stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
   </section>
 
   <section class="chap" id="c26">
@@ -6412,21 +3585,33 @@
     <div class="lang-en-only"><p>Trace the through-line yourself: <code>pi --verbose</code> for AgentEvents, open JSONL session file, compare pi-textbook workshop tests.</p></div>
 
     <div class="ladder">
-      <div class="ladder-step">
-        <div class="ladder-num">01</div>
-        <div class="ladder-body"><span class="lang-zh-only">pi --verbose</span><span class="lang-en-only">stderr 打印完整事件流</span></div>
+      <div class="ld-row">
+        <div class="ld-num">01</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">pi --verbose</span><span class="lang-en-only">stderr 打印完整事件流</span></div>
+
+        </div>
       </div>
-      <div class="ladder-step">
-        <div class="ladder-num">02</div>
-        <div class="ladder-body"><span class="lang-zh-only">~/.pi/sessions/</span><span class="lang-en-only">找到最新 .jsonl</span></div>
+      <div class="ld-row">
+        <div class="ld-num">02</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">~/.pi/sessions/</span><span class="lang-en-only">找到最新 .jsonl</span></div>
+
+        </div>
       </div>
-      <div class="ladder-step">
-        <div class="ladder-num">03</div>
-        <div class="ladder-body"><span class="lang-zh-only">agent-loop.test.ts</span><span class="lang-en-only">对照单元测试</span></div>
+      <div class="ld-row">
+        <div class="ld-num">03</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">agent-loop.test.ts</span><span class="lang-en-only">对照单元测试</span></div>
+
+        </div>
       </div>
-      <div class="ladder-step">
-        <div class="ladder-num">04</div>
-        <div class="ladder-body"><span class="lang-zh-only">workshop/test/agent-loop.test.ts</span><span class="lang-en-only">pi-textbook 离线复现</span></div>
+      <div class="ld-row">
+        <div class="ld-num">04</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">workshop/test/agent-loop.test.ts</span><span class="lang-en-only">pi-textbook 离线复现</span></div>
+
+        </div>
       </div>
     </div>
 
@@ -6459,140 +3644,6 @@
     <div class="note">
       <span class="lang-zh-only">本章 (26) 在主线 prompt「--verbose · event log · session file」路径上负责：<strong>怎么自己 trace 一轮</strong>。回到 C02 的 22 站地图定位这一章。</span>
       <span class="lang-en-only">Chapter (26) on the through-line path handles: <strong>How to trace a turn yourself</strong>. Return to C02's 22-station map to locate this chapter.</span>
-    </div>
-
-    <table class="cmp">
-      <thead><tr><th>路径</th><th>说明</th></tr></thead>
-      <tbody>
-      <tr><td><code>packages/coding-agent/test/</code></td><td>集成测试</td></tr>
-      <tr><td><code>packages/agent/test/</code></td><td>agent loop 测试</td></tr>
-      </tbody>
-    </table>
-
-    <h3 class="sub"><span class="lang-zh-only">怎么自己 trace 一轮 · 实现清单</span><span class="lang-en-only">How to trace a turn yourself · implementation checklist</span></h3>
-
-    <div class="note">
-      <span class="lang-zh-only">1. 定位生产文件：packages/agent/src/agent-loop.ts</span>
-      <span class="lang-en-only">1. Locate production file: packages/agent/src/agent-loop.ts</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">2. 对照 pi-textbook 同主题 checkpoint</span>
-      <span class="lang-en-only">2. Cross-read matching pi-textbook checkpoint</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">3. 用 --verbose 观察 AgentEvent</span>
-      <span class="lang-en-only">3. Observe AgentEvents with --verbose</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">4. 检查 JSONL 会话文件对应 entry</span>
-      <span class="lang-en-only">4. Inspect matching JSONL session entry</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">5. 阅读 packages/*/test/ 下相关测试</span>
-      <span class="lang-en-only">5. Read related tests under packages/*/test/</span>
-    </div>
-
-    <h3 class="sub"><span class="lang-zh-only">附录 · 怎么自己 trace 一轮 深度 trace</span><span class="lang-en-only">Appendix · deep trace for How to trace a turn yourself</span></h3>
-
-    <div class="lang-zh-only"><p>本章 (26) 属于 Phase「Coda」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
-    <div class="lang-en-only"><p>Chapter (26) belongs to Phase «Coda». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
-
-    <table class="cmp">
-      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
-      <tbody>
-      <tr><td>1</td><td>怎么自己 trace 一轮</td><td>--verbose · event log · session file</td></tr>
-      <tr><td>2</td><td>—</td><td>checkpoint 2</td></tr>
-      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
-      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
-      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
-      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
-      </tbody>
-    </table>
-
-    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// default trace</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 26 · 怎么自己 trace 一轮</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 26 · 怎么自己 trace 一轮</span></span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
-        <span class="src-tag">ref</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
-      <span class="src-line"><span class="src-comment">// chapter 26 · 怎么自己 trace 一轮</span></span>
-    </div>
-
-    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
-
-    <div class="lang-zh-only"><p><strong>AgentMessage</strong> — agent-core 内部消息 IR</p></div>
-    <div class="lang-en-only"><p><strong>AgentMessage</strong> — agent-core internal message IR</p></div>
-
-    <div class="lang-zh-only"><p><strong>StreamFn</strong> — 可注入的模型流函数</p></div>
-    <div class="lang-en-only"><p><strong>StreamFn</strong> — injectable model stream function</p></div>
-
-    <div class="lang-zh-only"><p><strong>leafId</strong> — JSONL 会话树当前叶</p></div>
-    <div class="lang-en-only"><p><strong>leafId</strong> — JSONL session tree current leaf</p></div>
-
-    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
-
-    <div class="note">
-      <span class="lang-zh-only">[26.1] 在 怎么自己 trace 一轮 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[26.1] At How to trace a turn yourself stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[26.2] 在 怎么自己 trace 一轮 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[26.2] At How to trace a turn yourself stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[26.3] 在 怎么自己 trace 一轮 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[26.3] At How to trace a turn yourself stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[26.4] 在 怎么自己 trace 一轮 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[26.4] At How to trace a turn yourself stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[26.5] 在 怎么自己 trace 一轮 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[26.5] At How to trace a turn yourself stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[26.6] 在 怎么自己 trace 一轮 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[26.6] At How to trace a turn yourself stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[26.7] 在 怎么自己 trace 一轮 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[26.7] At How to trace a turn yourself stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
-    </div>
-
-    <div class="note">
-      <span class="lang-zh-only">[26.8] 在 怎么自己 trace 一轮 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
-      <span class="lang-en-only">[26.8] At How to trace a turn yourself stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
     </div>
   </section>
 

--- a/public/immersive/pi-agent/index.html
+++ b/public/immersive/pi-agent/index.html
@@ -4284,46 +4284,46 @@
         <span>SOURCE &nbsp;·&nbsp; packages/agent/src/types.ts</span>
         <span class="src-tag">types</span>
       </div>
-      <span class="src-line">      <span class="src-ln"> 149</span> <span class="src-hl"><span class="src-kw">export</span> <span class="src-kw">interface</span> <span class="src-cls">AgentLoopConfig</span> extends <span class="src-cls">SimpleStreamOptions</span> {</span></span>
-      <span class="src-line">      <span class="src-ln"> 150</span> <span class="src-hl">	model: <span class="src-cls">Model</span>&lt;any&gt;;</span></span>
+      <span class="src-line">      <span class="src-ln"> 149</span> <span class="src-hl"><span class="src-kw">export</span> <span class="src-kw">interface</span> AgentLoopConfig extends SimpleStreamOptions {</span></span>
+      <span class="src-line">      <span class="src-ln"> 150</span> <span class="src-hl">	model: Model&lt;any&gt;;</span></span>
       <span class="src-line">      <span class="src-ln"> 151</span> <span class="src-hl"></span></span>
       <span class="src-line">      <span class="src-ln"> 152</span> <span class="src-hl">	/**</span></span>
-      <span class="src-line">      <span class="src-ln"> 153</span> <span class="src-hl">	 * <span class="src-cls">Converts</span> AgentMessage[] to <span class="src-cls">LLM</span>-compatible <span class="src-cls">Message</span>[] before each <span class="src-cls">LLM</span> call.</span></span>
+      <span class="src-line">      <span class="src-ln"> 153</span> <span class="src-hl">	 * Converts AgentMessage[] to LLM-compatible Message[] before each LLM call.</span></span>
       <span class="src-line">      <span class="src-ln"> 154</span> <span class="src-hl">	 *</span></span>
-      <span class="src-line">      <span class="src-ln"> 155</span> <span class="src-hl">	 * <span class="src-cls">Each</span> AgentMessage must be converted to a <span class="src-cls">UserMessage</span>, <span class="src-cls">AssistantMessage</span>, or <span class="src-cls">ToolResultMessage</span></span></span>
-      <span class="src-line">      <span class="src-ln"> 156</span> <span class="src-hl">	 * that the <span class="src-cls">LLM</span> can understand. <span class="src-cls">AgentMessages</span> that cannot be converted (e.g., <span class="src-cls">UI</span>-only notifications,</span></span>
+      <span class="src-line">      <span class="src-ln"> 155</span> <span class="src-hl">	 * Each AgentMessage must be converted to a UserMessage, AssistantMessage, or ToolResultMessage</span></span>
+      <span class="src-line">      <span class="src-ln"> 156</span> <span class="src-hl">	 * that the LLM can understand. AgentMessages that cannot be converted (e.g., UI-only notifications,</span></span>
       <span class="src-line">      <span class="src-ln"> 157</span> <span class="src-hl">	 * status messages) should be filtered out.</span></span>
       <span class="src-line">      <span class="src-ln"> 158</span> <span class="src-hl">	 *</span></span>
-      <span class="src-line">      <span class="src-ln"> 159</span> <span class="src-hl">	 * <span class="src-cls">Contract</span>: must not <span class="src-kw">throw</span> or reject. <span class="src-cls">Return</span> a safe fallback value instead.</span></span>
-      <span class="src-line">      <span class="src-ln"> 160</span> <span class="src-hl">	 * <span class="src-cls">Throwing</span> interrupts the low-level agent loop without producing a normal event sequence.</span></span>
+      <span class="src-line">      <span class="src-ln"> 159</span> <span class="src-hl">	 * Contract: must not <span class="src-kw">throw</span> or reject. Return a safe fallback value instead.</span></span>
+      <span class="src-line">      <span class="src-ln"> 160</span> <span class="src-hl">	 * Throwing interrupts the low-level agent loop without producing a normal event sequence.</span></span>
       <span class="src-line">      <span class="src-ln"> 161</span> <span class="src-hl">	 *</span></span>
       <span class="src-line">      <span class="src-ln"> 162</span> <span class="src-hl">	 * @example</span></span>
       <span class="src-line">      <span class="src-ln"> 163</span> <span class="src-hl">	 * ```typescript</span></span>
       <span class="src-line">      <span class="src-ln"> 164</span> <span class="src-hl">	 * convertToLlm: (messages) =&gt; messages.flatMap(m =&gt; {</span></span>
       <span class="src-line">      <span class="src-ln"> 165</span> <span class="src-hl">	 *   <span class="src-kw">if</span> (m.role === &quot;custom&quot;) {</span></span>
-      <span class="src-line">      <span class="src-ln"> 166</span> <span class="src-hl">	 *     <span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Convert</span> custom message to user message</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 166</span> <span class="src-hl">	 *     <span class="src-comment">// Convert custom message to user message</span></span></span>
       <span class="src-line">      <span class="src-ln"> 167</span> <span class="src-hl">	 *     <span class="src-kw">return</span> [{ role: &quot;user&quot;, content: m.content, timestamp: m.timestamp }];</span></span>
       <span class="src-line">      <span class="src-ln"> 168</span> <span class="src-hl">	 *   }</span></span>
       <span class="src-line">      <span class="src-ln"> 169</span> <span class="src-hl">	 *   <span class="src-kw">if</span> (m.role === &quot;notification&quot;) {</span></span>
-      <span class="src-line">      <span class="src-ln"> 170</span> <span class="src-hl">	 *     <span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Filter</span> out <span class="src-cls">UI</span>-only messages</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 170</span> <span class="src-hl">	 *     <span class="src-comment">// Filter out UI-only messages</span></span></span>
       <span class="src-line">      <span class="src-ln"> 171</span> <span class="src-hl">	 *     <span class="src-kw">return</span> [];</span></span>
       <span class="src-line">      <span class="src-ln"> 172</span> <span class="src-hl">	 *   }</span></span>
-      <span class="src-line">      <span class="src-ln"> 173</span> <span class="src-hl">	 *   <span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Pass</span> through standard <span class="src-cls">LLM</span> messages</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 173</span> <span class="src-hl">	 *   <span class="src-comment">// Pass through standard LLM messages</span></span></span>
       <span class="src-line">      <span class="src-ln"> 174</span> <span class="src-hl">	 *   <span class="src-kw">return</span> [m];</span></span>
       <span class="src-line">      <span class="src-ln"> 175</span> <span class="src-hl">	 * })</span></span>
       <span class="src-line">      <span class="src-ln"> 176</span> <span class="src-hl">	 * ```</span></span>
       <span class="src-line">      <span class="src-ln"> 177</span> <span class="src-hl">	 */</span></span>
-      <span class="src-line">      <span class="src-ln"> 178</span> <span class="src-hl">	convertToLlm: (messages: AgentMessage[]) =&gt; <span class="src-cls">Message</span>[] | <span class="src-cls">Promise</span>&lt;<span class="src-cls">Message</span>[]&gt;;</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-ln"> 178</span> <span class="src-hl">	convertToLlm: (messages: AgentMessage[]) =&gt; Message[] | Promise&lt;Message[]&gt;;</span> <span class="src-tag">◀ trace</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">convertToLlm：AgentMessage[] → Message[]，每次 LLM 调用前执行</span><span class="lang-en-only">convertToLlm: AgentMessage[] → Message[] before each LLM call</span></span></span>
       <span class="src-line">      <span class="src-ln"> 179</span> <span class="src-hl"></span></span>
       <span class="src-line">      <span class="src-ln"> 180</span> <span class="src-hl">	/**</span></span>
-      <span class="src-line">      <span class="src-ln"> 181</span> <span class="src-hl">	 * <span class="src-cls">Optional</span> transform applied to the context before <span class=<span class="src-str">"src-str"</span>>`convertToLlm`</span>.</span></span>
+      <span class="src-line">      <span class="src-ln"> 181</span> <span class="src-hl">	 * Optional transform applied to the context before <span class=<span class="src-str">"src-str"</span>>`convertToLlm`</span>.</span></span>
       <span class="src-line">      <span class="src-ln"> 182</span> <span class="src-hl">	 *</span></span>
-      <span class="src-line">      <span class="src-ln"> 183</span> <span class="src-hl">	 * <span class="src-cls">Use</span> this <span class="src-kw">for</span> operations that work at the AgentMessage level:</span></span>
-      <span class="src-line">      <span class="src-ln"> 184</span> <span class="src-hl">	 * - <span class="src-cls">Context</span> window management (pruning old messages)</span></span>
-      <span class="src-line">      <span class="src-ln"> 185</span> <span class="src-hl">	 * - <span class="src-cls">Injecting</span> context <span class="src-kw">from</span> external sources</span></span>
+      <span class="src-line">      <span class="src-ln"> 183</span> <span class="src-hl">	 * Use this <span class="src-kw">for</span> operations that work at the AgentMessage level:</span></span>
+      <span class="src-line">      <span class="src-ln"> 184</span> <span class="src-hl">	 * - Context window management (pruning old messages)</span></span>
+      <span class="src-line">      <span class="src-ln"> 185</span> <span class="src-hl">	 * - Injecting context <span class="src-kw">from</span> external sources</span></span>
       <span class="src-line">      <span class="src-ln"> 186</span> <span class="src-hl">	 *</span></span>
-      <span class="src-line">      <span class="src-ln"> 187</span> <span class="src-hl">	 * <span class="src-cls">Contract</span>: must not <span class="src-kw">throw</span> or reject. <span class="src-cls">Return</span> the original messages or another</span></span>
+      <span class="src-line">      <span class="src-ln"> 187</span> <span class="src-hl">	 * Contract: must not <span class="src-kw">throw</span> or reject. Return the original messages or another</span></span>
       <span class="src-line">      <span class="src-ln"> 188</span> <span class="src-hl">	 * safe fallback value instead.</span></span>
       <span class="src-line">      <span class="src-ln"> 189</span> <span class="src-hl">	 *</span></span>
       <span class="src-line">      <span class="src-ln"> 190</span> <span class="src-hl">	 * @example</span></span>
@@ -4336,7 +4336,7 @@
       <span class="src-line">      <span class="src-ln"> 197</span> <span class="src-hl">	 * }</span></span>
       <span class="src-line">      <span class="src-ln"> 198</span> <span class="src-hl">	 * ```</span></span>
       <span class="src-line">      <span class="src-ln"> 199</span> <span class="src-hl">	 */</span></span>
-      <span class="src-line">      <span class="src-ln"> 200</span> <span class="src-hl">	transformContext?: (messages: AgentMessage[], signal?: <span class="src-cls">AbortSignal</span>) =&gt; <span class="src-cls">Promise</span>&lt;AgentMessage[]&gt;;</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-ln"> 200</span> <span class="src-hl">	transformContext?: (messages: AgentMessage[], signal?: AbortSignal) =&gt; Promise&lt;AgentMessage[]&gt;;</span> <span class="src-tag">◀ trace</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">transformContext：在 convert 之前做 compaction / 剪枝</span><span class="lang-en-only">transformContext: compaction/prune before convert</span></span></span>
     </div>
 
@@ -4349,21 +4349,21 @@
         <span class="src-tag">convert</span>
       </div>
       <span class="src-line">      <span class="src-ln"> 140</span> <span class="src-hl">/**</span></span>
-      <span class="src-line">      <span class="src-ln"> 141</span> <span class="src-hl"> * <span class="src-cls">Transform</span> <span class="src-cls">AgentMessages</span> (including custom types) to <span class="src-cls">LLM</span>-compatible <span class="src-cls">Messages</span>.</span></span>
+      <span class="src-line">      <span class="src-ln"> 141</span> <span class="src-hl"> * Transform AgentMessages (including custom types) to LLM-compatible Messages.</span></span>
       <span class="src-line">      <span class="src-ln"> 142</span> <span class="src-hl"> *</span></span>
-      <span class="src-line">      <span class="src-ln"> 143</span> <span class="src-hl"> * <span class="src-cls">This</span> is used by:</span></span>
-      <span class="src-line">      <span class="src-ln"> 144</span> <span class="src-hl"> * - <span class="src-cls">Agent</span>&#x27;s transormToLlm option (<span class="src-kw">for</span> prompt calls and queued messages)</span></span>
-      <span class="src-line">      <span class="src-ln"> 145</span> <span class="src-hl"> * - <span class="src-cls">Compaction</span>&#x27;s generateSummary (<span class="src-kw">for</span> summarization)</span></span>
-      <span class="src-line">      <span class="src-ln"> 146</span> <span class="src-hl"> * - <span class="src-cls">Custom</span> extensions and tools</span></span>
+      <span class="src-line">      <span class="src-ln"> 143</span> <span class="src-hl"> * This is used by:</span></span>
+      <span class="src-line">      <span class="src-ln"> 144</span> <span class="src-hl"> * - Agent&#x27;s transormToLlm option (<span class="src-kw">for</span> prompt calls and queued messages)</span></span>
+      <span class="src-line">      <span class="src-ln"> 145</span> <span class="src-hl"> * - Compaction&#x27;s generateSummary (<span class="src-kw">for</span> summarization)</span></span>
+      <span class="src-line">      <span class="src-ln"> 146</span> <span class="src-hl"> * - Custom extensions and tools</span></span>
       <span class="src-line">      <span class="src-ln"> 147</span> <span class="src-hl"> */</span></span>
-      <span class="src-line">      <span class="src-ln"> 148</span> <span class="src-hl"><span class="src-kw">export</span> <span class="src-kw">function</span> convertToLlm(messages: AgentMessage[]): <span class="src-cls">Message</span>[] {</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-ln"> 148</span> <span class="src-hl"><span class="src-kw">export</span> <span class="src-kw">function</span> convertToLlm(messages: AgentMessage[]): Message[] {</span> <span class="src-tag">◀ trace</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">coding-agent 的生产 convertToLlm 实现</span><span class="lang-en-only">production convertToLlm in coding-agent</span></span></span>
       <span class="src-line">      <span class="src-ln"> 149</span> <span class="src-hl">	<span class="src-kw">return</span> messages</span></span>
-      <span class="src-line">      <span class="src-ln"> 150</span> <span class="src-hl">		.map((m): <span class="src-cls">Message</span> | <span class="src-kw">undefined</span> =&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln"> 150</span> <span class="src-hl">		.map((m): Message | <span class="src-kw">undefined</span> =&gt; {</span></span>
       <span class="src-line">      <span class="src-ln"> 151</span> <span class="src-hl">			<span class="src-kw">switch</span> (m.role) {</span></span>
       <span class="src-line">      <span class="src-ln"> 152</span> <span class="src-hl">				<span class="src-kw">case</span> &quot;bashExecution&quot;:</span> <span class="src-tag">◀ trace</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">switch(m.role)：custom / bashExecution / branchSummary 在此折叠</span><span class="lang-en-only">switch(m.role): custom/bash/branch fold here</span></span></span>
-      <span class="src-line">      <span class="src-ln"> 153</span> <span class="src-hl">					<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Skip</span> messages excluded <span class="src-kw">from</span> context (!! prefix)</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 153</span> <span class="src-hl">					<span class="src-comment">// Skip messages excluded from context (!! prefix)</span></span></span>
       <span class="src-line">      <span class="src-ln"> 154</span> <span class="src-hl">					<span class="src-kw">if</span> (m.excludeFromContext) {</span></span>
       <span class="src-line">      <span class="src-ln"> 155</span> <span class="src-hl">						<span class="src-kw">return</span> <span class="src-kw">undefined</span>;</span></span>
       <span class="src-line">      <span class="src-ln"> 156</span> <span class="src-hl">					}</span></span>
@@ -4400,7 +4400,7 @@
       <span class="src-line">      <span class="src-ln"> 186</span> <span class="src-hl">				<span class="src-kw">case</span> &quot;toolResult&quot;:</span></span>
       <span class="src-line">      <span class="src-ln"> 187</span> <span class="src-hl">					<span class="src-kw">return</span> m;</span></span>
       <span class="src-line">      <span class="src-ln"> 188</span> <span class="src-hl">				default:</span></span>
-      <span class="src-line">      <span class="src-ln"> 189</span> <span class="src-hl">					<span class=<span class="src-str">"src-comment"</span>>// biome-ignore lint/correctness/noSwitchDeclarations: fine</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 189</span> <span class="src-hl">					<span class="src-comment">// biome-ignore lint/correctness/noSwitchDeclarations: fine</span></span></span>
       <span class="src-line">      <span class="src-ln"> 190</span> <span class="src-hl">					<span class="src-kw">const</span> _exhaustiveCheck: never = m;</span></span>
       <span class="src-line">      <span class="src-ln"> 191</span> <span class="src-hl">					<span class="src-kw">return</span> <span class="src-kw">undefined</span>;</span></span>
       <span class="src-line">      <span class="src-ln"> 192</span> <span class="src-hl">			}</span></span>
@@ -4429,32 +4429,32 @@
         <span class="src-tag">stream</span>
       </div>
       <span class="src-line">      <span class="src-ln"> 281</span> <span class="src-hl"><span class="src-kw">async</span> <span class="src-kw">function</span> streamAssistantResponse(</span></span>
-      <span class="src-line">      <span class="src-ln"> 282</span> <span class="src-hl">	context: <span class="src-cls">AgentContext</span>,</span></span>
-      <span class="src-line">      <span class="src-ln"> 283</span> <span class="src-hl">	config: <span class="src-cls">AgentLoopConfig</span>,</span></span>
-      <span class="src-line">      <span class="src-ln"> 284</span> <span class="src-hl">	signal: <span class="src-cls">AbortSignal</span> | <span class="src-kw">undefined</span>,</span></span>
-      <span class="src-line">      <span class="src-ln"> 285</span> <span class="src-hl">	emit: <span class="src-cls">AgentEventSink</span>,</span></span>
-      <span class="src-line">      <span class="src-ln"> 286</span> <span class="src-hl">	streamFunction: <span class="src-cls">StreamFn</span>,</span></span>
-      <span class="src-line">      <span class="src-ln"> 287</span> <span class="src-hl">): <span class="src-cls">Promise</span>&lt;<span class="src-cls">AssistantMessage</span>&gt; {</span></span>
-      <span class="src-line">      <span class="src-ln"> 288</span> <span class="src-hl">	<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Apply</span> context transform <span class="src-kw">if</span> configured (AgentMessage[] → AgentMessage[])</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 282</span> <span class="src-hl">	context: AgentContext,</span></span>
+      <span class="src-line">      <span class="src-ln"> 283</span> <span class="src-hl">	config: AgentLoopConfig,</span></span>
+      <span class="src-line">      <span class="src-ln"> 284</span> <span class="src-hl">	signal: AbortSignal | <span class="src-kw">undefined</span>,</span></span>
+      <span class="src-line">      <span class="src-ln"> 285</span> <span class="src-hl">	emit: AgentEventSink,</span></span>
+      <span class="src-line">      <span class="src-ln"> 286</span> <span class="src-hl">	streamFunction: StreamFn,</span></span>
+      <span class="src-line">      <span class="src-ln"> 287</span> <span class="src-hl">): Promise&lt;AssistantMessage&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln"> 288</span> <span class="src-hl">	<span class="src-comment">// Apply context transform if configured (AgentMessage[] → AgentMessage[])</span></span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">transformContext 边界：仍是 AgentMessage[]</span><span class="lang-en-only">transformContext boundary: still AgentMessage[]</span></span></span>
       <span class="src-line">      <span class="src-ln"> 289</span> <span class="src-hl">	<span class="src-kw">let</span> messages = context.messages;</span></span>
       <span class="src-line">      <span class="src-ln"> 290</span> <span class="src-hl">	<span class="src-kw">if</span> (config.transformContext) {</span></span>
       <span class="src-line">      <span class="src-ln"> 291</span> <span class="src-hl">		messages = <span class="src-kw">await</span> config.transformContext(messages, signal);</span></span>
       <span class="src-line">      <span class="src-ln"> 292</span> <span class="src-hl">	}</span></span>
       <span class="src-line">      <span class="src-ln"> 293</span> <span class="src-hl"></span></span>
-      <span class="src-line">      <span class="src-ln"> 294</span> <span class="src-hl">	<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Convert</span> to <span class="src-cls">LLM</span>-compatible messages (AgentMessage[] → <span class="src-cls">Message</span>[])</span></span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-ln"> 294</span> <span class="src-hl">	<span class="src-comment">// Convert to LLM-compatible messages (AgentMessage[] → Message[])</span></span> <span class="src-tag">◀ trace</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">★ 唯一 convert 调用点</span><span class="lang-en-only">★ sole convert call site</span></span></span>
       <span class="src-line">      <span class="src-ln"> 295</span> <span class="src-hl">	<span class="src-kw">const</span> llmMessages = <span class="src-kw">await</span> config.convertToLlm(messages);</span> <span class="src-tag">◀ trace</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">llmMessages 进入 streamFunction</span><span class="lang-en-only">llmMessages enters streamFunction</span></span></span>
       <span class="src-line">      <span class="src-ln"> 296</span> <span class="src-hl"></span></span>
-      <span class="src-line">      <span class="src-ln"> 297</span> <span class="src-hl">	<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Build</span> <span class="src-cls">LLM</span> context</span></span></span>
-      <span class="src-line">      <span class="src-ln"> 298</span> <span class="src-hl">	<span class="src-kw">const</span> llmContext: <span class="src-cls">Context</span> = {</span></span>
+      <span class="src-line">      <span class="src-ln"> 297</span> <span class="src-hl">	<span class="src-comment">// Build LLM context</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 298</span> <span class="src-hl">	<span class="src-kw">const</span> llmContext: Context = {</span></span>
       <span class="src-line">      <span class="src-ln"> 299</span> <span class="src-hl">		systemPrompt: context.systemPrompt,</span></span>
       <span class="src-line">      <span class="src-ln"> 300</span> <span class="src-hl">		messages: llmMessages,</span></span>
       <span class="src-line">      <span class="src-ln"> 301</span> <span class="src-hl">		tools: context.tools,</span></span>
       <span class="src-line">      <span class="src-ln"> 302</span> <span class="src-hl">	};</span></span>
       <span class="src-line">      <span class="src-ln"> 303</span> <span class="src-hl"></span></span>
-      <span class="src-line">      <span class="src-ln"> 304</span> <span class="src-hl">	<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Resolve</span> <span class="src-cls">API</span> key (important <span class="src-kw">for</span> expiring tokens)</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 304</span> <span class="src-hl">	<span class="src-comment">// Resolve API key (important for expiring tokens)</span></span></span>
       <span class="src-line">      <span class="src-ln"> 305</span> <span class="src-hl">	<span class="src-kw">const</span> resolvedApiKey =</span></span>
       <span class="src-line">      <span class="src-ln"> 306</span> <span class="src-hl">		(config.getApiKey ? <span class="src-kw">await</span> config.getApiKey(config.model.provider) : <span class="src-kw">undefined</span>) || config.apiKey;</span></span>
       <span class="src-line">      <span class="src-ln"> 307</span> <span class="src-hl"></span></span>
@@ -4476,15 +4476,15 @@
       <span class="src-line">      <span class="src-ln"> 318</span> <span class="src-hl">}</span></span>
       <span class="src-line">      <span class="src-ln"> 319</span> <span class="src-hl"></span></span>
       <span class="src-line">      <span class="src-ln"> 320</span> <span class="src-hl">/**</span></span>
-      <span class="src-line">      <span class="src-ln"> 321</span> <span class="src-hl"> * AgentMessage: <span class="src-cls">Union</span> of <span class="src-cls">LLM</span> messages + custom messages.</span></span>
-      <span class="src-line">      <span class="src-ln"> 322</span> <span class="src-hl"> * <span class="src-cls">This</span> abstraction allows apps to add custom message types <span class="src-kw">while</span> maintaining</span></span>
-      <span class="src-line">      <span class="src-ln"> 323</span> <span class="src-hl"> * <span class="src-kw">type</span> safety and compatibility with the base <span class="src-cls">LLM</span> messages.</span></span>
+      <span class="src-line">      <span class="src-ln"> 321</span> <span class="src-hl"> * AgentMessage: Union of LLM messages + custom messages.</span></span>
+      <span class="src-line">      <span class="src-ln"> 322</span> <span class="src-hl"> * This abstraction allows apps to add custom message types <span class="src-kw">while</span> maintaining</span></span>
+      <span class="src-line">      <span class="src-ln"> 323</span> <span class="src-hl"> * <span class="src-kw">type</span> safety and compatibility with the base LLM messages.</span></span>
       <span class="src-line">      <span class="src-ln"> 324</span> <span class="src-hl"> */</span></span>
-      <span class="src-line">      <span class="src-ln"> 325</span> <span class="src-hl"><span class="src-kw">export</span> <span class="src-kw">type</span> AgentMessage = <span class="src-cls">Message</span> | <span class="src-cls">CustomAgentMessages</span>[keyof <span class="src-cls">CustomAgentMessages</span>];</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-ln"> 325</span> <span class="src-hl"><span class="src-kw">export</span> <span class="src-kw">type</span> AgentMessage = Message | CustomAgentMessages[keyof CustomAgentMessages];</span> <span class="src-tag">◀ trace</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">AgentMessage = Message | CustomAgentMessages 合并</span><span class="lang-en-only">AgentMessage = Message | CustomAgentMessages merge</span></span></span>
       <span class="src-line">      <span class="src-ln"> 326</span> <span class="src-hl"></span></span>
       <span class="src-line">      <span class="src-ln"> 327</span> <span class="src-hl">/**</span></span>
-      <span class="src-line">      <span class="src-ln"> 328</span> <span class="src-hl"> * <span class="src-cls">Public</span> agent state.</span></span>
+      <span class="src-line">      <span class="src-ln"> 328</span> <span class="src-hl"> * Public agent state.</span></span>
       <span class="src-line">      <span class="src-ln"> 329</span> <span class="src-hl"> *</span></span>
       <span class="src-line">      <span class="src-ln"> 330</span> <span class="src-hl"> * <span class=<span class="src-str">"src-str"</span>>`tools`</span> and <span class=<span class="src-str">"src-str"</span>>`messages`</span> use accessor properties so implementations can copy</span></span>
     </div>
@@ -4495,27 +4495,27 @@
         <span class="src-tag">events-type</span>
       </div>
       <span class="src-line">      <span class="src-ln"> 421</span> <span class="src-hl">/**</span></span>
-      <span class="src-line">      <span class="src-ln"> 422</span> <span class="src-hl"> * <span class="src-cls">Events</span> emitted by the <span class="src-cls">Agent</span> <span class="src-kw">for</span> <span class="src-cls">UI</span> updates.</span></span>
+      <span class="src-line">      <span class="src-ln"> 422</span> <span class="src-hl"> * Events emitted by the Agent <span class="src-kw">for</span> UI updates.</span></span>
       <span class="src-line">      <span class="src-ln"> 423</span> <span class="src-hl"> *</span></span>
-      <span class="src-line">      <span class="src-ln"> 424</span> <span class="src-hl"> * <span class=<span class="src-str">"src-str"</span>>`agent_end`</span> is the last event emitted <span class="src-kw">for</span> a run, but awaited <span class=<span class="src-str">"src-str"</span>>`<span class="src-cls">Agent</span>.subscribe()`</span></span></span>
-      <span class="src-line">      <span class="src-ln"> 425</span> <span class="src-hl"> * listeners <span class="src-kw">for</span> that event are still part of run settlement. <span class="src-cls">The</span> agent becomes</span></span>
+      <span class="src-line">      <span class="src-ln"> 424</span> <span class="src-hl"> * <span class=<span class="src-str">"src-str"</span>>`agent_end`</span> is the last event emitted <span class="src-kw">for</span> a run, but awaited <span class=<span class="src-str">"src-str"</span>>`Agent.subscribe()`</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 425</span> <span class="src-hl"> * listeners <span class="src-kw">for</span> that event are still part of run settlement. The agent becomes</span></span>
       <span class="src-line">      <span class="src-ln"> 426</span> <span class="src-hl"> * idle only after those listeners finish.</span></span>
       <span class="src-line">      <span class="src-ln"> 427</span> <span class="src-hl"> */</span></span>
-      <span class="src-line">      <span class="src-ln"> 428</span> <span class="src-hl"><span class="src-kw">export</span> <span class="src-kw">type</span> <span class="src-cls">AgentEvent</span> =</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-ln"> 428</span> <span class="src-hl"><span class="src-kw">export</span> <span class="src-kw">type</span> AgentEvent =</span> <span class="src-tag">◀ trace</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">AgentEvent：message_* 事件携带 AgentMessage 快照</span><span class="lang-en-only">AgentEvent: message_* carries AgentMessage snapshot</span></span></span>
-      <span class="src-line">      <span class="src-ln"> 429</span> <span class="src-hl">	<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Agent</span> lifecycle</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 429</span> <span class="src-hl">	<span class="src-comment">// Agent lifecycle</span></span></span>
       <span class="src-line">      <span class="src-ln"> 430</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;agent_start&quot; }</span></span>
       <span class="src-line">      <span class="src-ln"> 431</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;agent_end&quot;; messages: AgentMessage[] }</span></span>
-      <span class="src-line">      <span class="src-ln"> 432</span> <span class="src-hl">	<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Turn</span> lifecycle - a turn is one assistant response + any tool calls/results</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 432</span> <span class="src-hl">	<span class="src-comment">// Turn lifecycle - a turn is one assistant response + any tool calls/results</span></span></span>
       <span class="src-line">      <span class="src-ln"> 433</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;turn_start&quot; }</span></span>
-      <span class="src-line">      <span class="src-ln"> 434</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;turn_end&quot;; message: AgentMessage; toolResults: <span class="src-cls">ToolResultMessage</span>[] }</span></span>
-      <span class="src-line">      <span class="src-ln"> 435</span> <span class="src-hl">	<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Message</span> lifecycle - emitted <span class="src-kw">for</span> user, assistant, and toolResult messages</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 434</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;turn_end&quot;; message: AgentMessage; toolResults: ToolResultMessage[] }</span></span>
+      <span class="src-line">      <span class="src-ln"> 435</span> <span class="src-hl">	<span class="src-comment">// Message lifecycle - emitted for user, assistant, and toolResult messages</span></span></span>
       <span class="src-line">      <span class="src-ln"> 436</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;message_start&quot;; message: AgentMessage }</span></span>
-      <span class="src-line">      <span class="src-ln"> 437</span> <span class="src-hl">	<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Only</span> emitted <span class="src-kw">for</span> assistant messages during streaming</span></span></span>
-      <span class="src-line">      <span class="src-ln"> 438</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;message_update&quot;; message: AgentMessage; assistantMessageEvent: <span class="src-cls">AssistantMessageEvent</span> }</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-ln"> 437</span> <span class="src-hl">	<span class="src-comment">// Only emitted for assistant messages during streaming</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 438</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;message_update&quot;; message: AgentMessage; assistantMessageEvent: AssistantMessageEvent }</span> <span class="src-tag">◀ trace</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">message_update 仅 assistant 流式阶段</span><span class="lang-en-only">message_update only during assistant streaming</span></span></span>
       <span class="src-line">      <span class="src-ln"> 439</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;message_end&quot;; message: AgentMessage }</span></span>
-      <span class="src-line">      <span class="src-ln"> 440</span> <span class="src-hl">	<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Tool</span> execution lifecycle</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 440</span> <span class="src-hl">	<span class="src-comment">// Tool execution lifecycle</span></span></span>
       <span class="src-line">      <span class="src-ln"> 441</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;tool_execution_start&quot;; toolCallId: string; toolName: string; args: any }</span></span>
       <span class="src-line">      <span class="src-ln"> 442</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;tool_execution_update&quot;; toolCallId: string; toolName: string; args: any; partialResult: any }</span></span>
       <span class="src-line">      <span class="src-ln"> 443</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;tool_execution_end&quot;; toolCallId: string; toolName: string; result: any; isError: boolean };</span></span>
@@ -4829,26 +4829,26 @@
         <span class="src-tag">runloop</span>
       </div>
       <span class="src-line">      <span class="src-ln"> 155</span> <span class="src-hl"><span class="src-kw">async</span> <span class="src-kw">function</span> runLoop(</span></span>
-      <span class="src-line">      <span class="src-ln"> 156</span> <span class="src-hl">	initialContext: <span class="src-cls">AgentContext</span>,</span></span>
+      <span class="src-line">      <span class="src-ln"> 156</span> <span class="src-hl">	initialContext: AgentContext,</span></span>
       <span class="src-line">      <span class="src-ln"> 157</span> <span class="src-hl">	newMessages: AgentMessage[],</span></span>
-      <span class="src-line">      <span class="src-ln"> 158</span> <span class="src-hl">	initialConfig: <span class="src-cls">AgentLoopConfig</span>,</span></span>
-      <span class="src-line">      <span class="src-ln"> 159</span> <span class="src-hl">	signal: <span class="src-cls">AbortSignal</span> | <span class="src-kw">undefined</span>,</span></span>
-      <span class="src-line">      <span class="src-ln"> 160</span> <span class="src-hl">	emit: <span class="src-cls">AgentEventSink</span>,</span></span>
-      <span class="src-line">      <span class="src-ln"> 161</span> <span class="src-hl">	streamFunction: <span class="src-cls">StreamFn</span>,</span></span>
-      <span class="src-line">      <span class="src-ln"> 162</span> <span class="src-hl">): <span class="src-cls">Promise</span>&lt;void&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln"> 158</span> <span class="src-hl">	initialConfig: AgentLoopConfig,</span></span>
+      <span class="src-line">      <span class="src-ln"> 159</span> <span class="src-hl">	signal: AbortSignal | <span class="src-kw">undefined</span>,</span></span>
+      <span class="src-line">      <span class="src-ln"> 160</span> <span class="src-hl">	emit: AgentEventSink,</span></span>
+      <span class="src-line">      <span class="src-ln"> 161</span> <span class="src-hl">	streamFunction: StreamFn,</span></span>
+      <span class="src-line">      <span class="src-ln"> 162</span> <span class="src-hl">): Promise&lt;void&gt; {</span></span>
       <span class="src-line">      <span class="src-ln"> 163</span> <span class="src-hl">	<span class="src-kw">let</span> currentContext = initialContext;</span></span>
       <span class="src-line">      <span class="src-ln"> 164</span> <span class="src-hl">	<span class="src-kw">let</span> config = initialConfig;</span></span>
       <span class="src-line">      <span class="src-ln"> 165</span> <span class="src-hl">	<span class="src-kw">let</span> firstTurn = <span class="src-kw">true</span>;</span></span>
-      <span class="src-line">      <span class="src-ln"> 166</span> <span class="src-hl">	<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Check</span> <span class="src-kw">for</span> steering messages at start (user may have typed <span class="src-kw">while</span> waiting)</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 166</span> <span class="src-hl">	<span class="src-comment">// Check for steering messages at start (user may have typed while waiting)</span></span></span>
       <span class="src-line">      <span class="src-ln"> 167</span> <span class="src-hl">	<span class="src-kw">let</span> pendingMessages: AgentMessage[] = (<span class="src-kw">await</span> config.getSteeringMessages?.()) || [];</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">启动时先 drain steering 队列</span><span class="lang-en-only">drain steering queue at start</span></span></span>
       <span class="src-line">      <span class="src-ln"> 168</span> <span class="src-hl"></span></span>
-      <span class="src-line">      <span class="src-ln"> 169</span> <span class="src-hl">	<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Outer</span> loop: continues when queued follow-up messages arrive after agent would stop</span></span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-ln"> 169</span> <span class="src-hl">	<span class="src-comment">// Outer loop: continues when queued follow-up messages arrive after agent would stop</span></span> <span class="src-tag">◀ trace</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">外环：follow-up 到达时 agent 本可停止却继续</span><span class="lang-en-only">outer: continue when follow-up arrives</span></span></span>
       <span class="src-line">      <span class="src-ln"> 170</span> <span class="src-hl">	<span class="src-kw">while</span> (<span class="src-kw">true</span>) {</span></span>
       <span class="src-line">      <span class="src-ln"> 171</span> <span class="src-hl">		<span class="src-kw">let</span> hasMoreToolCalls = <span class="src-kw">true</span>;</span></span>
       <span class="src-line">      <span class="src-ln"> 172</span> <span class="src-hl"></span></span>
-      <span class="src-line">      <span class="src-ln"> 173</span> <span class="src-hl">		<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Inner</span> loop: process tool calls and steering messages</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 173</span> <span class="src-hl">		<span class="src-comment">// Inner loop: process tool calls and steering messages</span></span></span>
       <span class="src-line">      <span class="src-ln"> 174</span> <span class="src-hl">		<span class="src-kw">while</span> (hasMoreToolCalls || pendingMessages.length &gt; 0) {</span> <span class="src-tag">◀ trace</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">内环条件：还有 tool 或 pending steering</span><span class="lang-en-only">inner: more tools or pending steering</span></span></span>
       <span class="src-line">      <span class="src-ln"> 175</span> <span class="src-hl">			<span class="src-kw">if</span> (!firstTurn) {</span></span>
@@ -4857,7 +4857,7 @@
       <span class="src-line">      <span class="src-ln"> 178</span> <span class="src-hl">				firstTurn = <span class="src-kw">false</span>;</span></span>
       <span class="src-line">      <span class="src-ln"> 179</span> <span class="src-hl">			}</span></span>
       <span class="src-line">      <span class="src-ln"> 180</span> <span class="src-hl"></span></span>
-      <span class="src-line">      <span class="src-ln"> 181</span> <span class="src-hl">			<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Process</span> pending messages (inject before next assistant response)</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 181</span> <span class="src-hl">			<span class="src-comment">// Process pending messages (inject before next assistant response)</span></span></span>
       <span class="src-line">      <span class="src-ln"> 182</span> <span class="src-hl">			<span class="src-kw">if</span> (pendingMessages.length &gt; 0) {</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">steering 注入：message_start/end 无 streaming</span><span class="lang-en-only">steering inject: message_start/end, no streaming</span></span></span>
       <span class="src-line">      <span class="src-ln"> 183</span> <span class="src-hl">				<span class="src-kw">for</span> (<span class="src-kw">const</span> message of pendingMessages) {</span></span>
@@ -4869,7 +4869,7 @@
       <span class="src-line">      <span class="src-ln"> 189</span> <span class="src-hl">				pendingMessages = [];</span></span>
       <span class="src-line">      <span class="src-ln"> 190</span> <span class="src-hl">			}</span></span>
       <span class="src-line">      <span class="src-ln"> 191</span> <span class="src-hl"></span></span>
-      <span class="src-line">      <span class="src-ln"> 192</span> <span class="src-hl">			<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Stream</span> assistant response</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 192</span> <span class="src-hl">			<span class="src-comment">// Stream assistant response</span></span></span>
       <span class="src-line">      <span class="src-ln"> 193</span> <span class="src-hl">			<span class="src-kw">const</span> message = <span class="src-kw">await</span> streamAssistantResponse(currentContext, config, signal, emit, streamFunction);</span> <span class="src-tag">◀ trace</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">★ streamAssistantResponse：每圈内环一次 model</span><span class="lang-en-only">★ streamAssistantResponse: one model per inner round</span></span></span>
       <span class="src-line">      <span class="src-ln"> 194</span> <span class="src-hl">			newMessages.push(message);</span></span>
@@ -4880,16 +4880,16 @@
       <span class="src-line">      <span class="src-ln"> 199</span> <span class="src-hl">				<span class="src-kw">return</span>;</span></span>
       <span class="src-line">      <span class="src-ln"> 200</span> <span class="src-hl">			}</span></span>
       <span class="src-line">      <span class="src-ln"> 201</span> <span class="src-hl"></span></span>
-      <span class="src-line">      <span class="src-ln"> 202</span> <span class="src-hl">			<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Check</span> <span class="src-kw">for</span> tool calls</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 202</span> <span class="src-hl">			<span class="src-comment">// Check for tool calls</span></span></span>
       <span class="src-line">      <span class="src-ln"> 203</span> <span class="src-hl">			<span class="src-kw">const</span> toolCalls = message.content.filter((c) =&gt; c.<span class="src-kw">type</span> === &quot;toolCall&quot;);</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">从 assistant content 提取 toolCall</span><span class="lang-en-only">extract toolCall from assistant content</span></span></span>
       <span class="src-line">      <span class="src-ln"> 204</span> <span class="src-hl"></span></span>
-      <span class="src-line">      <span class="src-ln"> 205</span> <span class="src-hl">			<span class="src-kw">const</span> toolResults: <span class="src-cls">ToolResultMessage</span>[] = [];</span></span>
+      <span class="src-line">      <span class="src-ln"> 205</span> <span class="src-hl">			<span class="src-kw">const</span> toolResults: ToolResultMessage[] = [];</span></span>
       <span class="src-line">      <span class="src-ln"> 206</span> <span class="src-hl">			hasMoreToolCalls = <span class="src-kw">false</span>;</span></span>
       <span class="src-line">      <span class="src-ln"> 207</span> <span class="src-hl">			<span class="src-kw">if</span> (toolCalls.length &gt; 0) {</span></span>
-      <span class="src-line">      <span class="src-ln"> 208</span> <span class="src-hl">				<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">A</span> &quot;length&quot; stop means the output was cut off by the token limit, so</span></span></span>
-      <span class="src-line">      <span class="src-ln"> 209</span> <span class="src-hl">				<span class=<span class="src-str">"src-comment"</span>>// every tool call in the message may carry truncated arguments. <span class="src-cls">Fail</span></span></span></span>
-      <span class="src-line">      <span class="src-ln"> 210</span> <span class="src-hl">				<span class=<span class="src-str">"src-comment"</span>>// them all instead of executing potentially borked calls.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 208</span> <span class="src-hl">				<span class="src-comment">// A &amp;quot;length&amp;quot; stop means the output was cut off by the token limit, so</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 209</span> <span class="src-hl">				<span class="src-comment">// every tool call in the message may carry truncated arguments. Fail</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 210</span> <span class="src-hl">				<span class="src-comment">// them all instead of executing potentially borked calls.</span></span></span>
       <span class="src-line">      <span class="src-ln"> 211</span> <span class="src-hl">				<span class="src-kw">const</span> executedToolBatch =</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">stopReason=length → 批量 fail tool，不执行</span><span class="lang-en-only">stopReason=length → fail all tools, don't execute</span></span></span>
       <span class="src-line">      <span class="src-ln"> 212</span> <span class="src-hl">					message.stopReason === &quot;length&quot;</span></span>
@@ -4929,7 +4929,7 @@
         <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
         <span class="src-tag">stream-emit</span>
       </div>
-      <span class="src-line">      <span class="src-ln"> 314</span> <span class="src-hl">	<span class="src-kw">let</span> partialMessage: <span class="src-cls">AssistantMessage</span> | <span class="src-kw">null</span> = <span class="src-kw">null</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 314</span> <span class="src-hl">	<span class="src-kw">let</span> partialMessage: AssistantMessage | <span class="src-kw">null</span> = <span class="src-kw">null</span>;</span></span>
       <span class="src-line">      <span class="src-ln"> 315</span> <span class="src-hl">	<span class="src-kw">let</span> addedPartial = <span class="src-kw">false</span>;</span></span>
       <span class="src-line">      <span class="src-ln"> 316</span> <span class="src-hl"></span></span>
       <span class="src-line">      <span class="src-ln"> 317</span> <span class="src-hl">	<span class="src-kw">for</span> <span class="src-kw">await</span> (<span class="src-kw">const</span> event of response) {</span></span>
@@ -5007,17 +5007,17 @@
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">内环结束后再次 poll steering</span><span class="lang-en-only">poll steering again after inner loop</span></span></span>
       <span class="src-line">      <span class="src-ln"> 260</span> <span class="src-hl">		}</span></span>
       <span class="src-line">      <span class="src-ln"> 261</span> <span class="src-hl"></span></span>
-      <span class="src-line">      <span class="src-ln"> 262</span> <span class="src-hl">		<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Agent</span> would stop here. <span class="src-cls">Check</span> <span class="src-kw">for</span> follow-up messages.</span></span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-ln"> 262</span> <span class="src-hl">		<span class="src-comment">// Agent would stop here. Check for follow-up messages.</span></span> <span class="src-tag">◀ trace</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">外环 follow-up 检查点</span><span class="lang-en-only">outer follow-up checkpoint</span></span></span>
       <span class="src-line">      <span class="src-ln"> 263</span> <span class="src-hl">		<span class="src-kw">const</span> followUpMessages = (<span class="src-kw">await</span> config.getFollowUpMessages?.()) || [];</span></span>
       <span class="src-line">      <span class="src-ln"> 264</span> <span class="src-hl">		<span class="src-kw">if</span> (followUpMessages.length &gt; 0) {</span> <span class="src-tag">◀ trace</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">有 follow-up → pendingMessages → continue 外环</span><span class="lang-en-only">follow-up → pendingMessages → continue outer</span></span></span>
-      <span class="src-line">      <span class="src-ln"> 265</span> <span class="src-hl">			<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Set</span> as pending so inner loop processes them</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 265</span> <span class="src-hl">			<span class="src-comment">// Set as pending so inner loop processes them</span></span></span>
       <span class="src-line">      <span class="src-ln"> 266</span> <span class="src-hl">			pendingMessages = followUpMessages;</span></span>
       <span class="src-line">      <span class="src-ln"> 267</span> <span class="src-hl">			<span class="src-kw">continue</span>;</span></span>
       <span class="src-line">      <span class="src-ln"> 268</span> <span class="src-hl">		}</span></span>
       <span class="src-line">      <span class="src-ln"> 269</span> <span class="src-hl"></span></span>
-      <span class="src-line">      <span class="src-ln"> 270</span> <span class="src-hl">		<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">No</span> more messages, exit</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 270</span> <span class="src-hl">		<span class="src-comment">// No more messages, exit</span></span></span>
       <span class="src-line">      <span class="src-ln"> 271</span> <span class="src-hl">		<span class="src-kw">break</span>;</span></span>
       <span class="src-line">      <span class="src-ln"> 272</span> <span class="src-hl">	}</span></span>
       <span class="src-line">      <span class="src-ln"> 273</span> <span class="src-hl"></span></span>
@@ -5033,10 +5033,10 @@
       </div>
       <span class="src-line">      <span class="src-ln"> 381</span> <span class="src-hl"><span class="src-kw">async</span> <span class="src-kw">function</span> failToolCallsFromTruncatedMessage(</span> <span class="src-tag">◀ trace</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">length 截断时拒绝执行所有 tool call</span><span class="lang-en-only">length truncation rejects all tool calls</span></span></span>
-      <span class="src-line">      <span class="src-ln"> 382</span> <span class="src-hl">	toolCalls: <span class="src-cls">AgentToolCall</span>[],</span></span>
-      <span class="src-line">      <span class="src-ln"> 383</span> <span class="src-hl">	emit: <span class="src-cls">AgentEventSink</span>,</span></span>
-      <span class="src-line">      <span class="src-ln"> 384</span> <span class="src-hl">): <span class="src-cls">Promise</span>&lt;<span class="src-cls">ExecutedToolCallBatch</span>&gt; {</span></span>
-      <span class="src-line">      <span class="src-ln"> 385</span> <span class="src-hl">	<span class="src-kw">const</span> messages: <span class="src-cls">ToolResultMessage</span>[] = [];</span></span>
+      <span class="src-line">      <span class="src-ln"> 382</span> <span class="src-hl">	toolCalls: AgentToolCall[],</span></span>
+      <span class="src-line">      <span class="src-ln"> 383</span> <span class="src-hl">	emit: AgentEventSink,</span></span>
+      <span class="src-line">      <span class="src-ln"> 384</span> <span class="src-hl">): Promise&lt;ExecutedToolCallBatch&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln"> 385</span> <span class="src-hl">	<span class="src-kw">const</span> messages: ToolResultMessage[] = [];</span></span>
       <span class="src-line">      <span class="src-ln"> 386</span> <span class="src-hl">	<span class="src-kw">for</span> (<span class="src-kw">const</span> toolCall of toolCalls) {</span></span>
       <span class="src-line">      <span class="src-ln"> 387</span> <span class="src-hl">		<span class="src-kw">await</span> emit({</span></span>
       <span class="src-line">      <span class="src-ln"> 388</span> <span class="src-hl">			<span class="src-kw">type</span>: &quot;tool_execution_start&quot;,</span></span>
@@ -5044,10 +5044,10 @@
       <span class="src-line">      <span class="src-ln"> 390</span> <span class="src-hl">			toolName: toolCall.name,</span></span>
       <span class="src-line">      <span class="src-ln"> 391</span> <span class="src-hl">			args: toolCall.arguments,</span></span>
       <span class="src-line">      <span class="src-ln"> 392</span> <span class="src-hl">		});</span></span>
-      <span class="src-line">      <span class="src-ln"> 393</span> <span class="src-hl">		<span class="src-kw">const</span> finalized: <span class="src-cls">FinalizedToolCallOutcome</span> = {</span></span>
+      <span class="src-line">      <span class="src-ln"> 393</span> <span class="src-hl">		<span class="src-kw">const</span> finalized: FinalizedToolCallOutcome = {</span></span>
       <span class="src-line">      <span class="src-ln"> 394</span> <span class="src-hl">			toolCall,</span></span>
       <span class="src-line">      <span class="src-ln"> 395</span> <span class="src-hl">			result: createErrorToolResult(</span></span>
-      <span class="src-line">      <span class="src-ln"> 396</span> <span class="src-hl">				<span class=<span class="src-str">"src-str"</span>>`<span class="src-cls">Tool</span> call &quot;${toolCall.name}&quot; was not executed: the response hit the output token limit, so its arguments may be truncated. <span class="src-cls">Re</span>-issue the tool call with complete arguments.`</span>,</span></span>
+      <span class="src-line">      <span class="src-ln"> 396</span> <span class="src-hl">				<span class=<span class="src-str">"src-str"</span>>`Tool call &quot;${toolCall.name}&quot; was not executed: the response hit the output token limit, so its arguments may be truncated. Re-issue the tool call with complete arguments.`</span>,</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">错误 tool result 文案：要求模型重新发起完整参数</span><span class="lang-en-only">error tool result: ask model to re-issue full args</span></span></span>
       <span class="src-line">      <span class="src-ln"> 397</span> <span class="src-hl">			),</span></span>
       <span class="src-line">      <span class="src-ln"> 398</span> <span class="src-hl">			isError: <span class="src-kw">true</span>,</span></span>
@@ -5324,39 +5324,39 @@
         <span>SOURCE &nbsp;·&nbsp; packages/agent/src/types.ts</span>
         <span class="src-tag">config-hooks</span>
       </div>
-      <span class="src-line">      <span class="src-ln"> 230</span> <span class="src-hl">		context: <span class="src-cls">PrepareNextTurnContext</span>,</span></span>
-      <span class="src-line">      <span class="src-ln"> 231</span> <span class="src-hl">	) =&gt; <span class="src-cls">AgentLoopTurnUpdate</span> | <span class="src-kw">undefined</span> | <span class="src-cls">Promise</span>&lt;<span class="src-cls">AgentLoopTurnUpdate</span> | <span class="src-kw">undefined</span>&gt;;</span></span>
+      <span class="src-line">      <span class="src-ln"> 230</span> <span class="src-hl">		context: PrepareNextTurnContext,</span></span>
+      <span class="src-line">      <span class="src-ln"> 231</span> <span class="src-hl">	) =&gt; AgentLoopTurnUpdate | <span class="src-kw">undefined</span> | Promise&lt;AgentLoopTurnUpdate | <span class="src-kw">undefined</span>&gt;;</span></span>
       <span class="src-line">      <span class="src-ln"> 232</span> <span class="src-hl"></span></span>
       <span class="src-line">      <span class="src-ln"> 233</span> <span class="src-hl">	/**</span></span>
-      <span class="src-line">      <span class="src-ln"> 234</span> <span class="src-hl">	 * <span class="src-cls">Returns</span> steering messages to inject into the conversation mid-run.</span></span>
+      <span class="src-line">      <span class="src-ln"> 234</span> <span class="src-hl">	 * Returns steering messages to inject into the conversation mid-run.</span></span>
       <span class="src-line">      <span class="src-ln"> 235</span> <span class="src-hl">	 *</span></span>
-      <span class="src-line">      <span class="src-ln"> 236</span> <span class="src-hl">	 * <span class="src-cls">Called</span> after the current assistant turn finishes executing its tool calls, unless <span class=<span class="src-str">"src-str"</span>>`shouldStopAfterTurn`</span> exits first.</span></span>
-      <span class="src-line">      <span class="src-ln"> 237</span> <span class="src-hl">	 * <span class="src-cls">If</span> messages are returned, they are added to the context before the next <span class="src-cls">LLM</span> call.</span></span>
-      <span class="src-line">      <span class="src-ln"> 238</span> <span class="src-hl">	 * <span class="src-cls">Tool</span> calls <span class="src-kw">from</span> the current assistant message are not skipped.</span></span>
+      <span class="src-line">      <span class="src-ln"> 236</span> <span class="src-hl">	 * Called after the current assistant turn finishes executing its tool calls, unless <span class=<span class="src-str">"src-str"</span>>`shouldStopAfterTurn`</span> exits first.</span></span>
+      <span class="src-line">      <span class="src-ln"> 237</span> <span class="src-hl">	 * If messages are returned, they are added to the context before the next LLM call.</span></span>
+      <span class="src-line">      <span class="src-ln"> 238</span> <span class="src-hl">	 * Tool calls <span class="src-kw">from</span> the current assistant message are not skipped.</span></span>
       <span class="src-line">      <span class="src-ln"> 239</span> <span class="src-hl">	 *</span></span>
-      <span class="src-line">      <span class="src-ln"> 240</span> <span class="src-hl">	 * <span class="src-cls">Use</span> this <span class="src-kw">for</span> &quot;steering&quot; the agent <span class="src-kw">while</span> it&#x27;s working.</span></span>
+      <span class="src-line">      <span class="src-ln"> 240</span> <span class="src-hl">	 * Use this <span class="src-kw">for</span> &quot;steering&quot; the agent <span class="src-kw">while</span> it&#x27;s working.</span></span>
       <span class="src-line">      <span class="src-ln"> 241</span> <span class="src-hl">	 *</span></span>
-      <span class="src-line">      <span class="src-ln"> 242</span> <span class="src-hl">	 * <span class="src-cls">Contract</span>: must not <span class="src-kw">throw</span> or reject. <span class="src-cls">Return</span> [] when no steering messages are available.</span></span>
+      <span class="src-line">      <span class="src-ln"> 242</span> <span class="src-hl">	 * Contract: must not <span class="src-kw">throw</span> or reject. Return [] when no steering messages are available.</span></span>
       <span class="src-line">      <span class="src-ln"> 243</span> <span class="src-hl">	 */</span></span>
-      <span class="src-line">      <span class="src-ln"> 244</span> <span class="src-hl">	getSteeringMessages?: () =&gt; <span class="src-cls">Promise</span>&lt;AgentMessage[]&gt;;</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-ln"> 244</span> <span class="src-hl">	getSteeringMessages?: () =&gt; Promise&lt;AgentMessage[]&gt;;</span> <span class="src-tag">◀ trace</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">getSteeringMessages：内环每轮前 poll</span><span class="lang-en-only">getSteeringMessages: poll before each inner round</span></span></span>
       <span class="src-line">      <span class="src-ln"> 245</span> <span class="src-hl"></span></span>
       <span class="src-line">      <span class="src-ln"> 246</span> <span class="src-hl">	/**</span></span>
-      <span class="src-line">      <span class="src-ln"> 247</span> <span class="src-hl">	 * <span class="src-cls">Returns</span> follow-up messages to process after the agent would otherwise stop.</span></span>
+      <span class="src-line">      <span class="src-ln"> 247</span> <span class="src-hl">	 * Returns follow-up messages to process after the agent would otherwise stop.</span></span>
       <span class="src-line">      <span class="src-ln"> 248</span> <span class="src-hl">	 *</span></span>
-      <span class="src-line">      <span class="src-ln"> 249</span> <span class="src-hl">	 * <span class="src-cls">Called</span> when the agent has no more tool calls and no steering messages.</span></span>
-      <span class="src-line">      <span class="src-ln"> 250</span> <span class="src-hl">	 * <span class="src-cls">If</span> messages are returned, they&#x27;re added to the context and the agent</span></span>
+      <span class="src-line">      <span class="src-ln"> 249</span> <span class="src-hl">	 * Called when the agent has no more tool calls and no steering messages.</span></span>
+      <span class="src-line">      <span class="src-ln"> 250</span> <span class="src-hl">	 * If messages are returned, they&#x27;re added to the context and the agent</span></span>
       <span class="src-line">      <span class="src-ln"> 251</span> <span class="src-hl">	 * continues with another turn.</span></span>
       <span class="src-line">      <span class="src-ln"> 252</span> <span class="src-hl">	 *</span></span>
-      <span class="src-line">      <span class="src-ln"> 253</span> <span class="src-hl">	 * <span class="src-cls">Use</span> this <span class="src-kw">for</span> follow-up messages that should wait until the agent finishes.</span></span>
+      <span class="src-line">      <span class="src-ln"> 253</span> <span class="src-hl">	 * Use this <span class="src-kw">for</span> follow-up messages that should wait until the agent finishes.</span></span>
       <span class="src-line">      <span class="src-ln"> 254</span> <span class="src-hl">	 *</span></span>
-      <span class="src-line">      <span class="src-ln"> 255</span> <span class="src-hl">	 * <span class="src-cls">Contract</span>: must not <span class="src-kw">throw</span> or reject. <span class="src-cls">Return</span> [] when no follow-up messages are available.</span></span>
+      <span class="src-line">      <span class="src-ln"> 255</span> <span class="src-hl">	 * Contract: must not <span class="src-kw">throw</span> or reject. Return [] when no follow-up messages are available.</span></span>
       <span class="src-line">      <span class="src-ln"> 256</span> <span class="src-hl">	 */</span></span>
-      <span class="src-line">      <span class="src-ln"> 257</span> <span class="src-hl">	getFollowUpMessages?: () =&gt; <span class="src-cls">Promise</span>&lt;AgentMessage[]&gt;;</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-ln"> 257</span> <span class="src-hl">	getFollowUpMessages?: () =&gt; Promise&lt;AgentMessage[]&gt;;</span> <span class="src-tag">◀ trace</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">getFollowUpMessages：外环 would-stop 时 poll</span><span class="lang-en-only">getFollowUpMessages: poll at outer would-stop</span></span></span>
       <span class="src-line">      <span class="src-ln"> 258</span> <span class="src-hl"></span></span>
       <span class="src-line">      <span class="src-ln"> 259</span> <span class="src-hl">	/**</span></span>
-      <span class="src-line">      <span class="src-ln"> 260</span> <span class="src-hl">	 * <span class="src-cls">Tool</span> execution mode.</span></span>
+      <span class="src-line">      <span class="src-ln"> 260</span> <span class="src-hl">	 * Tool execution mode.</span></span>
     </div>
 
     <div class="src-stack">
@@ -5364,15 +5364,15 @@
         <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
         <span class="src-tag">inject</span>
       </div>
-      <span class="src-line">      <span class="src-ln"> 166</span> <span class="src-hl">	<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Check</span> <span class="src-kw">for</span> steering messages at start (user may have typed <span class="src-kw">while</span> waiting)</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 166</span> <span class="src-hl">	<span class="src-comment">// Check for steering messages at start (user may have typed while waiting)</span></span></span>
       <span class="src-line">      <span class="src-ln"> 167</span> <span class="src-hl">	<span class="src-kw">let</span> pendingMessages: AgentMessage[] = (<span class="src-kw">await</span> config.getSteeringMessages?.()) || [];</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">循环开头：await getSteeringMessages</span><span class="lang-en-only">loop start: await getSteeringMessages</span></span></span>
       <span class="src-line">      <span class="src-ln"> 168</span> <span class="src-hl"></span></span>
-      <span class="src-line">      <span class="src-ln"> 169</span> <span class="src-hl">	<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Outer</span> loop: continues when queued follow-up messages arrive after agent would stop</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 169</span> <span class="src-hl">	<span class="src-comment">// Outer loop: continues when queued follow-up messages arrive after agent would stop</span></span></span>
       <span class="src-line">      <span class="src-ln"> 170</span> <span class="src-hl">	<span class="src-kw">while</span> (<span class="src-kw">true</span>) {</span></span>
       <span class="src-line">      <span class="src-ln"> 171</span> <span class="src-hl">		<span class="src-kw">let</span> hasMoreToolCalls = <span class="src-kw">true</span>;</span></span>
       <span class="src-line">      <span class="src-ln"> 172</span> <span class="src-hl"></span></span>
-      <span class="src-line">      <span class="src-ln"> 173</span> <span class="src-hl">		<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Inner</span> loop: process tool calls and steering messages</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 173</span> <span class="src-hl">		<span class="src-comment">// Inner loop: process tool calls and steering messages</span></span></span>
       <span class="src-line">      <span class="src-ln"> 174</span> <span class="src-hl">		<span class="src-kw">while</span> (hasMoreToolCalls || pendingMessages.length &gt; 0) {</span></span>
       <span class="src-line">      <span class="src-ln"> 175</span> <span class="src-hl">			<span class="src-kw">if</span> (!firstTurn) {</span></span>
       <span class="src-line">      <span class="src-ln"> 176</span> <span class="src-hl">				<span class="src-kw">await</span> emit({ <span class="src-kw">type</span>: &quot;turn_start&quot; });</span></span>
@@ -5380,7 +5380,7 @@
       <span class="src-line">      <span class="src-ln"> 178</span> <span class="src-hl">				firstTurn = <span class="src-kw">false</span>;</span></span>
       <span class="src-line">      <span class="src-ln"> 179</span> <span class="src-hl">			}</span></span>
       <span class="src-line">      <span class="src-ln"> 180</span> <span class="src-hl"></span></span>
-      <span class="src-line">      <span class="src-ln"> 181</span> <span class="src-hl">			<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Process</span> pending messages (inject before next assistant response)</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 181</span> <span class="src-hl">			<span class="src-comment">// Process pending messages (inject before next assistant response)</span></span></span>
       <span class="src-line">      <span class="src-ln"> 182</span> <span class="src-hl">			<span class="src-kw">if</span> (pendingMessages.length &gt; 0) {</span> <span class="src-tag">◀ trace</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">pending 非空：逐条 push 到 context，无 LLM</span><span class="lang-en-only">pending non-empty: push to context, no LLM</span></span></span>
       <span class="src-line">      <span class="src-ln"> 183</span> <span class="src-hl">				<span class="src-kw">for</span> (<span class="src-kw">const</span> message of pendingMessages) {</span></span>
@@ -5404,11 +5404,11 @@
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">内环结束后再 poll steering</span><span class="lang-en-only">poll steering after inner loop</span></span></span>
       <span class="src-line">      <span class="src-ln"> 260</span> <span class="src-hl">		}</span></span>
       <span class="src-line">      <span class="src-ln"> 261</span> <span class="src-hl"></span></span>
-      <span class="src-line">      <span class="src-ln"> 262</span> <span class="src-hl">		<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Agent</span> would stop here. <span class="src-cls">Check</span> <span class="src-kw">for</span> follow-up messages.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 262</span> <span class="src-hl">		<span class="src-comment">// Agent would stop here. Check for follow-up messages.</span></span></span>
       <span class="src-line">      <span class="src-ln"> 263</span> <span class="src-hl">		<span class="src-kw">const</span> followUpMessages = (<span class="src-kw">await</span> config.getFollowUpMessages?.()) || [];</span> <span class="src-tag">◀ trace</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">★ follow-up：外环唯一重启条件</span><span class="lang-en-only">★ follow-up: sole outer restart condition</span></span></span>
       <span class="src-line">      <span class="src-ln"> 264</span> <span class="src-hl">		<span class="src-kw">if</span> (followUpMessages.length &gt; 0) {</span></span>
-      <span class="src-line">      <span class="src-ln"> 265</span> <span class="src-hl">			<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Set</span> as pending so inner loop processes them</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 265</span> <span class="src-hl">			<span class="src-comment">// Set as pending so inner loop processes them</span></span></span>
       <span class="src-line">      <span class="src-ln"> 266</span> <span class="src-hl">			pendingMessages = followUpMessages;</span> <span class="src-tag">◀ trace</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">follow-up 变成 pending，continue 外环</span><span class="lang-en-only">follow-up becomes pending, continue outer</span></span></span>
       <span class="src-line">      <span class="src-ln"> 267</span> <span class="src-hl">			<span class="src-kw">continue</span>;</span></span>
@@ -5431,23 +5431,23 @@
         <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/agent-session.ts</span>
         <span class="src-tag">session-queue</span>
       </div>
-      <span class="src-line">      <span class="src-ln"> 620</span> <span class="src-hl">	/** <span class="src-cls">Internal</span> handler <span class="src-kw">for</span> agent events - shared by subscribe and reconnect */</span></span>
-      <span class="src-line">      <span class="src-ln"> 621</span> <span class="src-hl">	private _handleAgentEvent = <span class="src-kw">async</span> (event: <span class="src-cls">AgentEvent</span>): <span class="src-cls">Promise</span>&lt;void&gt; =&gt; {</span></span>
-      <span class="src-line">      <span class="src-ln"> 622</span> <span class="src-hl">		<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">When</span> a user message starts, check <span class="src-kw">if</span> it&#x27;s <span class="src-kw">from</span> either queue and remove it <span class="src-cls">BEFORE</span> emitting</span></span></span>
-      <span class="src-line">      <span class="src-ln"> 623</span> <span class="src-hl">		<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">This</span> ensures the <span class="src-cls">UI</span> sees the updated queue state</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 620</span> <span class="src-hl">	/** Internal handler <span class="src-kw">for</span> agent events - shared by subscribe and reconnect */</span></span>
+      <span class="src-line">      <span class="src-ln"> 621</span> <span class="src-hl">	private _handleAgentEvent = <span class="src-kw">async</span> (event: AgentEvent): Promise&lt;void&gt; =&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln"> 622</span> <span class="src-hl">		<span class="src-comment">// When a user message starts, check if it&amp;#x27;s from either queue and remove it BEFORE emitting</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 623</span> <span class="src-hl">		<span class="src-comment">// This ensures the UI sees the updated queue state</span></span></span>
       <span class="src-line">      <span class="src-ln"> 624</span> <span class="src-hl">		<span class="src-kw">if</span> (event.<span class="src-kw">type</span> === &quot;message_start&quot; &amp;&amp; event.message.role === &quot;user&quot;) {</span> <span class="src-tag">◀ trace</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">message_start(user) 时从队列移除</span><span class="lang-en-only">on message_start(user) remove from queue</span></span></span>
       <span class="src-line">      <span class="src-ln"> 625</span> <span class="src-hl">			this._overflowRecoveryAttempted = <span class="src-kw">false</span>;</span></span>
       <span class="src-line">      <span class="src-ln"> 626</span> <span class="src-hl">			<span class="src-kw">const</span> messageText = contentText(event.message.content, &quot;&quot;);</span></span>
       <span class="src-line">      <span class="src-ln"> 627</span> <span class="src-hl">			<span class="src-kw">if</span> (messageText) {</span></span>
-      <span class="src-line">      <span class="src-ln"> 628</span> <span class="src-hl">				<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Check</span> steering queue first</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 628</span> <span class="src-hl">				<span class="src-comment">// Check steering queue first</span></span></span>
       <span class="src-line">      <span class="src-ln"> 629</span> <span class="src-hl">				<span class="src-kw">const</span> steeringIndex = this._steeringMessages.indexOf(messageText);</span> <span class="src-tag">◀ trace</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">先匹配 steering 队列</span><span class="lang-en-only">match steering queue first</span></span></span>
       <span class="src-line">      <span class="src-ln"> 630</span> <span class="src-hl">				<span class="src-kw">if</span> (steeringIndex !== -1) {</span></span>
       <span class="src-line">      <span class="src-ln"> 631</span> <span class="src-hl">					this._steeringMessages.splice(steeringIndex, 1);</span></span>
       <span class="src-line">      <span class="src-ln"> 632</span> <span class="src-hl">					this._emitQueueUpdate();</span></span>
       <span class="src-line">      <span class="src-ln"> 633</span> <span class="src-hl">				} <span class="src-kw">else</span> {</span></span>
-      <span class="src-line">      <span class="src-ln"> 634</span> <span class="src-hl">					<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Check</span> follow-up queue</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 634</span> <span class="src-hl">					<span class="src-comment">// Check follow-up queue</span></span></span>
       <span class="src-line">      <span class="src-ln"> 635</span> <span class="src-hl">					<span class="src-kw">const</span> followUpIndex = this._followUpMessages.indexOf(messageText);</span> <span class="src-tag">◀ trace</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">再匹配 follow-up 队列</span><span class="lang-en-only">then follow-up queue</span></span></span>
       <span class="src-line">      <span class="src-ln"> 636</span> <span class="src-hl">					<span class="src-kw">if</span> (followUpIndex !== -1) {</span></span>
@@ -5458,10 +5458,10 @@
       <span class="src-line">      <span class="src-ln"> 641</span> <span class="src-hl">			}</span></span>
       <span class="src-line">      <span class="src-ln"> 642</span> <span class="src-hl">		}</span></span>
       <span class="src-line">      <span class="src-ln"> 643</span> <span class="src-hl"></span></span>
-      <span class="src-line">      <span class="src-ln"> 644</span> <span class="src-hl">		<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Emit</span> to extensions first</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 644</span> <span class="src-hl">		<span class="src-comment">// Emit to extensions first</span></span></span>
       <span class="src-line">      <span class="src-ln"> 645</span> <span class="src-hl">		<span class="src-kw">await</span> this._emitExtensionEvent(event);</span></span>
       <span class="src-line">      <span class="src-ln"> 646</span> <span class="src-hl"></span></span>
-      <span class="src-line">      <span class="src-ln"> 647</span> <span class="src-hl">		<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Notify</span> all listeners</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 647</span> <span class="src-hl">		<span class="src-comment">// Notify all listeners</span></span></span>
       <span class="src-line">      <span class="src-ln"> 648</span> <span class="src-hl">		this._emit(event.<span class="src-kw">type</span> === &quot;agent_end&quot; ? { ...event, willRetry: this._willRetryAfterAgentEnd(event) } : event);</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">_emit 给 TUI 监听器</span><span class="lang-en-only">_emit to TUI listeners</span></span></span>
     </div>
@@ -5750,12 +5750,12 @@
         <span class="src-tag">dispatch</span>
       </div>
       <span class="src-line">      <span class="src-ln"> 411</span> <span class="src-hl"><span class="src-kw">async</span> <span class="src-kw">function</span> executeToolCalls(</span></span>
-      <span class="src-line">      <span class="src-ln"> 412</span> <span class="src-hl">	currentContext: <span class="src-cls">AgentContext</span>,</span></span>
-      <span class="src-line">      <span class="src-ln"> 413</span> <span class="src-hl">	assistantMessage: <span class="src-cls">AssistantMessage</span>,</span></span>
-      <span class="src-line">      <span class="src-ln"> 414</span> <span class="src-hl">	config: <span class="src-cls">AgentLoopConfig</span>,</span></span>
-      <span class="src-line">      <span class="src-ln"> 415</span> <span class="src-hl">	signal: <span class="src-cls">AbortSignal</span> | <span class="src-kw">undefined</span>,</span></span>
-      <span class="src-line">      <span class="src-ln"> 416</span> <span class="src-hl">	emit: <span class="src-cls">AgentEventSink</span>,</span></span>
-      <span class="src-line">      <span class="src-ln"> 417</span> <span class="src-hl">): <span class="src-cls">Promise</span>&lt;<span class="src-cls">ExecutedToolCallBatch</span>&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln"> 412</span> <span class="src-hl">	currentContext: AgentContext,</span></span>
+      <span class="src-line">      <span class="src-ln"> 413</span> <span class="src-hl">	assistantMessage: AssistantMessage,</span></span>
+      <span class="src-line">      <span class="src-ln"> 414</span> <span class="src-hl">	config: AgentLoopConfig,</span></span>
+      <span class="src-line">      <span class="src-ln"> 415</span> <span class="src-hl">	signal: AbortSignal | <span class="src-kw">undefined</span>,</span></span>
+      <span class="src-line">      <span class="src-ln"> 416</span> <span class="src-hl">	emit: AgentEventSink,</span></span>
+      <span class="src-line">      <span class="src-ln"> 417</span> <span class="src-hl">): Promise&lt;ExecutedToolCallBatch&gt; {</span></span>
       <span class="src-line">      <span class="src-ln"> 418</span> <span class="src-hl">	<span class="src-kw">const</span> toolCalls = assistantMessage.content.filter((c) =&gt; c.<span class="src-kw">type</span> === &quot;toolCall&quot;);</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">从 assistant content filter toolCall</span><span class="lang-en-only">filter toolCall from assistant content</span></span></span>
       <span class="src-line">      <span class="src-ln"> 419</span> <span class="src-hl">	<span class="src-kw">const</span> hasSequentialToolCall = toolCalls.some(</span></span>
@@ -5777,15 +5777,15 @@
         <span class="src-tag">sequential</span>
       </div>
       <span class="src-line">      <span class="src-ln"> 433</span> <span class="src-hl"><span class="src-kw">async</span> <span class="src-kw">function</span> executeToolCallsSequential(</span></span>
-      <span class="src-line">      <span class="src-ln"> 434</span> <span class="src-hl">	currentContext: <span class="src-cls">AgentContext</span>,</span></span>
-      <span class="src-line">      <span class="src-ln"> 435</span> <span class="src-hl">	assistantMessage: <span class="src-cls">AssistantMessage</span>,</span></span>
-      <span class="src-line">      <span class="src-ln"> 436</span> <span class="src-hl">	toolCalls: <span class="src-cls">AgentToolCall</span>[],</span></span>
-      <span class="src-line">      <span class="src-ln"> 437</span> <span class="src-hl">	config: <span class="src-cls">AgentLoopConfig</span>,</span></span>
-      <span class="src-line">      <span class="src-ln"> 438</span> <span class="src-hl">	signal: <span class="src-cls">AbortSignal</span> | <span class="src-kw">undefined</span>,</span></span>
-      <span class="src-line">      <span class="src-ln"> 439</span> <span class="src-hl">	emit: <span class="src-cls">AgentEventSink</span>,</span></span>
-      <span class="src-line">      <span class="src-ln"> 440</span> <span class="src-hl">): <span class="src-cls">Promise</span>&lt;<span class="src-cls">ExecutedToolCallBatch</span>&gt; {</span></span>
-      <span class="src-line">      <span class="src-ln"> 441</span> <span class="src-hl">	<span class="src-kw">const</span> finalizedCalls: <span class="src-cls">FinalizedToolCallOutcome</span>[] = [];</span></span>
-      <span class="src-line">      <span class="src-ln"> 442</span> <span class="src-hl">	<span class="src-kw">const</span> messages: <span class="src-cls">ToolResultMessage</span>[] = [];</span></span>
+      <span class="src-line">      <span class="src-ln"> 434</span> <span class="src-hl">	currentContext: AgentContext,</span></span>
+      <span class="src-line">      <span class="src-ln"> 435</span> <span class="src-hl">	assistantMessage: AssistantMessage,</span></span>
+      <span class="src-line">      <span class="src-ln"> 436</span> <span class="src-hl">	toolCalls: AgentToolCall[],</span></span>
+      <span class="src-line">      <span class="src-ln"> 437</span> <span class="src-hl">	config: AgentLoopConfig,</span></span>
+      <span class="src-line">      <span class="src-ln"> 438</span> <span class="src-hl">	signal: AbortSignal | <span class="src-kw">undefined</span>,</span></span>
+      <span class="src-line">      <span class="src-ln"> 439</span> <span class="src-hl">	emit: AgentEventSink,</span></span>
+      <span class="src-line">      <span class="src-ln"> 440</span> <span class="src-hl">): Promise&lt;ExecutedToolCallBatch&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln"> 441</span> <span class="src-hl">	<span class="src-kw">const</span> finalizedCalls: FinalizedToolCallOutcome[] = [];</span></span>
+      <span class="src-line">      <span class="src-ln"> 442</span> <span class="src-hl">	<span class="src-kw">const</span> messages: ToolResultMessage[] = [];</span></span>
       <span class="src-line">      <span class="src-ln"> 443</span> <span class="src-hl"></span></span>
       <span class="src-line">      <span class="src-ln"> 444</span> <span class="src-hl">	<span class="src-kw">for</span> (<span class="src-kw">const</span> toolCall of toolCalls) {</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">逐 toolCall：tool_execution_start</span><span class="lang-en-only">per toolCall: tool_execution_start</span></span></span>
@@ -5798,7 +5798,7 @@
       <span class="src-line">      <span class="src-ln"> 451</span> <span class="src-hl"></span></span>
       <span class="src-line">      <span class="src-ln"> 452</span> <span class="src-hl">		<span class="src-kw">const</span> preparation = <span class="src-kw">await</span> prepareToolCall(currentContext, assistantMessage, toolCall, config, signal);</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">prepareToolCall：参数校验 + 扩展 hook</span><span class="lang-en-only">prepareToolCall: validate + extension hook</span></span></span>
-      <span class="src-line">      <span class="src-ln"> 453</span> <span class="src-hl">		<span class="src-kw">let</span> finalized: <span class="src-cls">FinalizedToolCallOutcome</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 453</span> <span class="src-hl">		<span class="src-kw">let</span> finalized: FinalizedToolCallOutcome;</span></span>
       <span class="src-line">      <span class="src-ln"> 454</span> <span class="src-hl">		<span class="src-kw">if</span> (preparation.kind === &quot;immediate&quot;) {</span></span>
       <span class="src-line">      <span class="src-ln"> 455</span> <span class="src-hl">			finalized = {</span></span>
       <span class="src-line">      <span class="src-ln"> 456</span> <span class="src-hl">				toolCall,</span></span>
@@ -5833,14 +5833,14 @@
       <span class="src-line">      <span class="src-ln"> 209</span> <span class="src-hl"><span class="src-kw">export</span> <span class="src-kw">function</span> createReadToolDefinition(</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">createReadToolDefinition：schema + execute</span><span class="lang-en-only">createReadToolDefinition: schema + execute</span></span></span>
       <span class="src-line">      <span class="src-ln"> 210</span> <span class="src-hl">	cwd: string,</span></span>
-      <span class="src-line">      <span class="src-ln"> 211</span> <span class="src-hl">	options?: <span class="src-cls">ReadToolOptions</span>,</span></span>
-      <span class="src-line">      <span class="src-ln"> 212</span> <span class="src-hl">): <span class="src-cls">ToolDefinition</span>&lt;<span class="src-kw">typeof</span> readSchema, <span class="src-cls">ReadToolDetails</span> | <span class="src-kw">undefined</span>&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln"> 211</span> <span class="src-hl">	options?: ReadToolOptions,</span></span>
+      <span class="src-line">      <span class="src-ln"> 212</span> <span class="src-hl">): ToolDefinition&lt;<span class="src-kw">typeof</span> readSchema, ReadToolDetails | <span class="src-kw">undefined</span>&gt; {</span></span>
       <span class="src-line">      <span class="src-ln"> 213</span> <span class="src-hl">	<span class="src-kw">const</span> autoResizeImages = options?.autoResizeImages ?? <span class="src-kw">true</span>;</span></span>
       <span class="src-line">      <span class="src-ln"> 214</span> <span class="src-hl">	<span class="src-kw">const</span> ops = options?.operations ?? defaultReadOperations;</span></span>
       <span class="src-line">      <span class="src-ln"> 215</span> <span class="src-hl">	<span class="src-kw">return</span> {</span></span>
       <span class="src-line">      <span class="src-ln"> 216</span> <span class="src-hl">		name: &quot;read&quot;,</span></span>
       <span class="src-line">      <span class="src-ln"> 217</span> <span class="src-hl">		label: &quot;read&quot;,</span></span>
-      <span class="src-line">      <span class="src-ln"> 218</span> <span class="src-hl">		description: <span class=<span class="src-str">"src-str"</span>>`<span class="src-cls">Read</span> the contents of a file. <span class="src-cls">Supports</span> text files and images (jpg, png, gif, webp, bmp). <span class="src-cls">Images</span> are sent as attachments. <span class="src-cls">For</span> text files, output is truncated to ${DEFAULT_MAX_LINES} lines or ${DEFAULT_MAX_BYTES / 1024}<span class="src-cls">KB</span> (whichever is hit first). <span class="src-cls">Use</span> offset/limit <span class="src-kw">for</span> large files. <span class="src-cls">When</span> you need the full file, <span class="src-kw">continue</span> with offset until complete.`</span>,</span></span>
+      <span class="src-line">      <span class="src-ln"> 218</span> <span class="src-hl">		description: <span class=<span class="src-str">"src-str"</span>>`Read the contents of a file. Supports text files and images (jpg, png, gif, webp, bmp). Images are sent as attachments. For text files, output is truncated to ${DEFAULT_MAX_LINES} lines or ${DEFAULT_MAX_BYTES / 1024}KB (whichever is hit first). Use offset/limit <span class="src-kw">for</span> large files. When you need the full file, <span class="src-kw">continue</span> with offset until complete.`</span>,</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">DEFAULT_MAX_LINES / MAX_BYTES 截断说明在 description</span><span class="lang-en-only">truncation limits in description</span></span></span>
       <span class="src-line">      <span class="src-ln"> 219</span> <span class="src-hl">		promptSnippet: readToolSystemPromptContribution.snippet,</span></span>
       <span class="src-line">      <span class="src-ln"> 220</span> <span class="src-hl">		promptGuidelines: [...readToolSystemPromptContribution.guidelines],</span></span>
@@ -5850,11 +5850,11 @@
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">execute 入口：Promise + AbortSignal</span><span class="lang-en-only">execute entry: Promise + AbortSignal</span></span></span>
       <span class="src-line">      <span class="src-ln"> 224</span> <span class="src-hl">			_toolCallId,</span></span>
       <span class="src-line">      <span class="src-ln"> 225</span> <span class="src-hl">			{ path, offset, limit }: { path: string; offset?: number; limit?: number },</span></span>
-      <span class="src-line">      <span class="src-ln"> 226</span> <span class="src-hl">			signal?: <span class="src-cls">AbortSignal</span>,</span></span>
+      <span class="src-line">      <span class="src-ln"> 226</span> <span class="src-hl">			signal?: AbortSignal,</span></span>
       <span class="src-line">      <span class="src-ln"> 227</span> <span class="src-hl">			_onUpdate?,</span></span>
       <span class="src-line">      <span class="src-ln"> 228</span> <span class="src-hl">			ctx?,</span></span>
       <span class="src-line">      <span class="src-ln"> 229</span> <span class="src-hl">		) {</span></span>
-      <span class="src-line">      <span class="src-ln"> 230</span> <span class="src-hl">			<span class="src-kw">return</span> <span class="src-kw">new</span> <span class="src-cls">Promise</span>&lt;{ content: (<span class="src-cls">TextContent</span> | <span class="src-cls">ImageContent</span>)[]; details: <span class="src-cls">ReadToolDetails</span> | <span class="src-kw">undefined</span> }&gt;(</span></span>
+      <span class="src-line">      <span class="src-ln"> 230</span> <span class="src-hl">			<span class="src-kw">return</span> <span class="src-kw">new</span> Promise&lt;{ content: (TextContent | ImageContent)[]; details: ReadToolDetails | <span class="src-kw">undefined</span> }&gt;(</span></span>
     </div>
 
     <div class="src-stack">
@@ -5867,24 +5867,24 @@
       <span class="src-line">      <span class="src-ln"> 245</span> <span class="src-hl">							<span class="src-kw">const</span> absolutePath = <span class="src-kw">await</span> resolveReadPathAsync(path, cwd);</span> <span class="src-tag">◀ trace</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">resolveReadPathAsync：cwd 相对 → 绝对</span><span class="lang-en-only">resolveReadPathAsync: cwd-relative → absolute</span></span></span>
       <span class="src-line">      <span class="src-ln"> 246</span> <span class="src-hl">							<span class="src-kw">if</span> (aborted) <span class="src-kw">return</span>;</span></span>
-      <span class="src-line">      <span class="src-ln"> 247</span> <span class="src-hl">							<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Check</span> <span class="src-kw">if</span> file exists and is readable.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 247</span> <span class="src-hl">							<span class="src-comment">// Check if file exists and is readable.</span></span></span>
       <span class="src-line">      <span class="src-ln"> 248</span> <span class="src-hl">							<span class="src-kw">await</span> ops.access(absolutePath);</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">fs access 检查可读</span><span class="lang-en-only">fs access readability check</span></span></span>
       <span class="src-line">      <span class="src-ln"> 249</span> <span class="src-hl">							<span class="src-kw">if</span> (aborted) <span class="src-kw">return</span>;</span></span>
       <span class="src-line">      <span class="src-ln"> 250</span> <span class="src-hl">							<span class="src-kw">const</span> mimeType = ops.detectImageMimeType ? <span class="src-kw">await</span> ops.detectImageMimeType(absolutePath) : <span class="src-kw">undefined</span>;</span></span>
-      <span class="src-line">      <span class="src-ln"> 251</span> <span class="src-hl">							<span class="src-kw">let</span> content: (<span class="src-cls">TextContent</span> | <span class="src-cls">ImageContent</span>)[];</span></span>
-      <span class="src-line">      <span class="src-ln"> 252</span> <span class="src-hl">							<span class="src-kw">let</span> details: <span class="src-cls">ReadToolDetails</span> | <span class="src-kw">undefined</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 251</span> <span class="src-hl">							<span class="src-kw">let</span> content: (TextContent | ImageContent)[];</span></span>
+      <span class="src-line">      <span class="src-ln"> 252</span> <span class="src-hl">							<span class="src-kw">let</span> details: ReadToolDetails | <span class="src-kw">undefined</span>;</span></span>
       <span class="src-line">      <span class="src-ln"> 253</span> <span class="src-hl">							<span class="src-kw">const</span> nonVisionImageNote = getNonVisionImageNote(ctx?.model);</span></span>
       <span class="src-line">      <span class="src-ln"> 254</span> <span class="src-hl">							<span class="src-kw">if</span> (mimeType) {</span></span>
-      <span class="src-line">      <span class="src-ln"> 255</span> <span class="src-hl">								<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Read</span> image as binary.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 255</span> <span class="src-hl">								<span class="src-comment">// Read image as binary.</span></span></span>
       <span class="src-line">      <span class="src-ln"> 256</span> <span class="src-hl">								<span class="src-kw">const</span> buffer = <span class="src-kw">await</span> ops.readFile(absolutePath);</span></span>
       <span class="src-line">      <span class="src-ln"> 257</span> <span class="src-hl">								<span class="src-kw">const</span> processed = <span class="src-kw">await</span> processImage(buffer, mimeType, { autoResizeImages });</span></span>
       <span class="src-line">      <span class="src-ln"> 258</span> <span class="src-hl">								<span class="src-kw">if</span> (!processed.ok) {</span></span>
-      <span class="src-line">      <span class="src-ln"> 259</span> <span class="src-hl">									<span class="src-kw">let</span> textNote = <span class=<span class="src-str">"src-str"</span>>`<span class="src-cls">Read</span> image file [${mimeType}]\n${processed.message}`</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 259</span> <span class="src-hl">									<span class="src-kw">let</span> textNote = <span class=<span class="src-str">"src-str"</span>>`Read image file [${mimeType}]\n${processed.message}`</span>;</span></span>
       <span class="src-line">      <span class="src-ln"> 260</span> <span class="src-hl">									<span class="src-kw">if</span> (nonVisionImageNote) textNote += <span class=<span class="src-str">"src-str"</span>>`\n${nonVisionImageNote}`</span>;</span></span>
       <span class="src-line">      <span class="src-ln"> 261</span> <span class="src-hl">									content = [{ <span class="src-kw">type</span>: &quot;text&quot;, text: textNote }];</span></span>
       <span class="src-line">      <span class="src-ln"> 262</span> <span class="src-hl">								} <span class="src-kw">else</span> {</span></span>
-      <span class="src-line">      <span class="src-ln"> 263</span> <span class="src-hl">									<span class="src-kw">let</span> textNote = <span class=<span class="src-str">"src-str"</span>>`<span class="src-cls">Read</span> image file [${processed.mimeType}]`</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 263</span> <span class="src-hl">									<span class="src-kw">let</span> textNote = <span class=<span class="src-str">"src-str"</span>>`Read image file [${processed.mimeType}]`</span>;</span></span>
       <span class="src-line">      <span class="src-ln"> 264</span> <span class="src-hl">									<span class="src-kw">if</span> (processed.hints.length &gt; 0) textNote += <span class=<span class="src-str">"src-str"</span>>`\n${processed.hints.join(&quot;\n&quot;)}`</span>;</span></span>
       <span class="src-line">      <span class="src-ln"> 265</span> <span class="src-hl">									<span class="src-kw">if</span> (nonVisionImageNote) textNote += <span class=<span class="src-str">"src-str"</span>>`\n${nonVisionImageNote}`</span>;</span></span>
       <span class="src-line">      <span class="src-ln"> 266</span> <span class="src-hl">									content = [</span></span>
@@ -5893,57 +5893,57 @@
       <span class="src-line">      <span class="src-ln"> 269</span> <span class="src-hl">									];</span></span>
       <span class="src-line">      <span class="src-ln"> 270</span> <span class="src-hl">								}</span></span>
       <span class="src-line">      <span class="src-ln"> 271</span> <span class="src-hl">							} <span class="src-kw">else</span> {</span></span>
-      <span class="src-line">      <span class="src-ln"> 272</span> <span class="src-hl">								<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Read</span> text content.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 272</span> <span class="src-hl">								<span class="src-comment">// Read text content.</span></span></span>
       <span class="src-line">      <span class="src-ln"> 273</span> <span class="src-hl">								<span class="src-kw">const</span> buffer = <span class="src-kw">await</span> ops.readFile(absolutePath);</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">文本分支：buffer.toString utf-8</span><span class="lang-en-only">text branch: buffer.toString utf-8</span></span></span>
       <span class="src-line">      <span class="src-ln"> 274</span> <span class="src-hl">								<span class="src-kw">const</span> textContent = buffer.toString(&quot;utf-8&quot;);</span></span>
       <span class="src-line">      <span class="src-ln"> 275</span> <span class="src-hl">								<span class="src-kw">const</span> allLines = textContent.split(&quot;\n&quot;);</span></span>
       <span class="src-line">      <span class="src-ln"> 276</span> <span class="src-hl">								<span class="src-kw">const</span> totalFileLines = allLines.length;</span></span>
-      <span class="src-line">      <span class="src-ln"> 277</span> <span class="src-hl">								<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Apply</span> offset <span class="src-kw">if</span> specified. <span class="src-cls">Convert</span> <span class="src-kw">from</span> 1-indexed input to 0-indexed array access.</span></span></span>
-      <span class="src-line">      <span class="src-ln"> 278</span> <span class="src-hl">								<span class="src-kw">const</span> startLine = offset ? <span class="src-cls">Math</span>.max(0, offset - 1) : 0;</span></span>
+      <span class="src-line">      <span class="src-ln"> 277</span> <span class="src-hl">								<span class="src-comment">// Apply offset if specified. Convert from 1-indexed input to 0-indexed array access.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 278</span> <span class="src-hl">								<span class="src-kw">const</span> startLine = offset ? Math.max(0, offset - 1) : 0;</span></span>
       <span class="src-line">      <span class="src-ln"> 279</span> <span class="src-hl">								<span class="src-kw">const</span> startLineDisplay = startLine + 1;</span></span>
-      <span class="src-line">      <span class="src-ln"> 280</span> <span class="src-hl">								<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Check</span> <span class="src-kw">if</span> offset is out of bounds.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 280</span> <span class="src-hl">								<span class="src-comment">// Check if offset is out of bounds.</span></span></span>
       <span class="src-line">      <span class="src-ln"> 281</span> <span class="src-hl">								<span class="src-kw">if</span> (startLine &gt;= allLines.length) {</span></span>
-      <span class="src-line">      <span class="src-ln"> 282</span> <span class="src-hl">									<span class="src-kw">throw</span> <span class="src-kw">new</span> <span class="src-cls">Error</span>(<span class=<span class="src-str">"src-str"</span>>`<span class="src-cls">Offset</span> ${offset} is beyond end of file (${allLines.length} lines total)`</span>);</span></span>
+      <span class="src-line">      <span class="src-ln"> 282</span> <span class="src-hl">									<span class="src-kw">throw</span> <span class="src-kw">new</span> Error(<span class=<span class="src-str">"src-str"</span>>`Offset ${offset} is beyond end of file (${allLines.length} lines total)`</span>);</span></span>
       <span class="src-line">      <span class="src-ln"> 283</span> <span class="src-hl">								}</span></span>
       <span class="src-line">      <span class="src-ln"> 284</span> <span class="src-hl">								<span class="src-kw">let</span> selectedContent: string;</span></span>
       <span class="src-line">      <span class="src-ln"> 285</span> <span class="src-hl">								<span class="src-kw">let</span> userLimitedLines: number | <span class="src-kw">undefined</span>;</span></span>
-      <span class="src-line">      <span class="src-ln"> 286</span> <span class="src-hl">								<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">If</span> limit is specified by the user, honor it first. <span class="src-cls">Otherwise</span> truncateHead decides.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 286</span> <span class="src-hl">								<span class="src-comment">// If limit is specified by the user, honor it first. Otherwise truncateHead decides.</span></span></span>
       <span class="src-line">      <span class="src-ln"> 287</span> <span class="src-hl">								<span class="src-kw">if</span> (limit !== <span class="src-kw">undefined</span>) {</span></span>
-      <span class="src-line">      <span class="src-ln"> 288</span> <span class="src-hl">									<span class="src-kw">const</span> endLine = <span class="src-cls">Math</span>.min(startLine + limit, allLines.length);</span></span>
+      <span class="src-line">      <span class="src-ln"> 288</span> <span class="src-hl">									<span class="src-kw">const</span> endLine = Math.min(startLine + limit, allLines.length);</span></span>
       <span class="src-line">      <span class="src-ln"> 289</span> <span class="src-hl">									selectedContent = allLines.slice(startLine, endLine).join(&quot;\n&quot;);</span></span>
       <span class="src-line">      <span class="src-ln"> 290</span> <span class="src-hl">									userLimitedLines = endLine - startLine;</span></span>
       <span class="src-line">      <span class="src-ln"> 291</span> <span class="src-hl">								} <span class="src-kw">else</span> {</span></span>
       <span class="src-line">      <span class="src-ln"> 292</span> <span class="src-hl">									selectedContent = allLines.slice(startLine).join(&quot;\n&quot;);</span></span>
       <span class="src-line">      <span class="src-ln"> 293</span> <span class="src-hl">								}</span></span>
-      <span class="src-line">      <span class="src-ln"> 294</span> <span class="src-hl">								<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Apply</span> truncation, respecting both line and byte limits.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 294</span> <span class="src-hl">								<span class="src-comment">// Apply truncation, respecting both line and byte limits.</span></span></span>
       <span class="src-line">      <span class="src-ln"> 295</span> <span class="src-hl">								<span class="src-kw">const</span> truncation = truncateHead(selectedContent);</span> <span class="src-tag">◀ trace</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">★ truncateHead：超长按行/字节截断</span><span class="lang-en-only">★ truncateHead: line/byte truncation</span></span></span>
       <span class="src-line">      <span class="src-ln"> 296</span> <span class="src-hl">								<span class="src-kw">let</span> outputText: string;</span></span>
       <span class="src-line">      <span class="src-ln"> 297</span> <span class="src-hl">								<span class="src-kw">if</span> (truncation.firstLineExceedsLimit) {</span></span>
-      <span class="src-line">      <span class="src-ln"> 298</span> <span class="src-hl">									<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">First</span> line alone exceeds the byte limit. <span class="src-cls">Point</span> the model at a bash fallback.</span></span></span>
-      <span class="src-line">      <span class="src-ln"> 299</span> <span class="src-hl">									<span class="src-kw">const</span> firstLineSize = formatSize(<span class="src-cls">Buffer</span>.byteLength(allLines[startLine], &quot;utf-8&quot;));</span></span>
-      <span class="src-line">      <span class="src-ln"> 300</span> <span class="src-hl">									outputText = <span class=<span class="src-str">"src-str"</span>>`[<span class="src-cls">Line</span> ${startLineDisplay} is ${firstLineSize}, exceeds ${formatSize(DEFAULT_MAX_BYTES)} limit. <span class="src-cls">Use</span> bash: sed -n &#x27;${startLineDisplay}p&#x27; ${path} | head -c ${DEFAULT_MAX_BYTES}]`</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 298</span> <span class="src-hl">									<span class="src-comment">// First line alone exceeds the byte limit. Point the model at a bash fallback.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 299</span> <span class="src-hl">									<span class="src-kw">const</span> firstLineSize = formatSize(Buffer.byteLength(allLines[startLine], &quot;utf-8&quot;));</span></span>
+      <span class="src-line">      <span class="src-ln"> 300</span> <span class="src-hl">									outputText = <span class=<span class="src-str">"src-str"</span>>`[Line ${startLineDisplay} is ${firstLineSize}, exceeds ${formatSize(DEFAULT_MAX_BYTES)} limit. Use bash: sed -n &#x27;${startLineDisplay}p&#x27; ${path} | head -c ${DEFAULT_MAX_BYTES}]`</span>;</span></span>
       <span class="src-line">      <span class="src-ln"> 301</span> <span class="src-hl">									details = { truncation };</span></span>
       <span class="src-line">      <span class="src-ln"> 302</span> <span class="src-hl">								} <span class="src-kw">else</span> <span class="src-kw">if</span> (truncation.truncated) {</span></span>
-      <span class="src-line">      <span class="src-ln"> 303</span> <span class="src-hl">									<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Truncation</span> occurred. <span class="src-cls">Build</span> an actionable continuation notice.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 303</span> <span class="src-hl">									<span class="src-comment">// Truncation occurred. Build an actionable continuation notice.</span></span></span>
       <span class="src-line">      <span class="src-ln"> 304</span> <span class="src-hl">									<span class="src-kw">const</span> endLineDisplay = startLineDisplay + truncation.outputLines - 1;</span></span>
       <span class="src-line">      <span class="src-ln"> 305</span> <span class="src-hl">									<span class="src-kw">const</span> nextOffset = endLineDisplay + 1;</span></span>
       <span class="src-line">      <span class="src-ln"> 306</span> <span class="src-hl">									outputText = truncation.content;</span></span>
       <span class="src-line">      <span class="src-ln"> 307</span> <span class="src-hl">									<span class="src-kw">if</span> (truncation.truncatedBy === &quot;lines&quot;) {</span></span>
-      <span class="src-line">      <span class="src-ln"> 308</span> <span class="src-hl">										outputText += <span class=<span class="src-str">"src-str"</span>>`\n\n[<span class="src-cls">Showing</span> lines ${startLineDisplay}-${endLineDisplay} of ${totalFileLines}. <span class="src-cls">Use</span> offset=${nextOffset} to <span class="src-kw">continue</span>.]`</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 308</span> <span class="src-hl">										outputText += <span class=<span class="src-str">"src-str"</span>>`\n\n[Showing lines ${startLineDisplay}-${endLineDisplay} of ${totalFileLines}. Use offset=${nextOffset} to <span class="src-kw">continue</span>.]`</span>;</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">截断提示：offset=N 继续读</span><span class="lang-en-only">truncation hint: offset=N to continue</span></span></span>
       <span class="src-line">      <span class="src-ln"> 309</span> <span class="src-hl">									} <span class="src-kw">else</span> {</span></span>
-      <span class="src-line">      <span class="src-ln"> 310</span> <span class="src-hl">										outputText += <span class=<span class="src-str">"src-str"</span>>`\n\n[<span class="src-cls">Showing</span> lines ${startLineDisplay}-${endLineDisplay} of ${totalFileLines} (${formatSize(DEFAULT_MAX_BYTES)} limit). <span class="src-cls">Use</span> offset=${nextOffset} to <span class="src-kw">continue</span>.]`</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 310</span> <span class="src-hl">										outputText += <span class=<span class="src-str">"src-str"</span>>`\n\n[Showing lines ${startLineDisplay}-${endLineDisplay} of ${totalFileLines} (${formatSize(DEFAULT_MAX_BYTES)} limit). Use offset=${nextOffset} to <span class="src-kw">continue</span>.]`</span>;</span></span>
       <span class="src-line">      <span class="src-ln"> 311</span> <span class="src-hl">									}</span></span>
       <span class="src-line">      <span class="src-ln"> 312</span> <span class="src-hl">									details = { truncation };</span></span>
       <span class="src-line">      <span class="src-ln"> 313</span> <span class="src-hl">								} <span class="src-kw">else</span> <span class="src-kw">if</span> (userLimitedLines !== <span class="src-kw">undefined</span> &amp;&amp; startLine + userLimitedLines &lt; allLines.length) {</span></span>
-      <span class="src-line">      <span class="src-ln"> 314</span> <span class="src-hl">									<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">User</span>-specified limit stopped early, but the file still has more content.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 314</span> <span class="src-hl">									<span class="src-comment">// User-specified limit stopped early, but the file still has more content.</span></span></span>
       <span class="src-line">      <span class="src-ln"> 315</span> <span class="src-hl">									<span class="src-kw">const</span> remaining = allLines.length - (startLine + userLimitedLines);</span></span>
       <span class="src-line">      <span class="src-ln"> 316</span> <span class="src-hl">									<span class="src-kw">const</span> nextOffset = startLine + userLimitedLines + 1;</span></span>
-      <span class="src-line">      <span class="src-ln"> 317</span> <span class="src-hl">									outputText = <span class=<span class="src-str">"src-str"</span>>`${truncation.content}\n\n[${remaining} more lines in file. <span class="src-cls">Use</span> offset=${nextOffset} to <span class="src-kw">continue</span>.]`</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 317</span> <span class="src-hl">									outputText = <span class=<span class="src-str">"src-str"</span>>`${truncation.content}\n\n[${remaining} more lines in file. Use offset=${nextOffset} to <span class="src-kw">continue</span>.]`</span>;</span></span>
       <span class="src-line">      <span class="src-ln"> 318</span> <span class="src-hl">								} <span class="src-kw">else</span> {</span></span>
-      <span class="src-line">      <span class="src-ln"> 319</span> <span class="src-hl">									<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">No</span> truncation and no remaining user-limited content.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 319</span> <span class="src-hl">									<span class="src-comment">// No truncation and no remaining user-limited content.</span></span></span>
       <span class="src-line">      <span class="src-ln"> 320</span> <span class="src-hl">									outputText = truncation.content;</span></span>
       <span class="src-line">      <span class="src-ln"> 321</span> <span class="src-hl">								}</span></span>
       <span class="src-line">      <span class="src-ln"> 322</span> <span class="src-hl">								content = [{ <span class="src-kw">type</span>: &quot;text&quot;, text: outputText }];</span> <span class="src-tag">◀ trace</span></span>
@@ -6218,29 +6218,29 @@
         <span class="src-tag">event-union</span>
       </div>
       <span class="src-line">      <span class="src-ln"> 421</span> <span class="src-hl">/**</span></span>
-      <span class="src-line">      <span class="src-ln"> 422</span> <span class="src-hl"> * <span class="src-cls">Events</span> emitted by the <span class="src-cls">Agent</span> <span class="src-kw">for</span> <span class="src-cls">UI</span> updates.</span></span>
+      <span class="src-line">      <span class="src-ln"> 422</span> <span class="src-hl"> * Events emitted by the Agent <span class="src-kw">for</span> UI updates.</span></span>
       <span class="src-line">      <span class="src-ln"> 423</span> <span class="src-hl"> *</span></span>
-      <span class="src-line">      <span class="src-ln"> 424</span> <span class="src-hl"> * <span class=<span class="src-str">"src-str"</span>>`agent_end`</span> is the last event emitted <span class="src-kw">for</span> a run, but awaited <span class=<span class="src-str">"src-str"</span>>`<span class="src-cls">Agent</span>.subscribe()`</span></span></span>
-      <span class="src-line">      <span class="src-ln"> 425</span> <span class="src-hl"> * listeners <span class="src-kw">for</span> that event are still part of run settlement. <span class="src-cls">The</span> agent becomes</span></span>
+      <span class="src-line">      <span class="src-ln"> 424</span> <span class="src-hl"> * <span class=<span class="src-str">"src-str"</span>>`agent_end`</span> is the last event emitted <span class="src-kw">for</span> a run, but awaited <span class=<span class="src-str">"src-str"</span>>`Agent.subscribe()`</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 425</span> <span class="src-hl"> * listeners <span class="src-kw">for</span> that event are still part of run settlement. The agent becomes</span></span>
       <span class="src-line">      <span class="src-ln"> 426</span> <span class="src-hl"> * idle only after those listeners finish.</span></span>
       <span class="src-line">      <span class="src-ln"> 427</span> <span class="src-hl"> */</span></span>
-      <span class="src-line">      <span class="src-ln"> 428</span> <span class="src-hl"><span class="src-kw">export</span> <span class="src-kw">type</span> <span class="src-cls">AgentEvent</span> =</span></span>
-      <span class="src-line">      <span class="src-ln"> 429</span> <span class="src-hl">	<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Agent</span> lifecycle</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 428</span> <span class="src-hl"><span class="src-kw">export</span> <span class="src-kw">type</span> AgentEvent =</span></span>
+      <span class="src-line">      <span class="src-ln"> 429</span> <span class="src-hl">	<span class="src-comment">// Agent lifecycle</span></span></span>
       <span class="src-line">      <span class="src-ln"> 430</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;agent_start&quot; }</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">agent_start / agent_end 包裹整次 runLoop</span><span class="lang-en-only">agent_start/agent_end wrap runLoop</span></span></span>
       <span class="src-line">      <span class="src-ln"> 431</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;agent_end&quot;; messages: AgentMessage[] }</span></span>
-      <span class="src-line">      <span class="src-ln"> 432</span> <span class="src-hl">	<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Turn</span> lifecycle - a turn is one assistant response + any tool calls/results</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 432</span> <span class="src-hl">	<span class="src-comment">// Turn lifecycle - a turn is one assistant response + any tool calls/results</span></span></span>
       <span class="src-line">      <span class="src-ln"> 433</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;turn_start&quot; }</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">turn_start / turn_end 包裹每圈 model+tools</span><span class="lang-en-only">turn_start/turn_end wrap each model+tools round</span></span></span>
-      <span class="src-line">      <span class="src-ln"> 434</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;turn_end&quot;; message: AgentMessage; toolResults: <span class="src-cls">ToolResultMessage</span>[] }</span></span>
-      <span class="src-line">      <span class="src-ln"> 435</span> <span class="src-hl">	<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Message</span> lifecycle - emitted <span class="src-kw">for</span> user, assistant, and toolResult messages</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 434</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;turn_end&quot;; message: AgentMessage; toolResults: ToolResultMessage[] }</span></span>
+      <span class="src-line">      <span class="src-ln"> 435</span> <span class="src-hl">	<span class="src-comment">// Message lifecycle - emitted for user, assistant, and toolResult messages</span></span></span>
       <span class="src-line">      <span class="src-ln"> 436</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;message_start&quot;; message: AgentMessage }</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">message_start/end：user/assistant/toolResult 共用</span><span class="lang-en-only">message_start/end: shared by user/assistant/toolResult</span></span></span>
-      <span class="src-line">      <span class="src-ln"> 437</span> <span class="src-hl">	<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Only</span> emitted <span class="src-kw">for</span> assistant messages during streaming</span></span></span>
-      <span class="src-line">      <span class="src-ln"> 438</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;message_update&quot;; message: AgentMessage; assistantMessageEvent: <span class="src-cls">AssistantMessageEvent</span> }</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-ln"> 437</span> <span class="src-hl">	<span class="src-comment">// Only emitted for assistant messages during streaming</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 438</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;message_update&quot;; message: AgentMessage; assistantMessageEvent: AssistantMessageEvent }</span> <span class="src-tag">◀ trace</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">★ message_update：仅 assistant 流式</span><span class="lang-en-only">★ message_update: assistant streaming only</span></span></span>
       <span class="src-line">      <span class="src-ln"> 439</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;message_end&quot;; message: AgentMessage }</span></span>
-      <span class="src-line">      <span class="src-ln"> 440</span> <span class="src-hl">	<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Tool</span> execution lifecycle</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 440</span> <span class="src-hl">	<span class="src-comment">// Tool execution lifecycle</span></span></span>
       <span class="src-line">      <span class="src-ln"> 441</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;tool_execution_start&quot;; toolCallId: string; toolName: string; args: any }</span> <span class="src-tag">◀ trace</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">tool_execution_*：read 生命周期</span><span class="lang-en-only">tool_execution_*: read lifecycle</span></span></span>
       <span class="src-line">      <span class="src-ln"> 442</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;tool_execution_update&quot;; toolCallId: string; toolName: string; args: any; partialResult: any }</span></span>
@@ -6303,20 +6303,20 @@
         <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/agent-session.ts</span>
         <span class="src-tag">session-persist</span>
       </div>
-      <span class="src-line">      <span class="src-ln"> 644</span> <span class="src-hl">		<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Emit</span> to extensions first</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 644</span> <span class="src-hl">		<span class="src-comment">// Emit to extensions first</span></span></span>
       <span class="src-line">      <span class="src-ln"> 645</span> <span class="src-hl">		<span class="src-kw">await</span> this._emitExtensionEvent(event);</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">扩展先收到事件（可改写 message_end）</span><span class="lang-en-only">extensions receive first (can rewrite message_end)</span></span></span>
       <span class="src-line">      <span class="src-ln"> 646</span> <span class="src-hl"></span></span>
-      <span class="src-line">      <span class="src-ln"> 647</span> <span class="src-hl">		<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Notify</span> all listeners</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 647</span> <span class="src-hl">		<span class="src-comment">// Notify all listeners</span></span></span>
       <span class="src-line">      <span class="src-ln"> 648</span> <span class="src-hl">		this._emit(event.<span class="src-kw">type</span> === &quot;agent_end&quot; ? { ...event, willRetry: this._willRetryAfterAgentEnd(event) } : event);</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">fan-out 到 session 监听器</span><span class="lang-en-only">fan-out to session listeners</span></span></span>
       <span class="src-line">      <span class="src-ln"> 649</span> <span class="src-hl"></span></span>
-      <span class="src-line">      <span class="src-ln"> 650</span> <span class="src-hl">		<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Handle</span> session persistence</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 650</span> <span class="src-hl">		<span class="src-comment">// Handle session persistence</span></span></span>
       <span class="src-line">      <span class="src-ln"> 651</span> <span class="src-hl">		<span class="src-kw">if</span> (event.<span class="src-kw">type</span> === &quot;message_end&quot;) {</span> <span class="src-tag">◀ trace</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">★ message_end → SessionManager.appendMessage</span><span class="lang-en-only">★ message_end → SessionManager.appendMessage</span></span></span>
-      <span class="src-line">      <span class="src-ln"> 652</span> <span class="src-hl">			<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Check</span> <span class="src-kw">if</span> this is a custom message <span class="src-kw">from</span> extensions</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 652</span> <span class="src-hl">			<span class="src-comment">// Check if this is a custom message from extensions</span></span></span>
       <span class="src-line">      <span class="src-ln"> 653</span> <span class="src-hl">			<span class="src-kw">if</span> (event.message.role === &quot;custom&quot;) {</span></span>
-      <span class="src-line">      <span class="src-ln"> 654</span> <span class="src-hl">				<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Persist</span> as <span class="src-cls">CustomMessageEntry</span></span></span></span>
+      <span class="src-line">      <span class="src-ln"> 654</span> <span class="src-hl">				<span class="src-comment">// Persist as CustomMessageEntry</span></span></span>
       <span class="src-line">      <span class="src-ln"> 655</span> <span class="src-hl">				this.sessionManager.appendCustomMessageEntry(</span></span>
       <span class="src-line">      <span class="src-ln"> 656</span> <span class="src-hl">					event.message.customType,</span></span>
       <span class="src-line">      <span class="src-ln"> 657</span> <span class="src-hl">					event.message.content,</span></span>
@@ -6328,24 +6328,24 @@
       <span class="src-line">      <span class="src-ln"> 663</span> <span class="src-hl">				event.message.role === &quot;assistant&quot; ||</span></span>
       <span class="src-line">      <span class="src-ln"> 664</span> <span class="src-hl">				event.message.role === &quot;toolResult&quot;</span></span>
       <span class="src-line">      <span class="src-ln"> 665</span> <span class="src-hl">			) {</span></span>
-      <span class="src-line">      <span class="src-ln"> 666</span> <span class="src-hl">				<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Regular</span> <span class="src-cls">LLM</span> message - persist as <span class="src-cls">SessionMessageEntry</span></span></span></span>
+      <span class="src-line">      <span class="src-ln"> 666</span> <span class="src-hl">				<span class="src-comment">// Regular LLM message - persist as SessionMessageEntry</span></span></span>
       <span class="src-line">      <span class="src-ln"> 667</span> <span class="src-hl">				this.sessionManager.appendMessage(event.message);</span> <span class="src-tag">◀ trace</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">user/assistant/toolResult 写 JSONL</span><span class="lang-en-only">user/assistant/toolResult to JSONL</span></span></span>
       <span class="src-line">      <span class="src-ln"> 668</span> <span class="src-hl">			}</span></span>
-      <span class="src-line">      <span class="src-ln"> 669</span> <span class="src-hl">			<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Other</span> message types (bashExecution, compactionSummary, branchSummary) are persisted elsewhere</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 669</span> <span class="src-hl">			<span class="src-comment">// Other message types (bashExecution, compactionSummary, branchSummary) are persisted elsewhere</span></span></span>
       <span class="src-line">      <span class="src-ln"> 670</span> <span class="src-hl"></span></span>
-      <span class="src-line">      <span class="src-ln"> 671</span> <span class="src-hl">			<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Track</span> assistant message <span class="src-kw">for</span> auto-compaction (checked on agent_end)</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 671</span> <span class="src-hl">			<span class="src-comment">// Track assistant message for auto-compaction (checked on agent_end)</span></span></span>
       <span class="src-line">      <span class="src-ln"> 672</span> <span class="src-hl">			<span class="src-kw">if</span> (event.message.role === &quot;assistant&quot;) {</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">assistant message_end 触发 compaction 检查标记</span><span class="lang-en-only">assistant message_end sets compaction check flag</span></span></span>
       <span class="src-line">      <span class="src-ln"> 673</span> <span class="src-hl">				this._lastAssistantMessage = event.message;</span></span>
       <span class="src-line">      <span class="src-ln"> 674</span> <span class="src-hl"></span></span>
-      <span class="src-line">      <span class="src-ln"> 675</span> <span class="src-hl">				<span class="src-kw">const</span> assistantMsg = event.message as <span class="src-cls">AssistantMessage</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 675</span> <span class="src-hl">				<span class="src-kw">const</span> assistantMsg = event.message as AssistantMessage;</span></span>
       <span class="src-line">      <span class="src-ln"> 676</span> <span class="src-hl">				<span class="src-kw">if</span> (assistantMsg.stopReason !== &quot;error&quot; &amp;&amp; assistantMsg.stopReason !== &quot;length&quot;) {</span></span>
       <span class="src-line">      <span class="src-ln"> 677</span> <span class="src-hl">					this._overflowRecoveryAttempted = <span class="src-kw">false</span>;</span></span>
       <span class="src-line">      <span class="src-ln"> 678</span> <span class="src-hl">				}</span></span>
       <span class="src-line">      <span class="src-ln"> 679</span> <span class="src-hl"></span></span>
-      <span class="src-line">      <span class="src-ln"> 680</span> <span class="src-hl">				<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Reset</span> retry counter immediately on successful assistant response</span></span></span>
-      <span class="src-line">      <span class="src-ln"> 681</span> <span class="src-hl">				<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">This</span> prevents accumulation across multiple <span class="src-cls">LLM</span> calls within a turn</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 680</span> <span class="src-hl">				<span class="src-comment">// Reset retry counter immediately on successful assistant response</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 681</span> <span class="src-hl">				<span class="src-comment">// This prevents accumulation across multiple LLM calls within a turn</span></span></span>
       <span class="src-line">      <span class="src-ln"> 682</span> <span class="src-hl">				<span class="src-kw">if</span> (assistantMsg.stopReason !== &quot;error&quot; &amp;&amp; this._retryAttempt &gt; 0) {</span></span>
       <span class="src-line">      <span class="src-ln"> 683</span> <span class="src-hl">					this._emit({</span></span>
       <span class="src-line">      <span class="src-ln"> 684</span> <span class="src-hl">						<span class="src-kw">type</span>: &quot;auto_retry_end&quot;,</span></span>
@@ -6365,21 +6365,21 @@
         <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/agent-session.ts</span>
         <span class="src-tag">extension-fanout</span>
       </div>
-      <span class="src-line">      <span class="src-ln"> 738</span> <span class="src-hl">	private <span class="src-kw">async</span> _emitExtensionEvent(event: <span class="src-cls">AgentEvent</span>): <span class="src-cls">Promise</span>&lt;void&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln"> 738</span> <span class="src-hl">	private <span class="src-kw">async</span> _emitExtensionEvent(event: AgentEvent): Promise&lt;void&gt; {</span></span>
       <span class="src-line">      <span class="src-ln"> 739</span> <span class="src-hl">		<span class="src-kw">if</span> (event.<span class="src-kw">type</span> === &quot;agent_start&quot;) {</span></span>
       <span class="src-line">      <span class="src-ln"> 740</span> <span class="src-hl">			this._turnIndex = 0;</span></span>
       <span class="src-line">      <span class="src-ln"> 741</span> <span class="src-hl">			<span class="src-kw">await</span> this._extensionRunner.emit({ <span class="src-kw">type</span>: &quot;agent_start&quot; });</span></span>
       <span class="src-line">      <span class="src-ln"> 742</span> <span class="src-hl">		} <span class="src-kw">else</span> <span class="src-kw">if</span> (event.<span class="src-kw">type</span> === &quot;agent_end&quot;) {</span></span>
       <span class="src-line">      <span class="src-ln"> 743</span> <span class="src-hl">			<span class="src-kw">await</span> this._extensionRunner.emit({ <span class="src-kw">type</span>: &quot;agent_end&quot;, messages: event.messages });</span></span>
       <span class="src-line">      <span class="src-ln"> 744</span> <span class="src-hl">		} <span class="src-kw">else</span> <span class="src-kw">if</span> (event.<span class="src-kw">type</span> === &quot;turn_start&quot;) {</span></span>
-      <span class="src-line">      <span class="src-ln"> 745</span> <span class="src-hl">			<span class="src-kw">const</span> extensionEvent: <span class="src-cls">TurnStartEvent</span> = {</span></span>
+      <span class="src-line">      <span class="src-ln"> 745</span> <span class="src-hl">			<span class="src-kw">const</span> extensionEvent: TurnStartEvent = {</span></span>
       <span class="src-line">      <span class="src-ln"> 746</span> <span class="src-hl">				<span class="src-kw">type</span>: &quot;turn_start&quot;,</span></span>
       <span class="src-line">      <span class="src-ln"> 747</span> <span class="src-hl">				turnIndex: this._turnIndex,</span></span>
-      <span class="src-line">      <span class="src-ln"> 748</span> <span class="src-hl">				timestamp: <span class="src-cls">Date</span>.now(),</span></span>
+      <span class="src-line">      <span class="src-ln"> 748</span> <span class="src-hl">				timestamp: Date.now(),</span></span>
       <span class="src-line">      <span class="src-ln"> 749</span> <span class="src-hl">			};</span></span>
       <span class="src-line">      <span class="src-ln"> 750</span> <span class="src-hl">			<span class="src-kw">await</span> this._extensionRunner.emit(extensionEvent);</span></span>
       <span class="src-line">      <span class="src-ln"> 751</span> <span class="src-hl">		} <span class="src-kw">else</span> <span class="src-kw">if</span> (event.<span class="src-kw">type</span> === &quot;turn_end&quot;) {</span></span>
-      <span class="src-line">      <span class="src-ln"> 752</span> <span class="src-hl">			<span class="src-kw">const</span> extensionEvent: <span class="src-cls">TurnEndEvent</span> = {</span></span>
+      <span class="src-line">      <span class="src-ln"> 752</span> <span class="src-hl">			<span class="src-kw">const</span> extensionEvent: TurnEndEvent = {</span></span>
       <span class="src-line">      <span class="src-ln"> 753</span> <span class="src-hl">				<span class="src-kw">type</span>: &quot;turn_end&quot;,</span></span>
       <span class="src-line">      <span class="src-ln"> 754</span> <span class="src-hl">				turnIndex: this._turnIndex,</span></span>
       <span class="src-line">      <span class="src-ln"> 755</span> <span class="src-hl">				message: event.message,</span></span>
@@ -6388,29 +6388,29 @@
       <span class="src-line">      <span class="src-ln"> 758</span> <span class="src-hl">			<span class="src-kw">await</span> this._extensionRunner.emit(extensionEvent);</span></span>
       <span class="src-line">      <span class="src-ln"> 759</span> <span class="src-hl">			this._turnIndex++;</span></span>
       <span class="src-line">      <span class="src-ln"> 760</span> <span class="src-hl">		} <span class="src-kw">else</span> <span class="src-kw">if</span> (event.<span class="src-kw">type</span> === &quot;message_start&quot;) {</span></span>
-      <span class="src-line">      <span class="src-ln"> 761</span> <span class="src-hl">			<span class="src-kw">const</span> extensionEvent: <span class="src-cls">MessageStartEvent</span> = {</span></span>
+      <span class="src-line">      <span class="src-ln"> 761</span> <span class="src-hl">			<span class="src-kw">const</span> extensionEvent: MessageStartEvent = {</span></span>
       <span class="src-line">      <span class="src-ln"> 762</span> <span class="src-hl">				<span class="src-kw">type</span>: &quot;message_start&quot;,</span></span>
       <span class="src-line">      <span class="src-ln"> 763</span> <span class="src-hl">				message: event.message,</span></span>
       <span class="src-line">      <span class="src-ln"> 764</span> <span class="src-hl">			};</span></span>
       <span class="src-line">      <span class="src-ln"> 765</span> <span class="src-hl">			<span class="src-kw">await</span> this._extensionRunner.emit(extensionEvent);</span></span>
       <span class="src-line">      <span class="src-ln"> 766</span> <span class="src-hl">		} <span class="src-kw">else</span> <span class="src-kw">if</span> (event.<span class="src-kw">type</span> === &quot;message_update&quot;) {</span> <span class="src-tag">◀ trace</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">message_update → ExtensionRunner</span><span class="lang-en-only">message_update → ExtensionRunner</span></span></span>
-      <span class="src-line">      <span class="src-ln"> 767</span> <span class="src-hl">			<span class="src-kw">const</span> extensionEvent: <span class="src-cls">MessageUpdateEvent</span> = {</span></span>
+      <span class="src-line">      <span class="src-ln"> 767</span> <span class="src-hl">			<span class="src-kw">const</span> extensionEvent: MessageUpdateEvent = {</span></span>
       <span class="src-line">      <span class="src-ln"> 768</span> <span class="src-hl">				<span class="src-kw">type</span>: &quot;message_update&quot;,</span></span>
       <span class="src-line">      <span class="src-ln"> 769</span> <span class="src-hl">				message: event.message,</span></span>
       <span class="src-line">      <span class="src-ln"> 770</span> <span class="src-hl">				assistantMessageEvent: event.assistantMessageEvent,</span></span>
       <span class="src-line">      <span class="src-ln"> 771</span> <span class="src-hl">			};</span></span>
       <span class="src-line">      <span class="src-ln"> 772</span> <span class="src-hl">			<span class="src-kw">await</span> this._extensionRunner.emit(extensionEvent);</span></span>
       <span class="src-line">      <span class="src-ln"> 773</span> <span class="src-hl">		} <span class="src-kw">else</span> <span class="src-kw">if</span> (event.<span class="src-kw">type</span> === &quot;message_end&quot;) {</span></span>
-      <span class="src-line">      <span class="src-ln"> 774</span> <span class="src-hl">			<span class="src-kw">const</span> extensionEvent: <span class="src-cls">MessageEndEvent</span> = {</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-ln"> 774</span> <span class="src-hl">			<span class="src-kw">const</span> extensionEvent: MessageEndEvent = {</span> <span class="src-tag">◀ trace</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">message_end → emitMessageEnd 可替换消息</span><span class="lang-en-only">message_end → emitMessageEnd can replace message</span></span></span>
       <span class="src-line">      <span class="src-ln"> 775</span> <span class="src-hl">				<span class="src-kw">type</span>: &quot;message_end&quot;,</span></span>
       <span class="src-line">      <span class="src-ln"> 776</span> <span class="src-hl">				message: event.message,</span></span>
       <span class="src-line">      <span class="src-ln"> 777</span> <span class="src-hl">			};</span></span>
       <span class="src-line">      <span class="src-ln"> 778</span> <span class="src-hl">			<span class="src-kw">const</span> replacement = <span class="src-kw">await</span> this._extensionRunner.emitMessageEnd(extensionEvent);</span></span>
       <span class="src-line">      <span class="src-ln"> 779</span> <span class="src-hl">			<span class="src-kw">if</span> (replacement) {</span></span>
-      <span class="src-line">      <span class="src-ln"> 780</span> <span class="src-hl">				<span class=<span class="src-str">"src-comment"</span>>// <span class="src-cls">Untyped</span> extension handlers can <span class="src-kw">return</span> messages with <span class="src-kw">null</span>/missing content;</span></span></span>
-      <span class="src-line">      <span class="src-ln"> 781</span> <span class="src-hl">				<span class=<span class="src-str">"src-comment"</span>>// normalize so it never enters agent state or session history.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 780</span> <span class="src-hl">				<span class="src-comment">// Untyped extension handlers can return messages with null/missing content;</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 781</span> <span class="src-hl">				<span class="src-comment">// normalize so it never enters agent state or session history.</span></span></span>
       <span class="src-line">      <span class="src-ln"> 782</span> <span class="src-hl">				<span class="src-kw">const</span> normalized =</span></span>
       <span class="src-line">      <span class="src-ln"> 783</span> <span class="src-hl">					(replacement.role === &quot;user&quot; ||</span></span>
       <span class="src-line">      <span class="src-ln"> 784</span> <span class="src-hl">						replacement.role === &quot;assistant&quot; ||</span></span>
@@ -6422,7 +6422,7 @@
       <span class="src-line">      <span class="src-ln"> 790</span> <span class="src-hl">				this._replaceMessageInPlace(event.message, normalized);</span></span>
       <span class="src-line">      <span class="src-ln"> 791</span> <span class="src-hl">			}</span></span>
       <span class="src-line">      <span class="src-ln"> 792</span> <span class="src-hl">		} <span class="src-kw">else</span> <span class="src-kw">if</span> (event.<span class="src-kw">type</span> === &quot;tool_execution_start&quot;) {</span></span>
-      <span class="src-line">      <span class="src-ln"> 793</span> <span class="src-hl">			<span class="src-kw">const</span> extensionEvent: <span class="src-cls">ToolExecutionStartEvent</span> = {</span></span>
+      <span class="src-line">      <span class="src-ln"> 793</span> <span class="src-hl">			<span class="src-kw">const</span> extensionEvent: ToolExecutionStartEvent = {</span></span>
       <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">tool_execution_start 扩展可见</span><span class="lang-en-only">tool_execution_start visible to extensions</span></span></span>
       <span class="src-line">      <span class="src-ln"> 794</span> <span class="src-hl">				<span class="src-kw">type</span>: &quot;tool_execution_start&quot;,</span></span>
       <span class="src-line">      <span class="src-ln"> 795</span> <span class="src-hl">				toolCallId: event.toolCallId,</span></span>
@@ -6431,7 +6431,7 @@
       <span class="src-line">      <span class="src-ln"> 798</span> <span class="src-hl">			};</span></span>
       <span class="src-line">      <span class="src-ln"> 799</span> <span class="src-hl">			<span class="src-kw">await</span> this._extensionRunner.emit(extensionEvent);</span></span>
       <span class="src-line">      <span class="src-ln"> 800</span> <span class="src-hl">		} <span class="src-kw">else</span> <span class="src-kw">if</span> (event.<span class="src-kw">type</span> === &quot;tool_execution_update&quot;) {</span></span>
-      <span class="src-line">      <span class="src-ln"> 801</span> <span class="src-hl">			<span class="src-kw">const</span> extensionEvent: <span class="src-cls">ToolExecutionUpdateEvent</span> = {</span></span>
+      <span class="src-line">      <span class="src-ln"> 801</span> <span class="src-hl">			<span class="src-kw">const</span> extensionEvent: ToolExecutionUpdateEvent = {</span></span>
       <span class="src-line">      <span class="src-ln"> 802</span> <span class="src-hl">				<span class="src-kw">type</span>: &quot;tool_execution_update&quot;,</span></span>
       <span class="src-line">      <span class="src-ln"> 803</span> <span class="src-hl">				toolCallId: event.toolCallId,</span></span>
       <span class="src-line">      <span class="src-ln"> 804</span> <span class="src-hl">				toolName: event.toolName,</span></span>
@@ -6440,7 +6440,7 @@
       <span class="src-line">      <span class="src-ln"> 807</span> <span class="src-hl">			};</span></span>
       <span class="src-line">      <span class="src-ln"> 808</span> <span class="src-hl">			<span class="src-kw">await</span> this._extensionRunner.emit(extensionEvent);</span></span>
       <span class="src-line">      <span class="src-ln"> 809</span> <span class="src-hl">		} <span class="src-kw">else</span> <span class="src-kw">if</span> (event.<span class="src-kw">type</span> === &quot;tool_execution_end&quot;) {</span></span>
-      <span class="src-line">      <span class="src-ln"> 810</span> <span class="src-hl">			<span class="src-kw">const</span> extensionEvent: <span class="src-cls">ToolExecutionEndEvent</span> = {</span></span>
+      <span class="src-line">      <span class="src-ln"> 810</span> <span class="src-hl">			<span class="src-kw">const</span> extensionEvent: ToolExecutionEndEvent = {</span></span>
       <span class="src-line">      <span class="src-ln"> 811</span> <span class="src-hl">				<span class="src-kw">type</span>: &quot;tool_execution_end&quot;,</span></span>
       <span class="src-line">      <span class="src-ln"> 812</span> <span class="src-hl">				toolCallId: event.toolCallId,</span></span>
       <span class="src-line">      <span class="src-ln"> 813</span> <span class="src-hl">				toolName: event.toolName,</span></span>

--- a/public/immersive/pi-agent/index.html
+++ b/public/immersive/pi-agent/index.html
@@ -1546,31 +1546,31 @@
   
   <circle cx="48" cy="120" r="22" fill="#b35a1f" opacity="0.15" stroke="#b35a1f" stroke-width="2"/>
   <text x="48" y="116" text-anchor="middle" class="svg-tiny" fill="#b35a1f" font-weight="700">01</text>
-  <text x="48" y="130" text-anchor="middle" class="svg-micro">user_mes</text>
+  <text x="48" y="130" text-anchor="middle" class="svg-micro">user message</text>
   <text x="48" y="158" text-anchor="middle" class="svg-mute">user</text>
   <circle cx="148" cy="120" r="22" fill="#1f5c8c" opacity="0.15" stroke="#1f5c8c" stroke-width="2"/>
   <text x="148" y="116" text-anchor="middle" class="svg-tiny" fill="#1f5c8c" font-weight="700">02</text>
-  <text x="148" y="130" text-anchor="middle" class="svg-micro">model_st</text>
+  <text x="148" y="130" text-anchor="middle" class="svg-micro">model start</text>
   <text x="148" y="158" text-anchor="middle" class="svg-mute">model</text>
   <circle cx="248" cy="120" r="22" fill="#1f5c8c" opacity="0.15" stroke="#1f5c8c" stroke-width="2"/>
   <text x="248" y="116" text-anchor="middle" class="svg-tiny" fill="#1f5c8c" font-weight="700">03</text>
-  <text x="248" y="130" text-anchor="middle" class="svg-micro">assistan</text>
+  <text x="248" y="130" text-anchor="middle" class="svg-micro">assistant</text>
   <text x="248" y="158" text-anchor="middle" class="svg-mute">model</text>
   <circle cx="348" cy="120" r="22" fill="#6b3aa3" opacity="0.15" stroke="#6b3aa3" stroke-width="2"/>
   <text x="348" y="116" text-anchor="middle" class="svg-tiny" fill="#6b3aa3" font-weight="700">04</text>
-  <text x="348" y="130" text-anchor="middle" class="svg-micro">tool_sta</text>
+  <text x="348" y="130" text-anchor="middle" class="svg-micro">tool start</text>
   <text x="348" y="158" text-anchor="middle" class="svg-mute">loop</text>
   <circle cx="448" cy="120" r="22" fill="#2d6a4f" opacity="0.15" stroke="#2d6a4f" stroke-width="2"/>
   <text x="448" y="116" text-anchor="middle" class="svg-tiny" fill="#2d6a4f" font-weight="700">05</text>
-  <text x="448" y="130" text-anchor="middle" class="svg-micro">tool_res</text>
+  <text x="448" y="130" text-anchor="middle" class="svg-micro">tool result</text>
   <text x="448" y="158" text-anchor="middle" class="svg-mute">tool</text>
   <circle cx="548" cy="120" r="22" fill="#1f5c8c" opacity="0.15" stroke="#1f5c8c" stroke-width="2"/>
   <text x="548" y="116" text-anchor="middle" class="svg-tiny" fill="#1f5c8c" font-weight="700">06</text>
-  <text x="548" y="130" text-anchor="middle" class="svg-micro">model_st</text>
+  <text x="548" y="130" text-anchor="middle" class="svg-micro">model start</text>
   <text x="548" y="158" text-anchor="middle" class="svg-mute">model</text>
   <circle cx="648" cy="120" r="22" fill="#1f5c8c" opacity="0.15" stroke="#1f5c8c" stroke-width="2"/>
   <text x="648" y="116" text-anchor="middle" class="svg-tiny" fill="#1f5c8c" font-weight="700">07</text>
-  <text x="648" y="130" text-anchor="middle" class="svg-micro">assistan</text>
+  <text x="648" y="130" text-anchor="middle" class="svg-micro">assistant</text>
   <text x="648" y="158" text-anchor="middle" class="svg-mute">model</text>
   <text x="48" y="52" class="svg-label">pi-textbook checkpoint 00 · README read trace</text>
   <rect x="230" y="190" width="260" height="58" rx="4" class="svg-box paper"/>

--- a/public/immersive/pi-agent/index.html
+++ b/public/immersive/pi-agent/index.html
@@ -1,0 +1,6981 @@
+<!DOCTYPE html>
+<html lang="zh-CN" translate="no">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="google" content="notranslate">
+<meta name="referrer" content="strict-origin-when-cross-origin">
+<link rel="shortcut icon" href="https://airing.ursb.me/image/favicon.ico">
+<link rel="apple-touch-icon" href="https://airing.ursb.me/image/favicon.ico">
+<link rel="icon" href="https://airing.ursb.me/image/favicon.ico">
+<meta name="description" content="你在终端敲下「读取 README.md，用一句话告诉我这个项目做什么」之后，这串文字穿过 26 道工序、跨 6 个 npm 包、在 3 层消息模型里变形——对照 earendil-works/pi 生产源码与 pi-textbook 的 15 个 checkpoint 逐行读。">
+<meta name="author" content="Airing">
+<meta property="og:title" content="一条用户消息在 Pi Agent 里的一生 — Pi Agent 源码全景">
+<meta property="og:description" content="CLI → AgentSession → agentLoop → pi-ai → tools → JSONL → TUI diff · 真源码逐行。">
+<meta property="og:image" content="https://ursb.me/og/pi-agent.png">
+<meta property="og:url" content="https://ursb.me/immersive/pi-agent/">
+<meta property="og:type" content="article">
+<meta property="og:site_name" content="ursb.me · Airing">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="一条用户消息在 Pi Agent 里的一生">
+<meta name="twitter:description" content="After you type read README.md and tell me what this project does in one sentence, that string passes through 26 stations across six npm packages — cross-reading earendil-works/pi production source with pi-textbook checkpoints.">
+<meta name="twitter:image" content="https://ursb.me/og/pi-agent.png">
+<meta name="twitter:creator" content="@airingursb">
+<title>一条用户消息在 Pi Agent 里的一生 — Pi Agent 源码全景</title>
+<style>
+
+  :root {
+    --bg: #f4efe6;
+    --bg-soft: #ebe5d8;
+    --paper: #faf6ed;
+    --paper-2: #fdfbf3;
+    --ink: #15171c;
+    --ink-soft: #3c4148;
+    --ink-mute: #767c87;
+    --rule: #c7c4ba;
+    --rule-soft: #ddd9cd;
+    --accent: #1f5c8c;          /* cobalt — compute / matrix */
+    --accent-soft: #4a85b3;
+    --accent-pale: #c9dceb;
+    --copper: #b35a1f;          /* warm — tokenizer / prompt */
+    --copper-soft: #d1855a;
+    --copper-pale: #ecd3bf;
+    --good: #4a6b3e;
+    --warn: #a87a1f;
+    --asm: #2d6a4f;             /* green — KV cache / memory */
+    --asm-soft: #6b8f7a;
+    --asm-pale: #cfe2d7;
+    --gpu: #6b3aa3;             /* purple — attention / parallel */
+    --gpu-soft: #9572bd;
+    --gpu-pale: #d8c8e6;
+    --heat: #c3573a;            /* orange — hot kernels / sampling */
+    --heat-soft: #d99c87;
+    --heat-pale: #f3d6c8;
+    --serif: "Source Han Serif SC", "Noto Serif CJK SC", "Songti SC", "STSong", Georgia, "Times New Roman", serif;
+    --serif-en: "Source Serif Pro", "Source Serif 4", Georgia, "Times New Roman", "Source Han Serif SC", serif;
+    --sans: "Inter", -apple-system, "PingFang SC", "Helvetica Neue", system-ui, sans-serif;
+    --mono: "JetBrains Mono", "SF Mono", Menlo, ui-monospace, monospace;
+  }
+
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; overflow-x: hidden; }
+
+  body {
+    background: var(--bg);
+    color: var(--ink);
+    font-family: var(--serif);
+    font-size: 16px;
+    line-height: 1.85;
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+  }
+  body.lang-en { font-family: var(--serif-en); }
+
+  body::before {
+    content: "";
+    position: fixed; inset: 0;
+    background-image: radial-gradient(rgba(40,60,90,0.05) 1px, transparent 1px);
+    background-size: 3px 3px;
+    pointer-events: none;
+    z-index: 1;
+  }
+
+  .container {
+    max-width: 820px; margin: 0 auto;
+    padding: 0 32px;
+    position: relative; z-index: 2;
+  }
+
+  /* lang + back */
+  .lang-toggle {
+    position: fixed; top: 28px; right: 32px; z-index: 100;
+    font-family: var(--mono); font-size: 12px; letter-spacing: 0.12em;
+    background: var(--paper); border: 1px solid var(--rule);
+    padding: 6px 12px; border-radius: 99px;
+    display: flex; align-items: center; gap: 10px;
+    backdrop-filter: blur(6px); -webkit-backdrop-filter: blur(6px);
+  }
+  .lang-toggle button {
+    background: transparent; border: 0; padding: 2px 6px;
+    font: inherit; color: var(--ink-mute); cursor: pointer;
+    letter-spacing: inherit; border-radius: 99px; transition: color .15s;
+  }
+  .lang-toggle button:hover { color: var(--ink); }
+  .lang-toggle button.active { color: var(--ink); font-weight: 600; }
+  .lang-toggle .sep { color: var(--rule); user-select: none; }
+  body:not(.lang-en) .lang-en-only { display: none !important; }
+  body.lang-en .lang-zh-only { display: none !important; }
+
+  /* ====================== Side TOC (added 2026-06) ====================== */
+  .toc-side {
+    position: fixed; top: 84px; left: 22px;
+    z-index: 100; width: 200px;
+    max-height: calc(100vh - 120px);
+    overflow-y: auto;
+    font-family: var(--mono);
+    font-size: 10.5px; line-height: 1.4;
+    scrollbar-width: thin; scrollbar-color: var(--rule) transparent;
+    padding-right: 4px;
+  }
+  .toc-side::-webkit-scrollbar { width: 3px; }
+  .toc-side::-webkit-scrollbar-thumb { background: var(--rule); border-radius: 2px; }
+  .toc-side ol { list-style: none; margin: 0; padding: 0; }
+  .toc-side a { color: var(--ink-soft); text-decoration: none; }
+  .toc-side > .toc-label {
+    font-size: 9.5px; letter-spacing: 0.2em; color: var(--ink-mute);
+    text-transform: uppercase; margin-bottom: 8px; font-weight: 600;
+  }
+  .toc-side li { margin-bottom: 0; }
+  .toc-side li > a {
+    display: flex; align-items: baseline; gap: 8px;
+    padding: 2px 0; opacity: 0.55; transition: opacity 0.18s, color 0.18s;
+    border: none;
+    line-height: 1.35;
+  }
+  .toc-side li > a:hover { opacity: 0.9; color: var(--accent); }
+  .toc-side li.active > a { opacity: 1; color: var(--accent); font-weight: 600; }
+  .toc-side .toc-num {
+    flex-shrink: 0; width: 18px; color: var(--accent);
+    font-variant-numeric: tabular-nums; font-size: 9.5px;
+    font-weight: 700; letter-spacing: 0.04em;
+  }
+  @media (max-width: 1320px) { .toc-side { display: none; } }
+  .toc-side .ts-divider {
+    font-family: var(--mono); font-size: 8.5px;
+    letter-spacing: 0.16em; text-transform: uppercase;
+    color: var(--ink-mute);
+    margin: 8px 0 2px;
+    padding-top: 5px;
+    border-top: 1px dashed var(--rule);
+    opacity: 0.7;
+    line-height: 1.2;
+  }
+  .toc-side .ts-divider:first-child {
+    margin-top: 0;
+    border-top: 0;
+    padding-top: 0;
+  }
+
+
+
+  .ursb-backlink {
+    position: fixed; top: 28px; left: 32px; z-index: 100;
+    display: inline-flex; align-items: center; gap: 6px;
+    background: var(--paper); border: 1px solid var(--rule);
+    padding: 6px 14px 6px 12px; border-radius: 99px;
+    font-family: var(--mono); font-size: 12px; letter-spacing: 0.04em;
+    color: var(--ink-soft); text-decoration: none;
+    backdrop-filter: blur(6px); -webkit-backdrop-filter: blur(6px);
+    transition: all .18s ease;
+  }
+  .ursb-backlink:hover { color: var(--accent); border-color: var(--accent-soft); transform: translateX(-1px); }
+
+  /* hero */
+  .hero { padding: 120px 0 80px; border-bottom: 1px solid var(--rule); position: relative; }
+  .hero .meta {
+    font-family: var(--sans); font-size: 12px;
+    letter-spacing: 0.18em; text-transform: uppercase;
+    color: var(--ink-mute); margin-bottom: 32px;
+  }
+  .hero .meta span + span::before { content: "·"; margin: 0 12px; color: var(--rule); }
+  .hero h1 {
+    font-family: var(--serif); font-size: 64px; line-height: 1.1;
+    margin: 0 0 24px; font-weight: 600; letter-spacing: -0.01em;
+  }
+  body.lang-en .hero h1 { font-family: var(--serif-en); font-size: 60px; line-height: 1.05; letter-spacing: -0.02em; }
+  .hero h1 .accent { color: var(--accent); }
+  .hero h1 .copper { color: var(--copper); }
+  .hero h1 .gpu { color: var(--gpu); }
+  .hero h1 .heat { color: var(--heat); }
+  .hero h1 .asm { color: var(--asm); }
+  .hero .subtitle {
+    font-family: var(--mono); font-size: 14px; line-height: 1.6;
+    color: var(--ink-soft); margin: -8px 0 28px;
+    letter-spacing: 0.02em;
+  }
+  .hero .subtitle .arr { color: var(--ink-mute); margin: 0 8px; }
+  .hero .deck {
+    font-family: var(--sans); font-size: 19px; line-height: 1.55;
+    color: var(--ink-soft); max-width: 620px;
+    margin: 0 0 48px; font-weight: 300;
+  }
+  .byline {
+    font-family: var(--sans); font-size: 13px; color: var(--ink-mute);
+    display: flex; gap: 32px; flex-wrap: wrap;
+  }
+  .byline .label { color: var(--ink-mute); }
+  .byline .value { color: var(--ink); margin-left: 6px; }
+  .byline a.value {
+    text-decoration: none; border-bottom: 1px solid var(--rule);
+    transition: color .18s, border-color .18s;
+  }
+  .byline a.value:hover { color: var(--accent); border-bottom-color: var(--accent); }
+
+  .hero-notice {
+    margin: 36px 0 0; padding: 18px 22px;
+    background: var(--paper);
+    border: 1px solid var(--rule); border-left: 3px solid var(--copper);
+    border-radius: 0 4px 4px 0; max-width: 640px;
+  }
+  .hero-notice .hn-tag {
+    font-family: var(--mono); font-size: 10px;
+    letter-spacing: 0.18em; text-transform: uppercase;
+    color: var(--copper); font-weight: 700; margin-bottom: 8px;
+  }
+  .hero-notice .hn-body {
+    margin: 0; font-family: var(--sans);
+    font-size: 13.5px; line-height: 1.7; color: var(--ink-soft);
+  }
+  .hero-notice .hn-body strong { color: var(--ink); font-weight: 600; }
+  .hero-notice .hn-body em { color: var(--copper); font-style: normal; font-weight: 600; }
+
+  /* tldr 4-step */
+  .tldr {
+    margin: 36px 0 0; padding: 22px 24px;
+    background: var(--paper-2);
+    border: 1px solid var(--rule); border-left: 3px solid var(--accent);
+    border-radius: 0 4px 4px 0; max-width: 640px;
+  }
+  .tldr-tag {
+    font-family: var(--mono); font-size: 10px;
+    letter-spacing: 0.18em; text-transform: uppercase;
+    color: var(--accent); font-weight: 700; margin-bottom: 14px;
+  }
+  .tldr-steps {
+    display: grid; grid-template-columns: repeat(4, 1fr);
+    gap: 10px; margin: 0 0 14px;
+  }
+  .tldr-step {
+    background: var(--paper);
+    border: 1px solid var(--rule-soft);
+    border-top: 2px solid var(--accent);
+    border-radius: 3px; padding: 10px 12px;
+  }
+  .tldr-step:nth-child(2) { border-top-color: var(--copper); }
+  .tldr-step:nth-child(3) { border-top-color: var(--asm); }
+  .tldr-step:nth-child(4) { border-top-color: var(--heat); }
+  .tldr-step-n {
+    font-family: var(--mono); font-size: 9.5px;
+    letter-spacing: 0.18em; color: var(--ink-mute); margin-bottom: 4px;
+  }
+  .tldr-step-name {
+    font-family: var(--sans); font-size: 13px; font-weight: 700;
+    color: var(--ink); line-height: 1.3;
+  }
+  .tldr-step-hint {
+    font-family: var(--mono); font-size: 9.5px;
+    color: var(--ink-mute); margin-top: 4px; line-height: 1.4;
+  }
+  .tldr-skip {
+    margin-top: 14px; padding-top: 12px;
+    border-top: 1px dashed var(--rule);
+    font-family: var(--sans); font-size: 12px;
+    color: var(--ink-mute); line-height: 1.55;
+  }
+  .tldr-skip a {
+    color: var(--accent); border-bottom: 1px solid currentColor;
+    font-weight: 600;
+  }
+  .tldr-skip a:hover { color: var(--ink); }
+  @media (max-width: 720px) { .tldr-steps { grid-template-columns: 1fr 1fr; } }
+
+  /* pipeline bar — 18 stations */
+  .perf-bar {
+    margin: 56px 0 0; background: var(--paper);
+    border: 1px solid var(--rule); border-radius: 4px;
+    padding: 22px 24px; position: relative;
+  }
+  .perf-bar .pb-title {
+    font-family: var(--mono); font-size: 10px; letter-spacing: 0.18em;
+    color: var(--ink-mute); text-transform: uppercase; margin-bottom: 16px;
+    display: flex; justify-content: space-between;
+  }
+  .perf-bar .pb-title .pb-pulse { color: var(--heat); }
+  .perf-bar .pb-track {
+    display: grid; grid-template-columns: repeat(26, 1fr); gap: 3px;
+    height: 36px;
+  }
+  .perf-bar .pb-cell {
+    background: var(--bg-soft); border-radius: 2px;
+    cursor: pointer; transition: transform .15s;
+    position: relative; overflow: hidden;
+  }
+  .perf-bar .pb-cell:hover { transform: translateY(-2px); }
+  .perf-bar .pb-cell.p0 { background: var(--ink-mute); opacity: .55; }
+  .perf-bar .pb-cell.p1 { background: var(--copper); }
+  .perf-bar .pb-cell.p2 { background: var(--accent); }
+  .perf-bar .pb-cell.p3 { background: var(--gpu); }
+  .perf-bar .pb-cell.p4 { background: var(--heat); }
+  .perf-bar .pb-cell.p5 { background: var(--asm); }
+  .perf-bar .pb-cell.p6 { background: var(--asm-soft); }
+  .perf-bar .pb-cell.p7 { background: var(--gpu-soft); }
+  .perf-bar .pb-cell.p8 { background: var(--copper-soft); }
+  .perf-bar .pb-cell.pc { background: var(--ink-mute); opacity: .7; }
+  .perf-bar .pb-cell::after {
+    content: attr(data-n); position: absolute; inset: 0;
+    display: flex; align-items: center; justify-content: center;
+    font-family: var(--mono); font-size: 8px; font-weight: 700;
+    color: rgba(255,255,255,.85);
+  }
+  @media (max-width: 720px) {
+    .perf-bar .pb-cell::after { font-size: 0; }
+  }
+  .perf-bar .pb-axis {
+    display: flex; justify-content: space-between;
+    font-family: var(--mono); font-size: 9px; color: var(--ink-mute);
+    margin-top: 12px; letter-spacing: 0.06em;
+  }
+
+  /* TOC */
+  .toc-v2 { padding: 56px 0; border-bottom: 1px solid var(--rule); }
+  .toc-v2 .tv-head {
+    display: flex; align-items: baseline; justify-content: space-between;
+    margin-bottom: 6px;
+  }
+  .toc-v2 .tv-label {
+    font-family: var(--sans); font-size: 11px;
+    letter-spacing: 0.22em; text-transform: uppercase; color: var(--ink-mute);
+  }
+  .toc-v2 .tv-meta {
+    font-family: var(--mono); font-size: 10.5px;
+    color: var(--ink-mute); letter-spacing: 0.08em;
+  }
+  .toc-v2 .tv-meta .tv-now { color: var(--accent); font-weight: 700; }
+  .toc-v2 .tv-sub {
+    font-family: var(--sans); font-size: 13px;
+    color: var(--ink-mute); margin: 2px 0 26px; font-style: italic;
+  }
+
+  .toc-group {
+    margin-bottom: 18px;
+    border: 1px solid var(--rule);
+    border-left: 3px solid var(--ink-mute);
+    border-radius: 0 4px 4px 0;
+    background: var(--paper);
+    padding: 14px 18px 16px;
+  }
+  .toc-group[data-phase="bg"]   { border-left-color: var(--ink-mute); }
+  .toc-group[data-phase="in"]   { border-left-color: var(--copper); background: linear-gradient(135deg, rgba(179,90,31,0.04) 0%, var(--paper) 60%); }
+  .toc-group[data-phase="att"]  { border-left-color: var(--accent); background: linear-gradient(135deg, rgba(31,92,140,0.04) 0%, var(--paper) 60%); }
+  .toc-group[data-phase="var"]  { border-left-color: var(--gpu); background: linear-gradient(135deg, rgba(107,58,163,0.05) 0%, var(--paper) 60%); }
+  .toc-group[data-phase="out"]  { border-left-color: var(--heat); background: linear-gradient(135deg, rgba(195,87,58,0.05) 0%, var(--paper) 60%); }
+  .toc-group[data-phase="big"]  { border-left-color: var(--asm); background: linear-gradient(135deg, rgba(45,106,79,0.04) 0%, var(--paper) 60%); }
+  .toc-group[data-phase="prod"] { border-left-color: var(--heat); background: linear-gradient(135deg, rgba(195,87,58,0.05) 0%, var(--paper) 60%); }
+  .toc-group[data-phase="scale"]{ border-left-color: var(--asm); background: linear-gradient(135deg, rgba(45,106,79,0.05) 0%, var(--paper) 60%); }
+  .toc-group[data-phase="mile"] { border-left-color: var(--gpu); background: linear-gradient(135deg, rgba(107,58,163,0.04) 0%, var(--paper) 60%); }
+  .toc-group[data-phase="front"] { border-left-color: var(--copper); background: linear-gradient(135deg, rgba(179,90,31,0.06) 0%, var(--paper) 60%); }
+  .toc-group[data-phase="coda"] { border-left-color: var(--ink-mute); }
+
+  .toc-group-head {
+    display: flex; align-items: baseline; gap: 14px;
+    margin-bottom: 12px;
+    border-bottom: 1px dotted var(--rule);
+    padding-bottom: 10px;
+  }
+  .toc-group-head .tg-num {
+    font-family: var(--mono); font-size: 12px; font-weight: 700;
+    letter-spacing: 0.16em; color: var(--ink-mute); width: 32px;
+  }
+  .toc-group-head .tg-name {
+    font-family: var(--serif); font-size: 16px; font-weight: 700;
+    color: var(--ink); flex: 1;
+  }
+  body.lang-en .toc-group-head .tg-name { font-family: var(--serif-en); }
+  .toc-group-head .tg-en {
+    font-family: var(--mono); font-size: 9.5px;
+    letter-spacing: 0.18em; text-transform: uppercase; color: var(--ink-mute);
+  }
+  .toc-group-head .tg-count {
+    font-family: var(--mono); font-size: 10px; color: var(--ink-mute);
+    background: var(--bg-soft); padding: 2px 8px; border-radius: 999px;
+  }
+
+  .toc-chips {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: 5px;
+  }
+  .toc-chip {
+    display: flex; align-items: baseline; gap: 8px;
+    padding: 7px 10px; border-radius: 3px;
+    background: var(--paper-2); border: 1px solid var(--rule-soft);
+    text-decoration: none; color: var(--ink); transition: all .15s;
+  }
+  .toc-chip:hover { background: var(--bg-soft); border-color: var(--ink-mute); transform: translateX(2px); }
+  .toc-chip .tc-num {
+    font-family: var(--mono); font-size: 10px; font-weight: 700;
+    color: var(--ink-mute); min-width: 22px;
+  }
+  .toc-chip .tc-name {
+    flex: 1; font-family: var(--sans); font-size: 12.5px; font-weight: 600;
+    color: var(--ink); line-height: 1.3;
+  }
+  .toc-chip .tc-name .tc-en {
+    display: block; font-family: var(--mono); font-size: 9px;
+    color: var(--ink-mute); font-weight: 400; margin-top: 2px;
+    letter-spacing: 0.04em;
+  }
+  .toc-chip.tc-special { background: linear-gradient(135deg, rgba(31,92,140,0.06), var(--paper-2)); border-color: var(--accent-soft); }
+
+  /* chapters */
+  .chap { padding: 72px 0 56px; border-bottom: 1px solid var(--rule); }
+  .chap-num {
+    font-family: var(--mono); font-size: 11px;
+    letter-spacing: 0.22em; text-transform: uppercase;
+    color: var(--ink-mute); margin-bottom: 10px;
+  }
+  .chap-title {
+    font-family: var(--serif); font-size: 36px; font-weight: 600;
+    margin: 0 0 8px; line-height: 1.18; letter-spacing: -0.005em;
+  }
+  body.lang-en .chap-title { font-family: var(--serif-en); font-size: 34px; }
+  .chap-en {
+    font-family: var(--mono); font-size: 12px;
+    color: var(--ink-mute); letter-spacing: 0.04em; margin: 0 0 28px;
+  }
+
+  .chap p {
+    margin: 0 0 16px;
+    font-size: 16px; line-height: 1.9;
+    color: var(--ink-soft);
+  }
+  .chap p strong { color: var(--ink); font-weight: 700; }
+  .chap p em { font-style: italic; color: var(--ink); }
+  .chap p code, .chap li code, .chap td code, .chap th code {
+    font-family: var(--mono); font-size: 0.88em;
+    background: var(--bg-soft); padding: 1px 5px;
+    border-radius: 3px; color: var(--copper);
+  }
+  .chap .em { color: var(--accent); font-weight: 600; }
+  .chap .em-copper { color: var(--copper); font-weight: 600; }
+  .chap .em-gpu { color: var(--gpu); font-weight: 600; }
+  .chap .em-heat { color: var(--heat); font-weight: 600; }
+  .chap .em-asm { color: var(--asm); font-weight: 600; }
+
+  .chap ul, .chap ol {
+    margin: 0 0 18px; padding-left: 24px;
+    color: var(--ink-soft);
+  }
+  .chap li { margin-bottom: 6px; line-height: 1.85; }
+  .chap li strong { color: var(--ink); }
+
+  .sub {
+    font-family: var(--serif); font-size: 22px; font-weight: 700;
+    margin: 38px 0 14px; color: var(--ink);
+    letter-spacing: -0.005em;
+  }
+  body.lang-en .sub { font-family: var(--serif-en); }
+
+  /* source-code blocks (the "逐行源码" style) */
+  .src-stack {
+    background: var(--ink); color: #d8d8d8;
+    border-radius: 4px; padding: 18px 20px; margin: 18px 0;
+    font-family: var(--mono); font-size: 11.5px; line-height: 1.85;
+    overflow-x: auto;
+  }
+  .src-stack .src-h {
+    display: flex; justify-content: space-between;
+    font-family: var(--mono); font-size: 10px;
+    letter-spacing: 0.16em; text-transform: uppercase;
+    color: #888d96; margin-bottom: 12px;
+    padding-bottom: 10px; border-bottom: 1px dashed #2a2d33;
+  }
+  .src-stack .src-h .src-tag { color: #fcd34d; }
+  .src-stack .src-h .src-path { color: #5fc18a; text-transform: none; letter-spacing: 0; font-size: 10.5px; }
+  .src-stack .src-line { display: block; }
+  .src-stack .src-comment { color: #5a6172; font-style: italic; }
+  .src-stack .src-kw { color: #b48cd6; }
+  .src-stack .src-fn { color: #fcd34d; }
+  .src-stack .src-cls { color: var(--accent-soft); }
+  .src-stack .src-arg { color: #5fc18a; }
+  .src-stack .src-str { color: #5fc18a; }
+  .src-stack .src-num { color: #d1855a; }
+  .src-stack .src-op { color: #b48cd6; }
+  .src-stack .src-type { color: #6ec3d1; }
+  .src-stack .src-hl { background: rgba(252,211,77,0.10); display: inline-block; padding: 0 2px; border-radius: 2px; }
+  .src-stack .src-ln { color: #4a4d52; display: inline-block; width: 32px; user-select: none; }
+
+  /* note boxes */
+  .note {
+    margin: 22px 0; padding: 14px 18px;
+    background: var(--paper);
+    border: 1px solid var(--rule); border-left: 3px solid var(--ink-mute);
+    border-radius: 0 4px 4px 0;
+    font-family: var(--sans); font-size: 13.5px; line-height: 1.7;
+    color: var(--ink-soft);
+  }
+  .note .ntag {
+    display: inline-block;
+    font-family: var(--mono); font-size: 9.5px;
+    letter-spacing: 0.18em; text-transform: uppercase;
+    color: var(--ink-mute); font-weight: 700;
+    margin-right: 10px;
+  }
+  .note strong { color: var(--ink); }
+  .note.asm { border-left-color: var(--asm); }
+  .note.asm .ntag { color: var(--asm); }
+  .note.gpu { border-left-color: var(--gpu); }
+  .note.gpu .ntag { color: var(--gpu); }
+  .note.heat { border-left-color: var(--heat); }
+  .note.heat .ntag { color: var(--heat); }
+  .note.copper { border-left-color: var(--copper); }
+  .note.copper .ntag { color: var(--copper); }
+  .note.accent { border-left-color: var(--accent); }
+  .note.accent .ntag { color: var(--accent); }
+
+  /* figure */
+  figure {
+    margin: 26px 0;
+    border: 1px solid var(--rule);
+    background: var(--paper);
+    border-radius: 4px;
+    overflow: hidden;
+  }
+  .figbox { padding: 20px; }
+  figcaption {
+    border-top: 1px dashed var(--rule);
+    padding: 10px 18px;
+    font-family: var(--sans); font-size: 12px;
+    color: var(--ink-mute); line-height: 1.6;
+    background: var(--paper-2);
+  }
+  figcaption .figid {
+    font-family: var(--mono); font-size: 9.5px;
+    letter-spacing: 0.18em; text-transform: uppercase;
+    color: var(--accent); font-weight: 700; margin-right: 10px;
+  }
+
+  /* tables */
+  table.cmp {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 22px 0;
+    font-family: var(--sans); font-size: 13px;
+  }
+  table.cmp th, table.cmp td {
+    padding: 10px 12px; text-align: left;
+    border-bottom: 1px solid var(--rule-soft);
+    vertical-align: top;
+  }
+  table.cmp thead th {
+    background: var(--bg-soft);
+    font-family: var(--mono); font-size: 10.5px;
+    letter-spacing: 0.16em; text-transform: uppercase;
+    color: var(--ink-mute); font-weight: 700;
+    border-bottom: 1px solid var(--rule);
+  }
+  table.cmp td.good { color: var(--good); font-weight: 600; }
+  table.cmp td.bad { color: var(--heat); font-weight: 600; }
+  table.cmp td.heat { background: var(--heat-pale); color: var(--heat); font-weight: 600; }
+  table.cmp td code { font-family: var(--mono); font-size: 11px; background: var(--bg-soft); padding: 1px 5px; border-radius: 3px; color: var(--copper); }
+  table.cmp td.num { font-family: var(--mono); }
+
+  /* details (extended) */
+  details.extended {
+    margin: 22px 0;
+    border: 1px solid var(--rule);
+    border-radius: 4px;
+    background: var(--paper-2);
+  }
+  details.extended summary {
+    padding: 12px 16px;
+    cursor: pointer;
+    font-family: var(--sans); font-size: 13.5px;
+    color: var(--ink); font-weight: 600;
+    list-style: none;
+    display: flex; align-items: center; gap: 12px;
+  }
+  details.extended summary::-webkit-details-marker { display: none; }
+  details.extended summary::before {
+    content: "▸"; color: var(--ink-mute);
+    transition: transform .2s;
+    font-size: 10px;
+  }
+  details.extended[open] summary::before { transform: rotate(90deg); }
+  details.extended summary .ext-tag {
+    font-family: var(--mono); font-size: 9.5px;
+    letter-spacing: 0.18em; text-transform: uppercase;
+    color: var(--ink-mute); background: var(--bg-soft);
+    padding: 2px 8px; border-radius: 999px; font-weight: 700;
+  }
+  details.extended .ext-body { padding: 0 18px 16px; }
+  details.extended .ext-body p { font-size: 14.5px; }
+
+  /* tokenizer-vis */
+  .tok-vis { font-family: var(--mono); font-size: 13px; }
+  .tok-vis .tv-input-row {
+    display: flex; align-items: center; gap: 12px;
+    padding: 8px 12px; background: var(--paper-2);
+    border: 1px solid var(--rule-soft); border-radius: 3px;
+    margin-bottom: 14px;
+  }
+  .tok-vis .tv-input {
+    flex: 1; padding: 6px 10px;
+    font: inherit; border: 1px solid var(--rule);
+    border-radius: 3px; background: var(--paper); color: var(--ink);
+  }
+  .tok-vis .tv-tokens {
+    display: flex; flex-wrap: wrap; gap: 3px;
+    padding: 16px; background: var(--paper); border-radius: 3px;
+    min-height: 40px;
+  }
+  .tok-vis .tv-token {
+    display: inline-flex; flex-direction: column; align-items: center;
+    padding: 6px 10px; border-radius: 3px;
+    background: var(--copper-pale);
+    border: 1px solid var(--copper-soft);
+    color: var(--ink);
+  }
+  .tok-vis .tv-token .tv-tok-str { font-size: 12px; font-weight: 700; color: var(--copper); }
+  .tok-vis .tv-token .tv-tok-id { font-size: 9.5px; color: var(--ink-mute); margin-top: 2px; }
+
+  /* kv-vis */
+  .kv-vis {
+    font-family: var(--mono);
+    background: var(--paper-2); border: 1px solid var(--rule-soft);
+    padding: 16px; border-radius: 3px;
+  }
+  .kv-grid {
+    display: grid;
+    grid-template-columns: repeat(16, 1fr);
+    gap: 2px;
+    margin: 12px 0;
+  }
+  .kv-cell {
+    aspect-ratio: 1;
+    background: var(--bg-soft);
+    border-radius: 1px;
+  }
+  .kv-cell.used { background: var(--asm); }
+  .kv-cell.cur { background: var(--heat); animation: pulse 1.4s infinite; }
+  @keyframes pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.55; }
+  }
+  .kv-axis {
+    display: flex; justify-content: space-between;
+    font-size: 9px; color: var(--ink-mute);
+    letter-spacing: 0.06em;
+    margin-top: 6px;
+  }
+  .kv-legend {
+    display: flex; gap: 16px; margin-top: 10px;
+    font-size: 11px; color: var(--ink-soft);
+  }
+  .kv-legend .kl { display: inline-flex; align-items: center; gap: 6px; }
+  .kv-legend .kl .ksw { width: 10px; height: 10px; border-radius: 2px; background: var(--asm); }
+  .kv-legend .kl.free .ksw { background: var(--bg-soft); border: 1px solid var(--rule); }
+  .kv-legend .kl.cur .ksw { background: var(--heat); }
+
+  /* moe-vis */
+  .moe-vis {
+    font-family: var(--mono);
+    background: var(--paper-2); border: 1px solid var(--rule-soft);
+    padding: 18px; border-radius: 3px;
+  }
+  .moe-experts {
+    display: grid;
+    grid-template-columns: repeat(8, 1fr);
+    gap: 6px;
+    margin: 12px 0;
+  }
+  .moe-expert {
+    aspect-ratio: 1;
+    background: var(--bg-soft);
+    border: 1px solid var(--rule);
+    border-radius: 3px;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 11px; font-weight: 700;
+    color: var(--ink-mute);
+    transition: all .25s;
+  }
+  .moe-expert.active {
+    background: var(--gpu); border-color: var(--gpu); color: #fff;
+    transform: scale(1.08);
+    box-shadow: 0 4px 12px rgba(107,58,163,0.3);
+  }
+  .moe-expert .me-w {
+    display: block; font-size: 8px; font-weight: 400;
+    color: var(--ink-mute); margin-top: 2px;
+  }
+  .moe-expert.active .me-w { color: rgba(255,255,255,0.85); }
+  .moe-router {
+    text-align: center; padding: 8px 12px;
+    background: var(--paper); border: 1px solid var(--rule);
+    border-radius: 3px; font-size: 11px;
+    color: var(--ink-soft);
+    margin-bottom: 12px;
+  }
+
+  /* sampling-vis */
+  .smp-vis {
+    font-family: var(--mono);
+    background: var(--paper-2); border: 1px solid var(--rule-soft);
+    padding: 16px; border-radius: 3px;
+  }
+  .smp-bars { display: flex; flex-direction: column; gap: 4px; }
+  .smp-row { display: flex; align-items: center; gap: 8px; font-size: 11.5px; }
+  .smp-row .smp-tok { width: 90px; color: var(--copper); font-weight: 700; }
+  .smp-row .smp-bar {
+    height: 14px; background: var(--accent);
+    border-radius: 2px; flex: 0 0 auto;
+    min-width: 4px;
+    transition: width .3s, background .3s;
+  }
+  .smp-row.cut .smp-bar { background: var(--rule); opacity: 0.5; }
+  .smp-row.pick .smp-bar { background: var(--heat); }
+  .smp-row .smp-p { color: var(--ink-mute); font-size: 10px; }
+  .smp-ctrls {
+    display: flex; gap: 14px; flex-wrap: wrap;
+    padding: 10px 12px; background: var(--paper);
+    border: 1px solid var(--rule); border-radius: 3px;
+    margin-bottom: 14px;
+    font-size: 11px;
+  }
+  .smp-ctrls label { display: inline-flex; align-items: center; gap: 6px; color: var(--ink-soft); }
+  .smp-ctrls input[type="range"] { width: 90px; }
+  .smp-ctrls .smp-val { color: var(--accent); font-weight: 700; min-width: 32px; }
+
+  /* hot-bench bar */
+  .hot-bar {
+    background: var(--paper);
+    border: 1px solid var(--rule);
+    border-left: 3px solid var(--heat);
+    border-radius: 0 4px 4px 0;
+    padding: 14px 18px; margin: 22px 0;
+  }
+  .hot-bar .hb-tag {
+    font-family: var(--mono); font-size: 9.5px;
+    letter-spacing: 0.18em; text-transform: uppercase;
+    color: var(--heat); font-weight: 700;
+    margin-bottom: 8px;
+  }
+  .hot-bar table { width: 100%; font-family: var(--mono); font-size: 12px; }
+  .hot-bar td { padding: 3px 8px 3px 0; color: var(--ink-soft); }
+  .hot-bar td:first-child { color: var(--ink); font-weight: 600; min-width: 140px; }
+  .hot-bar td.num { color: var(--accent); font-weight: 700; }
+  .hot-bar td.bad { color: var(--heat); font-weight: 700; }
+
+  /* footer */
+  .footer {
+    padding: 60px 0 100px;
+    font-family: var(--sans); font-size: 13px;
+    color: var(--ink-mute); line-height: 1.7;
+  }
+  .footer .ft-rule {
+    display: flex; align-items: center; gap: 14px;
+    margin-bottom: 20px;
+  }
+  .footer .ft-rule::before, .footer .ft-rule::after {
+    content: ""; flex: 1; height: 1px; background: var(--rule);
+  }
+  .footer .ft-rule .ft-mark {
+    font-family: var(--mono); font-size: 10px;
+    letter-spacing: 0.22em; color: var(--ink-mute);
+  }
+  .footer p { margin: 0 0 10px; }
+  .footer a { color: var(--accent); text-decoration: none; border-bottom: 1px solid var(--rule); }
+  .footer a:hover { color: var(--ink); }
+  .footer .ft-links {
+    display: flex; gap: 18px; flex-wrap: wrap;
+    margin-top: 16px;
+    font-family: var(--mono); font-size: 11.5px;
+  }
+
+  @media (max-width: 720px) {
+    .container { padding: 0 20px; }
+    .hero { padding: 90px 0 60px; }
+    .hero h1 { font-size: 44px; }
+    body.lang-en .hero h1 { font-size: 42px; }
+    .hero .subtitle { font-size: 12px; }
+    .chap-title { font-size: 28px; }
+    body.lang-en .chap-title { font-size: 26px; }
+    .perf-bar .pb-track { grid-template-columns: repeat(9, 1fr); grid-auto-rows: 28px; height: auto; }
+    .kv-grid { grid-template-columns: repeat(8, 1fr); }
+    .moe-experts { grid-template-columns: repeat(4, 1fr); }
+    .lang-toggle, .ursb-backlink { top: 16px; }
+    .ursb-backlink { left: 16px; padding: 5px 12px 5px 10px; font-size: 11px; }
+    .lang-toggle { right: 16px; font-size: 11px; }
+  }
+
+  .toc-group[data-phase="heart"] { border-left-color: var(--accent); background: linear-gradient(135deg, rgba(31,92,140,0.04) 0%, var(--paper) 60%); }
+  .toc-group[data-phase="llm"] { border-left-color: var(--gpu); background: linear-gradient(135deg, rgba(107,58,163,0.05) 0%, var(--paper) 60%); }
+  .toc-group[data-phase="tui"] { border-left-color: var(--asm); background: linear-gradient(135deg, rgba(45,106,79,0.04) 0%, var(--paper) 60%); }
+  .toc-group[data-phase="ext"] { border-left-color: var(--heat); background: linear-gradient(135deg, rgba(195,87,58,0.05) 0%, var(--paper) 60%); }
+  .toc-group[data-phase="persist"] { border-left-color: var(--copper); background: linear-gradient(135deg, rgba(179,90,31,0.05) 0%, var(--paper) 60%); }
+  .toc-group[data-phase="land"] { border-left-color: var(--gpu-soft); }
+  .toc-group[data-phase="card"] { border-left-color: var(--ink-mute); }
+  .perf-bar .pb-track { grid-template-columns: repeat(26, 1fr); }
+  .perf-bar .pb-cell.lit { transform: translateY(-2px); box-shadow: 0 0 0 2px rgba(31,92,140,0.45); }
+  #readProgress {
+    position: fixed; top: 0; left: 0; height: 2px; width: 0%;
+    background: linear-gradient(90deg, var(--copper), var(--accent));
+    z-index: 200; transition: width 0.08s linear;
+  }
+  .session-tree {
+    font-family: var(--mono); font-size: 11px; line-height: 1.7;
+    padding: 16px; background: var(--paper-2);
+  }
+  .session-tree .st-node { padding: 4px 0 4px 20px; border-left: 2px solid var(--rule); margin-left: 8px; }
+  .session-tree .st-leaf { color: var(--accent); font-weight: 700; }
+  .event-flow { font-family: var(--mono); font-size: 11px; }
+  .event-flow .ef-row { display: grid; grid-template-columns: 100px 1fr; gap: 12px; padding: 6px 0; border-bottom: 1px dashed var(--rule-soft); }
+  .event-flow .ef-type { color: var(--accent); font-weight: 600; }
+  .milestone-table td.owner-user { color: var(--copper); }
+  .milestone-table td.owner-model { color: var(--accent); }
+  .milestone-table td.owner-loop { color: var(--gpu); }
+  .milestone-table td.owner-tool { color: var(--asm); }
+  .case-study {
+    margin: 22px 0; padding: 18px 20px;
+    background: var(--paper-2); border: 1px solid var(--rule);
+    border-left: 3px solid var(--accent); border-radius: 0 4px 4px 0;
+  }
+  .case-study .cs-tag {
+    font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.18em;
+    text-transform: uppercase; color: var(--accent); font-weight: 700; margin-bottom: 8px;
+  }
+
+</style>
+<script async defer src="https://analytics.ursb.me/script.js" data-website-id="aa8d5a16-df21-4058-a0a8-0191cdd3798d"></script>
+<style>
+
+.ursb-interactive { background: var(--bg-soft); border-top: 1px solid var(--rule); padding: 24px 24px 80px; position: relative; z-index: 2; }
+.ursb-interactive .ursb-fbody { max-width: 720px; margin: 0 auto; }
+.ui-divider { text-align: center; margin: 28px 0 28px; position: relative; }
+.ui-divider::before { content: ''; position: absolute; top: 50%; left: 0; right: 0; height: 1px; background: var(--rule); }
+.ui-divider-mark { position: relative; background: var(--bg-soft); padding: 0 18px; color: var(--accent); font-size: 14px; letter-spacing: 0.2em; }
+.ui-stats-row { display: flex; align-items: center; justify-content: center; gap: 6px; margin: 36px 0 56px; flex-wrap: wrap; }
+.ui-like, .ui-share, .ui-views {
+  display: inline-flex; align-items: center; gap: 9px;
+  padding: 9px 18px; border-radius: 999px;
+  background: transparent; border: 1px solid var(--rule);
+  font-family: var(--sans); font-size: 12.5px; font-weight: 500; color: var(--ink-mute); line-height: 1;
+  transition: all 0.18s ease;
+}
+.ui-like, .ui-share { cursor: pointer; }
+.ui-like:hover, .ui-share:hover { border-color: var(--accent-soft); color: var(--accent); background: rgba(31,92,140,0.04); }
+.ui-like:disabled, .ui-share:disabled, .ui-comment-form button:disabled { opacity: 0.55; cursor: wait; }
+.ui-like.liked { border-color: var(--accent); background: rgba(31,92,140,0.08); color: var(--accent); }
+.ui-like.liked svg { fill: var(--accent); stroke: var(--accent); }
+.ui-like.liked .ui-count { color: var(--accent); }
+.ui-views { cursor: default; color: var(--ink-mute); }
+.ui-views:hover { background: transparent; border-color: var(--rule); color: var(--ink-mute); }
+.ui-online {
+  display: inline-flex; align-items: center; gap: 9px;
+  padding: 9px 18px; border-radius: 999px;
+  background: rgba(34,197,94,0.06); border: 1px solid rgba(34,197,94,0.28);
+  font-family: var(--sans); font-size: 12.5px; font-weight: 500; color: #15803d; line-height: 1;
+  cursor: default; opacity: 0; transition: opacity 0.4s;
+}
+.ui-online.loaded { opacity: 1; }
+.ui-online .ui-count { color: #15803d; }
+.ui-online-dot {
+  display: inline-block; width: 6px; height: 6px; border-radius: 50%;
+  background: #22c55e; box-shadow: 0 0 0 0 rgba(34,197,94,0.55);
+  animation: ui-online-pulse 2s ease-in-out infinite;
+}
+@keyframes ui-online-pulse {
+  0%   { box-shadow: 0 0 0 0 rgba(34,197,94,0.55); }
+  70%  { box-shadow: 0 0 0 5px rgba(34,197,94,0); }
+  100% { box-shadow: 0 0 0 0 rgba(34,197,94,0); }
+}
+.ui-count { font-family: var(--serif); font-weight: 700; color: var(--ink); font-variant-numeric: tabular-nums; font-size: 13.5px; }
+.ui-count-small { font-family: var(--mono); font-size: 12px; color: var(--ink-mute); font-weight: 400; margin-left: 8px; }
+.ui-section-title { font-family: var(--serif); font-size: 20px; font-weight: 700; color: var(--ink); margin: 36px 0 14px; }
+.ui-comment-form { background: var(--paper); border: 1px solid var(--rule); border-radius: 6px; padding: 20px; margin-bottom: 32px; }
+.ui-form-row { display: grid; grid-template-columns: 1fr 1.5fr; gap: 10px; margin-bottom: 10px; }
+.ui-form-row input, .ui-comment-form textarea {
+  width: 100%; padding: 10px 12px; border: 1px solid var(--rule); border-radius: 4px;
+  font-size: 14px; font-family: var(--sans); color: var(--ink);
+  box-sizing: border-box; background: #fefcf6;
+}
+.ui-comment-form textarea { resize: vertical; min-height: 84px; line-height: 1.55; }
+.ui-form-row input:focus, .ui-comment-form textarea:focus { outline: none; border-color: var(--accent); box-shadow: 0 0 0 3px rgba(31,92,140,0.10); }
+.ui-form-foot { display: flex; justify-content: space-between; align-items: center; margin-top: 12px; gap: 12px; }
+.ui-form-status { font-size: 12px; color: var(--ink-mute); flex: 1; }
+.ui-form-status.error { color: var(--copper); }
+.ui-form-status.success { color: var(--good); font-weight: 600; }
+.ui-comment-form button[type="submit"] {
+  background: var(--ink); color: var(--paper); border: none; padding: 10px 22px; border-radius: 999px;
+  font-size: 13px; font-weight: 600; cursor: pointer; transition: all 0.2s; font-family: var(--sans);
+}
+.ui-comment-form button[type="submit"]:hover { background: var(--accent); }
+.ui-comment-loading, .ui-comment-empty { text-align: center; color: var(--ink-mute); padding: 36px 0; font-family: var(--serif); font-style: italic; font-size: 14px; }
+.ui-comment { padding: 18px 0; border-bottom: 1px solid var(--rule); }
+.ui-comment:last-child { border-bottom: none; }
+.ui-comment-head { display: flex; align-items: baseline; gap: 12px; margin-bottom: 6px; font-size: 13px; }
+.ui-comment-name { font-weight: 700; color: var(--ink); }
+.ui-comment-date { color: var(--ink-mute); font-family: var(--serif); font-size: 12px; }
+.ui-comment-body { color: var(--ink-soft); line-height: 1.65; font-size: 14px; white-space: pre-wrap; word-wrap: break-word; }
+@media (max-width: 768px) {
+  .ui-form-row { grid-template-columns: 1fr; }
+  .ui-stats-row { gap: 8px; }
+  .ui-like, .ui-share { padding: 8px 14px; font-size: 12px; }
+}
+  body:not(.lang-en) .ursb-fbody [lang="en"] { display: none !important; }
+  body.lang-en .ursb-fbody [lang="zh"] { display: none !important; }
+
+</style>
+</head>
+<body>
+<div id="readProgress" aria-hidden="true"></div>
+
+
+<a class="ursb-backlink" href="https://ursb.me/notes/pi-agent/">← ursb.me</a>
+<div class="lang-toggle" role="navigation" aria-label="language">
+  <button id="lang-zh" class="active" aria-pressed="true">中</button>
+  <span class="sep">/</span>
+  <button id="lang-en" aria-pressed="false">EN</button>
+</div>
+
+<nav class="toc-side" aria-label="Side contents">
+  <div class="toc-label">CONTENTS</div>
+  <ol>
+    <li class="ts-divider"><span class="lang-zh-only">背景</span><span class="lang-en-only">· · Background</span></li>
+    <li data-section="c3"><a href="#c3"><span class="toc-num">03</span><span class="lang-zh-only">pi-mono 家谱</span><span class="lang-en-only">The pi-mono family tree</span></a></li>
+    <li data-section="c4"><a href="#c4"><span class="toc-num">04</span><span class="lang-zh-only">六层蛋糕</span><span class="lang-en-only">The six-layer cake</span></a></li>
+    <li data-section="c5"><a href="#c5"><span class="toc-num">05</span><span class="lang-zh-only">故意不做的功能</span><span class="lang-en-only">Intentionally missing features</span></a></li>
+    <li data-section="c1"><a href="#c1"><span class="toc-num">01</span><span class="lang-zh-only">Harness 不是 Product</span><span class="lang-en-only">Harness is not a product</span></a></li>
+    <li data-section="c2"><a href="#c2"><span class="toc-num">02</span><span class="lang-zh-only">一条消息的 22 站</span><span class="lang-en-only">22 stations for one message</span></a></li>
+    <li class="ts-divider"><span class="lang-zh-only">I · 入口</span><span class="lang-en-only">I · Intake</span></li>
+    <li data-section="c6"><a href="#c6"><span class="toc-num">06</span><span class="lang-zh-only">CLI 启动链</span><span class="lang-en-only">CLI boot chain</span></a></li>
+    <li data-section="c7"><a href="#c7"><span class="toc-num">07</span><span class="lang-zh-only">AgentSession 编排</span><span class="lang-en-only">AgentSession orchestration</span></a></li>
+    <li data-section="c8"><a href="#c8"><span class="toc-num">08</span><span class="lang-zh-only">AGENTS.md 上下文栈</span><span class="lang-en-only">The AGENTS.md context stack</span></a></li>
+    <li class="ts-divider"><span class="lang-zh-only">II · 心脏</span><span class="lang-en-only">II · Heart</span></li>
+    <li data-section="c9"><a href="#c9"><span class="toc-num">09</span><span class="lang-zh-only">两层消息模型</span><span class="lang-en-only">Two-layer message model</span></a></li>
+    <li data-section="c10"><a href="#c10"><span class="toc-num">10</span><span class="lang-zh-only">runLoop 双环</span><span class="lang-en-only">The runLoop twin loops</span></a></li>
+    <li data-section="c11"><a href="#c11"><span class="toc-num">11</span><span class="lang-zh-only">Steering 与 Follow-up</span><span class="lang-en-only">Steering and follow-up</span></a></li>
+    <li data-section="c12"><a href="#c12"><span class="toc-num">12</span><span class="lang-zh-only">Tool 执行管线</span><span class="lang-en-only">Tool execution pipeline</span></a></li>
+    <li data-section="c13"><a href="#c13"><span class="toc-num">13</span><span class="lang-zh-only">事件总线</span><span class="lang-en-only">The event bus</span></a></li>
+    <li class="ts-divider"><span class="lang-zh-only">III · LLM</span><span class="lang-en-only">III · LLM</span></li>
+    <li data-section="c14"><a href="#c14"><span class="toc-num">14</span><span class="lang-zh-only">pi-ai 提供商抽象</span><span class="lang-en-only">pi-ai provider abstraction</span></a></li>
+    <li data-section="c15"><a href="#c15"><span class="toc-num">15</span><span class="lang-zh-only">流式 EventStream</span><span class="lang-en-only">Streaming EventStream</span></a></li>
+    <li data-section="c16"><a href="#c16"><span class="toc-num">16</span><span class="lang-zh-only">认证与模型目录</span><span class="lang-en-only">Auth and model catalog</span></a></li>
+    <li class="ts-divider"><span class="lang-zh-only">IV · 终端</span><span class="lang-en-only">IV · Terminal</span></li>
+    <li data-section="c17"><a href="#c17"><span class="toc-num">17</span><span class="lang-zh-only">差分渲染 TUI</span><span class="lang-en-only">Differential-render TUI</span></a></li>
+    <li data-section="c18"><a href="#c18"><span class="toc-num">18</span><span class="lang-zh-only">Interactive Mode</span><span class="lang-en-only">Interactive mode</span></a></li>
+    <li class="ts-divider"><span class="lang-zh-only">V · 扩展</span><span class="lang-en-only">V · Extensions</span></li>
+    <li data-section="c19"><a href="#c19"><span class="toc-num">19</span><span class="lang-zh-only">Extension API 面</span><span class="lang-en-only">Extension API surface</span></a></li>
+    <li data-section="c20"><a href="#c20"><span class="toc-num">20</span><span class="lang-zh-only">ExtensionRunner</span><span class="lang-en-only">ExtensionRunner</span></a></li>
+    <li data-section="c21"><a href="#c21"><span class="toc-num">21</span><span class="lang-zh-only">Pi Packages</span><span class="lang-en-only">Pi packages</span></a></li>
+    <li class="ts-divider"><span class="lang-zh-only">VI · 持久化</span><span class="lang-en-only">VI · Persistence</span></li>
+    <li data-section="c22"><a href="#c22"><span class="toc-num">22</span><span class="lang-zh-only">JSONL 会话树</span><span class="lang-en-only">JSONL session tree</span></a></li>
+    <li data-section="c23"><a href="#c23"><span class="toc-num">23</span><span class="lang-zh-only">Compaction 与 Harness</span><span class="lang-en-only">Compaction and harness</span></a></li>
+    <li class="ts-divider"><span class="lang-zh-only">VII · 全景</span><span class="lang-en-only">VII · Landscape</span></li>
+    <li data-section="c24"><a href="#c24"><span class="toc-num">24</span><span class="lang-zh-only">对比 Claude Code / Cursor</span><span class="lang-en-only">vs Claude Code / Cursor</span></a></li>
+    <li data-section="c25"><a href="#c25"><span class="toc-num">25</span><span class="lang-zh-only">RPC 与 pi-server</span><span class="lang-en-only">RPC and pi-server</span></a></li>
+    <li class="ts-divider"><span class="lang-zh-only">Coda</span><span class="lang-en-only">∎ · Coda</span></li>
+    <li data-section="c26"><a href="#c26"><span class="toc-num">26</span><span class="lang-zh-only">怎么自己 trace 一轮</span><span class="lang-en-only">How to trace a turn yourself</span></a></li>
+  </ol>
+</nav>
+
+<div class="container">
+
+  <header class="hero">
+    <div class="meta">
+      <span>FIELD&nbsp;NOTE&nbsp;/&nbsp;10</span>
+      <span class="lang-zh-only">Pi Agent · Harness 工程</span>
+      <span class="lang-en-only">Pi Agent · Harness Engineering</span>
+      <span>2026</span>
+    </div>
+    <h1 class="lang-zh-only">一条用户消息在<br><span class="copper">Pi Agent</span>里的<span class="accent">一生</span>。</h1>
+    <h1 class="lang-en-only">The <span class="copper">life</span> of one user message<br>inside <span class="accent">Pi Agent</span>.</h1>
+    <p class="subtitle lang-zh-only">CLI → AgentSession → agentLoop → pi-ai → tools → JSONL → TUI diff</p>
+    <p class="subtitle lang-en-only">CLI → AgentSession → agentLoop → pi-ai → tools → JSONL → TUI diff</p>
+    <p class="deck lang-zh-only">你在终端里敲下一行「读取 README.md，用一句话告诉我这个项目做什么」之后，这串文字要穿过 26 道工序、跨 6 个 npm 包、在 3 层消息模型里变形，最后才变成屏幕上滚动的 token 和磁盘上的一行 JSONL。对照 earendil-works/pi 生产源码与 hahhforest/pi-textbook 的 15 个 checkpoint，把每一步的类层级、事件流、owner 分工、可视化全摊开。</p>
+    <p class="deck lang-en-only">After you type «read README.md and tell me what this project does in one sentence», that string passes through 26 stations, crosses six npm packages, morphs across three message layers, and only then becomes scrolling tokens on screen and one JSONL line on disk. Cross-reading earendil-works/pi production source with hahhforest/pi-textbook's 15 checkpoints — every step: class hierarchy, event flow, owner roles, and diagrams.</p>
+    <div class="byline">
+      <span><span class="label">AUTHOR</span><a class="value" href="https://ursb.me" target="_blank" rel="noopener">Airing</a></span>
+      <span><span class="label">SOURCE</span><span class="value">earendil-works/pi · hahhforest/pi-textbook</span></span>
+      <span><span class="label">FORMAT</span><span class="value">Long Read</span></span>
+    </div>
+
+    <aside class="hero-notice">
+      <div class="hn-tag">
+        <span class="lang-zh-only">这篇要解决什么</span>
+        <span class="lang-en-only">What this is for</span>
+      </div>
+      <p class="hn-body lang-zh-only">主线 prompt 固定为：<strong>「读取 README.md，用一句话告诉我这个项目做什么」</strong>——与 pi-textbook 序章相同。这不是 Pi 的使用教程，而是<strong>把一条用户消息从终端回车追到 JSONL 落盘</strong>的源码级 walkthrough。对照生产仓库 <code>earendil-works/pi</code> 与教学仓库 <code>hahhforest/pi-textbook</code> 的 15 个 checkpoint，每一章对应一层真实抽象。</p>
+      <p class="hn-body lang-en-only">The through-line prompt is fixed: <strong>«read README.md and tell me what this project does in one sentence»</strong> — same as the pi-textbook prologue. This is not a Pi user guide but a <strong>source-level walkthrough from Enter to JSONL on disk</strong>. Cross-reading production <code>earendil-works/pi</code> with <code>hahhforest/pi-textbook</code>'s 15 checkpoints — each chapter maps to one real abstraction layer.</p>
+    </aside>
+
+    <aside class="tldr">
+      <div class="tldr-tag">
+        <span class="lang-zh-only">主线 · 七个里程碑</span>
+        <span class="lang-en-only">Through-line · seven milestones</span>
+      </div>
+      <div class="tldr-steps">
+        <div class="tldr-step">
+          <div class="tldr-step-n">01</div>
+          <div class="tldr-step-name lang-zh-only">用户消息</div>
+          <div class="tldr-step-name lang-en-only">user_message</div>
+          <div class="tldr-step-hint">owner=user</div>
+        </div>
+        <div class="tldr-step">
+          <div class="tldr-step-n">02</div>
+          <div class="tldr-step-name lang-zh-only">第一次 model</div>
+          <div class="tldr-step-name lang-en-only">model_start</div>
+          <div class="tldr-step-hint">turn=1 · toolUse</div>
+        </div>
+        <div class="tldr-step">
+          <div class="tldr-step-n">03</div>
+          <div class="tldr-step-name lang-zh-only">read 工具调用</div>
+          <div class="tldr-step-name lang-en-only">tool_start</div>
+          <div class="tldr-step-hint">call_1 · README</div>
+        </div>
+        <div class="tldr-step">
+          <div class="tldr-step-n">04</div>
+          <div class="tldr-step-name lang-zh-only">最终回答</div>
+          <div class="tldr-step-name lang-en-only">assistant stop</div>
+          <div class="tldr-step-hint">turn=2 · stopReason=stop</div>
+        </div>
+      </div>
+      <div class="tldr-skip">
+        <span class="lang-zh-only">已经懂 agent 基础? 直接跳到 → <a href="#c7">AgentSession</a> · <a href="#c10">runLoop 双环</a> · <a href="#c14">pi-ai</a> · <a href="#c17">TUI diff</a> · <a href="#c22">JSONL 会话树</a> · <a href="#c24">vs Claude Code</a></span>
+        <span class="lang-en-only">Know agent basics? Skip to → <a href="#c7">AgentSession</a> · <a href="#c10">runLoop twin loops</a> · <a href="#c14">pi-ai</a> · <a href="#c17">TUI diff</a> · <a href="#c22">JSONL session tree</a> · <a href="#c24">vs Claude Code</a></span>
+      </div>
+    </aside>
+
+    <div class="perf-bar">
+      <div class="pb-title">
+        <span class="lang-zh-only">一条用户消息 · 26 个站</span>
+        <span class="lang-en-only">One user message · 26 stations</span>
+        <span class="pb-pulse">▸ live trace</span>
+      </div>
+      <div class="pb-track" id="pbTrack">
+        <div class="pb-cell p0" data-n="01" data-jump="#c1" title="C01 Harness 不是 Product"></div>
+        <div class="pb-cell p0" data-n="02" data-jump="#c2" title="C02 一条消息的 22 站"></div>
+        <div class="pb-cell p1" data-n="03" data-jump="#c3" title="C03 pi-mono 家谱"></div>
+        <div class="pb-cell p1" data-n="04" data-jump="#c4" title="C04 六层蛋糕"></div>
+        <div class="pb-cell p1" data-n="05" data-jump="#c5" title="C05 故意不做的功能"></div>
+        <div class="pb-cell p2" data-n="06" data-jump="#c6" title="C06 CLI 启动链"></div>
+        <div class="pb-cell p2" data-n="07" data-jump="#c7" title="C07 AgentSession 编排"></div>
+        <div class="pb-cell p2" data-n="08" data-jump="#c8" title="C08 AGENTS.md 上下文栈"></div>
+        <div class="pb-cell p3" data-n="09" data-jump="#c9" title="C09 两层消息模型"></div>
+        <div class="pb-cell p3" data-n="10" data-jump="#c10" title="C10 runLoop 双环"></div>
+        <div class="pb-cell p3" data-n="11" data-jump="#c11" title="C11 Steering 与 Follow-up"></div>
+        <div class="pb-cell p3" data-n="12" data-jump="#c12" title="C12 Tool 执行管线"></div>
+        <div class="pb-cell p3" data-n="13" data-jump="#c13" title="C13 事件总线"></div>
+        <div class="pb-cell p4" data-n="14" data-jump="#c14" title="C14 pi-ai 提供商抽象"></div>
+        <div class="pb-cell p4" data-n="15" data-jump="#c15" title="C15 流式 EventStream"></div>
+        <div class="pb-cell p4" data-n="16" data-jump="#c16" title="C16 认证与模型目录"></div>
+        <div class="pb-cell p5" data-n="17" data-jump="#c17" title="C17 差分渲染 TUI"></div>
+        <div class="pb-cell p5" data-n="18" data-jump="#c18" title="C18 Interactive Mode"></div>
+        <div class="pb-cell p6" data-n="19" data-jump="#c19" title="C19 Extension API 面"></div>
+        <div class="pb-cell p6" data-n="20" data-jump="#c20" title="C20 ExtensionRunner"></div>
+        <div class="pb-cell p6" data-n="21" data-jump="#c21" title="C21 Pi Packages"></div>
+        <div class="pb-cell p7" data-n="22" data-jump="#c22" title="C22 JSONL 会话树"></div>
+        <div class="pb-cell p7" data-n="23" data-jump="#c23" title="C23 Compaction 与 Harness"></div>
+        <div class="pb-cell p8" data-n="24" data-jump="#c24" title="C24 对比 Claude Code / Cursor"></div>
+        <div class="pb-cell p8" data-n="25" data-jump="#c25" title="C25 RPC 与 pi-server"></div>
+        <div class="pb-cell pc" data-n="26" data-jump="#c26" title="C26 怎么自己 trace 一轮"></div>
+      </div>
+      <div class="pb-axis">
+        <span class="lang-zh-only">回车</span><span class="lang-en-only">Enter</span>
+        <span></span><span></span><span></span><span></span><span></span>
+        <span class="lang-zh-only">JSONL</span><span class="lang-en-only">JSONL</span>
+      </div>
+    </div>
+  </header>
+
+  <nav class="toc-v2" aria-label="Contents">
+    <div class="tv-head">
+      <div class="tv-label lang-zh-only">CONTENTS · 目录</div>
+      <div class="tv-label lang-en-only">CONTENTS</div>
+      <div class="tv-meta"><span class="tv-now">26</span> <span class="lang-zh-only">章 · 8 个 Phase + Coda</span><span class="lang-en-only">chapters · 8 phases + coda</span></div>
+    </div>
+    <div class="tv-sub lang-zh-only">「<em>读取 README.md，用一句话告诉我这个项目做什么</em>」· 26 个站。点任意一格跳转。</div>
+    <div class="tv-sub lang-en-only">«<em>read README.md and tell me what this project does in one sentence</em>» · 26 stations. Click any chip.</div>
+
+    <div class="toc-group" data-phase="card">
+      <div class="toc-group-head">
+        <div class="tg-num">·</div>
+        <div class="tg-name lang-zh-only">背景</div>
+        <div class="tg-name lang-en-only">Background</div>
+        <div class="tg-count">3</div>
+      </div>
+      <div class="tg-en">3 chapters · monorepo</div>
+      <div class="toc-chips">
+        <a href="#c3" class="toc-chip"><span class="tc-num">03</span><div class="tc-name"><span class="lang-zh-only">pi-mono 家谱</span><span class="lang-en-only">The pi-mono family tree</span><span class="tc-en">Mario Zechner and earendil-works</span></div></a>
+        <a href="#c4" class="toc-chip"><span class="tc-num">04</span><div class="tc-name"><span class="lang-zh-only">六层蛋糕</span><span class="lang-en-only">The six-layer cake</span><span class="tc-en">agent-core · ai · tui · coding-agent</span></div></a>
+        <a href="#c5" class="toc-chip tc-special"><span class="tc-num">05</span><div class="tc-name"><span class="lang-zh-only">故意不做的功能</span><span class="lang-en-only">Intentionally missing features</span><span class="tc-en">No MCP · No sub-agents · No plan mode</span></div></a>
+      </div>
+    </div>
+    <div class="toc-group" data-phase="bg">
+      <div class="toc-group-head">
+        <div class="tg-num">0</div>
+        <div class="tg-name lang-zh-only">引子</div>
+        <div class="tg-name lang-en-only">Prologue</div>
+        <div class="tg-count">2</div>
+      </div>
+      <div class="tg-en">2 chapters · framing</div>
+      <div class="toc-chips">
+        <a href="#c1" class="toc-chip"><span class="tc-num">01</span><div class="tc-name"><span class="lang-zh-only">Harness 不是 Product</span><span class="lang-en-only">Harness is not a product</span><span class="tc-en">a third path in the agent product war</span></div></a>
+        <a href="#c2" class="toc-chip"><span class="tc-num">02</span><div class="tc-name"><span class="lang-zh-only">一条消息的 22 站</span><span class="lang-en-only">22 stations for one message</span><span class="tc-en">from Enter to JSONL, the full map</span></div></a>
+      </div>
+    </div>
+    <div class="toc-group" data-phase="in">
+      <div class="toc-group-head">
+        <div class="tg-num">I</div>
+        <div class="tg-name lang-zh-only">入口</div>
+        <div class="tg-name lang-en-only">Intake</div>
+        <div class="tg-count">3</div>
+      </div>
+      <div class="tg-en">3 chapters · CLI to context</div>
+      <div class="toc-chips">
+        <a href="#c6" class="toc-chip"><span class="tc-num">06</span><div class="tc-name"><span class="lang-zh-only">CLI 启动链</span><span class="lang-en-only">CLI boot chain</span><span class="tc-en">cli.ts → main.ts → createAgentSession</span></div></a>
+        <a href="#c7" class="toc-chip"><span class="tc-num">07</span><div class="tc-name"><span class="lang-zh-only">AgentSession 编排</span><span class="lang-en-only">AgentSession orchestration</span><span class="tc-en">the single orchestration hub</span></div></a>
+        <a href="#c8" class="toc-chip"><span class="tc-num">08</span><div class="tc-name"><span class="lang-zh-only">AGENTS.md 上下文栈</span><span class="lang-en-only">The AGENTS.md context stack</span><span class="tc-en">instructions stacked from ~/.pi to project root</span></div></a>
+      </div>
+    </div>
+    <div class="toc-group" data-phase="heart">
+      <div class="toc-group-head">
+        <div class="tg-num">II</div>
+        <div class="tg-name lang-zh-only">心脏</div>
+        <div class="tg-name lang-en-only">Heart</div>
+        <div class="tg-count">5</div>
+      </div>
+      <div class="tg-en">5 chapters · agent loop</div>
+      <div class="toc-chips">
+        <a href="#c9" class="toc-chip tc-special"><span class="tc-num">09</span><div class="tc-name"><span class="lang-zh-only">两层消息模型</span><span class="lang-en-only">Two-layer message model</span><span class="tc-en">AgentMessage ≠ Message</span></div></a>
+        <a href="#c10" class="toc-chip tc-special"><span class="tc-num">10</span><div class="tc-name"><span class="lang-zh-only">runLoop 双环</span><span class="lang-en-only">The runLoop twin loops</span><span class="tc-en">outer follow-up · inner tool batch</span></div></a>
+        <a href="#c11" class="toc-chip"><span class="tc-num">11</span><div class="tc-name"><span class="lang-zh-only">Steering 与 Follow-up</span><span class="lang-en-only">Steering and follow-up</span><span class="tc-en">mid-run injection and post-stop follow-up</span></div></a>
+        <a href="#c12" class="toc-chip"><span class="tc-num">12</span><div class="tc-name"><span class="lang-zh-only">Tool 执行管线</span><span class="lang-en-only">Tool execution pipeline</span><span class="tc-en">parallel vs sequential · length truncation</span></div></a>
+        <a href="#c13" class="toc-chip"><span class="tc-num">13</span><div class="tc-name"><span class="lang-zh-only">事件总线</span><span class="lang-en-only">The event bus</span><span class="tc-en">how message_update drives the TUI</span></div></a>
+      </div>
+    </div>
+    <div class="toc-group" data-phase="llm">
+      <div class="toc-group-head">
+        <div class="tg-num">III</div>
+        <div class="tg-name lang-zh-only">LLM</div>
+        <div class="tg-name lang-en-only">LLM</div>
+        <div class="tg-count">3</div>
+      </div>
+      <div class="tg-en">3 chapters · pi-ai</div>
+      <div class="toc-chips">
+        <a href="#c14" class="toc-chip"><span class="tc-num">14</span><div class="tc-name"><span class="lang-zh-only">pi-ai 提供商抽象</span><span class="lang-en-only">pi-ai provider abstraction</span><span class="tc-en">Models · createProvider · streamSimple</span></div></a>
+        <a href="#c15" class="toc-chip"><span class="tc-num">15</span><div class="tc-name"><span class="lang-zh-only">流式 EventStream</span><span class="lang-en-only">Streaming EventStream</span><span class="tc-en">text_delta · toolcall_delta · done</span></div></a>
+        <a href="#c16" class="toc-chip"><span class="tc-num">16</span><div class="tc-name"><span class="lang-zh-only">认证与模型目录</span><span class="lang-en-only">Auth and model catalog</span><span class="tc-en">40+ providers · OAuth · models.generated.ts</span></div></a>
+      </div>
+    </div>
+    <div class="toc-group" data-phase="tui">
+      <div class="toc-group-head">
+        <div class="tg-num">IV</div>
+        <div class="tg-name lang-zh-only">终端</div>
+        <div class="tg-name lang-en-only">Terminal</div>
+        <div class="tg-count">2</div>
+      </div>
+      <div class="tg-en">2 chapters · differential TUI</div>
+      <div class="toc-chips">
+        <a href="#c17" class="toc-chip tc-special"><span class="tc-num">17</span><div class="tc-name"><span class="lang-zh-only">差分渲染 TUI</span><span class="lang-en-only">Differential-render TUI</span><span class="tc-en">CSI 2026 · firstChanged → lastChanged</span></div></a>
+        <a href="#c18" class="toc-chip"><span class="tc-num">18</span><div class="tc-name"><span class="lang-zh-only">Interactive Mode</span><span class="lang-en-only">Interactive mode</span><span class="tc-en">Editor · Markdown · tool renderers</span></div></a>
+      </div>
+    </div>
+    <div class="toc-group" data-phase="ext">
+      <div class="toc-group-head">
+        <div class="tg-num">V</div>
+        <div class="tg-name lang-zh-only">扩展</div>
+        <div class="tg-name lang-en-only">Extensions</div>
+        <div class="tg-count">3</div>
+      </div>
+      <div class="tg-en">3 chapters · TypeScript hooks</div>
+      <div class="toc-chips">
+        <a href="#c19" class="toc-chip"><span class="tc-num">19</span><div class="tc-name"><span class="lang-zh-only">Extension API 面</span><span class="lang-en-only">Extension API surface</span><span class="tc-en">registerTool · registerCommand · events</span></div></a>
+        <a href="#c20" class="toc-chip"><span class="tc-num">20</span><div class="tc-name"><span class="lang-zh-only">ExtensionRunner</span><span class="lang-en-only">ExtensionRunner</span><span class="tc-en">jiti load · event merge · hook injection</span></div></a>
+        <a href="#c21" class="toc-chip"><span class="tc-num">21</span><div class="tc-name"><span class="lang-zh-only">Pi Packages</span><span class="lang-en-only">Pi packages</span><span class="tc-en">npm · git · shareable harness capabilities</span></div></a>
+      </div>
+    </div>
+    <div class="toc-group" data-phase="persist">
+      <div class="toc-group-head">
+        <div class="tg-num">VI</div>
+        <div class="tg-name lang-zh-only">持久化</div>
+        <div class="tg-name lang-en-only">Persistence</div>
+        <div class="tg-count">2</div>
+      </div>
+      <div class="tg-en">2 chapters · JSONL + harness</div>
+      <div class="toc-chips">
+        <a href="#c22" class="toc-chip tc-special"><span class="tc-num">22</span><div class="tc-name"><span class="lang-zh-only">JSONL 会话树</span><span class="lang-en-only">JSONL session tree</span><span class="tc-en">parentId · leafId · fork</span></div></a>
+        <a href="#c23" class="toc-chip"><span class="tc-num">23</span><div class="tc-name"><span class="lang-zh-only">Compaction 与 Harness</span><span class="lang-en-only">Compaction and harness</span><span class="tc-en">context compression · SQLite lanes</span></div></a>
+      </div>
+    </div>
+    <div class="toc-group" data-phase="land">
+      <div class="toc-group-head">
+        <div class="tg-num">VII</div>
+        <div class="tg-name lang-zh-only">全景</div>
+        <div class="tg-name lang-en-only">Landscape</div>
+        <div class="tg-count">2</div>
+      </div>
+      <div class="tg-en">2 chapters · ecosystem</div>
+      <div class="toc-chips">
+        <a href="#c24" class="toc-chip"><span class="tc-num">24</span><div class="tc-name"><span class="lang-zh-only">对比 Claude Code / Cursor</span><span class="lang-en-only">vs Claude Code / Cursor</span><span class="tc-en">design trade-offs of a minimal harness</span></div></a>
+        <a href="#c25" class="toc-chip"><span class="tc-num">25</span><div class="tc-name"><span class="lang-zh-only">RPC 与 pi-server</span><span class="lang-en-only">RPC and pi-server</span><span class="tc-en">JSONL process protocol · CBOR remote sessions</span></div></a>
+      </div>
+    </div>
+    <div class="toc-group" data-phase="coda">
+      <div class="toc-group-head">
+        <div class="tg-num">∎</div>
+        <div class="tg-name lang-zh-only">Coda</div>
+        <div class="tg-name lang-en-only">Coda</div>
+        <div class="tg-count">1</div>
+      </div>
+      <div class="tg-en">trace it yourself</div>
+      <div class="toc-chips">
+        <a href="#c26" class="toc-chip"><span class="tc-num">26</span><div class="tc-name"><span class="lang-zh-only">怎么自己 trace 一轮</span><span class="lang-en-only">How to trace a turn yourself</span><span class="tc-en">--verbose · event log · session file</span></div></a>
+      </div>
+    </div>
+  </nav>
+
+  <section class="chap" id="c1">
+    <div class="chap-num">CHAPTER&nbsp;01&nbsp;·&nbsp;引子</div>
+    <h2 class="chap-title lang-zh-only">Harness 不是 Product</h2>
+    <h2 class="chap-title lang-en-only">Harness is not a product</h2>
+    <p class="chap-en lang-zh-only">agent 产品战争里的第三条路</p>
+    <p class="chap-en lang-en-only">a third path in the agent product war</p>
+    <div class="lang-zh-only"><p>2025–2026 年的 coding agent 市场被两条路线撕成两半：<strong>密封产品</strong>（Claude Code、Cursor、Windsurf）和<strong>可组合 harness</strong>（Pi、OpenCode、aider 变体）。我们的主线 prompt——<code>读取 README.md，用一句话告诉我这个项目做什么</code>——在两种架构里走的路径完全不同：产品把中间层焊死在二进制里；harness 把每一站写成可测试的 TypeScript。</p></div>
+    <div class="lang-en-only"><p>The 2025–2026 coding-agent market splits into sealed products (Claude Code, Cursor, Windsurf) and composable harnesses (Pi, OpenCode, aider variants). Our through-line prompt — <code>read README.md and tell me what this project does in one sentence</code> — takes completely different paths: products weld the middle layers into a binary; harnesses write every station as testable TypeScript.</p></div>
+
+    <div class="stage-purpose">
+      <div class="sp-row">
+        <div class="sp-key"><span class="lang-zh-only">产品思维</span><span class="lang-en-only">Product mindset</span></div>
+        <div class="sp-val"><span class="lang-zh-only">用户买的是<strong>体验闭环</strong>——从安装到第一次 commit 零配置</span><span class="lang-en-only">Users buy a <strong>closed loop</strong> — zero config from install to first commit</span></div>
+      </div>
+      <div class="sp-row">
+        <div class="sp-key"><span class="lang-zh-only">Harness 思维</span><span class="lang-en-only">Harness mindset</span></div>
+        <div class="sp-val"><span class="lang-zh-only">开发者买的是<strong>可观测编排</strong>——每一层都有源码和测试</span><span class="lang-en-only">Developers buy <strong>observable orchestration</strong> — every layer has source and tests</span></div>
+      </div>
+      <div class="sp-row">
+        <div class="sp-key"><span class="lang-zh-only">Pi 的赌注</span><span class="lang-en-only">Pi's bet</span></div>
+        <div class="sp-val"><span class="lang-zh-only">终端原生 + JSONL 会话树 + TypeScript 扩展 > IDE 锁定</span><span class="lang-en-only">Terminal-native + JSONL session tree + TS extensions > IDE lock-in</span></div>
+      </div>
+      <div class="sp-row">
+        <div class="sp-key"><span class="lang-zh-only">代价</span><span class="lang-en-only">The cost</span></div>
+        <div class="sp-val"><span class="lang-zh-only">没有 MCP 协议层、没有子 agent、没有 Plan 模式——<em>故意不做</em></span><span class="lang-en-only">No MCP layer, no sub-agents, no plan mode — <em>intentionally omitted</em></span></div>
+      </div>
+    </div>
+
+    <div class="formula">
+      <div class="ftitle"><span class="lang-zh-only">架构公式</span><span class="lang-en-only">ARCHITECTURE</span></div>
+      <span class="cond"><span class="term">Product</span> = UX × Integrations × Policy</span>
+      <span class="cond"><span class="term-cu">Harness</span> = AgentLoop × Tools × Session × Extensions</span>
+      <div class="out"><span class="lang-zh-only">Pi 选择右边那条等式</span><span class="lang-en-only">Pi chooses the right-hand equation</span></div>
+    </div>
+
+    <table class="cmp">
+      <thead><tr><th></th><th>Claude Code</th><th>Cursor</th><th>Pi</th></tr></thead>
+      <tbody>
+      <tr><td>定位</td><td>密封 CLI 产品</td><td>密封 IDE 产品</td><td>开源 harness</td></tr>
+      <tr><td>会话格式</td><td>专有</td><td>专有</td><td>JSONL 树</td></tr>
+      <tr><td>扩展</td><td>MCP + 插件</td><td>VS Code 生态</td><td>TypeScript hooks</td></tr>
+      <tr><td>可 fork</td><td>✗</td><td>✗</td><td>✓ pi-mono</td></tr>
+      <tr><td>主线可读</td><td>黑盒</td><td>黑盒</td><td>agent-loop.ts 逐行</td></tr>
+      </tbody>
+    </table>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/sdk.ts</span>
+        <span class="src-tag">sdk</span>
+      </div>
+      <span class="src-line"><span class="src-comment">/** CreateAgentSessionOptions — harness entry contract */</span></span>
+      <span class="src-line"><span class="src-kw">export interface</span> <span class="src-cls">CreateAgentSessionOptions</span> {</span>
+      <span class="src-line">  <span class="src-arg">cwd</span>?: <span class="src-cls">string</span>;</span>
+      <span class="src-line">  <span class="src-arg">model</span>?: <span class="src-cls">Model</span>&lt;<span class="src-cls">any</span>&gt;;</span>
+      <span class="src-line">  <span class="src-arg">tools</span>?: <span class="src-cls">string</span>[];</span>
+      <span class="src-line">  <span class="src-arg">resourceLoader</span>?: <span class="src-cls">ResourceLoader</span>;</span>
+      <span class="src-line">  <span class="src-arg">sessionManager</span>?: <span class="src-cls">SessionManager</span>;</span>
+      <span class="src-line">}</span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">为什么「最小」是特性而不是缺陷</span><span class="lang-en-only">Why "minimal" is a feature, not a bug</span></h3>
+
+    <div class="lang-zh-only"><p>密封产品的复杂度藏在黑盒里：你不知道 steering 消息如何插队、compaction 的精确阈值、tool 并行策略。Pi 把这三件事写进 <code>agent-loop.ts</code> 和 <code>agent-session.ts</code>，用单元测试锁住行为。你可以 fork pi-mono 换工具、写扩展注入 lint、用 <code>--mode rpc</code> 嵌进 CI。</p></div>
+    <div class="lang-en-only"><p>Sealed products hide complexity. Pi writes steering, compaction, and tool parallelism into <code>agent-loop.ts</code> and <code>agent-session.ts</code>, locked by tests. Fork pi-mono, swap tools, inject lint via extensions, embed with <code>--mode rpc</code>.</p></div>
+
+    <div class="keynum-row">
+      <div class="keynum">
+        <div class="kn-val">6</div>
+        <div class="kn-label"><span class="lang-zh-only">npm 包</span><span class="lang-en-only">npm packages</span></div>
+        <div class="kn-desc"><span class="lang-zh-only">agent-core · ai · tui · coding-agent · protocol · server</span><span class="lang-en-only">agent-core · ai · tui · coding-agent · protocol · server</span></div>
+      </div>
+      <div class="keynum">
+        <div class="kn-val">26</div>
+        <div class="kn-label"><span class="lang-zh-only">工序站</span><span class="lang-en-only">stations</span></div>
+        <div class="kn-desc"><span class="lang-zh-only">一条用户消息穿越的完整链路</span><span class="lang-en-only">full path of one user message</span></div>
+      </div>
+      <div class="keynum">
+        <div class="kn-val">15</div>
+        <div class="kn-label"><span class="lang-zh-only">checkpoint</span><span class="lang-en-only">checkpoints</span></div>
+        <div class="kn-desc"><span class="lang-zh-only">pi-textbook 教学里程碑</span><span class="lang-en-only">pi-textbook teaching milestones</span></div>
+      </div>
+    </div>
+
+    <div class="note copper">
+      <span class="lang-zh-only">Claude Code 和 Cursor 解决<strong>普通开发者</strong>的问题；Pi 解决<strong>想理解 agent 内部机制</strong>的人的问题。</span>
+      <span class="lang-en-only">Claude Code and Cursor serve average developers; Pi serves people who want to understand agent internals.</span>
+    </div>
+
+    <blockquote class="pull copper">
+      <span class="lang-zh-only">产品卖的是答案。<br>Harness 卖的是<strong>能问出下一个问题</strong>的显微镜。</span>
+      <span class="lang-en-only">Products sell answers.<br>Harnesses sell the microscope to ask the <strong>next question</strong>.</span>
+      <cite>Field Note · 10</cite>
+    </blockquote>
+
+    <div class="note copper">
+      <span class="lang-zh-only">📘 <strong>pi-textbook checkpoint 00</strong>：一次 README 读取的七个里程碑（<code>prologue.ts</code>）· 生产映射：<code>packages/coding-agent/src/main.ts · packages/agent/src/agent-loop.ts</code></span>
+      <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 00</strong>: 一次 README 读取的七个里程碑 (<code>prologue.ts</code>) · production: <code>packages/coding-agent/src/main.ts · packages/agent/src/agent-loop.ts</code></span>
+    </div>
+
+    <figure>
+      <div class="figbox"><div class="fig-placeholder">diagram</div></div>
+      <figcaption>
+        <span class="figid">FIG</span>
+        <span class="lang-zh-only">Harness vs Product 光谱：密封体验在左，可组合层在右，Pi 落在右侧但保持终端原生。</span>
+        <span class="lang-en-only">Harness vs product spectrum: sealed UX left, composable layers right; Pi stays terminal-native.</span>
+      </figcaption>
+    </figure>
+
+    <h3 class="sub"><span class="lang-zh-only">设计哲学</span><span class="lang-en-only">Design philosophy</span></h3>
+
+    <div class="lang-zh-only"><p>Pi 把 agent 拆成可测试的纯函数环，而不是把所有策略塞进一个 God class。</p></div>
+    <div class="lang-en-only"><p>Pi splits the agent into testable pure-function loops instead of one God class.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">可 fork 意味着什么</span><span class="lang-en-only">What forkable means</span></h3>
+
+    <div class="lang-zh-only"><p>你可以换 streamFn、换 tool registry、换 SessionManager 实现，而不改 TUI。</p></div>
+    <div class="lang-en-only"><p>Swap streamFn, tool registry, SessionManager without touching TUI.</p></div>
+
+    <div class="note">
+      <span class="lang-zh-only">本章 (01) 在主线 prompt「agent 产品战争里的第三条路」路径上负责：<strong>Harness 不是 Product</strong>。回到 C02 的 22 站地图定位这一章。</span>
+      <span class="lang-en-only">Chapter (01) on the through-line path handles: <strong>Harness is not a product</strong>. Return to C02's 22-station map to locate this chapter.</span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+      <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
+      <tbody>
+      <tr><td>00</td><td>一次 README 读取的七个里程碑</td><td>prologue.ts</td><td>packages/coding-agent/src/main.ts · packages/agent/src/agent-loop.ts</td></tr>
+      <tr><td>13</td><td>Composition Root</td><td>composition-root</td><td>packages/coding-agent/src/core/agent-session.ts · sdk.ts</td></tr>
+      </tbody>
+    </table>
+
+    <div class="case-study">
+      <div class="cs-tag">CASE STUDY</div>
+      <h4 class="sub2"><span class="lang-zh-only">从 Claude Code 迁移到 Pi</span><span class="lang-en-only">Migrating mental model from Claude Code to Pi</span></h4>
+      <div class="lang-zh-only"><p>Claude Code 用户习惯「一条命令搞定」；Pi 用户需要理解 AgentSession 和 JSONL。迁移的第一步是跑通 pi-textbook checkpoint 00 的七里程碑。</p></div>
+      <div class="lang-en-only"><p>Claude Code users expect one command does all; Pi users need AgentSession and JSONL. First migration step: run pi-textbook checkpoint 00 seven milestones.</p></div>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">Pi 是产品吗？</span><span class="lang-en-only">Is Pi a product?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>不是。Pi 是 harness——你 fork 后自己成为产品作者。</p></div><div class="lang-en-only"><p>No. Pi is a harness — you fork and become the product author.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">为什么终端原生？</span><span class="lang-en-only">Why terminal-native?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>Mario 的背景是游戏引擎和 CLI 工具；终端是最高带宽的开发者接口。</p></div><div class="lang-en-only"><p>Mario's background is game engines and CLI tools; terminal is highest-bandwidth dev interface.</p></div></div></details>
+
+    <h3 class="sub"><span class="lang-zh-only">附录 · Harness 不是 Product 深度 trace</span><span class="lang-en-only">Appendix · deep trace for Harness is not a product</span></h3>
+
+    <div class="lang-zh-only"><p>本章 (01) 属于 Phase「引子」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
+    <div class="lang-en-only"><p>Chapter (01) belongs to Phase «Prologue». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
+
+    <table class="cmp">
+      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
+      <tbody>
+      <tr><td>1</td><td>概念层</td><td>harness vs product 定位</td></tr>
+      <tr><td>2</td><td>—</td><td>checkpoint 2</td></tr>
+      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
+      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
+      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
+      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
+      </tbody>
+    </table>
+
+    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/sdk.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// harness 入口契约</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 01 · Harness 不是 Product</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 01 · Harness 不是 Product</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 01 · Harness 不是 Product</span></span>
+    </div>
+
+    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
+
+    <div class="lang-zh-only"><p><strong>AgentMessage</strong> — agent-core 内部消息 IR</p></div>
+    <div class="lang-en-only"><p><strong>AgentMessage</strong> — agent-core internal message IR</p></div>
+
+    <div class="lang-zh-only"><p><strong>StreamFn</strong> — 可注入的模型流函数</p></div>
+    <div class="lang-en-only"><p><strong>StreamFn</strong> — injectable model stream function</p></div>
+
+    <div class="lang-zh-only"><p><strong>leafId</strong> — JSONL 会话树当前叶</p></div>
+    <div class="lang-en-only"><p><strong>leafId</strong> — JSONL session tree current leaf</p></div>
+
+    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
+
+    <div class="note">
+      <span class="lang-zh-only">[01.1] 在 Harness 不是 Product 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[01.1] At Harness is not a product stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[01.2] 在 Harness 不是 Product 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[01.2] At Harness is not a product stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[01.3] 在 Harness 不是 Product 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[01.3] At Harness is not a product stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[01.4] 在 Harness 不是 Product 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[01.4] At Harness is not a product stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[01.5] 在 Harness 不是 Product 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[01.5] At Harness is not a product stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[01.6] 在 Harness 不是 Product 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[01.6] At Harness is not a product stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[01.7] 在 Harness 不是 Product 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[01.7] At Harness is not a product stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[01.8] 在 Harness 不是 Product 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[01.8] At Harness is not a product stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+  </section>
+
+  <section class="chap" id="c2">
+    <div class="chap-num">CHAPTER&nbsp;02&nbsp;·&nbsp;引子</div>
+    <h2 class="chap-title lang-zh-only">一条消息的 22 站</h2>
+    <h2 class="chap-title lang-en-only">22 stations for one message</h2>
+    <p class="chap-en lang-zh-only">从回车到 JSONL 的全景图</p>
+    <p class="chap-en lang-en-only">from Enter to JSONL, the full map</p>
+    <div class="lang-zh-only"><p>按下回车之后，<code>读取 README.md，用一句话告诉我这个项目做什么</code> 不是直接发给 LLM——它要先变成 <code>AgentMessage</code>，穿过 <code>AgentSession.prompt()</code>，触发 <code>agentLoop()</code>，在 <code>runLoop</code> 的双环里转两圈 model stream，中间插一次 <code>read</code> 工具，最后才在 TUI 里滚动、在 JSONL 里落盘。</p></div>
+    <div class="lang-en-only"><p>After Enter, <code>read README.md and tell me what this project does in one sentence</code> does not go straight to the LLM — it becomes an <code>AgentMessage</code>, passes through <code>AgentSession.prompt()</code>, triggers <code>agentLoop()</code>, spins two model streams in <code>runLoop</code>'s twin loops with a <code>read</code> tool in between, then scrolls in the TUI and lands on disk as JSONL.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">七个里程碑 · pi-textbook 序章</span><span class="lang-en-only">Seven milestones · pi-textbook prologue</span></h3>
+
+    <div class="lang-zh-only"><p>pi-textbook 用离线 <code>ScriptedModel</code> 固定了主线 prompt 的七步 trace。生产代码 <code>agent-loop.ts</code> 产生语义等价但事件更细的事件流。</p></div>
+    <div class="lang-en-only"><p>pi-textbook fixes a seven-step trace for the through-line prompt with offline <code>ScriptedModel</code>. Production <code>agent-loop.ts</code> emits semantically equivalent but finer-grained events.</p></div>
+
+    <table class="cmp milestone-table"><thead><tr><th>#</th><th>type</th><th>owner</th><th>detail</th></tr></thead><tbody><tr><td>01</td><td>user_message</td><td class="owner-user">user</td><td>读取 README.md，用一句话告诉我…</td></tr><tr><td>02</td><td>model_start</td><td class="owner-model">model</td><td>turn=1</td></tr><tr><td>03</td><td>assistant_message</td><td class="owner-model">model</td><td>stopReason=toolUse · call_1</td></tr><tr><td>04</td><td>tool_start</td><td class="owner-loop">loop</td><td>read(call_1)</td></tr><tr><td>05</td><td>tool_result</td><td class="owner-tool">tool</td><td>README fixture</td></tr><tr><td>06</td><td>model_start</td><td class="owner-model">model</td><td>turn=2</td></tr><tr><td>07</td><td>assistant_message</td><td class="owner-model">model</td><td>stopReason=stop</td></tr></tbody></table>
+
+    <h3 class="sub"><span class="lang-zh-only">22 站全景（前 22 站）</span><span class="lang-en-only">22-station panorama (first 22)</span></h3>
+
+    <div class="ladder">
+      <div class="ladder-step">
+        <div class="ladder-num">01</div>
+        <div class="ladder-body"><span class="lang-zh-only">CLI 解析 argv</span><span class="lang-en-only">cli.ts parses argv</span></div>
+      </div>
+      <div class="ladder-step">
+        <div class="ladder-num">02</div>
+        <div class="ladder-body"><span class="lang-zh-only">main 启动</span><span class="lang-en-only">main.ts boot</span></div>
+      </div>
+      <div class="ladder-step">
+        <div class="ladder-num">03</div>
+        <div class="ladder-body"><span class="lang-zh-only">createAgentSession</span><span class="lang-en-only">session factory</span></div>
+      </div>
+      <div class="ladder-step">
+        <div class="ladder-num">04</div>
+        <div class="ladder-body"><span class="lang-zh-only">ResourceLoader AGENTS.md</span><span class="lang-en-only">context stack</span></div>
+      </div>
+      <div class="ladder-step">
+        <div class="ladder-num">05</div>
+        <div class="ladder-body"><span class="lang-zh-only">user message 入队</span><span class="lang-en-only">prompt queued</span></div>
+      </div>
+      <div class="ladder-step">
+        <div class="ladder-num">06</div>
+        <div class="ladder-body"><span class="lang-zh-only">agent_start 事件</span><span class="lang-en-only">agent_start event</span></div>
+      </div>
+      <div class="ladder-step">
+        <div class="ladder-num">07</div>
+        <div class="ladder-body"><span class="lang-zh-only">turn_start</span><span class="lang-en-only">turn_start</span></div>
+      </div>
+      <div class="ladder-step">
+        <div class="ladder-num">08</div>
+        <div class="ladder-body"><span class="lang-zh-only">convertToLlm</span><span class="lang-en-only">AgentMessage → Message[]</span></div>
+      </div>
+      <div class="ladder-step">
+        <div class="ladder-num">09</div>
+        <div class="ladder-body"><span class="lang-zh-only">streamSimple</span><span class="lang-en-only">pi-ai stream</span></div>
+      </div>
+      <div class="ladder-step">
+        <div class="ladder-num">10</div>
+        <div class="ladder-body"><span class="lang-zh-only">text_delta</span><span class="lang-en-only">token streaming</span></div>
+      </div>
+      <div class="ladder-step">
+        <div class="ladder-num">11</div>
+        <div class="ladder-body"><span class="lang-zh-only">toolcall_delta</span><span class="lang-en-only">tool call assembly</span></div>
+      </div>
+      <div class="ladder-step">
+        <div class="ladder-num">12</div>
+        <div class="ladder-body"><span class="lang-zh-only">assistant stopReason=toolUse</span><span class="lang-en-only">read tool requested</span></div>
+      </div>
+      <div class="ladder-step">
+        <div class="ladder-num">13</div>
+        <div class="ladder-body"><span class="lang-zh-only">executeTool parallel/seq</span><span class="lang-en-only">tool dispatch</span></div>
+      </div>
+      <div class="ladder-step">
+        <div class="ladder-num">14</div>
+        <div class="ladder-body"><span class="lang-zh-only">read README.md</span><span class="lang-en-only">filesystem I/O</span></div>
+      </div>
+      <div class="ladder-step">
+        <div class="ladder-num">15</div>
+        <div class="ladder-body"><span class="lang-zh-only">tool_result 消息</span><span class="lang-en-only">tool result message</span></div>
+      </div>
+      <div class="ladder-step">
+        <div class="ladder-num">16</div>
+        <div class="ladder-body"><span class="lang-zh-only">第二次 streamSimple</span><span class="lang-en-only">turn 2 model call</span></div>
+      </div>
+      <div class="ladder-step">
+        <div class="ladder-num">17</div>
+        <div class="ladder-body"><span class="lang-zh-only">最终 assistant stop</span><span class="lang-en-only">final answer</span></div>
+      </div>
+      <div class="ladder-step">
+        <div class="ladder-num">18</div>
+        <div class="ladder-body"><span class="lang-zh-only">message_end 事件</span><span class="lang-en-only">message_end</span></div>
+      </div>
+      <div class="ladder-step">
+        <div class="ladder-num">19</div>
+        <div class="ladder-body"><span class="lang-zh-only">SessionManager.append</span><span class="lang-en-only">JSONL write</span></div>
+      </div>
+      <div class="ladder-step">
+        <div class="ladder-num">20</div>
+        <div class="ladder-body"><span class="lang-zh-only">TUI message_update</span><span class="lang-en-only">diff render</span></div>
+      </div>
+      <div class="ladder-step">
+        <div class="ladder-num">21</div>
+        <div class="ladder-body"><span class="lang-zh-only">ExtensionRunner hooks</span><span class="lang-en-only">extension events</span></div>
+      </div>
+      <div class="ladder-step">
+        <div class="ladder-num">22</div>
+        <div class="ladder-body"><span class="lang-zh-only">compaction 检查</span><span class="lang-en-only">context check</span></div>
+      </div>
+    </div>
+
+    <figure>
+      <div class="figbox"><div class="event-flow">
+      <div class="ef-row"><div class="ef-type">agent_start</div><div><span class="lang-zh-only">循环开始 · 订阅者收到首事件</span><span class="lang-en-only">Loop begins · subscribers receive first event</span></div></div>
+      <div class="ef-row"><div class="ef-type">turn_start</div><div><span class="lang-zh-only">新 turn · 可能含 steering 注入</span><span class="lang-en-only">New turn · may include steering injection</span></div></div>
+      <div class="ef-row"><div class="ef-type">message_start</div><div><span class="lang-zh-only">用户消息或 tool result 进入 transcript</span><span class="lang-en-only">User message or tool result enters transcript</span></div></div>
+      <div class="ef-row"><div class="ef-type">message_update</div><div><span class="lang-zh-only">流式 delta · TUI 差分渲染的燃料</span><span class="lang-en-only">Streaming delta · fuel for TUI differential render</span></div></div>
+      <div class="ef-row"><div class="ef-type">message_end</div><div><span class="lang-zh-only">消息定稿 · SessionManager 落盘</span><span class="lang-en-only">Message finalized · SessionManager persists</span></div></div>
+      <div class="ef-row"><div class="ef-type">tool_execution_start</div><div><span class="lang-zh-only">read 开始 · cwd 相对路径解析</span><span class="lang-en-only">read begins · cwd-relative path resolution</span></div></div>
+      <div class="ef-row"><div class="ef-type">tool_execution_end</div><div><span class="lang-zh-only">read 结束 · 结果截断策略生效</span><span class="lang-en-only">read ends · truncation policy applied</span></div></div>
+      <div class="ef-row"><div class="ef-type">turn_end</div><div><span class="lang-zh-only">本 turn 结束 · 检查 follow-up 队列</span><span class="lang-en-only">Turn ends · check follow-up queue</span></div></div>
+      <div class="ef-row"><div class="ef-type">agent_end</div><div><span class="lang-zh-only">循环退出 · 返回 newMessages[]</span><span class="lang-en-only">Loop exits · returns newMessages[]</span></div></div>
+    </div>
+      </div>
+      <figcaption><span class="figid">EVT</span><span class="lang-zh-only">AgentEvent 流 · 主线 prompt</span><span class="lang-en-only">AgentEvent stream · through-line prompt</span></figcaption>
+    </figure>
+
+    <div class="stage-purpose">
+      <div class="sp-row">
+        <div class="sp-key"><span class="lang-zh-only">owner=user</span><span class="lang-en-only">owner=user</span></div>
+        <div class="sp-val"><span class="lang-zh-only">只有用户消息</span><span class="lang-en-only">user messages only</span></div>
+      </div>
+      <div class="sp-row">
+        <div class="sp-key"><span class="lang-zh-only">owner=model</span><span class="lang-en-only">owner=model</span></div>
+        <div class="sp-val"><span class="lang-zh-only">model_start + assistant_message</span><span class="lang-en-only">model_start + assistant_message</span></div>
+      </div>
+      <div class="sp-row">
+        <div class="sp-key"><span class="lang-zh-only">owner=loop</span><span class="lang-en-only">owner=loop</span></div>
+        <div class="sp-val"><span class="lang-zh-only">tool_start · 调度决策</span><span class="lang-en-only">tool_start · dispatch decisions</span></div>
+      </div>
+      <div class="sp-row">
+        <div class="sp-key"><span class="lang-zh-only">owner=tool</span><span class="lang-en-only">owner=tool</span></div>
+        <div class="sp-val"><span class="lang-zh-only">tool_result · 环境事实</span><span class="lang-en-only">tool_result · environment facts</span></div>
+      </div>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/src/demo/prologue.ts</span>
+        <span class="src-tag">prologue</span>
+      </div>
+      <span class="src-line"><span class="src-kw">const</span> <span class="src-arg">README_FIXTURE</span> = <span class="src-str">"# tiny-pi\n用于学习 Agent 内核的 TypeScript 项目。"</span>;</span>
+      <span class="src-line"><span class="src-comment">// 07 assistant_message stopReason=stop → 最终回答</span></span>
+      <span class="src-line"><span class="src-fn">appendTrace</span>(trace, { <span class="src-arg">owner</span>: <span class="src-str">"model"</span>, <span class="src-arg">type</span>: <span class="src-str">"assistant_message"</span>, ... });</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">从 C02 到 C26，每一章解释<strong>两站之间的过渡</strong>。持住这条 22 站骨架，细节才不会丢。</span>
+      <span class="lang-en-only">From C02 to C26, each chapter explains <strong>one transition between stations</strong>. Hold this 22-station skeleton and the details won't drift.</span>
+    </div>
+
+    <blockquote class="pull copper">
+      <span class="lang-zh-only">七个里程碑是望远镜。<br>二十六个章节是显微镜。</span>
+      <span class="lang-en-only">Seven milestones are the telescope.<br>Twenty-six chapters are the microscope.</span>
+      <cite>Field Note · 10</cite>
+    </blockquote>
+
+    <div class="note">
+      <span class="lang-zh-only">本章 (02) 在主线 prompt「从回车到 JSONL 的全景图」路径上负责：<strong>一条消息的 22 站</strong>。回到 C02 的 22 站地图定位这一章。</span>
+      <span class="lang-en-only">Chapter (02) on the through-line path handles: <strong>22 stations for one message</strong>. Return to C02's 22-station map to locate this chapter.</span>
+    </div>
+
+    <table class="cmp">
+      <thead><tr><th>owner</th><th>职责</th><th>主线例子</th></tr></thead>
+      <tbody>
+      <tr><td>user</td><td>发起目标</td><td>读取 README.md…</td></tr>
+      <tr><td>model</td><td>推理与 toolUse 决策</td><td>turn=1 toolUse read</td></tr>
+      <tr><td>loop</td><td>调度与顺序</td><td>tool_start call_1</td></tr>
+      <tr><td>tool</td><td>环境 I/O</td><td>README fixture 返回</td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">AgentEvent 完整目录</span><span class="lang-en-only">Full AgentEvent catalog</span></h3>    <table class="cmp">
+      <thead><tr><th>事件</th><th>中文</th><th>主线关联</th></tr></thead>
+      <tbody>
+      <tr><td><code>agent_start</code></td><td>循环开始</td><td>AgentSession 订阅</td></tr>
+      <tr><td><code>agent_end</code></td><td>循环结束</td><td>返回 messages[]</td></tr>
+      <tr><td><code>turn_start</code></td><td>新 turn</td><td>可能含 steering</td></tr>
+      <tr><td><code>turn_end</code></td><td>turn 结束</td><td>附带 toolResults</td></tr>
+      <tr><td><code>message_start</code></td><td>消息开始</td><td>user/assistant/tool</td></tr>
+      <tr><td><code>message_update</code></td><td>流式更新</td><td>text_delta/toolcall_delta</td></tr>
+      <tr><td><code>message_end</code></td><td>消息结束</td><td>触发 JSONL 写入</td></tr>
+      <tr><td><code>tool_execution_start</code></td><td>工具开始</td><td>read/write/bash</td></tr>
+      <tr><td><code>tool_execution_update</code></td><td>工具进度</td><td>bash 流式输出</td></tr>
+      <tr><td><code>tool_execution_end</code></td><td>工具结束</td><td>结果截断</td></tr>
+      </tbody>
+    </table>
+
+    <div class="note">
+      <span class="lang-zh-only">站 01：在完整 26 章路线图中，前 22 站覆盖从 CLI 到 compaction 检查的主线；站 1 的详细实现见对应章节。</span>
+      <span class="lang-en-only">Station 01: in the full 26-chapter route, the first 22 stations cover CLI through compaction check; see matching chapter for station 1 implementation.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">站 02：在完整 26 章路线图中，前 22 站覆盖从 CLI 到 compaction 检查的主线；站 2 的详细实现见对应章节。</span>
+      <span class="lang-en-only">Station 02: in the full 26-chapter route, the first 22 stations cover CLI through compaction check; see matching chapter for station 2 implementation.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">站 03：在完整 26 章路线图中，前 22 站覆盖从 CLI 到 compaction 检查的主线；站 3 的详细实现见对应章节。</span>
+      <span class="lang-en-only">Station 03: in the full 26-chapter route, the first 22 stations cover CLI through compaction check; see matching chapter for station 3 implementation.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">站 04：在完整 26 章路线图中，前 22 站覆盖从 CLI 到 compaction 检查的主线；站 4 的详细实现见对应章节。</span>
+      <span class="lang-en-only">Station 04: in the full 26-chapter route, the first 22 stations cover CLI through compaction check; see matching chapter for station 4 implementation.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">站 05：在完整 26 章路线图中，前 22 站覆盖从 CLI 到 compaction 检查的主线；站 5 的详细实现见对应章节。</span>
+      <span class="lang-en-only">Station 05: in the full 26-chapter route, the first 22 stations cover CLI through compaction check; see matching chapter for station 5 implementation.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">站 06：在完整 26 章路线图中，前 22 站覆盖从 CLI 到 compaction 检查的主线；站 6 的详细实现见对应章节。</span>
+      <span class="lang-en-only">Station 06: in the full 26-chapter route, the first 22 stations cover CLI through compaction check; see matching chapter for station 6 implementation.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">站 07：在完整 26 章路线图中，前 22 站覆盖从 CLI 到 compaction 检查的主线；站 7 的详细实现见对应章节。</span>
+      <span class="lang-en-only">Station 07: in the full 26-chapter route, the first 22 stations cover CLI through compaction check; see matching chapter for station 7 implementation.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">站 08：在完整 26 章路线图中，前 22 站覆盖从 CLI 到 compaction 检查的主线；站 8 的详细实现见对应章节。</span>
+      <span class="lang-en-only">Station 08: in the full 26-chapter route, the first 22 stations cover CLI through compaction check; see matching chapter for station 8 implementation.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">站 09：在完整 26 章路线图中，前 22 站覆盖从 CLI 到 compaction 检查的主线；站 9 的详细实现见对应章节。</span>
+      <span class="lang-en-only">Station 09: in the full 26-chapter route, the first 22 stations cover CLI through compaction check; see matching chapter for station 9 implementation.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">站 10：在完整 26 章路线图中，前 22 站覆盖从 CLI 到 compaction 检查的主线；站 10 的详细实现见对应章节。</span>
+      <span class="lang-en-only">Station 10: in the full 26-chapter route, the first 22 stations cover CLI through compaction check; see matching chapter for station 10 implementation.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">站 11：在完整 26 章路线图中，前 22 站覆盖从 CLI 到 compaction 检查的主线；站 11 的详细实现见对应章节。</span>
+      <span class="lang-en-only">Station 11: in the full 26-chapter route, the first 22 stations cover CLI through compaction check; see matching chapter for station 11 implementation.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">站 12：在完整 26 章路线图中，前 22 站覆盖从 CLI 到 compaction 检查的主线；站 12 的详细实现见对应章节。</span>
+      <span class="lang-en-only">Station 12: in the full 26-chapter route, the first 22 stations cover CLI through compaction check; see matching chapter for station 12 implementation.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">站 13：在完整 26 章路线图中，前 22 站覆盖从 CLI 到 compaction 检查的主线；站 13 的详细实现见对应章节。</span>
+      <span class="lang-en-only">Station 13: in the full 26-chapter route, the first 22 stations cover CLI through compaction check; see matching chapter for station 13 implementation.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">站 14：在完整 26 章路线图中，前 22 站覆盖从 CLI 到 compaction 检查的主线；站 14 的详细实现见对应章节。</span>
+      <span class="lang-en-only">Station 14: in the full 26-chapter route, the first 22 stations cover CLI through compaction check; see matching chapter for station 14 implementation.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">站 15：在完整 26 章路线图中，前 22 站覆盖从 CLI 到 compaction 检查的主线；站 15 的详细实现见对应章节。</span>
+      <span class="lang-en-only">Station 15: in the full 26-chapter route, the first 22 stations cover CLI through compaction check; see matching chapter for station 15 implementation.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">站 16：在完整 26 章路线图中，前 22 站覆盖从 CLI 到 compaction 检查的主线；站 16 的详细实现见对应章节。</span>
+      <span class="lang-en-only">Station 16: in the full 26-chapter route, the first 22 stations cover CLI through compaction check; see matching chapter for station 16 implementation.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">站 17：在完整 26 章路线图中，前 22 站覆盖从 CLI 到 compaction 检查的主线；站 17 的详细实现见对应章节。</span>
+      <span class="lang-en-only">Station 17: in the full 26-chapter route, the first 22 stations cover CLI through compaction check; see matching chapter for station 17 implementation.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">站 18：在完整 26 章路线图中，前 22 站覆盖从 CLI 到 compaction 检查的主线；站 18 的详细实现见对应章节。</span>
+      <span class="lang-en-only">Station 18: in the full 26-chapter route, the first 22 stations cover CLI through compaction check; see matching chapter for station 18 implementation.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">站 19：在完整 26 章路线图中，前 22 站覆盖从 CLI 到 compaction 检查的主线；站 19 的详细实现见对应章节。</span>
+      <span class="lang-en-only">Station 19: in the full 26-chapter route, the first 22 stations cover CLI through compaction check; see matching chapter for station 19 implementation.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">站 20：在完整 26 章路线图中，前 22 站覆盖从 CLI 到 compaction 检查的主线；站 20 的详细实现见对应章节。</span>
+      <span class="lang-en-only">Station 20: in the full 26-chapter route, the first 22 stations cover CLI through compaction check; see matching chapter for station 20 implementation.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">站 21：在完整 26 章路线图中，前 22 站覆盖从 CLI 到 compaction 检查的主线；站 21 的详细实现见对应章节。</span>
+      <span class="lang-en-only">Station 21: in the full 26-chapter route, the first 22 stations cover CLI through compaction check; see matching chapter for station 21 implementation.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">站 22：在完整 26 章路线图中，前 22 站覆盖从 CLI 到 compaction 检查的主线；站 22 的详细实现见对应章节。</span>
+      <span class="lang-en-only">Station 22: in the full 26-chapter route, the first 22 stations cover CLI through compaction check; see matching chapter for station 22 implementation.</span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">附录 · 一条消息的 22 站 深度 trace</span><span class="lang-en-only">Appendix · deep trace for 22 stations for one message</span></h3>
+
+    <div class="lang-zh-only"><p>本章 (02) 属于 Phase「引子」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
+    <div class="lang-en-only"><p>Chapter (02) belongs to Phase «Prologue». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
+
+    <table class="cmp">
+      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
+      <tbody>
+      <tr><td>1</td><td>user</td><td>prompt 入队</td></tr>
+      <tr><td>2</td><td>loop</td><td>agent_start</td></tr>
+      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
+      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
+      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
+      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
+      </tbody>
+    </table>
+
+    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// default trace</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 02 · 一条消息的 22 站</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 02 · 一条消息的 22 站</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 02 · 一条消息的 22 站</span></span>
+    </div>
+
+    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
+
+    <div class="lang-zh-only"><p><strong>AgentMessage</strong> — agent-core 内部消息 IR</p></div>
+    <div class="lang-en-only"><p><strong>AgentMessage</strong> — agent-core internal message IR</p></div>
+
+    <div class="lang-zh-only"><p><strong>StreamFn</strong> — 可注入的模型流函数</p></div>
+    <div class="lang-en-only"><p><strong>StreamFn</strong> — injectable model stream function</p></div>
+
+    <div class="lang-zh-only"><p><strong>leafId</strong> — JSONL 会话树当前叶</p></div>
+    <div class="lang-en-only"><p><strong>leafId</strong> — JSONL session tree current leaf</p></div>
+
+    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
+
+    <div class="note">
+      <span class="lang-zh-only">[02.1] 在 一条消息的 22 站 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[02.1] At 22 stations for one message stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[02.2] 在 一条消息的 22 站 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[02.2] At 22 stations for one message stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[02.3] 在 一条消息的 22 站 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[02.3] At 22 stations for one message stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[02.4] 在 一条消息的 22 站 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[02.4] At 22 stations for one message stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[02.5] 在 一条消息的 22 站 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[02.5] At 22 stations for one message stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[02.6] 在 一条消息的 22 站 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[02.6] At 22 stations for one message stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[02.7] 在 一条消息的 22 站 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[02.7] At 22 stations for one message stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[02.8] 在 一条消息的 22 站 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[02.8] At 22 stations for one message stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+  </section>
+
+  <section class="chap" id="c3">
+    <div class="chap-num">CHAPTER&nbsp;03&nbsp;·&nbsp;BACKGROUND</div>
+    <h2 class="chap-title lang-zh-only">pi-mono 家谱</h2>
+    <h2 class="chap-title lang-en-only">The pi-mono family tree</h2>
+    <p class="chap-en lang-zh-only">Mario Zechner 与 earendil-works</p>
+    <p class="chap-en lang-en-only">Mario Zechner and earendil-works</p>
+    <div class="lang-zh-only"><p>pi-mono 是 Mario Zechner（Badlogic Games，libGDX 作者）在 earendil-works 组织下的 monorepo。它不是「又一个 ChatGPT 套壳」——而是一套可 fork 的 agent harness，npm 发布六个包。</p></div>
+    <div class="lang-en-only"><p>pi-mono is Mario Zechner's (Badlogic Games, libGDX author) monorepo under earendil-works. Not another ChatGPT wrapper — a forkable agent harness published as six npm packages.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">仓库拓扑</span><span class="lang-en-only">Repository topology</span></h3>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; pi-mono/package.json · workspaces</span>
+        <span class="src-tag">root</span>
+      </div>
+      <span class="src-line"><span class="src-str">"workspaces"</span>: [</span>
+      <span class="src-line">  <span class="src-str">"packages/agent"</span>,</span>
+      <span class="src-line">  <span class="src-str">"packages/ai"</span>,</span>
+      <span class="src-line">  <span class="src-str">"packages/tui"</span>,</span>
+      <span class="src-line">  <span class="src-str">"packages/coding-agent"</span>,</span>
+      <span class="src-line">  <span class="src-str">"packages/protocol"</span>,</span>
+      <span class="src-line">]</span>
+    </div>
+
+    <table class="cmp">
+      <thead><tr><th>Package</th><th>职责 / Role</th><th>主线 touchpoint</th></tr></thead>
+      <tbody>
+      <tr><td>@earendil-works/pi-agent-core</td><td>agentLoop · types · StreamFn</td><td>C07–C13</td></tr>
+      <tr><td>@earendil-works/pi-ai</td><td>Models · providers · EventStream</td><td>C14–C16</td></tr>
+      <tr><td>@earendil-works/pi-tui</td><td>Terminal · diff render · Editor</td><td>C17–C18</td></tr>
+      <tr><td>@earendil-works/coding-agent</td><td>CLI · AgentSession · tools</td><td>C06–C08</td></tr>
+      <tr><td>@earendil-works/pi-protocol</td><td>RPC JSONL 协议</td><td>C25</td></tr>
+      <tr><td>pi-server</td><td>远程会话 CBOR</td><td>C25</td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">与 pi-textbook 的关系</span><span class="lang-en-only">Relationship to pi-textbook</span></h3>
+
+    <div class="lang-zh-only"><p>pi-textbook 把生产代码<strong>降维</strong>成 15 个 checkpoint 的可运行 workshop。每个 checkpoint 对应 pi-mono 里一个真实目录，但剥离了 OAuth、40+ provider、TUI 差分渲染等生产复杂度。</p></div>
+    <div class="lang-en-only"><p>pi-textbook <strong>reduces</strong> production code into 15 runnable workshop checkpoints. Each maps to a real pi-mono directory, stripped of OAuth, 40+ providers, TUI diff rendering, etc.</p></div>
+
+    <table class="cmp">
+      <thead><tr><th>Checkpoint</th><th>教学焦点</th><th>生产文件</th></tr></thead>
+      <tbody>
+      <tr><td>00</td><td>一次 README 读取的七个里程碑</td><td>packages/coding-agent/src/main.ts · packages/agent/src/agent-loop.ts</td></tr>
+      <tr><td>01</td><td>TypeScript 生存集</td><td>—</td></tr>
+      <tr><td>02</td><td>EventStream</td><td>packages/ai/src/utils/event-stream.ts</td></tr>
+      <tr><td>03</td><td>Message IR</td><td>packages/agent/src/types.ts · packages/coding-agent/src/core/messages.ts</td></tr>
+      <tr><td>04</td><td>ScriptedModel</td><td>—</td></tr>
+      <tr><td>05</td><td>Provider Adapter</td><td>packages/ai/src/api/*.ts · packages/ai/src/models.ts</td></tr>
+      <tr><td>06</td><td>Tool Contract</td><td>packages/agent/src/agent-loop.ts · packages/coding-agent/src/core/tools/</td></tr>
+      <tr><td>07</td><td>Agent Loop</td><td>packages/agent/src/agent-loop.ts</td></tr>
+      </tbody>
+    </table>
+
+    <div class="keynum-row">
+      <div class="keynum">
+        <div class="kn-val">2015</div>
+        <div class="kn-label"><span class="lang-zh-only">libGDX</span><span class="lang-en-only">libGDX era</span></div>
+        <div class="kn-desc"><span class="lang-zh-only">Mario 的游戏引擎背景影响 TUI 性能偏执</span><span class="lang-en-only">Mario's game-engine background shapes TUI perf obsession</span></div>
+      </div>
+      <div class="keynum">
+        <div class="kn-val">40+</div>
+        <div class="kn-label"><span class="lang-zh-only">providers</span><span class="lang-en-only">providers</span></div>
+        <div class="kn-desc"><span class="lang-zh-only">pi-ai 支持的模型提供商数量</span><span class="lang-en-only">model providers supported by pi-ai</span></div>
+      </div>
+      <div class="keynum">
+        <div class="kn-val">v3</div>
+        <div class="kn-label"><span class="lang-zh-only">session</span><span class="lang-en-only">session version</span></div>
+        <div class="kn-desc"><span class="lang-zh-only">JSONL CURRENT_SESSION_VERSION</span><span class="lang-en-only">JSONL CURRENT_SESSION_VERSION</span></div>
+      </div>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">读 pi-mono 时建议开两个窗口：生产仓库 + pi-textbook 对应 checkpoint 的 workshop 测试。</span>
+      <span class="lang-en-only">When reading pi-mono, keep two windows: production repo + pi-textbook workshop test for the matching checkpoint.</span>
+    </div>
+
+    <figure>
+      <div class="figbox"><div class="fig-placeholder">diagram</div></div>
+      <figcaption>
+        <span class="figid">FIG</span>
+        <span class="lang-zh-only">pi-mono 六包依赖图：coding-agent 在顶层组装，agent-core 是心脏，pi-ai 是 LLM 边界。</span>
+        <span class="lang-en-only">pi-mono six-package dependency graph: coding-agent composes at top, agent-core is the heart, pi-ai is the LLM boundary.</span>
+      </figcaption>
+    </figure>
+
+    <div class="note">
+      <span class="lang-zh-only">本章 (03) 在主线 prompt「Mario Zechner 与 earendil-works」路径上负责：<strong>pi-mono 家谱</strong>。回到 C02 的 22 站地图定位这一章。</span>
+      <span class="lang-en-only">Chapter (03) on the through-line path handles: <strong>The pi-mono family tree</strong>. Return to C02's 22-station map to locate this chapter.</span>
+    </div>
+
+    <table class="cmp">
+      <thead><tr><th>路径</th><th>说明</th></tr></thead>
+      <tbody>
+      <tr><td><code>packages/agent/</code></td><td>agent-core 包</td></tr>
+      <tr><td><code>packages/ai/</code></td><td>pi-ai 包</td></tr>
+      <tr><td><code>packages/tui/</code></td><td>终端 UI 包</td></tr>
+      <tr><td><code>packages/coding-agent/</code></td><td>CLI 与组装</td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">pi-mono 家谱 · 实现清单</span><span class="lang-en-only">The pi-mono family tree · implementation checklist</span></h3>
+
+    <div class="note">
+      <span class="lang-zh-only">1. 定位生产文件：packages/agent/src/agent-loop.ts</span>
+      <span class="lang-en-only">1. Locate production file: packages/agent/src/agent-loop.ts</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">2. 对照 pi-textbook 同主题 checkpoint</span>
+      <span class="lang-en-only">2. Cross-read matching pi-textbook checkpoint</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">3. 用 --verbose 观察 AgentEvent</span>
+      <span class="lang-en-only">3. Observe AgentEvents with --verbose</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">4. 检查 JSONL 会话文件对应 entry</span>
+      <span class="lang-en-only">4. Inspect matching JSONL session entry</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">5. 阅读 packages/*/test/ 下相关测试</span>
+      <span class="lang-en-only">5. Read related tests under packages/*/test/</span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">附录 · pi-mono 家谱 深度 trace</span><span class="lang-en-only">Appendix · deep trace for The pi-mono family tree</span></h3>
+
+    <div class="lang-zh-only"><p>本章 (03) 属于 Phase「背景」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
+    <div class="lang-en-only"><p>Chapter (03) belongs to Phase «Background». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
+
+    <table class="cmp">
+      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
+      <tbody>
+      <tr><td>1</td><td>pi-mono 家谱</td><td>Mario Zechner 与 earendil-works</td></tr>
+      <tr><td>2</td><td>—</td><td>checkpoint 2</td></tr>
+      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
+      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
+      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
+      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
+      </tbody>
+    </table>
+
+    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// default trace</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 03 · pi-mono 家谱</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 03 · pi-mono 家谱</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 03 · pi-mono 家谱</span></span>
+    </div>
+
+    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
+
+    <div class="lang-zh-only"><p><strong>AgentMessage</strong> — agent-core 内部消息 IR</p></div>
+    <div class="lang-en-only"><p><strong>AgentMessage</strong> — agent-core internal message IR</p></div>
+
+    <div class="lang-zh-only"><p><strong>StreamFn</strong> — 可注入的模型流函数</p></div>
+    <div class="lang-en-only"><p><strong>StreamFn</strong> — injectable model stream function</p></div>
+
+    <div class="lang-zh-only"><p><strong>leafId</strong> — JSONL 会话树当前叶</p></div>
+    <div class="lang-en-only"><p><strong>leafId</strong> — JSONL session tree current leaf</p></div>
+
+    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
+
+    <div class="note">
+      <span class="lang-zh-only">[03.1] 在 pi-mono 家谱 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[03.1] At The pi-mono family tree stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[03.2] 在 pi-mono 家谱 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[03.2] At The pi-mono family tree stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[03.3] 在 pi-mono 家谱 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[03.3] At The pi-mono family tree stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[03.4] 在 pi-mono 家谱 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[03.4] At The pi-mono family tree stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[03.5] 在 pi-mono 家谱 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[03.5] At The pi-mono family tree stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[03.6] 在 pi-mono 家谱 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[03.6] At The pi-mono family tree stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[03.7] 在 pi-mono 家谱 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[03.7] At The pi-mono family tree stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[03.8] 在 pi-mono 家谱 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[03.8] At The pi-mono family tree stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+  </section>
+
+  <section class="chap" id="c4">
+    <div class="chap-num">CHAPTER&nbsp;04&nbsp;·&nbsp;BACKGROUND</div>
+    <h2 class="chap-title lang-zh-only">六层蛋糕</h2>
+    <h2 class="chap-title lang-en-only">The six-layer cake</h2>
+    <p class="chap-en lang-zh-only">agent-core · ai · tui · coding-agent</p>
+    <p class="chap-en lang-en-only">agent-core · ai · tui · coding-agent</p>
+    <div class="lang-zh-only"><p>主线 prompt <code>读取 README.md，用一句话告诉我这个项目做什么</code> 从 L6 进入，在 L5 循环，L4 调模型，L3 渲染，L2/L1 只在 RPC 模式参与。</p></div>
+    <div class="lang-en-only"><p>Through-line prompt enters at L6, loops in L5, calls model at L4, renders at L3; L2/L1 only in RPC mode.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">六层蛋糕</span><span class="lang-en-only">Six-layer cake</span></h3>
+
+    <div class="ladder">
+      <div class="ladder-step">
+        <div class="ladder-num">01</div>
+        <div class="ladder-body"><span class="lang-zh-only">L6 · coding-agent</span><span class="lang-en-only">L6 · coding-agent — CLI · AgentSession · tools · extensions</span></div>
+      </div>
+      <div class="ladder-step">
+        <div class="ladder-num">02</div>
+        <div class="ladder-body"><span class="lang-zh-only">L5 · agent-core</span><span class="lang-en-only">L5 · agent-core — agentLoop · AgentMessage · events</span></div>
+      </div>
+      <div class="ladder-step">
+        <div class="ladder-num">03</div>
+        <div class="ladder-body"><span class="lang-zh-only">L4 · pi-ai</span><span class="lang-en-only">L4 · pi-ai — Models · streamSimple · providers</span></div>
+      </div>
+      <div class="ladder-step">
+        <div class="ladder-num">04</div>
+        <div class="ladder-body"><span class="lang-zh-only">L3 · pi-tui</span><span class="lang-en-only">L3 · pi-tui — TUI · Editor · Markdown · diff</span></div>
+      </div>
+      <div class="ladder-step">
+        <div class="ladder-num">05</div>
+        <div class="ladder-body"><span class="lang-zh-only">L2 · protocol</span><span class="lang-en-only">L2 · protocol — JSONL RPC 帧</span></div>
+      </div>
+      <div class="ladder-step">
+        <div class="ladder-num">06</div>
+        <div class="ladder-body"><span class="lang-zh-only">L1 · server</span><span class="lang-en-only">L1 · server — 远程会话</span></div>
+      </div>
+    </div>
+
+    <div class="formula">
+      <div class="ftitle"><span class="lang-zh-only">依赖方向</span><span class="lang-en-only">DEPENDENCY</span></div>
+      <span class="cond"><span class="term">coding-agent</span> → agent-core → pi-ai</span>
+      <span class="cond"><span class="term-cu">pi-tui</span> ← coding-agent (UI only)</span>
+      <div class="out"><span class="lang-zh-only">上层组装下层，不反向依赖</span><span class="lang-en-only">Upper layers compose lower; no reverse deps</span></div>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/agent/package.json</span>
+        <span class="src-tag">agent</span>
+      </div>
+      <span class="src-line"><span class="src-str">"name"</span>: <span class="src-str">"@earendil-works/pi-agent-core"</span>,</span>
+      <span class="src-line"><span class="src-str">"exports"</span>: { <span class="src-str">"."</span>: <span class="src-str">"./src/index.ts"</span> }</span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/ai/package.json</span>
+        <span class="src-tag">ai</span>
+      </div>
+      <span class="src-line"><span class="src-str">"name"</span>: <span class="src-str">"@earendil-works/pi-ai"</span>,</span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">边界纪律</span><span class="lang-en-only">Boundary discipline</span></h3>
+
+    <div class="lang-zh-only"><p><code>AgentMessage</code> 在整个 agent-core 内流通；只在 <code>streamAssistantResponse</code> 调用点通过 <code>convertToLlm</code> 变成 pi-ai 的 <code>Message[]</code>。这条边界是 pi-textbook checkpoint 03 的核心教训。</p></div>
+    <div class="lang-en-only"><p><code>AgentMessage</code> flows through agent-core; only at <code>streamAssistantResponse</code> does <code>convertToLlm</code> produce pi-ai <code>Message[]</code>. Core lesson of textbook checkpoint 03.</p></div>
+
+    <table class="cmp">
+      <thead><tr><th>层</th><th>可替换?</th><th>例子</th></tr></thead>
+      <tbody>
+      <tr><td>agent-core</td><td>✓ fork</td><td>自定义 runLoop</td></tr>
+      <tr><td>pi-ai</td><td>✓</td><td>换 provider adapter</td></tr>
+      <tr><td>coding-agent tools</td><td>✓</td><td>registerTool</td></tr>
+      <tr><td>JSONL format</td><td>△</td><td>version 字段演进</td></tr>
+      </tbody>
+    </table>
+
+    <div class="note copper">
+      <span class="lang-zh-only">📘 <strong>pi-textbook checkpoint 03</strong>：Message IR（<code>types.ts</code>）· 生产映射：<code>packages/agent/src/types.ts · packages/coding-agent/src/core/messages.ts</code></span>
+      <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 03</strong>: Message IR (<code>types.ts</code>) · production: <code>packages/agent/src/types.ts · packages/coding-agent/src/core/messages.ts</code></span>
+    </div>
+
+    <div class="note copper">
+      <span class="lang-zh-only">📘 <strong>pi-textbook checkpoint 13</strong>：Composition Root（<code>composition-root</code>）· 生产映射：<code>packages/coding-agent/src/core/agent-session.ts · sdk.ts</code></span>
+      <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 13</strong>: Composition Root (<code>composition-root</code>) · production: <code>packages/coding-agent/src/core/agent-session.ts · sdk.ts</code></span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">本章 (04) 在主线 prompt「agent-core · ai · tui · coding-agent」路径上负责：<strong>六层蛋糕</strong>。回到 C02 的 22 站地图定位这一章。</span>
+      <span class="lang-en-only">Chapter (04) on the through-line path handles: <strong>The six-layer cake</strong>. Return to C02's 22-station map to locate this chapter.</span>
+    </div>
+
+    <table class="cmp">
+      <thead><tr><th>路径</th><th>说明</th></tr></thead>
+      <tbody>
+      <tr><td><code>packages/agent/</code></td><td>agent-core 包</td></tr>
+      <tr><td><code>packages/ai/</code></td><td>pi-ai 包</td></tr>
+      <tr><td><code>packages/tui/</code></td><td>终端 UI 包</td></tr>
+      <tr><td><code>packages/coding-agent/</code></td><td>CLI 与组装</td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">六层蛋糕 · 实现清单</span><span class="lang-en-only">The six-layer cake · implementation checklist</span></h3>
+
+    <div class="note">
+      <span class="lang-zh-only">1. 定位生产文件：packages/agent/src/agent-loop.ts</span>
+      <span class="lang-en-only">1. Locate production file: packages/agent/src/agent-loop.ts</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">2. 对照 pi-textbook 同主题 checkpoint</span>
+      <span class="lang-en-only">2. Cross-read matching pi-textbook checkpoint</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">3. 用 --verbose 观察 AgentEvent</span>
+      <span class="lang-en-only">3. Observe AgentEvents with --verbose</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">4. 检查 JSONL 会话文件对应 entry</span>
+      <span class="lang-en-only">4. Inspect matching JSONL session entry</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">5. 阅读 packages/*/test/ 下相关测试</span>
+      <span class="lang-en-only">5. Read related tests under packages/*/test/</span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">附录 · 六层蛋糕 深度 trace</span><span class="lang-en-only">Appendix · deep trace for The six-layer cake</span></h3>
+
+    <div class="lang-zh-only"><p>本章 (04) 属于 Phase「背景」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
+    <div class="lang-en-only"><p>Chapter (04) belongs to Phase «Background». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
+
+    <table class="cmp">
+      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
+      <tbody>
+      <tr><td>1</td><td>六层蛋糕</td><td>agent-core · ai · tui · coding-agent</td></tr>
+      <tr><td>2</td><td>—</td><td>checkpoint 2</td></tr>
+      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
+      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
+      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
+      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
+      </tbody>
+    </table>
+
+    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// default trace</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 04 · 六层蛋糕</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 04 · 六层蛋糕</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 04 · 六层蛋糕</span></span>
+    </div>
+
+    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
+
+    <div class="lang-zh-only"><p><strong>AgentMessage</strong> — agent-core 内部消息 IR</p></div>
+    <div class="lang-en-only"><p><strong>AgentMessage</strong> — agent-core internal message IR</p></div>
+
+    <div class="lang-zh-only"><p><strong>StreamFn</strong> — 可注入的模型流函数</p></div>
+    <div class="lang-en-only"><p><strong>StreamFn</strong> — injectable model stream function</p></div>
+
+    <div class="lang-zh-only"><p><strong>leafId</strong> — JSONL 会话树当前叶</p></div>
+    <div class="lang-en-only"><p><strong>leafId</strong> — JSONL session tree current leaf</p></div>
+
+    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
+
+    <div class="note">
+      <span class="lang-zh-only">[04.1] 在 六层蛋糕 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[04.1] At The six-layer cake stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[04.2] 在 六层蛋糕 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[04.2] At The six-layer cake stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[04.3] 在 六层蛋糕 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[04.3] At The six-layer cake stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[04.4] 在 六层蛋糕 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[04.4] At The six-layer cake stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[04.5] 在 六层蛋糕 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[04.5] At The six-layer cake stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[04.6] 在 六层蛋糕 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[04.6] At The six-layer cake stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[04.7] 在 六层蛋糕 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[04.7] At The six-layer cake stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[04.8] 在 六层蛋糕 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[04.8] At The six-layer cake stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+  </section>
+
+  <section class="chap" id="c5">
+    <div class="chap-num">CHAPTER&nbsp;05&nbsp;·&nbsp;BACKGROUND</div>
+    <h2 class="chap-title lang-zh-only">故意不做的功能</h2>
+    <h2 class="chap-title lang-en-only">Intentionally missing features</h2>
+    <p class="chap-en lang-zh-only">No MCP · No sub-agents · No plan mode</p>
+    <p class="chap-en lang-en-only">No MCP · No sub-agents · No plan mode</p>
+    <div class="lang-zh-only"><p>Pi 的 README 明确列出<strong>故意不做</strong>的功能：No MCP · No sub-agents · No plan mode。这不是遗漏——是 harness 哲学的边界声明。</p></div>
+    <div class="lang-en-only"><p>Pi's README explicitly lists <strong>intentionally omitted</strong> features: No MCP · No sub-agents · No plan mode. Not oversights — boundary statements of harness philosophy.</p></div>
+
+    <table class="cmp">
+      <thead><tr><th>功能</th><th>Claude Code</th><th>Pi</th><th>替代路径</th></tr></thead>
+      <tbody>
+      <tr><td>MCP</td><td>一等协议</td><td>✗</td><td>TypeScript Extension API</td></tr>
+      <tr><td>Sub-agents</td><td>内置</td><td>✗</td><td>fork session + RPC</td></tr>
+      <tr><td>Plan mode</td><td>专用 UI</td><td>✗</td><td>thinking level + 用户消息</td></tr>
+      <tr><td>IDE 集成</td><td>原生</td><td>终端 only</td><td>外部编辑器</td></tr>
+      <tr><td>权限弹窗</td><td>GUI</td><td>终端确认</td><td>tool 级别 policy</td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">为什么 No MCP</span><span class="lang-en-only">Why no MCP</span></h3>
+
+    <div class="lang-zh-only"><p>MCP 把工具发现协议化，但 Pi 选择 <code>registerTool</code> + npm/git 扩展包——类型安全、可测试、与 agent loop 同进程。代价是生态不互通 Claude Desktop 的 MCP 市场。</p></div>
+    <div class="lang-en-only"><p>MCP protocolizes tool discovery; Pi chooses <code>registerTool</code> + npm/git extension packages — type-safe, testable, same process as agent loop. Cost: no interchange with Claude Desktop's MCP marketplace.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">为什么 No sub-agents</span><span class="lang-en-only">Why no sub-agents</span></h3>
+
+    <div class="lang-zh-only"><p>子 agent 本质是嵌套 agentLoop + 独立 context。Pi 用 <strong>session fork</strong>（JSONL parentSession）+ <strong>RPC 模式</strong> 达到类似效果，但不隐藏嵌套层。</p></div>
+    <div class="lang-en-only"><p>Sub-agents are nested agentLoop + isolated context. Pi achieves similar via <strong>session fork</strong> (JSONL parentSession) + <strong>RPC mode</strong> without hiding the nesting.</p></div>
+
+    <div class="note copper">
+      <span class="lang-zh-only">「故意不做」= 把复杂度推给扩展作者，而不是推给终端用户。</span>
+      <span class="lang-en-only">«Intentionally omitted» = push complexity to extension authors, not terminal users.</span>
+    </div>
+
+    <blockquote class="pull copper">
+      <span class="lang-zh-only">少即是多：<br>每一层省略的功能，都是一层可观测性。</span>
+      <span class="lang-en-only">Less is more:<br>every omitted feature is a layer of observability gained.</span>
+      <cite>Field Note · 10</cite>
+    </blockquote>
+
+    <div class="note">
+      <span class="lang-zh-only">本章 (05) 在主线 prompt「No MCP · No sub-agents · No plan mode」路径上负责：<strong>故意不做的功能</strong>。回到 C02 的 22 站地图定位这一章。</span>
+      <span class="lang-en-only">Chapter (05) on the through-line path handles: <strong>Intentionally missing features</strong>. Return to C02's 22-station map to locate this chapter.</span>
+    </div>
+
+    <table class="cmp">
+      <thead><tr><th>路径</th><th>说明</th></tr></thead>
+      <tbody>
+      <tr><td><code>packages/agent/</code></td><td>agent-core 包</td></tr>
+      <tr><td><code>packages/ai/</code></td><td>pi-ai 包</td></tr>
+      <tr><td><code>packages/tui/</code></td><td>终端 UI 包</td></tr>
+      <tr><td><code>packages/coding-agent/</code></td><td>CLI 与组装</td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">故意不做的功能 · 实现清单</span><span class="lang-en-only">Intentionally missing features · implementation checklist</span></h3>
+
+    <div class="note">
+      <span class="lang-zh-only">1. 定位生产文件：packages/agent/src/agent-loop.ts</span>
+      <span class="lang-en-only">1. Locate production file: packages/agent/src/agent-loop.ts</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">2. 对照 pi-textbook 同主题 checkpoint</span>
+      <span class="lang-en-only">2. Cross-read matching pi-textbook checkpoint</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">3. 用 --verbose 观察 AgentEvent</span>
+      <span class="lang-en-only">3. Observe AgentEvents with --verbose</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">4. 检查 JSONL 会话文件对应 entry</span>
+      <span class="lang-en-only">4. Inspect matching JSONL session entry</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">5. 阅读 packages/*/test/ 下相关测试</span>
+      <span class="lang-en-only">5. Read related tests under packages/*/test/</span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">附录 · 故意不做的功能 深度 trace</span><span class="lang-en-only">Appendix · deep trace for Intentionally missing features</span></h3>
+
+    <div class="lang-zh-only"><p>本章 (05) 属于 Phase「背景」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
+    <div class="lang-en-only"><p>Chapter (05) belongs to Phase «Background». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
+
+    <table class="cmp">
+      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
+      <tbody>
+      <tr><td>1</td><td>故意不做的功能</td><td>No MCP · No sub-agents · No plan mode</td></tr>
+      <tr><td>2</td><td>—</td><td>checkpoint 2</td></tr>
+      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
+      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
+      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
+      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
+      </tbody>
+    </table>
+
+    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// default trace</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 05 · 故意不做的功能</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 05 · 故意不做的功能</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 05 · 故意不做的功能</span></span>
+    </div>
+
+    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
+
+    <div class="lang-zh-only"><p><strong>AgentMessage</strong> — agent-core 内部消息 IR</p></div>
+    <div class="lang-en-only"><p><strong>AgentMessage</strong> — agent-core internal message IR</p></div>
+
+    <div class="lang-zh-only"><p><strong>StreamFn</strong> — 可注入的模型流函数</p></div>
+    <div class="lang-en-only"><p><strong>StreamFn</strong> — injectable model stream function</p></div>
+
+    <div class="lang-zh-only"><p><strong>leafId</strong> — JSONL 会话树当前叶</p></div>
+    <div class="lang-en-only"><p><strong>leafId</strong> — JSONL session tree current leaf</p></div>
+
+    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
+
+    <div class="note">
+      <span class="lang-zh-only">[05.1] 在 故意不做的功能 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[05.1] At Intentionally missing features stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[05.2] 在 故意不做的功能 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[05.2] At Intentionally missing features stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[05.3] 在 故意不做的功能 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[05.3] At Intentionally missing features stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[05.4] 在 故意不做的功能 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[05.4] At Intentionally missing features stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[05.5] 在 故意不做的功能 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[05.5] At Intentionally missing features stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[05.6] 在 故意不做的功能 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[05.6] At Intentionally missing features stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[05.7] 在 故意不做的功能 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[05.7] At Intentionally missing features stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[05.8] 在 故意不做的功能 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[05.8] At Intentionally missing features stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+  </section>
+
+  <section class="chap" id="c6">
+    <div class="chap-num">CHAPTER&nbsp;06&nbsp;·&nbsp;INTAKE</div>
+    <h2 class="chap-title lang-zh-only">CLI 启动链</h2>
+    <h2 class="chap-title lang-en-only">CLI boot chain</h2>
+    <p class="chap-en lang-zh-only">cli.ts → main.ts → createAgentSession</p>
+    <p class="chap-en lang-en-only">cli.ts → main.ts → createAgentSession</p>
+    <div class="lang-zh-only"><p>你在 shell 里输入 <code>pi</code> 或 <code>npx @earendil-works/coding-agent</code>，启动链从 <code>cli.ts</code> 解析 argv，到 <code>main.ts</code> 选择 interactive/print/rpc 模式，最终调用 <code>createAgentSession()</code>。</p></div>
+    <div class="lang-en-only"><p>You type <code>pi</code> or <code>npx @earendil-works/coding-agent</code>; boot chain parses argv in <code>cli.ts</code>, <code>main.ts</code> picks interactive/print/rpc mode, then <code>createAgentSession()</code>.</p></div>
+
+    <div class="ladder">
+      <div class="ladder-step">
+        <div class="ladder-num">01</div>
+        <div class="ladder-body"><span class="lang-zh-only">cli.ts</span><span class="lang-en-only">argv · --model · --mode rpc</span></div>
+      </div>
+      <div class="ladder-step">
+        <div class="ladder-num">02</div>
+        <div class="ladder-body"><span class="lang-zh-only">main.ts</span><span class="lang-en-only">mode dispatch · theme · keybindings</span></div>
+      </div>
+      <div class="ladder-step">
+        <div class="ladder-num">03</div>
+        <div class="ladder-body"><span class="lang-zh-only">createAgentSession</span><span class="lang-en-only">AgentSession + ExtensionRunner</span></div>
+      </div>
+      <div class="ladder-step">
+        <div class="ladder-num">04</div>
+        <div class="ladder-body"><span class="lang-zh-only">interactive mode</span><span class="lang-en-only">TUI loop · Editor</span></div>
+      </div>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/cli.ts</span>
+        <span class="src-tag">cli</span>
+      </div>
+      <span class="src-line"><span class="src-kw">import</span> { <span class="src-fn">main</span> } <span class="src-kw">from</span> <span class="src-str">"./main.ts"</span>;</span>
+      <span class="src-line"><span class="src-fn">main</span>(process.argv.slice(<span class="src-num">2</span>)).catch(...);</span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/main.ts</span>
+        <span class="src-tag">main</span>
+      </div>
+      <span class="src-line"><span class="src-kw">export async function</span> <span class="src-fn">main</span>(<span class="src-arg">args</span>: <span class="src-cls">string</span>[]) {</span>
+      <span class="src-line">  <span class="src-kw">const</span> mode = <span class="src-fn">parseMode</span>(args); <span class="src-comment">// interactive | print | rpc</span></span>
+      <span class="src-line">  <span class="src-kw">const</span> session = <span class="src-kw">await</span> <span class="src-fn">createAgentSession</span>({ cwd, model, ... });</span>
+      <span class="src-line">}</span>
+    </div>
+
+    <div class="stage-purpose">
+      <div class="sp-row">
+        <div class="sp-key"><span class="lang-zh-only">--verbose</span><span class="lang-en-only">--verbose</span></div>
+        <div class="sp-val"><span class="lang-zh-only">打印 AgentEvent 到 stderr</span><span class="lang-en-only">log AgentEvents to stderr</span></div>
+      </div>
+      <div class="sp-row">
+        <div class="sp-key"><span class="lang-zh-only">--mode rpc</span><span class="lang-en-only">--mode rpc</span></div>
+        <div class="sp-val"><span class="lang-zh-only">JSONL  stdin/stdout 协议</span><span class="lang-en-only">JSONL stdin/stdout protocol</span></div>
+      </div>
+      <div class="sp-row">
+        <div class="sp-key"><span class="lang-zh-only">--continue</span><span class="lang-en-only">--continue</span></div>
+        <div class="sp-val"><span class="lang-zh-only">加载 leafId 会话</span><span class="lang-en-only">load leafId session</span></div>
+      </div>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">Case study：第一次启动</span><span class="lang-en-only">Case study: first boot</span></h3>
+
+    <div class="lang-zh-only"><p>冷启动时 <code>ModelRegistry</code> 读取 <code>models.generated.ts</code>，<code>ResourceLoader</code> 扫描 AGENTS.md 栈，<code>SessionManager</code> 创建新 JSONL 文件。用户尚未输入主线 prompt，但 harness 已就绪。</p></div>
+    <div class="lang-en-only"><p>On cold boot <code>ModelRegistry</code> reads <code>models.generated.ts</code>, <code>ResourceLoader</code> scans AGENTS.md stack, <code>SessionManager</code> creates new JSONL. User hasn't typed the through-line prompt yet, but harness is ready.</p></div>
+
+    <div class="note copper">
+      <span class="lang-zh-only">📘 <strong>pi-textbook checkpoint 13</strong>：Composition Root（<code>composition-root</code>）· 生产映射：<code>packages/coding-agent/src/core/agent-session.ts · sdk.ts</code></span>
+      <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 13</strong>: Composition Root (<code>composition-root</code>) · production: <code>packages/coding-agent/src/core/agent-session.ts · sdk.ts</code></span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">本章 (06) 在主线 prompt「cli.ts → main.ts → createAgentSession」路径上负责：<strong>CLI 启动链</strong>。回到 C02 的 22 站地图定位这一章。</span>
+      <span class="lang-en-only">Chapter (06) on the through-line path handles: <strong>CLI boot chain</strong>. Return to C02's 22-station map to locate this chapter.</span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent · chapter 06</span>
+        <span class="src-tag">trace</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// Through-line: cli.ts → main.ts → createAgentSession</span></span>
+      <span class="src-line"><span class="src-comment">// Phase: 入口 / Intake</span></span>
+      <span class="src-line"><span class="src-kw">await</span> <span class="src-fn">traceTurn</span>({ <span class="src-arg">prompt</span>: <span class="src-str">"README.md"</span> });</span>
+    </div>
+
+    <table class="cmp">
+      <thead><tr><th>路径</th><th>说明</th></tr></thead>
+      <tbody>
+      <tr><td><code>packages/coding-agent/src/cli.ts</code></td><td>CLI 入口</td></tr>
+      <tr><td><code>packages/coding-agent/src/main.ts</code></td><td>模式分发</td></tr>
+      <tr><td><code>packages/coding-agent/src/core/agent-session.ts</code></td><td>中枢调度</td></tr>
+      <tr><td><code>packages/coding-agent/src/core/resource-loader.ts</code></td><td>AGENTS.md 栈</td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">CLI 启动链 · 实现清单</span><span class="lang-en-only">CLI boot chain · implementation checklist</span></h3>
+
+    <div class="note">
+      <span class="lang-zh-only">1. 定位生产文件：packages/agent/src/agent-loop.ts</span>
+      <span class="lang-en-only">1. Locate production file: packages/agent/src/agent-loop.ts</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">2. 对照 pi-textbook 同主题 checkpoint</span>
+      <span class="lang-en-only">2. Cross-read matching pi-textbook checkpoint</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">3. 用 --verbose 观察 AgentEvent</span>
+      <span class="lang-en-only">3. Observe AgentEvents with --verbose</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">4. 检查 JSONL 会话文件对应 entry</span>
+      <span class="lang-en-only">4. Inspect matching JSONL session entry</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">5. 阅读 packages/*/test/ 下相关测试</span>
+      <span class="lang-en-only">5. Read related tests under packages/*/test/</span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">附录 · CLI 启动链 深度 trace</span><span class="lang-en-only">Appendix · deep trace for CLI boot chain</span></h3>
+
+    <div class="lang-zh-only"><p>本章 (06) 属于 Phase「入口」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
+    <div class="lang-en-only"><p>Chapter (06) belongs to Phase «Intake». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
+
+    <table class="cmp">
+      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
+      <tbody>
+      <tr><td>1</td><td>cli.ts</td><td>argv 解析</td></tr>
+      <tr><td>2</td><td>main.ts</td><td>mode=interactive</td></tr>
+      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
+      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
+      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
+      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
+      </tbody>
+    </table>
+
+    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/cli.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// CLI</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 06 · CLI 启动链</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/main.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// main</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 06 · CLI 启动链</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 06 · CLI 启动链</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 06 · CLI 启动链</span></span>
+    </div>
+
+    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
+
+    <div class="lang-zh-only"><p><strong>AgentMessage</strong> — agent-core 内部消息 IR</p></div>
+    <div class="lang-en-only"><p><strong>AgentMessage</strong> — agent-core internal message IR</p></div>
+
+    <div class="lang-zh-only"><p><strong>StreamFn</strong> — 可注入的模型流函数</p></div>
+    <div class="lang-en-only"><p><strong>StreamFn</strong> — injectable model stream function</p></div>
+
+    <div class="lang-zh-only"><p><strong>leafId</strong> — JSONL 会话树当前叶</p></div>
+    <div class="lang-en-only"><p><strong>leafId</strong> — JSONL session tree current leaf</p></div>
+
+    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
+
+    <div class="note">
+      <span class="lang-zh-only">[06.1] 在 CLI 启动链 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[06.1] At CLI boot chain stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[06.2] 在 CLI 启动链 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[06.2] At CLI boot chain stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[06.3] 在 CLI 启动链 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[06.3] At CLI boot chain stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[06.4] 在 CLI 启动链 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[06.4] At CLI boot chain stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[06.5] 在 CLI 启动链 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[06.5] At CLI boot chain stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[06.6] 在 CLI 启动链 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[06.6] At CLI boot chain stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[06.7] 在 CLI 启动链 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[06.7] At CLI boot chain stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[06.8] 在 CLI 启动链 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[06.8] At CLI boot chain stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+  </section>
+
+  <section class="chap" id="c7">
+    <div class="chap-num">CHAPTER&nbsp;07&nbsp;·&nbsp;INTAKE</div>
+    <h2 class="chap-title lang-zh-only">AgentSession 编排</h2>
+    <h2 class="chap-title lang-en-only">AgentSession orchestration</h2>
+    <p class="chap-en lang-zh-only">唯一的中枢调度器</p>
+    <p class="chap-en lang-en-only">the single orchestration hub</p>
+    <div class="lang-zh-only"><p><code>AgentSession</code> 是 Pi 的<strong>唯一中枢调度器</strong>——所有模式（interactive、print、rpc）共享它。主线 prompt 通过 <code>prompt()</code> 进入，内部调用 <code>agentLoop()</code> 并订阅事件写 JSONL。</p></div>
+    <div class="lang-en-only"><p><code>AgentSession</code> is Pi's <strong>single orchestration hub</strong> — all modes share it. Through-line prompt enters via <code>prompt()</code>, internally calls <code>agentLoop()</code> and subscribes to events for JSONL persistence.</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/agent-session.ts</span>
+        <span class="src-tag">session</span>
+      </div>
+      <span class="src-line"><span class="src-comment">/** AgentSession - Core abstraction for agent lifecycle */</span></span>
+      <span class="src-line"><span class="src-kw">export class</span> <span class="src-cls">AgentSession</span> {</span>
+      <span class="src-line">  <span class="src-kw">async</span> <span class="src-fn">prompt</span>(<span class="src-arg">text</span>: <span class="src-cls">string</span>): <span class="src-cls">Promise</span>&lt;<span class="src-cls">void</span>&gt; { ... }</span>
+      <span class="src-line">  <span class="src-kw">private async</span> <span class="src-fn">runLoop</span>(...): <span class="src-cls">Promise</span>&lt;<span class="src-cls">void</span>&gt; { ... }</span>
+      <span class="src-line">}</span>
+    </div>
+
+    <figure>
+      <div class="figbox"><div class="event-flow">
+      <div class="ef-row"><div class="ef-type">session_start</div><div><span class="lang-zh-only">会话加载/创建 · 扩展收到 session_start</span><span class="lang-en-only">Session load/create · extensions get session_start</span></div></div>
+      <div class="ef-row"><div class="ef-type">turn_start</div><div><span class="lang-zh-only">用户 prompt 触发新 turn</span><span class="lang-en-only">User prompt triggers new turn</span></div></div>
+      <div class="ef-row"><div class="ef-type">message_update</div><div><span class="lang-zh-only">流式内容 · TUI 订阅</span><span class="lang-en-only">Streaming content · TUI subscribes</span></div></div>
+      <div class="ef-row"><div class="ef-type">turn_end</div><div><span class="lang-zh-only">turn 完成 · 检查 auto-compact</span><span class="lang-en-only">Turn complete · check auto-compact</span></div></div>
+    </div>
+      </div>
+      <figcaption><span class="figid">EVT</span><span class="lang-zh-only">AgentEvent 流 · 主线 prompt</span><span class="lang-en-only">AgentEvent stream · through-line prompt</span></figcaption>
+    </figure>
+
+    <h3 class="sub"><span class="lang-zh-only">AgentSession 职责矩阵</span><span class="lang-en-only">AgentSession responsibility matrix</span></h3>
+
+    <table class="cmp">
+      <thead><tr><th>职责</th><th>类/模块</th><th>主线时刻</th></tr></thead>
+      <tbody>
+      <tr><td>编排 agentLoop</td><td>agent-session.ts</td><td>prompt() 调用时</td></tr>
+      <tr><td>持久化</td><td>SessionManager</td><td>每个 message_end</td></tr>
+      <tr><td>扩展</td><td>ExtensionRunner</td><td>全程 hook</td></tr>
+      <tr><td>压缩</td><td>compaction/</td><td>token 超阈值</td></tr>
+      <tr><td>模型切换</td><td>ModelRegistry</td><td>model_change entry</td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">与 agent-core 的分工</span><span class="lang-en-only">Split with agent-core</span></h3>
+
+    <div class="lang-zh-only"><p><code>AgentSession</code> 拥有 I/O 和持久化；<code>agentLoop</code> 是纯函数式循环，不知道 JSONL 和 TUI 的存在。测试 agent loop 不需要启动终端。</p></div>
+    <div class="lang-en-only"><p><code>AgentSession</code> owns I/O and persistence; <code>agentLoop</code> is a pure loop unaware of JSONL and TUI. Testing agent loop needs no terminal.</p></div>
+
+    <div class="note copper">
+      <span class="lang-zh-only">📘 <strong>pi-textbook checkpoint 07</strong>：Agent Loop（<code>agent-loop.ts</code>）· 生产映射：<code>packages/agent/src/agent-loop.ts</code></span>
+      <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 07</strong>: Agent Loop (<code>agent-loop.ts</code>) · production: <code>packages/agent/src/agent-loop.ts</code></span>
+    </div>
+
+    <div class="note copper">
+      <span class="lang-zh-only">📘 <strong>pi-textbook checkpoint 09</strong>：Stateful Agent（<code>stateful-agent</code>）· 生产映射：<code>packages/agent/src/agent.ts</code></span>
+      <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 09</strong>: Stateful Agent (<code>stateful-agent</code>) · production: <code>packages/agent/src/agent.ts</code></span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">pi-textbook checkpoint 09 Stateful Agent 讲 steer/follow-up/abort——生产代码在 AgentSession + agent-loop 的 getSteeringMessages / queueFollowUp。</span>
+      <span class="lang-en-only">Textbook checkpoint 09 covers steer/follow-up/abort — production code in AgentSession + agent-loop getSteeringMessages / queueFollowUp.</span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">prompt() 内部</span><span class="lang-en-only">Inside prompt()</span></h3>
+
+    <div class="lang-zh-only"><p>创建 UserMessage → 调用 agentLoop → for-await 事件 → SessionManager.append → ExtensionRunner 广播。</p></div>
+    <div class="lang-en-only"><p>Create UserMessage → call agentLoop → for-await events → SessionManager.append → ExtensionRunner broadcast.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">错误恢复</span><span class="lang-en-only">Error recovery</span></h3>
+
+    <div class="lang-zh-only"><p>isRetryableAssistantError 触发重试；isContextOverflow 触发 compact 或分支摘要。</p></div>
+    <div class="lang-en-only"><p>isRetryableAssistantError triggers retry; isContextOverflow triggers compact or branch summary.</p></div>
+
+    <div class="note">
+      <span class="lang-zh-only">本章 (07) 在主线 prompt「唯一的中枢调度器」路径上负责：<strong>AgentSession 编排</strong>。回到 C02 的 22 站地图定位这一章。</span>
+      <span class="lang-en-only">Chapter (07) on the through-line path handles: <strong>AgentSession orchestration</strong>. Return to C02's 22-station map to locate this chapter.</span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent · chapter 07</span>
+        <span class="src-tag">trace</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// Through-line: 唯一的中枢调度器</span></span>
+      <span class="src-line"><span class="src-comment">// Phase: 入口 / Intake</span></span>
+      <span class="src-line"><span class="src-kw">await</span> <span class="src-fn">traceTurn</span>({ <span class="src-arg">prompt</span>: <span class="src-str">"README.md"</span> });</span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/agent-session.ts</span>
+        <span class="src-tag">walkthrough</span>
+      </div>
+      <span class="src-line"><span class="src-ln">  1</span> <span class="src-hl">async prompt(text: string)</span></span>
+      <span class="src-line"><span class="src-comment">     // 用户主线入口 / user through-line entry</span></span>
+      <span class="src-line"><span class="src-ln">  2</span> <span class="src-hl">const userMsg = createUserMessage(text)</span></span>
+      <span class="src-line"><span class="src-comment">     // 构造 AgentMessage / construct AgentMessage</span></span>
+      <span class="src-line"><span class="src-ln">  3</span> <span class="src-hl">const stream = agentLoop([userMsg], ctx, config, signal, streamFn)</span></span>
+      <span class="src-line"><span class="src-comment">     // 委托 agent-core / delegate to agent-core</span></span>
+      <span class="src-line"><span class="src-ln">  4</span> <span class="src-hl">for await (const event of stream)</span></span>
+      <span class="src-line"><span class="src-comment">     // 事件泵 / event pump</span></span>
+      <span class="src-line"><span class="src-ln">  5</span> <span class="src-hl">await this.sessionManager.append(event)</span></span>
+      <span class="src-line"><span class="src-comment">     // 持久化 / persist</span></span>
+      <span class="src-line"><span class="src-ln">  6</span> <span class="src-hl">this.extensionRunner.emit(event)</span></span>
+      <span class="src-line"><span class="src-comment">     // 扩展广播 / extension broadcast</span></span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">AgentSession vs agentLoop？</span><span class="lang-en-only">AgentSession vs agentLoop?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>Session 有状态+I/O；Loop 纯编排。</p></div><div class="lang-en-only"><p>Session has state+I/O; Loop is pure orchestration.</p></div></div></details>
+
+    <h3 class="sub"><span class="lang-zh-only">附录 · AgentSession 编排 深度 trace</span><span class="lang-en-only">Appendix · deep trace for AgentSession orchestration</span></h3>
+
+    <div class="lang-zh-only"><p>本章 (07) 属于 Phase「入口」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
+    <div class="lang-en-only"><p>Chapter (07) belongs to Phase «Intake». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
+
+    <table class="cmp">
+      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
+      <tbody>
+      <tr><td>1</td><td>AgentSession</td><td>prompt()</td></tr>
+      <tr><td>2</td><td>agentLoop</td><td>订阅</td></tr>
+      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
+      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
+      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
+      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
+      </tbody>
+    </table>
+
+    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/agent-session.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// AgentSession</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 07 · AgentSession 编排</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 07 · AgentSession 编排</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 07 · AgentSession 编排</span></span>
+    </div>
+
+    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
+
+    <div class="lang-zh-only"><p><strong>AgentMessage</strong> — agent-core 内部消息 IR</p></div>
+    <div class="lang-en-only"><p><strong>AgentMessage</strong> — agent-core internal message IR</p></div>
+
+    <div class="lang-zh-only"><p><strong>StreamFn</strong> — 可注入的模型流函数</p></div>
+    <div class="lang-en-only"><p><strong>StreamFn</strong> — injectable model stream function</p></div>
+
+    <div class="lang-zh-only"><p><strong>leafId</strong> — JSONL 会话树当前叶</p></div>
+    <div class="lang-en-only"><p><strong>leafId</strong> — JSONL session tree current leaf</p></div>
+
+    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
+
+    <div class="note">
+      <span class="lang-zh-only">[07.1] 在 AgentSession 编排 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[07.1] At AgentSession orchestration stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[07.2] 在 AgentSession 编排 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[07.2] At AgentSession orchestration stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[07.3] 在 AgentSession 编排 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[07.3] At AgentSession orchestration stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[07.4] 在 AgentSession 编排 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[07.4] At AgentSession orchestration stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[07.5] 在 AgentSession 编排 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[07.5] At AgentSession orchestration stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[07.6] 在 AgentSession 编排 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[07.6] At AgentSession orchestration stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[07.7] 在 AgentSession 编排 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[07.7] At AgentSession orchestration stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[07.8] 在 AgentSession 编排 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[07.8] At AgentSession orchestration stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+  </section>
+
+  <section class="chap" id="c8">
+    <div class="chap-num">CHAPTER&nbsp;08&nbsp;·&nbsp;INTAKE</div>
+    <h2 class="chap-title lang-zh-only">AGENTS.md 上下文栈</h2>
+    <h2 class="chap-title lang-en-only">The AGENTS.md context stack</h2>
+    <p class="chap-en lang-zh-only">从 ~/.pi 到项目根的指令叠加</p>
+    <p class="chap-en lang-en-only">instructions stacked from ~/.pi to project root</p>
+    <div class="lang-zh-only"><p>在主线 prompt 到达模型之前，<code>ResourceLoader</code> 把从 <code>~/.pi/AGENTS.md</code> 到项目根目录的指令文件<strong>叠加</strong>进 system context。每一层目录的 AGENTS.md 追加规则。</p></div>
+    <div class="lang-en-only"><p>Before the through-line prompt reaches the model, <code>ResourceLoader</code> <strong>stacks</strong> instruction files from <code>~/.pi/AGENTS.md</code> to project root into system context.</p></div>
+
+    <div class="ladder">
+      <div class="ladder-step">
+        <div class="ladder-num">01</div>
+        <div class="ladder-body"><span class="lang-zh-only">~/.pi/AGENTS.md</span><span class="lang-en-only">全局 harness 指令</span></div>
+      </div>
+      <div class="ladder-step">
+        <div class="ladder-num">02</div>
+        <div class="ladder-body"><span class="lang-zh-only">~/.pi/PROJECT.md</span><span class="lang-en-only">用户级项目偏好</span></div>
+      </div>
+      <div class="ladder-step">
+        <div class="ladder-num">03</div>
+        <div class="ladder-body"><span class="lang-zh-only">./AGENTS.md</span><span class="lang-en-only">仓库级规则</span></div>
+      </div>
+      <div class="ladder-step">
+        <div class="ladder-num">04</div>
+        <div class="ladder-body"><span class="lang-zh-only">./subdir/AGENTS.md</span><span class="lang-en-only">子目录覆盖（若存在）</span></div>
+      </div>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/resource-loader.ts</span>
+        <span class="src-tag">loader</span>
+      </div>
+      <span class="src-line"><span class="src-kw">export class</span> <span class="src-cls">ResourceLoader</span> {</span>
+      <span class="src-line">  <span class="src-fn">loadResources</span>(<span class="src-arg">cwd</span>): <span class="src-cls">ResourceBundle</span> { ... }</span>
+      <span class="src-line">  <span class="src-comment">// merges AGENTS.md chain into system prompt</span></span>
+      <span class="src-line">}</span>
+    </div>
+
+    <div class="stage-purpose">
+      <div class="sp-row">
+        <div class="sp-key"><span class="lang-zh-only">叠加顺序</span><span class="lang-en-only">Stack order</span></div>
+        <div class="sp-val"><span class="lang-zh-only">从全局到局部，后加载的优先级更高</span><span class="lang-en-only">global → local, later wins</span></div>
+      </div>
+      <div class="sp-row">
+        <div class="sp-key"><span class="lang-zh-only">frontmatter</span><span class="lang-en-only">frontmatter</span></div>
+        <div class="sp-val"><span class="lang-zh-only">YAML 头可指定 tool 白名单</span><span class="lang-en-only">YAML header can whitelist tools</span></div>
+      </div>
+      <div class="sp-row">
+        <div class="sp-key"><span class="lang-zh-only">刷新</span><span class="lang-en-only">Refresh</span></div>
+        <div class="sp-val"><span class="lang-zh-only">文件变更可触发 reload（扩展 hook）</span><span class="lang-en-only">file change can trigger reload via extension hook</span></div>
+      </div>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">主线 prompt 时的 context 长什么样</span><span class="lang-en-only">What context looks like at through-line prompt</span></h3>
+
+    <div class="lang-zh-only"><p>模型看到的不是裸的「读取 README」——而是 <code>system: [AGENTS.md 栈] + user: 读取 README.md…</code>。工具 schema 也在 system 或 tools 参数里。</p></div>
+    <div class="lang-en-only"><p>Model sees not bare «read README» but <code>system: [AGENTS.md stack] + user: read README.md…</code>. Tool schemas live in system or tools param.</p></div>
+
+    <div class="note copper">
+      <span class="lang-zh-only">📘 <strong>pi-textbook checkpoint 12</strong>：Resources + Extensions（<code>resources-extensions</code>）· 生产映射：<code>packages/coding-agent/src/core/extensions/ · resource-loader.ts</code></span>
+      <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 12</strong>: Resources + Extensions (<code>resources-extensions</code>) · production: <code>packages/coding-agent/src/core/extensions/ · resource-loader.ts</code></span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">本章 (08) 在主线 prompt「从 ~/.pi 到项目根的指令叠加」路径上负责：<strong>AGENTS.md 上下文栈</strong>。回到 C02 的 22 站地图定位这一章。</span>
+      <span class="lang-en-only">Chapter (08) on the through-line path handles: <strong>The AGENTS.md context stack</strong>. Return to C02's 22-station map to locate this chapter.</span>
+    </div>
+
+    <table class="cmp">
+      <thead><tr><th>路径</th><th>说明</th></tr></thead>
+      <tbody>
+      <tr><td><code>packages/coding-agent/src/cli.ts</code></td><td>CLI 入口</td></tr>
+      <tr><td><code>packages/coding-agent/src/main.ts</code></td><td>模式分发</td></tr>
+      <tr><td><code>packages/coding-agent/src/core/agent-session.ts</code></td><td>中枢调度</td></tr>
+      <tr><td><code>packages/coding-agent/src/core/resource-loader.ts</code></td><td>AGENTS.md 栈</td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">AGENTS.md 上下文栈 · 实现清单</span><span class="lang-en-only">The AGENTS.md context stack · implementation checklist</span></h3>
+
+    <div class="note">
+      <span class="lang-zh-only">1. 定位生产文件：packages/agent/src/agent-loop.ts</span>
+      <span class="lang-en-only">1. Locate production file: packages/agent/src/agent-loop.ts</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">2. 对照 pi-textbook 同主题 checkpoint</span>
+      <span class="lang-en-only">2. Cross-read matching pi-textbook checkpoint</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">3. 用 --verbose 观察 AgentEvent</span>
+      <span class="lang-en-only">3. Observe AgentEvents with --verbose</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">4. 检查 JSONL 会话文件对应 entry</span>
+      <span class="lang-en-only">4. Inspect matching JSONL session entry</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">5. 阅读 packages/*/test/ 下相关测试</span>
+      <span class="lang-en-only">5. Read related tests under packages/*/test/</span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">Coding Tools 目录</span><span class="lang-en-only">Coding tools catalog</span></h3>    <table class="cmp">
+      <thead><tr><th>Tool</th><th>名称</th><th>实现要点</th></tr></thead>
+      <tbody>
+      <tr><td>read</td><td>读取文件</td><td>UTF-8 · 二进制检测 · 路径解析</td></tr>
+      <tr><td>write</td><td>写入文件</td><td>创建/覆盖 · 权限检查</td></tr>
+      <tr><td>edit</td><td>编辑文件</td><td>search/replace 块</td></tr>
+      <tr><td>bash</td><td>执行 shell</td><td>cwd 继承 · 超时 · 输出截断</td></tr>
+      <tr><td>glob</td><td>文件匹配</td><td>ripgrep 风格</td></tr>
+      <tr><td>grep</td><td>内容搜索</td><td>正则 · 上下文行</td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">附录 · AGENTS.md 上下文栈 深度 trace</span><span class="lang-en-only">Appendix · deep trace for The AGENTS.md context stack</span></h3>
+
+    <div class="lang-zh-only"><p>本章 (08) 属于 Phase「入口」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
+    <div class="lang-en-only"><p>Chapter (08) belongs to Phase «Intake». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
+
+    <table class="cmp">
+      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
+      <tbody>
+      <tr><td>1</td><td>AGENTS.md 上下文栈</td><td>从 ~/.pi 到项目根的指令叠加</td></tr>
+      <tr><td>2</td><td>—</td><td>checkpoint 2</td></tr>
+      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
+      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
+      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
+      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
+      </tbody>
+    </table>
+
+    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// default trace</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 08 · AGENTS.md 上下文栈</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 08 · AGENTS.md 上下文栈</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 08 · AGENTS.md 上下文栈</span></span>
+    </div>
+
+    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
+
+    <div class="lang-zh-only"><p><strong>AgentMessage</strong> — agent-core 内部消息 IR</p></div>
+    <div class="lang-en-only"><p><strong>AgentMessage</strong> — agent-core internal message IR</p></div>
+
+    <div class="lang-zh-only"><p><strong>StreamFn</strong> — 可注入的模型流函数</p></div>
+    <div class="lang-en-only"><p><strong>StreamFn</strong> — injectable model stream function</p></div>
+
+    <div class="lang-zh-only"><p><strong>leafId</strong> — JSONL 会话树当前叶</p></div>
+    <div class="lang-en-only"><p><strong>leafId</strong> — JSONL session tree current leaf</p></div>
+
+    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
+
+    <div class="note">
+      <span class="lang-zh-only">[08.1] 在 AGENTS.md 上下文栈 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[08.1] At The AGENTS.md context stack stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[08.2] 在 AGENTS.md 上下文栈 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[08.2] At The AGENTS.md context stack stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[08.3] 在 AGENTS.md 上下文栈 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[08.3] At The AGENTS.md context stack stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[08.4] 在 AGENTS.md 上下文栈 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[08.4] At The AGENTS.md context stack stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[08.5] 在 AGENTS.md 上下文栈 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[08.5] At The AGENTS.md context stack stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[08.6] 在 AGENTS.md 上下文栈 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[08.6] At The AGENTS.md context stack stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[08.7] 在 AGENTS.md 上下文栈 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[08.7] At The AGENTS.md context stack stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[08.8] 在 AGENTS.md 上下文栈 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[08.8] At The AGENTS.md context stack stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+  </section>
+
+  <section class="chap" id="c9">
+    <div class="chap-num">CHAPTER&nbsp;09&nbsp;·&nbsp;HEART</div>
+    <h2 class="chap-title lang-zh-only">两层消息模型</h2>
+    <h2 class="chap-title lang-en-only">Two-layer message model</h2>
+    <p class="chap-en lang-zh-only">AgentMessage ≠ Message</p>
+    <p class="chap-en lang-en-only">AgentMessage ≠ Message</p>
+    <div class="lang-zh-only"><p>Pi 维护<strong>两层消息模型</strong>：<code>AgentMessage</code>（agent-core 内部，可含自定义 role）和 <code>Message</code>（pi-ai LLM API，严格 user/assistant/tool）。<code>convertToLlm</code> 是唯一转换点。</p></div>
+    <div class="lang-en-only"><p>Pi maintains <strong>two message layers</strong>: <code>AgentMessage</code> (agent-core, custom roles) and <code>Message</code> (pi-ai LLM API, strict user/assistant/tool). <code>convertToLlm</code> is the sole conversion point.</p></div>
+
+    <table class="cmp">
+      <thead><tr><th>层</th><th>类型</th><th>谁能看</th><th>例子</th></tr></thead>
+      <tbody>
+      <tr><td>Transcript</td><td>AgentMessage[]</td><td>agent loop · JSONL</td><td>user · assistant · toolResult · custom</td></tr>
+      <tr><td>LLM API</td><td>Message[]</td><td>pi-ai providers</td><td>user · assistant · tool_result</td></tr>
+      <tr><td>TUI</td><td>RenderedMessage</td><td>终端组件</td><td>Markdown · tool 卡片</td></tr>
+      </tbody>
+    </table>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/types.ts</span>
+        <span class="src-tag">types</span>
+      </div>
+      <span class="src-line"><span class="src-kw">export type</span> <span class="src-cls">AgentMessage</span> =</span>
+      <span class="src-line">  | <span class="src-cls">UserMessage</span> | <span class="src-cls">AssistantMessage</span></span>
+      <span class="src-line">  | <span class="src-cls">ToolResultMessage</span> | <span class="src-cls">CustomMessage</span>;</span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/messages.ts</span>
+        <span class="src-tag">convert</span>
+      </div>
+      <span class="src-line"><span class="src-kw">export function</span> <span class="src-fn">convertToLlm</span>(<span class="src-arg">messages</span>: <span class="src-cls">AgentMessage</span>[]): <span class="src-cls">Message</span>[]</span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">三层 canonical transcript</span><span class="lang-en-only">Three-layer canonical transcript</span></h3>
+
+    <div class="lang-zh-only"><p>pi-textbook checkpoint 03 强调：transcript 是<strong>唯一真相源</strong>；LLM 请求是投影；TUI 是另一个投影。fork 会话时只复制 AgentMessage 链。</p></div>
+    <div class="lang-en-only"><p>Textbook checkpoint 03: transcript is the <strong>single source of truth</strong>; LLM request is a projection; TUI is another. Session fork copies AgentMessage chain only.</p></div>
+
+    <div class="formula">
+      <div class="ftitle"><span class="lang-zh-only">投影</span><span class="lang-en-only">PROJECTION</span></div>
+      <span class="cond"><span class="term">AgentMessage[]</span> — canonical</span>
+      <span class="cond"><span class="term-cu">convertToLlm()</span> → Message[]</span>
+      <span class="cond"><span class="term">renderMessage()</span> → TUI cells</span>
+      <div class="out"><span class="lang-zh-only">主线 prompt 在三层各出现一次</span><span class="lang-en-only">Through-line prompt appears once per layer</span></div>
+    </div>
+
+    <div class="note copper">
+      <span class="lang-zh-only">📘 <strong>pi-textbook checkpoint 03</strong>：Message IR（<code>types.ts</code>）· 生产映射：<code>packages/agent/src/types.ts · packages/coding-agent/src/core/messages.ts</code></span>
+      <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 03</strong>: Message IR (<code>types.ts</code>) · production: <code>packages/agent/src/types.ts · packages/coding-agent/src/core/messages.ts</code></span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">本章 (09) 在主线 prompt「AgentMessage ≠ Message」路径上负责：<strong>两层消息模型</strong>。回到 C02 的 22 站地图定位这一章。</span>
+      <span class="lang-en-only">Chapter (09) on the through-line path handles: <strong>Two-layer message model</strong>. Return to C02's 22-station map to locate this chapter.</span>
+    </div>
+
+    <table class="cmp">
+      <thead><tr><th>路径</th><th>说明</th></tr></thead>
+      <tbody>
+      <tr><td><code>packages/agent/src/agent-loop.ts</code></td><td>runLoop 双环</td></tr>
+      <tr><td><code>packages/agent/src/types.ts</code></td><td>AgentMessage / AgentEvent</td></tr>
+      <tr><td><code>packages/coding-agent/src/core/tools/</code></td><td>coding tools</td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">两层消息模型 · 实现清单</span><span class="lang-en-only">Two-layer message model · implementation checklist</span></h3>
+
+    <div class="note">
+      <span class="lang-zh-only">1. 定位生产文件：packages/agent/src/agent-loop.ts</span>
+      <span class="lang-en-only">1. Locate production file: packages/agent/src/agent-loop.ts</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">2. 对照 pi-textbook 同主题 checkpoint</span>
+      <span class="lang-en-only">2. Cross-read matching pi-textbook checkpoint</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">3. 用 --verbose 观察 AgentEvent</span>
+      <span class="lang-en-only">3. Observe AgentEvents with --verbose</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">4. 检查 JSONL 会话文件对应 entry</span>
+      <span class="lang-en-only">4. Inspect matching JSONL session entry</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">5. 阅读 packages/*/test/ 下相关测试</span>
+      <span class="lang-en-only">5. Read related tests under packages/*/test/</span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">AgentEvent 完整目录</span><span class="lang-en-only">Full AgentEvent catalog</span></h3>    <table class="cmp">
+      <thead><tr><th>事件</th><th>中文</th><th>主线关联</th></tr></thead>
+      <tbody>
+      <tr><td><code>agent_start</code></td><td>循环开始</td><td>AgentSession 订阅</td></tr>
+      <tr><td><code>agent_end</code></td><td>循环结束</td><td>返回 messages[]</td></tr>
+      <tr><td><code>turn_start</code></td><td>新 turn</td><td>可能含 steering</td></tr>
+      <tr><td><code>turn_end</code></td><td>turn 结束</td><td>附带 toolResults</td></tr>
+      <tr><td><code>message_start</code></td><td>消息开始</td><td>user/assistant/tool</td></tr>
+      <tr><td><code>message_update</code></td><td>流式更新</td><td>text_delta/toolcall_delta</td></tr>
+      <tr><td><code>message_end</code></td><td>消息结束</td><td>触发 JSONL 写入</td></tr>
+      <tr><td><code>tool_execution_start</code></td><td>工具开始</td><td>read/write/bash</td></tr>
+      <tr><td><code>tool_execution_update</code></td><td>工具进度</td><td>bash 流式输出</td></tr>
+      <tr><td><code>tool_execution_end</code></td><td>工具结束</td><td>结果截断</td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">附录 · 两层消息模型 深度 trace</span><span class="lang-en-only">Appendix · deep trace for Two-layer message model</span></h3>
+
+    <div class="lang-zh-only"><p>本章 (09) 属于 Phase「心脏」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
+    <div class="lang-en-only"><p>Chapter (09) belongs to Phase «Heart». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
+
+    <table class="cmp">
+      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
+      <tbody>
+      <tr><td>1</td><td>两层消息模型</td><td>AgentMessage ≠ Message</td></tr>
+      <tr><td>2</td><td>—</td><td>checkpoint 2</td></tr>
+      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
+      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
+      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
+      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
+      </tbody>
+    </table>
+
+    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/types.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// AgentMessage</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 09 · 两层消息模型</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/messages.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// convertToLlm</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 09 · 两层消息模型</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 09 · 两层消息模型</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 09 · 两层消息模型</span></span>
+    </div>
+
+    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
+
+    <div class="lang-zh-only"><p><strong>convertToLlm</strong> — AgentMessage → Message[] 投影</p></div>
+    <div class="lang-en-only"><p><strong>convertToLlm</strong> — AgentMessage → Message[] projection</p></div>
+
+    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
+
+    <div class="note">
+      <span class="lang-zh-only">[09.1] 在 两层消息模型 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[09.1] At Two-layer message model stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[09.2] 在 两层消息模型 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[09.2] At Two-layer message model stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[09.3] 在 两层消息模型 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[09.3] At Two-layer message model stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[09.4] 在 两层消息模型 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[09.4] At Two-layer message model stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[09.5] 在 两层消息模型 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[09.5] At Two-layer message model stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[09.6] 在 两层消息模型 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[09.6] At Two-layer message model stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[09.7] 在 两层消息模型 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[09.7] At Two-layer message model stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[09.8] 在 两层消息模型 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[09.8] At Two-layer message model stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+  </section>
+
+  <section class="chap" id="c10">
+    <div class="chap-num">CHAPTER&nbsp;10&nbsp;·&nbsp;HEART</div>
+    <h2 class="chap-title lang-zh-only">runLoop 双环</h2>
+    <h2 class="chap-title lang-en-only">The runLoop twin loops</h2>
+    <p class="chap-en lang-zh-only">outer follow-up · inner tool batch</p>
+    <p class="chap-en lang-en-only">outer follow-up · inner tool batch</p>
+    <div class="lang-zh-only"><p><code>runLoop</code> 是 agent 的心脏：<strong>外环</strong>处理 follow-up 队列（用户在你以为结束时又发了一条），<strong>内环</strong>处理 tool batch 和 steering 注入。</p></div>
+    <div class="lang-en-only"><p><code>runLoop</code> is the agent heart: <strong>outer loop</strong> handles follow-up queue; <strong>inner loop</strong> handles tool batch and steering injection.</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
+        <span class="src-tag">loop</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// Outer loop: continues when queued follow-up messages arrive</span></span>
+      <span class="src-line"><span class="src-kw">while</span> (<span class="src-num">true</span>) {</span>
+      <span class="src-line">  <span class="src-comment">// Inner loop: process tool calls and steering</span></span>
+      <span class="src-line">  <span class="src-kw">while</span> (hasMoreToolCalls || pendingMessages.length > 0) {</span>
+      <span class="src-line">    <span class="src-kw">const</span> message = <span class="src-kw">await</span> <span class="src-fn">streamAssistantResponse</span>(...);</span>
+      <span class="src-line">  }</span>
+      <span class="src-line">}</span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">主线 prompt 的两圈 model stream</span><span class="lang-en-only">Two model streams for through-line prompt</span></h3>
+
+    <div class="ladder">
+      <div class="ladder-step">
+        <div class="ladder-num">01</div>
+        <div class="ladder-body"><span class="lang-zh-only">Turn 1</span><span class="lang-en-only">user → assistant(toolUse: read)</span></div>
+      </div>
+      <div class="ladder-step">
+        <div class="ladder-num">02</div>
+        <div class="ladder-body"><span class="lang-zh-only">Tool batch</span><span class="lang-en-only">executeTool(read) → toolResult</span></div>
+      </div>
+      <div class="ladder-step">
+        <div class="ladder-num">03</div>
+        <div class="ladder-body"><span class="lang-zh-only">Turn 2</span><span class="lang-en-only">context+result → assistant(stop)</span></div>
+      </div>
+    </div>
+
+    <div class="stage-purpose">
+      <div class="sp-row">
+        <div class="sp-key"><span class="lang-zh-only">外环退出条件</span><span class="lang-en-only">Outer exit</span></div>
+        <div class="sp-val"><span class="lang-zh-only">无 follow-up 且内环完成</span><span class="lang-en-only">no follow-up and inner loop done</span></div>
+      </div>
+      <div class="sp-row">
+        <div class="sp-key"><span class="lang-zh-only">内环继续条件</span><span class="lang-en-only">Inner continue</span></div>
+        <div class="sp-val"><span class="lang-zh-only">stopReason=toolUse 或 pending steering</span><span class="lang-en-only">stopReason=toolUse or pending steering</span></div>
+      </div>
+      <div class="sp-row">
+        <div class="sp-key"><span class="lang-zh-only">streamFn 注入</span><span class="lang-en-only">streamFn inject</span></div>
+        <div class="sp-val"><span class="lang-zh-only">测试用 ScriptedModel 替换</span><span class="lang-en-only">ScriptedModel for tests</span></div>
+      </div>
+    </div>
+
+    <figure>
+      <div class="figbox"><div class="event-flow">
+      <div class="ef-row"><div class="ef-type">turn_start</div><div><span class="lang-zh-only">每圈 model 前</span><span class="lang-en-only">before each model round</span></div></div>
+      <div class="ef-row"><div class="ef-type">message_update</div><div><span class="lang-zh-only">text_delta / toolcall_delta</span><span class="lang-en-only">streaming deltas</span></div></div>
+      <div class="ef-row"><div class="ef-type">turn_end</div><div><span class="lang-zh-only">assistant 定稿后</span><span class="lang-en-only">after assistant finalized</span></div></div>
+    </div>
+      </div>
+      <figcaption><span class="figid">EVT</span><span class="lang-zh-only">AgentEvent 流 · 主线 prompt</span><span class="lang-en-only">AgentEvent stream · through-line prompt</span></figcaption>
+    </figure>
+
+    <div class="note copper">
+      <span class="lang-zh-only">📘 <strong>pi-textbook checkpoint 07</strong>：Agent Loop（<code>agent-loop.ts</code>）· 生产映射：<code>packages/agent/src/agent-loop.ts</code></span>
+      <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 07</strong>: Agent Loop (<code>agent-loop.ts</code>) · production: <code>packages/agent/src/agent-loop.ts</code></span>
+    </div>
+
+    <blockquote class="pull copper">
+      <span class="lang-zh-only">外环是耐心。<br>内环是纪律。</span>
+      <span class="lang-en-only">Outer loop is patience.<br>Inner loop is discipline.</span>
+      <cite>Field Note · 10</cite>
+    </blockquote>
+
+    <h3 class="sub"><span class="lang-zh-only">streamAssistantResponse</span><span class="lang-en-only">streamAssistantResponse</span></h3>
+
+    <div class="lang-zh-only"><p>convertToLlm → streamFn → 累积 delta → 组装 AssistantMessage → emit message_end。</p></div>
+    <div class="lang-en-only"><p>convertToLlm → streamFn → accumulate deltas → assemble AssistantMessage → emit message_end.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">stopReason 分支</span><span class="lang-en-only">stopReason branches</span></h3>
+
+    <div class="lang-zh-only"><p>toolUse 进内环；stop 可能退出；error/aborted 立即 agent_end。</p></div>
+    <div class="lang-en-only"><p>toolUse enters inner loop; stop may exit; error/aborted immediate agent_end.</p></div>
+
+    <div class="note">
+      <span class="lang-zh-only">本章 (10) 在主线 prompt「outer follow-up · inner tool batch」路径上负责：<strong>runLoop 双环</strong>。回到 C02 的 22 站地图定位这一章。</span>
+      <span class="lang-en-only">Chapter (10) on the through-line path handles: <strong>The runLoop twin loops</strong>. Return to C02's 22-station map to locate this chapter.</span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent · chapter 10</span>
+        <span class="src-tag">trace</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// Through-line: outer follow-up · inner tool batch</span></span>
+      <span class="src-line"><span class="src-comment">// Phase: 心脏 / Heart</span></span>
+      <span class="src-line"><span class="src-kw">await</span> <span class="src-fn">traceTurn</span>({ <span class="src-arg">prompt</span>: <span class="src-str">"README.md"</span> });</span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
+        <span class="src-tag">walkthrough</span>
+      </div>
+      <span class="src-line"><span class="src-ln">  1</span> <span class="src-hl">while (true) {</span></span>
+      <span class="src-line"><span class="src-comment">     // 外环：follow-up / outer: follow-up</span></span>
+      <span class="src-line"><span class="src-ln">  2</span> <span class="src-hl">while (hasMoreToolCalls || pendingMessages.length)</span></span>
+      <span class="src-line"><span class="src-comment">     // 内环：tool+steer / inner: tool+steer</span></span>
+      <span class="src-line"><span class="src-ln">  3</span> <span class="src-hl">await streamAssistantResponse(...)</span></span>
+      <span class="src-line"><span class="src-comment">     // 调 LLM / call LLM</span></span>
+      <span class="src-line"><span class="src-ln">  4</span> <span class="src-hl">if (message.stopReason === 'toolUse')</span></span>
+      <span class="src-line"><span class="src-comment">     // 需要工具 / needs tools</span></span>
+      <span class="src-line"><span class="src-ln">  5</span> <span class="src-hl">await executeToolCalls(...)</span></span>
+      <span class="src-line"><span class="src-comment">     // 执行 read 等 / execute read etc</span></span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+      <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
+      <tbody>
+      <tr><td>07</td><td>Agent Loop</td><td>agent-loop.ts</td><td>packages/agent/src/agent-loop.ts</td></tr>
+      <tr><td>09</td><td>Stateful Agent</td><td>stateful-agent</td><td>packages/agent/src/agent.ts</td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">AgentEvent 完整目录</span><span class="lang-en-only">Full AgentEvent catalog</span></h3>    <table class="cmp">
+      <thead><tr><th>事件</th><th>中文</th><th>主线关联</th></tr></thead>
+      <tbody>
+      <tr><td><code>agent_start</code></td><td>循环开始</td><td>AgentSession 订阅</td></tr>
+      <tr><td><code>agent_end</code></td><td>循环结束</td><td>返回 messages[]</td></tr>
+      <tr><td><code>turn_start</code></td><td>新 turn</td><td>可能含 steering</td></tr>
+      <tr><td><code>turn_end</code></td><td>turn 结束</td><td>附带 toolResults</td></tr>
+      <tr><td><code>message_start</code></td><td>消息开始</td><td>user/assistant/tool</td></tr>
+      <tr><td><code>message_update</code></td><td>流式更新</td><td>text_delta/toolcall_delta</td></tr>
+      <tr><td><code>message_end</code></td><td>消息结束</td><td>触发 JSONL 写入</td></tr>
+      <tr><td><code>tool_execution_start</code></td><td>工具开始</td><td>read/write/bash</td></tr>
+      <tr><td><code>tool_execution_update</code></td><td>工具进度</td><td>bash 流式输出</td></tr>
+      <tr><td><code>tool_execution_end</code></td><td>工具结束</td><td>结果截断</td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">附录 · runLoop 双环 深度 trace</span><span class="lang-en-only">Appendix · deep trace for The runLoop twin loops</span></h3>
+
+    <div class="lang-zh-only"><p>本章 (10) 属于 Phase「心脏」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
+    <div class="lang-en-only"><p>Chapter (10) belongs to Phase «Heart». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
+
+    <table class="cmp">
+      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
+      <tbody>
+      <tr><td>1</td><td>runLoop</td><td>外环启动</td></tr>
+      <tr><td>2</td><td>inner</td><td>streamAssistantResponse</td></tr>
+      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
+      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
+      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
+      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
+      </tbody>
+    </table>
+
+    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// runLoop</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 10 · runLoop 双环</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 10 · runLoop 双环</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 10 · runLoop 双环</span></span>
+    </div>
+
+    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
+
+    <div class="lang-zh-only"><p><strong>runLoop</strong> — 外环 follow-up + 内环 tool</p></div>
+    <div class="lang-en-only"><p><strong>runLoop</strong> — outer follow-up + inner tool loop</p></div>
+
+    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
+
+    <div class="note">
+      <span class="lang-zh-only">[10.1] 在 runLoop 双环 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[10.1] At The runLoop twin loops stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[10.2] 在 runLoop 双环 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[10.2] At The runLoop twin loops stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[10.3] 在 runLoop 双环 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[10.3] At The runLoop twin loops stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[10.4] 在 runLoop 双环 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[10.4] At The runLoop twin loops stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[10.5] 在 runLoop 双环 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[10.5] At The runLoop twin loops stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[10.6] 在 runLoop 双环 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[10.6] At The runLoop twin loops stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[10.7] 在 runLoop 双环 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[10.7] At The runLoop twin loops stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[10.8] 在 runLoop 双环 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[10.8] At The runLoop twin loops stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+  </section>
+
+  <section class="chap" id="c11">
+    <div class="chap-num">CHAPTER&nbsp;11&nbsp;·&nbsp;HEART</div>
+    <h2 class="chap-title lang-zh-only">Steering 与 Follow-up</h2>
+    <h2 class="chap-title lang-en-only">Steering and follow-up</h2>
+    <p class="chap-en lang-zh-only">运行中插队与结束后续</p>
+    <p class="chap-en lang-en-only">mid-run injection and post-stop follow-up</p>
+    <div class="lang-zh-only"><p><strong>Steering</strong>：运行中用户插入新消息（内环下一轮前注入）。<strong>Follow-up</strong>：agent 即将停止时队列里的后续消息（外环重启）。</p></div>
+    <div class="lang-en-only"><p><strong>Steering</strong>: user inserts mid-run (injected before next inner round). <strong>Follow-up</strong>: queued messages when agent would stop (outer loop restarts).</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
+        <span class="src-tag">steer</span>
+      </div>
+      <span class="src-line"><span class="src-kw">let</span> pendingMessages = (<span class="src-kw">await</span> config.<span class="src-fn">getSteeringMessages</span>?.()) || [];</span>
+      <span class="src-line"><span class="src-kw">if</span> (pendingMessages.length > 0) {</span>
+      <span class="src-line">  <span class="src-kw">for</span> (<span class="src-kw">const</span> message <span class="src-kw">of</span> pendingMessages) { ... }</span>
+      <span class="src-line">}</span>
+    </div>
+
+    <table class="cmp">
+      <thead><tr><th>机制</th><th>触发时机</th><th>典型场景</th></tr></thead>
+      <tbody>
+      <tr><td>Steering</td><td>内环每轮前</td><td>「别读 README 了，先 ls」</td></tr>
+      <tr><td>Follow-up</td><td>外环 would-stop</td><td>批量任务第二条命令</td></tr>
+      <tr><td>Abort</td><td>AbortSignal</td><td>Ctrl+C · 扩展取消</td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">Case study：read 中途改主意</span><span class="lang-en-only">Case study: change mind mid-read</span></h3>
+
+    <div class="lang-zh-only"><p>用户发出主线 prompt 后，模型开始 toolUse read；用户在 TUI 里输入 steering「先列出目录」。内环在 executeTool 前收到 pendingMessages，注入 user 消息，可能改变 tool 选择。</p></div>
+    <div class="lang-en-only"><p>After through-line prompt, model starts toolUse read; user steers «list directory first». Inner loop receives pendingMessages before executeTool, may change tool choice.</p></div>
+
+    <div class="note copper">
+      <span class="lang-zh-only">📘 <strong>pi-textbook checkpoint 09</strong>：Stateful Agent（<code>stateful-agent</code>）· 生产映射：<code>packages/agent/src/agent.ts</code></span>
+      <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 09</strong>: Stateful Agent (<code>stateful-agent</code>) · production: <code>packages/agent/src/agent.ts</code></span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">本章 (11) 在主线 prompt「运行中插队与结束后续」路径上负责：<strong>Steering 与 Follow-up</strong>。回到 C02 的 22 站地图定位这一章。</span>
+      <span class="lang-en-only">Chapter (11) on the through-line path handles: <strong>Steering and follow-up</strong>. Return to C02's 22-station map to locate this chapter.</span>
+    </div>
+
+    <table class="cmp">
+      <thead><tr><th>路径</th><th>说明</th></tr></thead>
+      <tbody>
+      <tr><td><code>packages/agent/src/agent-loop.ts</code></td><td>runLoop 双环</td></tr>
+      <tr><td><code>packages/agent/src/types.ts</code></td><td>AgentMessage / AgentEvent</td></tr>
+      <tr><td><code>packages/coding-agent/src/core/tools/</code></td><td>coding tools</td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">Steering 与 Follow-up · 实现清单</span><span class="lang-en-only">Steering and follow-up · implementation checklist</span></h3>
+
+    <div class="note">
+      <span class="lang-zh-only">1. 定位生产文件：packages/agent/src/agent-loop.ts</span>
+      <span class="lang-en-only">1. Locate production file: packages/agent/src/agent-loop.ts</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">2. 对照 pi-textbook 同主题 checkpoint</span>
+      <span class="lang-en-only">2. Cross-read matching pi-textbook checkpoint</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">3. 用 --verbose 观察 AgentEvent</span>
+      <span class="lang-en-only">3. Observe AgentEvents with --verbose</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">4. 检查 JSONL 会话文件对应 entry</span>
+      <span class="lang-en-only">4. Inspect matching JSONL session entry</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">5. 阅读 packages/*/test/ 下相关测试</span>
+      <span class="lang-en-only">5. Read related tests under packages/*/test/</span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">AgentEvent 完整目录</span><span class="lang-en-only">Full AgentEvent catalog</span></h3>    <table class="cmp">
+      <thead><tr><th>事件</th><th>中文</th><th>主线关联</th></tr></thead>
+      <tbody>
+      <tr><td><code>agent_start</code></td><td>循环开始</td><td>AgentSession 订阅</td></tr>
+      <tr><td><code>agent_end</code></td><td>循环结束</td><td>返回 messages[]</td></tr>
+      <tr><td><code>turn_start</code></td><td>新 turn</td><td>可能含 steering</td></tr>
+      <tr><td><code>turn_end</code></td><td>turn 结束</td><td>附带 toolResults</td></tr>
+      <tr><td><code>message_start</code></td><td>消息开始</td><td>user/assistant/tool</td></tr>
+      <tr><td><code>message_update</code></td><td>流式更新</td><td>text_delta/toolcall_delta</td></tr>
+      <tr><td><code>message_end</code></td><td>消息结束</td><td>触发 JSONL 写入</td></tr>
+      <tr><td><code>tool_execution_start</code></td><td>工具开始</td><td>read/write/bash</td></tr>
+      <tr><td><code>tool_execution_update</code></td><td>工具进度</td><td>bash 流式输出</td></tr>
+      <tr><td><code>tool_execution_end</code></td><td>工具结束</td><td>结果截断</td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">附录 · Steering 与 Follow-up 深度 trace</span><span class="lang-en-only">Appendix · deep trace for Steering and follow-up</span></h3>
+
+    <div class="lang-zh-only"><p>本章 (11) 属于 Phase「心脏」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
+    <div class="lang-en-only"><p>Chapter (11) belongs to Phase «Heart». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
+
+    <table class="cmp">
+      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
+      <tbody>
+      <tr><td>1</td><td>Steering 与 Follow-up</td><td>运行中插队与结束后续</td></tr>
+      <tr><td>2</td><td>—</td><td>checkpoint 2</td></tr>
+      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
+      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
+      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
+      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
+      </tbody>
+    </table>
+
+    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// default trace</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 11 · Steering 与 Follow-up</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 11 · Steering 与 Follow-up</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 11 · Steering 与 Follow-up</span></span>
+    </div>
+
+    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
+
+    <div class="lang-zh-only"><p><strong>steering</strong> — 运行中插队消息</p></div>
+    <div class="lang-en-only"><p><strong>steering</strong> — mid-run injected messages</p></div>
+
+    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
+
+    <div class="note">
+      <span class="lang-zh-only">[11.1] 在 Steering 与 Follow-up 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[11.1] At Steering and follow-up stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[11.2] 在 Steering 与 Follow-up 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[11.2] At Steering and follow-up stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[11.3] 在 Steering 与 Follow-up 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[11.3] At Steering and follow-up stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[11.4] 在 Steering 与 Follow-up 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[11.4] At Steering and follow-up stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[11.5] 在 Steering 与 Follow-up 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[11.5] At Steering and follow-up stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[11.6] 在 Steering 与 Follow-up 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[11.6] At Steering and follow-up stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[11.7] 在 Steering 与 Follow-up 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[11.7] At Steering and follow-up stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[11.8] 在 Steering 与 Follow-up 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[11.8] At Steering and follow-up stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+  </section>
+
+  <section class="chap" id="c12">
+    <div class="chap-num">CHAPTER&nbsp;12&nbsp;·&nbsp;HEART</div>
+    <h2 class="chap-title lang-zh-only">Tool 执行管线</h2>
+    <h2 class="chap-title lang-en-only">Tool execution pipeline</h2>
+    <p class="chap-en lang-zh-only">parallel vs sequential · length 截断</p>
+    <p class="chap-en lang-en-only">parallel vs sequential · length truncation</p>
+    <div class="lang-zh-only"><p>模型返回 toolUse 后，<code>executeTools</code> 按 <code>parallel</code> 或 <code>sequential</code> 策略调度。read/write/edit/bash 各有 executor；结果超长时 <code>truncateToolResult</code> 截断。</p></div>
+    <div class="lang-en-only"><p>After model returns toolUse, <code>executeTools</code> dispatches per <code>parallel</code> or <code>sequential</code> policy. read/write/edit/bash have executors; oversized results hit <code>truncateToolResult</code>.</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/tools/index.ts</span>
+        <span class="src-tag">tools</span>
+      </div>
+      <span class="src-line"><span class="src-kw">export const</span> <span class="src-arg">CODING_TOOLS</span> = [readTool, writeTool, editTool, bashTool, ...];</span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
+        <span class="src-tag">exec</span>
+      </div>
+      <span class="src-line"><span class="src-kw">async function</span> <span class="src-fn">executeToolCalls</span>(...)</span>
+      <span class="src-line">  <span class="src-comment">// validateToolArguments → execute → normalize images</span></span>
+    </div>
+
+    <table class="cmp">
+      <thead><tr><th>Tool</th><th>并行安全?</th><th>主线用例</th></tr></thead>
+      <tbody>
+      <tr><td>read</td><td>✓</td><td>README.md</td></tr>
+      <tr><td>bash</td><td>△</td><td>需确认</td></tr>
+      <tr><td>write/edit</td><td>✗ sequential</td><td>—</td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">read README 的完整路径</span><span class="lang-en-only">Full path of read README</span></h3>
+
+    <div class="ladder">
+      <div class="ladder-step">
+        <div class="ladder-num">01</div>
+        <div class="ladder-body"><span class="lang-zh-only">validateToolArguments</span><span class="lang-en-only">{ "path": "README.md" }</span></div>
+      </div>
+      <div class="ladder-step">
+        <div class="ladder-num">02</div>
+        <div class="ladder-body"><span class="lang-zh-only">resolvePath(cwd)</span><span class="lang-en-only">绝对路径</span></div>
+      </div>
+      <div class="ladder-step">
+        <div class="ladder-num">03</div>
+        <div class="ladder-body"><span class="lang-zh-only">readFileSync</span><span class="lang-en-only">UTF-8 内容</span></div>
+      </div>
+      <div class="ladder-step">
+        <div class="ladder-num">04</div>
+        <div class="ladder-body"><span class="lang-zh-only">truncate if needed</span><span class="lang-en-only">默认 max length</span></div>
+      </div>
+      <div class="ladder-step">
+        <div class="ladder-num">05</div>
+        <div class="ladder-body"><span class="lang-zh-only">toolResult AgentMessage</span><span class="lang-en-only">toolCallId=call_1</span></div>
+      </div>
+    </div>
+
+    <div class="note copper">
+      <span class="lang-zh-only">📘 <strong>pi-textbook checkpoint 06</strong>：Tool Contract（<code>tool-contract</code>）· 生产映射：<code>packages/agent/src/agent-loop.ts · packages/coding-agent/src/core/tools/</code></span>
+      <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 06</strong>: Tool Contract (<code>tool-contract</code>) · production: <code>packages/agent/src/agent-loop.ts · packages/coding-agent/src/core/tools/</code></span>
+    </div>
+
+    <div class="note copper">
+      <span class="lang-zh-only">📘 <strong>pi-textbook checkpoint 08</strong>：Coding Tools（<code>coding-tools</code>）· 生产映射：<code>packages/coding-agent/src/core/tools/index.ts</code></span>
+      <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 08</strong>: Coding Tools (<code>coding-tools</code>) · production: <code>packages/coding-agent/src/core/tools/index.ts</code></span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">本章 (12) 在主线 prompt「parallel vs sequential · length 截断」路径上负责：<strong>Tool 执行管线</strong>。回到 C02 的 22 站地图定位这一章。</span>
+      <span class="lang-en-only">Chapter (12) on the through-line path handles: <strong>Tool execution pipeline</strong>. Return to C02's 22-station map to locate this chapter.</span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent · chapter 12</span>
+        <span class="src-tag">trace</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// Through-line: parallel vs sequential · length 截断</span></span>
+      <span class="src-line"><span class="src-comment">// Phase: 心脏 / Heart</span></span>
+      <span class="src-line"><span class="src-kw">await</span> <span class="src-fn">traceTurn</span>({ <span class="src-arg">prompt</span>: <span class="src-str">"README.md"</span> });</span>
+    </div>
+
+    <table class="cmp">
+      <thead><tr><th>路径</th><th>说明</th></tr></thead>
+      <tbody>
+      <tr><td><code>packages/agent/src/agent-loop.ts</code></td><td>runLoop 双环</td></tr>
+      <tr><td><code>packages/agent/src/types.ts</code></td><td>AgentMessage / AgentEvent</td></tr>
+      <tr><td><code>packages/coding-agent/src/core/tools/</code></td><td>coding tools</td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">Tool 执行管线 · 实现清单</span><span class="lang-en-only">Tool execution pipeline · implementation checklist</span></h3>
+
+    <div class="note">
+      <span class="lang-zh-only">1. 定位生产文件：packages/agent/src/agent-loop.ts</span>
+      <span class="lang-en-only">1. Locate production file: packages/agent/src/agent-loop.ts</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">2. 对照 pi-textbook 同主题 checkpoint</span>
+      <span class="lang-en-only">2. Cross-read matching pi-textbook checkpoint</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">3. 用 --verbose 观察 AgentEvent</span>
+      <span class="lang-en-only">3. Observe AgentEvents with --verbose</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">4. 检查 JSONL 会话文件对应 entry</span>
+      <span class="lang-en-only">4. Inspect matching JSONL session entry</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">5. 阅读 packages/*/test/ 下相关测试</span>
+      <span class="lang-en-only">5. Read related tests under packages/*/test/</span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">AgentEvent 完整目录</span><span class="lang-en-only">Full AgentEvent catalog</span></h3>    <table class="cmp">
+      <thead><tr><th>事件</th><th>中文</th><th>主线关联</th></tr></thead>
+      <tbody>
+      <tr><td><code>agent_start</code></td><td>循环开始</td><td>AgentSession 订阅</td></tr>
+      <tr><td><code>agent_end</code></td><td>循环结束</td><td>返回 messages[]</td></tr>
+      <tr><td><code>turn_start</code></td><td>新 turn</td><td>可能含 steering</td></tr>
+      <tr><td><code>turn_end</code></td><td>turn 结束</td><td>附带 toolResults</td></tr>
+      <tr><td><code>message_start</code></td><td>消息开始</td><td>user/assistant/tool</td></tr>
+      <tr><td><code>message_update</code></td><td>流式更新</td><td>text_delta/toolcall_delta</td></tr>
+      <tr><td><code>message_end</code></td><td>消息结束</td><td>触发 JSONL 写入</td></tr>
+      <tr><td><code>tool_execution_start</code></td><td>工具开始</td><td>read/write/bash</td></tr>
+      <tr><td><code>tool_execution_update</code></td><td>工具进度</td><td>bash 流式输出</td></tr>
+      <tr><td><code>tool_execution_end</code></td><td>工具结束</td><td>结果截断</td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">Coding Tools 目录</span><span class="lang-en-only">Coding tools catalog</span></h3>    <table class="cmp">
+      <thead><tr><th>Tool</th><th>名称</th><th>实现要点</th></tr></thead>
+      <tbody>
+      <tr><td>read</td><td>读取文件</td><td>UTF-8 · 二进制检测 · 路径解析</td></tr>
+      <tr><td>write</td><td>写入文件</td><td>创建/覆盖 · 权限检查</td></tr>
+      <tr><td>edit</td><td>编辑文件</td><td>search/replace 块</td></tr>
+      <tr><td>bash</td><td>执行 shell</td><td>cwd 继承 · 超时 · 输出截断</td></tr>
+      <tr><td>glob</td><td>文件匹配</td><td>ripgrep 风格</td></tr>
+      <tr><td>grep</td><td>内容搜索</td><td>正则 · 上下文行</td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">附录 · Tool 执行管线 深度 trace</span><span class="lang-en-only">Appendix · deep trace for Tool execution pipeline</span></h3>
+
+    <div class="lang-zh-only"><p>本章 (12) 属于 Phase「心脏」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
+    <div class="lang-en-only"><p>Chapter (12) belongs to Phase «Heart». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
+
+    <table class="cmp">
+      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
+      <tbody>
+      <tr><td>1</td><td>toolUse</td><td>read call_1</td></tr>
+      <tr><td>2</td><td>executeTool</td><td>README 内容</td></tr>
+      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
+      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
+      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
+      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
+      </tbody>
+    </table>
+
+    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// default trace</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 12 · Tool 执行管线</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 12 · Tool 执行管线</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 12 · Tool 执行管线</span></span>
+    </div>
+
+    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
+
+    <div class="lang-zh-only"><p><strong>AgentMessage</strong> — agent-core 内部消息 IR</p></div>
+    <div class="lang-en-only"><p><strong>AgentMessage</strong> — agent-core internal message IR</p></div>
+
+    <div class="lang-zh-only"><p><strong>StreamFn</strong> — 可注入的模型流函数</p></div>
+    <div class="lang-en-only"><p><strong>StreamFn</strong> — injectable model stream function</p></div>
+
+    <div class="lang-zh-only"><p><strong>leafId</strong> — JSONL 会话树当前叶</p></div>
+    <div class="lang-en-only"><p><strong>leafId</strong> — JSONL session tree current leaf</p></div>
+
+    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
+
+    <div class="note">
+      <span class="lang-zh-only">[12.1] 在 Tool 执行管线 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[12.1] At Tool execution pipeline stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[12.2] 在 Tool 执行管线 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[12.2] At Tool execution pipeline stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[12.3] 在 Tool 执行管线 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[12.3] At Tool execution pipeline stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[12.4] 在 Tool 执行管线 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[12.4] At Tool execution pipeline stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[12.5] 在 Tool 执行管线 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[12.5] At Tool execution pipeline stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[12.6] 在 Tool 执行管线 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[12.6] At Tool execution pipeline stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[12.7] 在 Tool 执行管线 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[12.7] At Tool execution pipeline stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[12.8] 在 Tool 执行管线 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[12.8] At Tool execution pipeline stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+  </section>
+
+  <section class="chap" id="c13">
+    <div class="chap-num">CHAPTER&nbsp;13&nbsp;·&nbsp;HEART</div>
+    <h2 class="chap-title lang-zh-only">事件总线</h2>
+    <h2 class="chap-title lang-en-only">The event bus</h2>
+    <p class="chap-en lang-zh-only">message_update 如何驱动 TUI</p>
+    <p class="chap-en lang-en-only">how message_update drives the TUI</p>
+    <div class="lang-zh-only"><p>agent-core 通过 <code>AgentEvent</code> tagged union 广播状态变化。<code>message_update</code> 携带 <code>text_delta</code> 或 <code>toolcall_delta</code>——TUI 差分渲染的唯一输入。</p></div>
+    <div class="lang-en-only"><p>agent-core broadcasts state via <code>AgentEvent</code> tagged union. <code>message_update</code> carries <code>text_delta</code> or <code>toolcall_delta</code> — sole input for TUI differential render.</p></div>
+
+    <table class="cmp">
+      <thead><tr><th>事件</th><th>订阅者</th><th>副作用</th></tr></thead>
+      <tbody>
+      <tr><td>agent_start</td><td>AgentSession 订阅者</td><td>TUI / JSONL / Extension</td></tr>
+      <tr><td>turn_start</td><td>AgentSession 订阅者</td><td>TUI / JSONL / Extension</td></tr>
+      <tr><td>message_start</td><td>AgentSession 订阅者</td><td>TUI / JSONL / Extension</td></tr>
+      <tr><td>message_update</td><td>AgentSession 订阅者</td><td>TUI / JSONL / Extension</td></tr>
+      <tr><td>message_end</td><td>AgentSession 订阅者</td><td>TUI / JSONL / Extension</td></tr>
+      <tr><td>tool_execution_start</td><td>AgentSession 订阅者</td><td>TUI / JSONL / Extension</td></tr>
+      <tr><td>tool_execution_update</td><td>AgentSession 订阅者</td><td>TUI / JSONL / Extension</td></tr>
+      <tr><td>tool_execution_end</td><td>AgentSession 订阅者</td><td>TUI / JSONL / Extension</td></tr>
+      <tr><td>turn_end</td><td>AgentSession 订阅者</td><td>TUI / JSONL / Extension</td></tr>
+      <tr><td>agent_end</td><td>AgentSession 订阅者</td><td>TUI / JSONL / Extension</td></tr>
+      </tbody>
+    </table>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/types.ts</span>
+        <span class="src-tag">events</span>
+      </div>
+      <span class="src-line"><span class="src-kw">export type</span> <span class="src-cls">AgentEvent</span> =</span>
+      <span class="src-line">  | { <span class="src-arg">type</span>: <span class="src-str">"message_update"</span>; <span class="src-arg">message</span>: ...; <span class="src-arg">delta</span>: ... }</span>
+      <span class="src-line">  | { <span class="src-arg">type</span>: <span class="src-str">"tool_execution_start"</span>; ... };</span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">主线一轮的事件顺序</span><span class="lang-en-only">Event order for one through-line turn</span></h3>
+
+    <div class="lang-zh-only"><p>简化版：agent_start → turn_start → message_start(user) → message_end(user) → message_update×N → message_end(assistant) → tool_execution_* → message_update×M → message_end(assistant) → turn_end → agent_end。</p></div>
+    <div class="lang-en-only"><p>Simplified: agent_start → turn_start → message_start(user) → … → agent_end.</p></div>
+
+    <div class="note copper">
+      <span class="lang-zh-only">📘 <strong>pi-textbook checkpoint 01</strong>：TypeScript 生存集（<code>events.ts</code>）· 生产映射：<code></code></span>
+      <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 01</strong>: TypeScript 生存集 (<code>events.ts</code>) · production: <code></code></span>
+    </div>
+
+    <div class="note copper">
+      <span class="lang-zh-only">📘 <strong>pi-textbook checkpoint 02</strong>：EventStream（<code>event-stream.ts</code>）· 生产映射：<code>packages/ai/src/utils/event-stream.ts</code></span>
+      <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 02</strong>: EventStream (<code>event-stream.ts</code>) · production: <code>packages/ai/src/utils/event-stream.ts</code></span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">本章 (13) 在主线 prompt「message_update 如何驱动 TUI」路径上负责：<strong>事件总线</strong>。回到 C02 的 22 站地图定位这一章。</span>
+      <span class="lang-en-only">Chapter (13) on the through-line path handles: <strong>The event bus</strong>. Return to C02's 22-station map to locate this chapter.</span>
+    </div>
+
+    <table class="cmp">
+      <thead><tr><th>路径</th><th>说明</th></tr></thead>
+      <tbody>
+      <tr><td><code>packages/agent/src/agent-loop.ts</code></td><td>runLoop 双环</td></tr>
+      <tr><td><code>packages/agent/src/types.ts</code></td><td>AgentMessage / AgentEvent</td></tr>
+      <tr><td><code>packages/coding-agent/src/core/tools/</code></td><td>coding tools</td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">事件总线 · 实现清单</span><span class="lang-en-only">The event bus · implementation checklist</span></h3>
+
+    <div class="note">
+      <span class="lang-zh-only">1. 定位生产文件：packages/agent/src/agent-loop.ts</span>
+      <span class="lang-en-only">1. Locate production file: packages/agent/src/agent-loop.ts</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">2. 对照 pi-textbook 同主题 checkpoint</span>
+      <span class="lang-en-only">2. Cross-read matching pi-textbook checkpoint</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">3. 用 --verbose 观察 AgentEvent</span>
+      <span class="lang-en-only">3. Observe AgentEvents with --verbose</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">4. 检查 JSONL 会话文件对应 entry</span>
+      <span class="lang-en-only">4. Inspect matching JSONL session entry</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">5. 阅读 packages/*/test/ 下相关测试</span>
+      <span class="lang-en-only">5. Read related tests under packages/*/test/</span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">AgentEvent 完整目录</span><span class="lang-en-only">Full AgentEvent catalog</span></h3>    <table class="cmp">
+      <thead><tr><th>事件</th><th>中文</th><th>主线关联</th></tr></thead>
+      <tbody>
+      <tr><td><code>agent_start</code></td><td>循环开始</td><td>AgentSession 订阅</td></tr>
+      <tr><td><code>agent_end</code></td><td>循环结束</td><td>返回 messages[]</td></tr>
+      <tr><td><code>turn_start</code></td><td>新 turn</td><td>可能含 steering</td></tr>
+      <tr><td><code>turn_end</code></td><td>turn 结束</td><td>附带 toolResults</td></tr>
+      <tr><td><code>message_start</code></td><td>消息开始</td><td>user/assistant/tool</td></tr>
+      <tr><td><code>message_update</code></td><td>流式更新</td><td>text_delta/toolcall_delta</td></tr>
+      <tr><td><code>message_end</code></td><td>消息结束</td><td>触发 JSONL 写入</td></tr>
+      <tr><td><code>tool_execution_start</code></td><td>工具开始</td><td>read/write/bash</td></tr>
+      <tr><td><code>tool_execution_update</code></td><td>工具进度</td><td>bash 流式输出</td></tr>
+      <tr><td><code>tool_execution_end</code></td><td>工具结束</td><td>结果截断</td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">附录 · 事件总线 深度 trace</span><span class="lang-en-only">Appendix · deep trace for The event bus</span></h3>
+
+    <div class="lang-zh-only"><p>本章 (13) 属于 Phase「心脏」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
+    <div class="lang-en-only"><p>Chapter (13) belongs to Phase «Heart». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
+
+    <table class="cmp">
+      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
+      <tbody>
+      <tr><td>1</td><td>事件总线</td><td>message_update 如何驱动 TUI</td></tr>
+      <tr><td>2</td><td>—</td><td>checkpoint 2</td></tr>
+      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
+      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
+      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
+      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
+      </tbody>
+    </table>
+
+    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// default trace</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 13 · 事件总线</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 13 · 事件总线</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 13 · 事件总线</span></span>
+    </div>
+
+    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
+
+    <div class="lang-zh-only"><p><strong>AgentMessage</strong> — agent-core 内部消息 IR</p></div>
+    <div class="lang-en-only"><p><strong>AgentMessage</strong> — agent-core internal message IR</p></div>
+
+    <div class="lang-zh-only"><p><strong>StreamFn</strong> — 可注入的模型流函数</p></div>
+    <div class="lang-en-only"><p><strong>StreamFn</strong> — injectable model stream function</p></div>
+
+    <div class="lang-zh-only"><p><strong>leafId</strong> — JSONL 会话树当前叶</p></div>
+    <div class="lang-en-only"><p><strong>leafId</strong> — JSONL session tree current leaf</p></div>
+
+    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
+
+    <div class="note">
+      <span class="lang-zh-only">[13.1] 在 事件总线 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[13.1] At The event bus stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[13.2] 在 事件总线 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[13.2] At The event bus stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[13.3] 在 事件总线 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[13.3] At The event bus stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[13.4] 在 事件总线 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[13.4] At The event bus stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[13.5] 在 事件总线 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[13.5] At The event bus stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[13.6] 在 事件总线 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[13.6] At The event bus stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[13.7] 在 事件总线 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[13.7] At The event bus stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[13.8] 在 事件总线 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[13.8] At The event bus stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+  </section>
+
+  <section class="chap" id="c14">
+    <div class="chap-num">CHAPTER&nbsp;14&nbsp;·&nbsp;LLM</div>
+    <h2 class="chap-title lang-zh-only">pi-ai 提供商抽象</h2>
+    <h2 class="chap-title lang-en-only">pi-ai provider abstraction</h2>
+    <p class="chap-en lang-zh-only">Models · createProvider · streamSimple</p>
+    <p class="chap-en lang-en-only">Models · createProvider · streamSimple</p>
+    <div class="lang-zh-only"><p><code>pi-ai</code> 抽象 40+ provider：<code>Models</code> 目录 · <code>createProvider</code> 工厂 · <code>streamSimple</code> 统一流式入口。agent-loop 只依赖 <code>StreamFn</code> 签名。</p></div>
+    <div class="lang-en-only"><p><code>pi-ai</code> abstracts 40+ providers: <code>Models</code> catalog · <code>createProvider</code> factory · <code>streamSimple</code> unified streaming entry. agent-loop depends only on <code>StreamFn</code> signature.</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/ai/src/stream.ts</span>
+        <span class="src-tag">stream</span>
+      </div>
+      <span class="src-line"><span class="src-kw">export async function</span> <span class="src-fn">streamSimple</span>(<span class="src-arg">model</span>, <span class="src-arg">context</span>, <span class="src-arg">options</span>)</span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/ai/src/models.ts</span>
+        <span class="src-tag">models</span>
+      </div>
+      <span class="src-line"><span class="src-kw">export const</span> <span class="src-arg">Models</span> = { ... }; <span class="src-comment">// models.generated.ts</span></span>
+    </div>
+
+    <table class="cmp">
+      <thead><tr><th>Provider 族</th><th>认证</th><th>流式协议</th></tr></thead>
+      <tbody>
+      <tr><td>OpenAI-compatible</td><td>API key</td><td>SSE</td></tr>
+      <tr><td>Anthropic</td><td>API key</td><td>SSE events</td></tr>
+      <tr><td>OAuth (Kimi etc.)</td><td>OAuth token</td><td>provider-specific</td></tr>
+      </tbody>
+    </table>
+
+    <div class="note copper">
+      <span class="lang-zh-only">📘 <strong>pi-textbook checkpoint 05</strong>：Provider Adapter（<code>provider-adapter.ts</code>）· 生产映射：<code>packages/ai/src/api/*.ts · packages/ai/src/models.ts</code></span>
+      <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 05</strong>: Provider Adapter (<code>provider-adapter.ts</code>) · production: <code>packages/ai/src/api/*.ts · packages/ai/src/models.ts</code></span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">本章 (14) 在主线 prompt「Models · createProvider · streamSimple」路径上负责：<strong>pi-ai 提供商抽象</strong>。回到 C02 的 22 站地图定位这一章。</span>
+      <span class="lang-en-only">Chapter (14) on the through-line path handles: <strong>pi-ai provider abstraction</strong>. Return to C02's 22-station map to locate this chapter.</span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent · chapter 14</span>
+        <span class="src-tag">trace</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// Through-line: Models · createProvider · streamSimple</span></span>
+      <span class="src-line"><span class="src-comment">// Phase: LLM / LLM</span></span>
+      <span class="src-line"><span class="src-kw">await</span> <span class="src-fn">traceTurn</span>({ <span class="src-arg">prompt</span>: <span class="src-str">"README.md"</span> });</span>
+    </div>
+
+    <table class="cmp">
+      <thead><tr><th>路径</th><th>说明</th></tr></thead>
+      <tbody>
+      <tr><td><code>packages/ai/src/stream.ts</code></td><td>streamSimple</td></tr>
+      <tr><td><code>packages/ai/src/utils/event-stream.ts</code></td><td>EventStream</td></tr>
+      <tr><td><code>packages/ai/src/models.ts</code></td><td>模型目录</td></tr>
+      <tr><td><code>packages/ai/src/api/</code></td><td>provider adapters</td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">pi-ai 提供商抽象 · 实现清单</span><span class="lang-en-only">pi-ai provider abstraction · implementation checklist</span></h3>
+
+    <div class="note">
+      <span class="lang-zh-only">1. 定位生产文件：packages/agent/src/agent-loop.ts</span>
+      <span class="lang-en-only">1. Locate production file: packages/agent/src/agent-loop.ts</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">2. 对照 pi-textbook 同主题 checkpoint</span>
+      <span class="lang-en-only">2. Cross-read matching pi-textbook checkpoint</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">3. 用 --verbose 观察 AgentEvent</span>
+      <span class="lang-en-only">3. Observe AgentEvents with --verbose</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">4. 检查 JSONL 会话文件对应 entry</span>
+      <span class="lang-en-only">4. Inspect matching JSONL session entry</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">5. 阅读 packages/*/test/ 下相关测试</span>
+      <span class="lang-en-only">5. Read related tests under packages/*/test/</span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">pi-ai 流事件目录</span><span class="lang-en-only">pi-ai stream event catalog</span></h3>    <table class="cmp">
+      <thead><tr><th>事件</th><th>名称</th><th>说明</th></tr></thead>
+      <tbody>
+      <tr><td>start</td><td>流开始</td><td>model id · usage 初始化</td></tr>
+      <tr><td>text_delta</td><td>文本增量</td><td>TUI 逐字显示</td></tr>
+      <tr><td>toolcall_delta</td><td>工具调用增量</td><td>JSON 参数组装</td></tr>
+      <tr><td>thinking_delta</td><td>思考增量</td><td>reasoning 模型</td></tr>
+      <tr><td>done</td><td>流结束</td><td>stopReason 确定</td></tr>
+      <tr><td>error</td><td>流错误</td><td>重试判定</td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">附录 · pi-ai 提供商抽象 深度 trace</span><span class="lang-en-only">Appendix · deep trace for pi-ai provider abstraction</span></h3>
+
+    <div class="lang-zh-only"><p>本章 (14) 属于 Phase「LLM」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
+    <div class="lang-en-only"><p>Chapter (14) belongs to Phase «LLM». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
+
+    <table class="cmp">
+      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
+      <tbody>
+      <tr><td>1</td><td>streamSimple</td><td>SSE 连接</td></tr>
+      <tr><td>2</td><td>EventStream</td><td>delta 推送</td></tr>
+      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
+      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
+      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
+      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
+      </tbody>
+    </table>
+
+    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/ai/src/stream.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// streamSimple</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 14 · pi-ai 提供商抽象</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 14 · pi-ai 提供商抽象</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 14 · pi-ai 提供商抽象</span></span>
+    </div>
+
+    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
+
+    <div class="lang-zh-only"><p><strong>AgentMessage</strong> — agent-core 内部消息 IR</p></div>
+    <div class="lang-en-only"><p><strong>AgentMessage</strong> — agent-core internal message IR</p></div>
+
+    <div class="lang-zh-only"><p><strong>StreamFn</strong> — 可注入的模型流函数</p></div>
+    <div class="lang-en-only"><p><strong>StreamFn</strong> — injectable model stream function</p></div>
+
+    <div class="lang-zh-only"><p><strong>leafId</strong> — JSONL 会话树当前叶</p></div>
+    <div class="lang-en-only"><p><strong>leafId</strong> — JSONL session tree current leaf</p></div>
+
+    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
+
+    <div class="note">
+      <span class="lang-zh-only">[14.1] 在 pi-ai 提供商抽象 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[14.1] At pi-ai provider abstraction stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[14.2] 在 pi-ai 提供商抽象 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[14.2] At pi-ai provider abstraction stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[14.3] 在 pi-ai 提供商抽象 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[14.3] At pi-ai provider abstraction stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[14.4] 在 pi-ai 提供商抽象 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[14.4] At pi-ai provider abstraction stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[14.5] 在 pi-ai 提供商抽象 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[14.5] At pi-ai provider abstraction stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[14.6] 在 pi-ai 提供商抽象 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[14.6] At pi-ai provider abstraction stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[14.7] 在 pi-ai 提供商抽象 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[14.7] At pi-ai provider abstraction stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[14.8] 在 pi-ai 提供商抽象 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[14.8] At pi-ai provider abstraction stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+  </section>
+
+  <section class="chap" id="c15">
+    <div class="chap-num">CHAPTER&nbsp;15&nbsp;·&nbsp;LLM</div>
+    <h2 class="chap-title lang-zh-only">流式 EventStream</h2>
+    <h2 class="chap-title lang-en-only">Streaming EventStream</h2>
+    <p class="chap-en lang-zh-only">text_delta · toolcall_delta · done</p>
+    <p class="chap-en lang-en-only">text_delta · toolcall_delta · done</p>
+    <div class="lang-zh-only"><p><code>EventStream&lt;T&gt;</code> 同时交付<strong>过程项</strong>（delta）和<strong>终态</strong>（done）。TUI 订阅过程项；agent-loop 等待终态 AssistantMessage。</p></div>
+    <div class="lang-en-only"><p><code>EventStream&lt;T&gt;</code> delivers both <strong>progress items</strong> (deltas) and <strong>terminal state</strong> (done). TUI subscribes to progress; agent-loop awaits terminal AssistantMessage.</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/ai/src/utils/event-stream.ts</span>
+        <span class="src-tag">es</span>
+      </div>
+      <span class="src-line"><span class="src-kw">export class</span> <span class="src-cls">EventStream</span>&lt;TEvent, TResult&gt; {</span>
+      <span class="src-line">  <span class="src-fn">push</span>(event: TEvent): <span class="src-cls">void</span>;</span>
+      <span class="src-line">  <span class="src-fn">end</span>(result: TResult): <span class="src-cls">void</span>;</span>
+      <span class="src-line">}</span>
+    </div>
+
+    <table class="cmp">
+      <thead><tr><th>事件</th><th>消费者</th><th>主线时刻</th></tr></thead>
+      <tbody>
+      <tr><td>text_delta</td><td>TUI Markdown</td><td>最终回答流式显示</td></tr>
+      <tr><td>toolcall_delta</td><td>TUI tool 卡片</td><td>read 参数组装</td></tr>
+      <tr><td>done</td><td>agent-loop</td><td>stopReason 判定</td></tr>
+      </tbody>
+    </table>
+
+    <div class="note copper">
+      <span class="lang-zh-only">📘 <strong>pi-textbook checkpoint 02</strong>：EventStream（<code>event-stream.ts</code>）· 生产映射：<code>packages/ai/src/utils/event-stream.ts</code></span>
+      <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 02</strong>: EventStream (<code>event-stream.ts</code>) · production: <code>packages/ai/src/utils/event-stream.ts</code></span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">本章 (15) 在主线 prompt「text_delta · toolcall_delta · done」路径上负责：<strong>流式 EventStream</strong>。回到 C02 的 22 站地图定位这一章。</span>
+      <span class="lang-en-only">Chapter (15) on the through-line path handles: <strong>Streaming EventStream</strong>. Return to C02's 22-station map to locate this chapter.</span>
+    </div>
+
+    <table class="cmp">
+      <thead><tr><th>路径</th><th>说明</th></tr></thead>
+      <tbody>
+      <tr><td><code>packages/ai/src/stream.ts</code></td><td>streamSimple</td></tr>
+      <tr><td><code>packages/ai/src/utils/event-stream.ts</code></td><td>EventStream</td></tr>
+      <tr><td><code>packages/ai/src/models.ts</code></td><td>模型目录</td></tr>
+      <tr><td><code>packages/ai/src/api/</code></td><td>provider adapters</td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">流式 EventStream · 实现清单</span><span class="lang-en-only">Streaming EventStream · implementation checklist</span></h3>
+
+    <div class="note">
+      <span class="lang-zh-only">1. 定位生产文件：packages/agent/src/agent-loop.ts</span>
+      <span class="lang-en-only">1. Locate production file: packages/agent/src/agent-loop.ts</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">2. 对照 pi-textbook 同主题 checkpoint</span>
+      <span class="lang-en-only">2. Cross-read matching pi-textbook checkpoint</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">3. 用 --verbose 观察 AgentEvent</span>
+      <span class="lang-en-only">3. Observe AgentEvents with --verbose</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">4. 检查 JSONL 会话文件对应 entry</span>
+      <span class="lang-en-only">4. Inspect matching JSONL session entry</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">5. 阅读 packages/*/test/ 下相关测试</span>
+      <span class="lang-en-only">5. Read related tests under packages/*/test/</span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">pi-ai 流事件目录</span><span class="lang-en-only">pi-ai stream event catalog</span></h3>    <table class="cmp">
+      <thead><tr><th>事件</th><th>名称</th><th>说明</th></tr></thead>
+      <tbody>
+      <tr><td>start</td><td>流开始</td><td>model id · usage 初始化</td></tr>
+      <tr><td>text_delta</td><td>文本增量</td><td>TUI 逐字显示</td></tr>
+      <tr><td>toolcall_delta</td><td>工具调用增量</td><td>JSON 参数组装</td></tr>
+      <tr><td>thinking_delta</td><td>思考增量</td><td>reasoning 模型</td></tr>
+      <tr><td>done</td><td>流结束</td><td>stopReason 确定</td></tr>
+      <tr><td>error</td><td>流错误</td><td>重试判定</td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">附录 · 流式 EventStream 深度 trace</span><span class="lang-en-only">Appendix · deep trace for Streaming EventStream</span></h3>
+
+    <div class="lang-zh-only"><p>本章 (15) 属于 Phase「LLM」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
+    <div class="lang-en-only"><p>Chapter (15) belongs to Phase «LLM». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
+
+    <table class="cmp">
+      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
+      <tbody>
+      <tr><td>1</td><td>流式 EventStream</td><td>text_delta · toolcall_delta · done</td></tr>
+      <tr><td>2</td><td>—</td><td>checkpoint 2</td></tr>
+      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
+      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
+      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
+      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
+      </tbody>
+    </table>
+
+    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// default trace</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 15 · 流式 EventStream</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 15 · 流式 EventStream</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 15 · 流式 EventStream</span></span>
+    </div>
+
+    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
+
+    <div class="lang-zh-only"><p><strong>AgentMessage</strong> — agent-core 内部消息 IR</p></div>
+    <div class="lang-en-only"><p><strong>AgentMessage</strong> — agent-core internal message IR</p></div>
+
+    <div class="lang-zh-only"><p><strong>StreamFn</strong> — 可注入的模型流函数</p></div>
+    <div class="lang-en-only"><p><strong>StreamFn</strong> — injectable model stream function</p></div>
+
+    <div class="lang-zh-only"><p><strong>leafId</strong> — JSONL 会话树当前叶</p></div>
+    <div class="lang-en-only"><p><strong>leafId</strong> — JSONL session tree current leaf</p></div>
+
+    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
+
+    <div class="note">
+      <span class="lang-zh-only">[15.1] 在 流式 EventStream 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[15.1] At Streaming EventStream stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[15.2] 在 流式 EventStream 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[15.2] At Streaming EventStream stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[15.3] 在 流式 EventStream 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[15.3] At Streaming EventStream stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[15.4] 在 流式 EventStream 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[15.4] At Streaming EventStream stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[15.5] 在 流式 EventStream 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[15.5] At Streaming EventStream stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[15.6] 在 流式 EventStream 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[15.6] At Streaming EventStream stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[15.7] 在 流式 EventStream 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[15.7] At Streaming EventStream stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[15.8] 在 流式 EventStream 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[15.8] At Streaming EventStream stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+  </section>
+
+  <section class="chap" id="c16">
+    <div class="chap-num">CHAPTER&nbsp;16&nbsp;·&nbsp;LLM</div>
+    <h2 class="chap-title lang-zh-only">认证与模型目录</h2>
+    <h2 class="chap-title lang-en-only">Auth and model catalog</h2>
+    <p class="chap-en lang-zh-only">40+ providers · OAuth · models.generated.ts</p>
+    <p class="chap-en lang-en-only">40+ providers · OAuth · models.generated.ts</p>
+    <div class="lang-zh-only"><p><code>models.generated.ts</code> 由脚本从模型目录生成；OAuth 流程把 token 存 agent dir。无 key 时 <code>formatNoApiKeyFoundMessage</code> 给可操作的引导。</p></div>
+    <div class="lang-en-only"><p><code>models.generated.ts</code> is script-generated from model catalog; OAuth stores tokens in agent dir. Without keys, <code>formatNoApiKeyFoundMessage</code> gives actionable guidance.</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/auth-guidance.ts</span>
+        <span class="src-tag">auth</span>
+      </div>
+      <span class="src-line"><span class="src-kw">export function</span> <span class="src-fn">formatNoApiKeyFoundMessage</span>(...)</span>
+    </div>
+
+    <div class="stage-purpose">
+      <div class="sp-row">
+        <div class="sp-key"><span class="lang-zh-only">ModelRegistry</span><span class="lang-en-only">ModelRegistry</span></div>
+        <div class="sp-val"><span class="lang-zh-only">解析 model id → Model 对象</span><span class="lang-en-only">resolve model id → Model object</span></div>
+      </div>
+      <div class="sp-row">
+        <div class="sp-key"><span class="lang-zh-only">thinking level</span><span class="lang-en-only">thinking level</span></div>
+        <div class="sp-val"><span class="lang-zh-only">clamped per model capability</span><span class="lang-en-only">clamped per model capability</span></div>
+      </div>
+      <div class="sp-row">
+        <div class="sp-key"><span class="lang-zh-only">retry</span><span class="lang-en-only">retry</span></div>
+        <div class="sp-val"><span class="lang-zh-only">isRetryableAssistantError + backoff</span><span class="lang-en-only">isRetryableAssistantError + backoff</span></div>
+      </div>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">本章 (16) 在主线 prompt「40+ providers · OAuth · models.generated.ts」路径上负责：<strong>认证与模型目录</strong>。回到 C02 的 22 站地图定位这一章。</span>
+      <span class="lang-en-only">Chapter (16) on the through-line path handles: <strong>Auth and model catalog</strong>. Return to C02's 22-station map to locate this chapter.</span>
+    </div>
+
+    <table class="cmp">
+      <thead><tr><th>路径</th><th>说明</th></tr></thead>
+      <tbody>
+      <tr><td><code>packages/ai/src/stream.ts</code></td><td>streamSimple</td></tr>
+      <tr><td><code>packages/ai/src/utils/event-stream.ts</code></td><td>EventStream</td></tr>
+      <tr><td><code>packages/ai/src/models.ts</code></td><td>模型目录</td></tr>
+      <tr><td><code>packages/ai/src/api/</code></td><td>provider adapters</td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">认证与模型目录 · 实现清单</span><span class="lang-en-only">Auth and model catalog · implementation checklist</span></h3>
+
+    <div class="note">
+      <span class="lang-zh-only">1. 定位生产文件：packages/agent/src/agent-loop.ts</span>
+      <span class="lang-en-only">1. Locate production file: packages/agent/src/agent-loop.ts</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">2. 对照 pi-textbook 同主题 checkpoint</span>
+      <span class="lang-en-only">2. Cross-read matching pi-textbook checkpoint</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">3. 用 --verbose 观察 AgentEvent</span>
+      <span class="lang-en-only">3. Observe AgentEvents with --verbose</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">4. 检查 JSONL 会话文件对应 entry</span>
+      <span class="lang-en-only">4. Inspect matching JSONL session entry</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">5. 阅读 packages/*/test/ 下相关测试</span>
+      <span class="lang-en-only">5. Read related tests under packages/*/test/</span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">pi-ai 流事件目录</span><span class="lang-en-only">pi-ai stream event catalog</span></h3>    <table class="cmp">
+      <thead><tr><th>事件</th><th>名称</th><th>说明</th></tr></thead>
+      <tbody>
+      <tr><td>start</td><td>流开始</td><td>model id · usage 初始化</td></tr>
+      <tr><td>text_delta</td><td>文本增量</td><td>TUI 逐字显示</td></tr>
+      <tr><td>toolcall_delta</td><td>工具调用增量</td><td>JSON 参数组装</td></tr>
+      <tr><td>thinking_delta</td><td>思考增量</td><td>reasoning 模型</td></tr>
+      <tr><td>done</td><td>流结束</td><td>stopReason 确定</td></tr>
+      <tr><td>error</td><td>流错误</td><td>重试判定</td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">附录 · 认证与模型目录 深度 trace</span><span class="lang-en-only">Appendix · deep trace for Auth and model catalog</span></h3>
+
+    <div class="lang-zh-only"><p>本章 (16) 属于 Phase「LLM」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
+    <div class="lang-en-only"><p>Chapter (16) belongs to Phase «LLM». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
+
+    <table class="cmp">
+      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
+      <tbody>
+      <tr><td>1</td><td>认证与模型目录</td><td>40+ providers · OAuth · models.generated.ts</td></tr>
+      <tr><td>2</td><td>—</td><td>checkpoint 2</td></tr>
+      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
+      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
+      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
+      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
+      </tbody>
+    </table>
+
+    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// default trace</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 16 · 认证与模型目录</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 16 · 认证与模型目录</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 16 · 认证与模型目录</span></span>
+    </div>
+
+    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
+
+    <div class="lang-zh-only"><p><strong>AgentMessage</strong> — agent-core 内部消息 IR</p></div>
+    <div class="lang-en-only"><p><strong>AgentMessage</strong> — agent-core internal message IR</p></div>
+
+    <div class="lang-zh-only"><p><strong>StreamFn</strong> — 可注入的模型流函数</p></div>
+    <div class="lang-en-only"><p><strong>StreamFn</strong> — injectable model stream function</p></div>
+
+    <div class="lang-zh-only"><p><strong>leafId</strong> — JSONL 会话树当前叶</p></div>
+    <div class="lang-en-only"><p><strong>leafId</strong> — JSONL session tree current leaf</p></div>
+
+    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
+
+    <div class="note">
+      <span class="lang-zh-only">[16.1] 在 认证与模型目录 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[16.1] At Auth and model catalog stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[16.2] 在 认证与模型目录 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[16.2] At Auth and model catalog stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[16.3] 在 认证与模型目录 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[16.3] At Auth and model catalog stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[16.4] 在 认证与模型目录 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[16.4] At Auth and model catalog stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[16.5] 在 认证与模型目录 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[16.5] At Auth and model catalog stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[16.6] 在 认证与模型目录 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[16.6] At Auth and model catalog stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[16.7] 在 认证与模型目录 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[16.7] At Auth and model catalog stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[16.8] 在 认证与模型目录 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[16.8] At Auth and model catalog stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+  </section>
+
+  <section class="chap" id="c17">
+    <div class="chap-num">CHAPTER&nbsp;17&nbsp;·&nbsp;TERMINAL</div>
+    <h2 class="chap-title lang-zh-only">差分渲染 TUI</h2>
+    <h2 class="chap-title lang-en-only">Differential-render TUI</h2>
+    <p class="chap-en lang-zh-only">CSI 2026 · firstChanged → lastChanged</p>
+    <p class="chap-en lang-en-only">CSI 2026 · firstChanged → lastChanged</p>
+    <div class="lang-zh-only"><p>Pi TUI 用 <strong>CSI 2026</strong> 差分更新：<code>firstChanged</code> 到 <code>lastChanged</code> 行重绘，而非全屏刷新。流式 token 因此不闪烁。</p></div>
+    <div class="lang-en-only"><p>Pi TUI uses <strong>CSI 2026</strong> differential updates: redraw <code>firstChanged</code> to <code>lastChanged</code> lines, not full screen. Streaming tokens don't flicker.</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/tui/src/tui.ts</span>
+        <span class="src-tag">tui</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// SGR 2026 — synchronized output / damage tracking</span></span>
+      <span class="src-line"><span class="src-fn">render</span>(<span class="src-arg">firstChanged</span>, <span class="src-arg">lastChanged</span>): <span class="src-cls">void</span></span>
+    </div>
+
+    <table class="cmp">
+      <thead><tr><th>策略</th><th>全屏刷新</th><th>差分渲染</th></tr></thead>
+      <tbody>
+      <tr><td>带宽</td><td>O(screen)</td><td>O(changed lines)</td></tr>
+      <tr><td>闪烁</td><td>明显</td><td>minimal</td></tr>
+      <tr><td>实现复杂度</td><td>低</td><td>需 damage tracking</td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">message_update → 像素</span><span class="lang-en-only">message_update → pixels</span></h3>
+
+    <div class="lang-zh-only"><p>AgentSession 把 message_update 交给 interactive mode → TUI 组件树 → Markdown 增量解析 → 终端 write。</p></div>
+    <div class="lang-en-only"><p>AgentSession hands message_update to interactive mode → TUI component tree → incremental Markdown → terminal write.</p></div>
+
+    <div class="note">
+      <span class="lang-zh-only">本章 (17) 在主线 prompt「CSI 2026 · firstChanged → lastChanged」路径上负责：<strong>差分渲染 TUI</strong>。回到 C02 的 22 站地图定位这一章。</span>
+      <span class="lang-en-only">Chapter (17) on the through-line path handles: <strong>Differential-render TUI</strong>. Return to C02's 22-station map to locate this chapter.</span>
+    </div>
+
+    <table class="cmp">
+      <thead><tr><th>路径</th><th>说明</th></tr></thead>
+      <tbody>
+      <tr><td><code>packages/tui/src/tui.ts</code></td><td>差分渲染</td></tr>
+      <tr><td><code>packages/tui/src/components/editor.ts</code></td><td>输入编辑器</td></tr>
+      <tr><td><code>packages/tui/src/components/markdown.ts</code></td><td>Markdown 渲染</td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">差分渲染 TUI · 实现清单</span><span class="lang-en-only">Differential-render TUI · implementation checklist</span></h3>
+
+    <div class="note">
+      <span class="lang-zh-only">1. 定位生产文件：packages/agent/src/agent-loop.ts</span>
+      <span class="lang-en-only">1. Locate production file: packages/agent/src/agent-loop.ts</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">2. 对照 pi-textbook 同主题 checkpoint</span>
+      <span class="lang-en-only">2. Cross-read matching pi-textbook checkpoint</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">3. 用 --verbose 观察 AgentEvent</span>
+      <span class="lang-en-only">3. Observe AgentEvents with --verbose</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">4. 检查 JSONL 会话文件对应 entry</span>
+      <span class="lang-en-only">4. Inspect matching JSONL session entry</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">5. 阅读 packages/*/test/ 下相关测试</span>
+      <span class="lang-en-only">5. Read related tests under packages/*/test/</span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">附录 · 差分渲染 TUI 深度 trace</span><span class="lang-en-only">Appendix · deep trace for Differential-render TUI</span></h3>
+
+    <div class="lang-zh-only"><p>本章 (17) 属于 Phase「终端」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
+    <div class="lang-en-only"><p>Chapter (17) belongs to Phase «Terminal». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
+
+    <table class="cmp">
+      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
+      <tbody>
+      <tr><td>1</td><td>message_update</td><td>TUI 收到</td></tr>
+      <tr><td>2</td><td>tui.ts</td><td>CSI 2026 差分</td></tr>
+      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
+      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
+      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
+      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
+      </tbody>
+    </table>
+
+    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/tui/src/tui.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// diff render</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 17 · 差分渲染 TUI</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 17 · 差分渲染 TUI</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 17 · 差分渲染 TUI</span></span>
+    </div>
+
+    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
+
+    <div class="lang-zh-only"><p><strong>AgentMessage</strong> — agent-core 内部消息 IR</p></div>
+    <div class="lang-en-only"><p><strong>AgentMessage</strong> — agent-core internal message IR</p></div>
+
+    <div class="lang-zh-only"><p><strong>StreamFn</strong> — 可注入的模型流函数</p></div>
+    <div class="lang-en-only"><p><strong>StreamFn</strong> — injectable model stream function</p></div>
+
+    <div class="lang-zh-only"><p><strong>leafId</strong> — JSONL 会话树当前叶</p></div>
+    <div class="lang-en-only"><p><strong>leafId</strong> — JSONL session tree current leaf</p></div>
+
+    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
+
+    <div class="note">
+      <span class="lang-zh-only">[17.1] 在 差分渲染 TUI 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[17.1] At Differential-render TUI stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[17.2] 在 差分渲染 TUI 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[17.2] At Differential-render TUI stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[17.3] 在 差分渲染 TUI 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[17.3] At Differential-render TUI stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[17.4] 在 差分渲染 TUI 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[17.4] At Differential-render TUI stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[17.5] 在 差分渲染 TUI 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[17.5] At Differential-render TUI stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[17.6] 在 差分渲染 TUI 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[17.6] At Differential-render TUI stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[17.7] 在 差分渲染 TUI 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[17.7] At Differential-render TUI stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[17.8] 在 差分渲染 TUI 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[17.8] At Differential-render TUI stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+  </section>
+
+  <section class="chap" id="c18">
+    <div class="chap-num">CHAPTER&nbsp;18&nbsp;·&nbsp;TERMINAL</div>
+    <h2 class="chap-title lang-zh-only">Interactive Mode</h2>
+    <h2 class="chap-title lang-en-only">Interactive mode</h2>
+    <p class="chap-en lang-zh-only">Editor · Markdown · tool renderers</p>
+    <p class="chap-en lang-en-only">Editor · Markdown · tool renderers</p>
+    <div class="lang-zh-only"><p>Interactive mode 组合 <code>Editor</code>（输入）、<code>Markdown</code>（输出）、<code>tool renderers</code>（read 结果预览）。主线 prompt 在 Editor 提交，最终结果在 Markdown 区滚动。</p></div>
+    <div class="lang-en-only"><p>Interactive mode composes <code>Editor</code> (input), <code>Markdown</code> (output), <code>tool renderers</code> (read preview). Through-line prompt submits from Editor; final answer scrolls in Markdown area.</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/tui/src/components/editor.ts</span>
+        <span class="src-tag">editor</span>
+      </div>
+      <span class="src-line"><span class="src-kw">export class</span> <span class="src-cls">Editor</span> <span class="src-kw">extends</span> <span class="src-cls">Component</span> { ... }</span>
+    </div>
+
+    <div class="stage-purpose">
+      <div class="sp-row">
+        <div class="sp-key"><span class="lang-zh-only">Alt-screen</span><span class="lang-en-only">Alt-screen</span></div>
+        <div class="sp-val"><span class="lang-zh-only">全屏 TUI 不污染 scrollback</span><span class="lang-en-only">fullscreen TUI preserves scrollback</span></div>
+      </div>
+      <div class="sp-row">
+        <div class="sp-key"><span class="lang-zh-only">keybindings</span><span class="lang-en-only">keybindings</span></div>
+        <div class="sp-val"><span class="lang-zh-only">可配置 · 与 readline 不同</span><span class="lang-en-only">configurable · unlike readline</span></div>
+      </div>
+      <div class="sp-row">
+        <div class="sp-key"><span class="lang-zh-only">tool 卡片</span><span class="lang-en-only">tool cards</span></div>
+        <div class="sp-val"><span class="lang-zh-only">read 显示路径+行数</span><span class="lang-en-only">read shows path + line count</span></div>
+      </div>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">本章 (18) 在主线 prompt「Editor · Markdown · tool renderers」路径上负责：<strong>Interactive Mode</strong>。回到 C02 的 22 站地图定位这一章。</span>
+      <span class="lang-en-only">Chapter (18) on the through-line path handles: <strong>Interactive mode</strong>. Return to C02's 22-station map to locate this chapter.</span>
+    </div>
+
+    <table class="cmp">
+      <thead><tr><th>路径</th><th>说明</th></tr></thead>
+      <tbody>
+      <tr><td><code>packages/tui/src/tui.ts</code></td><td>差分渲染</td></tr>
+      <tr><td><code>packages/tui/src/components/editor.ts</code></td><td>输入编辑器</td></tr>
+      <tr><td><code>packages/tui/src/components/markdown.ts</code></td><td>Markdown 渲染</td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">Interactive Mode · 实现清单</span><span class="lang-en-only">Interactive mode · implementation checklist</span></h3>
+
+    <div class="note">
+      <span class="lang-zh-only">1. 定位生产文件：packages/agent/src/agent-loop.ts</span>
+      <span class="lang-en-only">1. Locate production file: packages/agent/src/agent-loop.ts</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">2. 对照 pi-textbook 同主题 checkpoint</span>
+      <span class="lang-en-only">2. Cross-read matching pi-textbook checkpoint</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">3. 用 --verbose 观察 AgentEvent</span>
+      <span class="lang-en-only">3. Observe AgentEvents with --verbose</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">4. 检查 JSONL 会话文件对应 entry</span>
+      <span class="lang-en-only">4. Inspect matching JSONL session entry</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">5. 阅读 packages/*/test/ 下相关测试</span>
+      <span class="lang-en-only">5. Read related tests under packages/*/test/</span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">附录 · Interactive Mode 深度 trace</span><span class="lang-en-only">Appendix · deep trace for Interactive mode</span></h3>
+
+    <div class="lang-zh-only"><p>本章 (18) 属于 Phase「终端」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
+    <div class="lang-en-only"><p>Chapter (18) belongs to Phase «Terminal». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
+
+    <table class="cmp">
+      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
+      <tbody>
+      <tr><td>1</td><td>Interactive Mode</td><td>Editor · Markdown · tool renderers</td></tr>
+      <tr><td>2</td><td>—</td><td>checkpoint 2</td></tr>
+      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
+      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
+      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
+      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
+      </tbody>
+    </table>
+
+    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// default trace</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 18 · Interactive Mode</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 18 · Interactive Mode</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 18 · Interactive Mode</span></span>
+    </div>
+
+    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
+
+    <div class="lang-zh-only"><p><strong>AgentMessage</strong> — agent-core 内部消息 IR</p></div>
+    <div class="lang-en-only"><p><strong>AgentMessage</strong> — agent-core internal message IR</p></div>
+
+    <div class="lang-zh-only"><p><strong>StreamFn</strong> — 可注入的模型流函数</p></div>
+    <div class="lang-en-only"><p><strong>StreamFn</strong> — injectable model stream function</p></div>
+
+    <div class="lang-zh-only"><p><strong>leafId</strong> — JSONL 会话树当前叶</p></div>
+    <div class="lang-en-only"><p><strong>leafId</strong> — JSONL session tree current leaf</p></div>
+
+    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
+
+    <div class="note">
+      <span class="lang-zh-only">[18.1] 在 Interactive Mode 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[18.1] At Interactive mode stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[18.2] 在 Interactive Mode 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[18.2] At Interactive mode stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[18.3] 在 Interactive Mode 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[18.3] At Interactive mode stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[18.4] 在 Interactive Mode 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[18.4] At Interactive mode stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[18.5] 在 Interactive Mode 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[18.5] At Interactive mode stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[18.6] 在 Interactive Mode 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[18.6] At Interactive mode stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[18.7] 在 Interactive Mode 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[18.7] At Interactive mode stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[18.8] 在 Interactive Mode 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[18.8] At Interactive mode stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+  </section>
+
+  <section class="chap" id="c19">
+    <div class="chap-num">CHAPTER&nbsp;19&nbsp;·&nbsp;EXTENSIONS</div>
+    <h2 class="chap-title lang-zh-only">Extension API 面</h2>
+    <h2 class="chap-title lang-en-only">Extension API surface</h2>
+    <p class="chap-en lang-zh-only">registerTool · registerCommand · events</p>
+    <p class="chap-en lang-en-only">registerTool · registerCommand · events</p>
+    <div class="lang-zh-only"><p>扩展通过 <code>registerTool</code> · <code>registerCommand</code> · 事件 hook 注入能力——无需 MCP，同进程 TypeScript。</p></div>
+    <div class="lang-en-only"><p>Extensions inject via <code>registerTool</code> · <code>registerCommand</code> · event hooks — no MCP, same-process TypeScript.</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/extensions/types.ts</span>
+        <span class="src-tag">ext</span>
+      </div>
+      <span class="src-line"><span class="src-kw">export interface</span> <span class="src-cls">ExtensionAPI</span> {</span>
+      <span class="src-line">  <span class="src-fn">registerTool</span>(def: <span class="src-cls">ToolDefinition</span>): <span class="src-cls">void</span>;</span>
+      <span class="src-line">  <span class="src-fn">on</span>(<span class="src-arg">event</span>, <span class="src-arg">handler</span>): <span class="src-cls">void</span>;</span>
+      <span class="src-line">}</span>
+    </div>
+
+    <table class="cmp">
+      <thead><tr><th>Hook</th><th>时机</th><th>用例</th></tr></thead>
+      <tbody>
+      <tr><td>session_start</td><td>会话加载</td><td>恢复扩展状态</td></tr>
+      <tr><td>before_compact</td><td>压缩前</td><td>保留 artifact 索引</td></tr>
+      <tr><td>tool_execution_end</td><td>工具后</td><td>自动 lint</td></tr>
+      </tbody>
+    </table>
+
+    <div class="note copper">
+      <span class="lang-zh-only">📘 <strong>pi-textbook checkpoint 12</strong>：Resources + Extensions（<code>resources-extensions</code>）· 生产映射：<code>packages/coding-agent/src/core/extensions/ · resource-loader.ts</code></span>
+      <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 12</strong>: Resources + Extensions (<code>resources-extensions</code>) · production: <code>packages/coding-agent/src/core/extensions/ · resource-loader.ts</code></span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">本章 (19) 在主线 prompt「registerTool · registerCommand · events」路径上负责：<strong>Extension API 面</strong>。回到 C02 的 22 站地图定位这一章。</span>
+      <span class="lang-en-only">Chapter (19) on the through-line path handles: <strong>Extension API surface</strong>. Return to C02's 22-station map to locate this chapter.</span>
+    </div>
+
+    <table class="cmp">
+      <thead><tr><th>路径</th><th>说明</th></tr></thead>
+      <tbody>
+      <tr><td><code>packages/coding-agent/src/core/extensions/</code></td><td>Extension API</td></tr>
+      <tr><td><code>packages/coding-agent/src/core/extensions/runner.ts</code></td><td>ExtensionRunner</td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">Extension API 面 · 实现清单</span><span class="lang-en-only">Extension API surface · implementation checklist</span></h3>
+
+    <div class="note">
+      <span class="lang-zh-only">1. 定位生产文件：packages/agent/src/agent-loop.ts</span>
+      <span class="lang-en-only">1. Locate production file: packages/agent/src/agent-loop.ts</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">2. 对照 pi-textbook 同主题 checkpoint</span>
+      <span class="lang-en-only">2. Cross-read matching pi-textbook checkpoint</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">3. 用 --verbose 观察 AgentEvent</span>
+      <span class="lang-en-only">3. Observe AgentEvents with --verbose</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">4. 检查 JSONL 会话文件对应 entry</span>
+      <span class="lang-en-only">4. Inspect matching JSONL session entry</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">5. 阅读 packages/*/test/ 下相关测试</span>
+      <span class="lang-en-only">5. Read related tests under packages/*/test/</span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">附录 · Extension API 面 深度 trace</span><span class="lang-en-only">Appendix · deep trace for Extension API surface</span></h3>
+
+    <div class="lang-zh-only"><p>本章 (19) 属于 Phase「扩展」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
+    <div class="lang-en-only"><p>Chapter (19) belongs to Phase «Extensions». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
+
+    <table class="cmp">
+      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
+      <tbody>
+      <tr><td>1</td><td>Extension API 面</td><td>registerTool · registerCommand · events</td></tr>
+      <tr><td>2</td><td>—</td><td>checkpoint 2</td></tr>
+      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
+      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
+      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
+      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
+      </tbody>
+    </table>
+
+    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/extensions/types.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// Extension API</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 19 · Extension API 面</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 19 · Extension API 面</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 19 · Extension API 面</span></span>
+    </div>
+
+    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
+
+    <div class="lang-zh-only"><p><strong>AgentMessage</strong> — agent-core 内部消息 IR</p></div>
+    <div class="lang-en-only"><p><strong>AgentMessage</strong> — agent-core internal message IR</p></div>
+
+    <div class="lang-zh-only"><p><strong>StreamFn</strong> — 可注入的模型流函数</p></div>
+    <div class="lang-en-only"><p><strong>StreamFn</strong> — injectable model stream function</p></div>
+
+    <div class="lang-zh-only"><p><strong>leafId</strong> — JSONL 会话树当前叶</p></div>
+    <div class="lang-en-only"><p><strong>leafId</strong> — JSONL session tree current leaf</p></div>
+
+    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
+
+    <div class="note">
+      <span class="lang-zh-only">[19.1] 在 Extension API 面 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[19.1] At Extension API surface stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[19.2] 在 Extension API 面 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[19.2] At Extension API surface stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[19.3] 在 Extension API 面 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[19.3] At Extension API surface stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[19.4] 在 Extension API 面 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[19.4] At Extension API surface stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[19.5] 在 Extension API 面 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[19.5] At Extension API surface stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[19.6] 在 Extension API 面 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[19.6] At Extension API surface stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[19.7] 在 Extension API 面 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[19.7] At Extension API surface stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[19.8] 在 Extension API 面 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[19.8] At Extension API surface stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+  </section>
+
+  <section class="chap" id="c20">
+    <div class="chap-num">CHAPTER&nbsp;20&nbsp;·&nbsp;EXTENSIONS</div>
+    <h2 class="chap-title lang-zh-only">ExtensionRunner</h2>
+    <h2 class="chap-title lang-en-only">ExtensionRunner</h2>
+    <p class="chap-en lang-zh-only">jiti 加载 · 事件合并 · hook 注入</p>
+    <p class="chap-en lang-en-only">jiti load · event merge · hook injection</p>
+    <div class="lang-zh-only"><p><code>ExtensionRunner</code> 用 <code>jiti</code> 动态加载扩展 TS，合并事件处理器，在 agent 生命周期关键点注入 hook。</p></div>
+    <div class="lang-en-only"><p><code>ExtensionRunner</code> uses <code>jiti</code> to load extension TS, merges event handlers, injects hooks at agent lifecycle points.</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/extensions/runner.ts</span>
+        <span class="src-tag">runner</span>
+      </div>
+      <span class="src-line"><span class="src-kw">export class</span> <span class="src-cls">ExtensionRunner</span> {</span>
+      <span class="src-line">  <span class="src-kw">async</span> <span class="src-fn">loadExtensions</span>(paths: <span class="src-cls">string</span>[]): <span class="src-cls">Promise</span>&lt;<span class="src-cls">void</span>&gt;</span>
+      <span class="src-line">}</span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">事件合并语义</span><span class="lang-en-only">Event merge semantics</span></h3>
+
+    <div class="lang-zh-only"><p>多个扩展可订阅同一事件；Runner 按加载顺序调用；<code>before_compact</code> 可返回修改后的 summary。</p></div>
+    <div class="lang-en-only"><p>Multiple extensions can subscribe; Runner calls in load order; <code>before_compact</code> can return modified summary.</p></div>
+
+    <div class="note copper">
+      <span class="lang-zh-only">📘 <strong>pi-textbook checkpoint 13</strong>：Composition Root（<code>composition-root</code>）· 生产映射：<code>packages/coding-agent/src/core/agent-session.ts · sdk.ts</code></span>
+      <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 13</strong>: Composition Root (<code>composition-root</code>) · production: <code>packages/coding-agent/src/core/agent-session.ts · sdk.ts</code></span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">本章 (20) 在主线 prompt「jiti 加载 · 事件合并 · hook 注入」路径上负责：<strong>ExtensionRunner</strong>。回到 C02 的 22 站地图定位这一章。</span>
+      <span class="lang-en-only">Chapter (20) on the through-line path handles: <strong>ExtensionRunner</strong>. Return to C02's 22-station map to locate this chapter.</span>
+    </div>
+
+    <table class="cmp">
+      <thead><tr><th>路径</th><th>说明</th></tr></thead>
+      <tbody>
+      <tr><td><code>packages/coding-agent/src/core/extensions/</code></td><td>Extension API</td></tr>
+      <tr><td><code>packages/coding-agent/src/core/extensions/runner.ts</code></td><td>ExtensionRunner</td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">ExtensionRunner · 实现清单</span><span class="lang-en-only">ExtensionRunner · implementation checklist</span></h3>
+
+    <div class="note">
+      <span class="lang-zh-only">1. 定位生产文件：packages/agent/src/agent-loop.ts</span>
+      <span class="lang-en-only">1. Locate production file: packages/agent/src/agent-loop.ts</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">2. 对照 pi-textbook 同主题 checkpoint</span>
+      <span class="lang-en-only">2. Cross-read matching pi-textbook checkpoint</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">3. 用 --verbose 观察 AgentEvent</span>
+      <span class="lang-en-only">3. Observe AgentEvents with --verbose</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">4. 检查 JSONL 会话文件对应 entry</span>
+      <span class="lang-en-only">4. Inspect matching JSONL session entry</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">5. 阅读 packages/*/test/ 下相关测试</span>
+      <span class="lang-en-only">5. Read related tests under packages/*/test/</span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">附录 · ExtensionRunner 深度 trace</span><span class="lang-en-only">Appendix · deep trace for ExtensionRunner</span></h3>
+
+    <div class="lang-zh-only"><p>本章 (20) 属于 Phase「扩展」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
+    <div class="lang-en-only"><p>Chapter (20) belongs to Phase «Extensions». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
+
+    <table class="cmp">
+      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
+      <tbody>
+      <tr><td>1</td><td>ExtensionRunner</td><td>jiti 加载 · 事件合并 · hook 注入</td></tr>
+      <tr><td>2</td><td>—</td><td>checkpoint 2</td></tr>
+      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
+      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
+      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
+      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
+      </tbody>
+    </table>
+
+    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// default trace</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 20 · ExtensionRunner</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 20 · ExtensionRunner</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 20 · ExtensionRunner</span></span>
+    </div>
+
+    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
+
+    <div class="lang-zh-only"><p><strong>AgentMessage</strong> — agent-core 内部消息 IR</p></div>
+    <div class="lang-en-only"><p><strong>AgentMessage</strong> — agent-core internal message IR</p></div>
+
+    <div class="lang-zh-only"><p><strong>StreamFn</strong> — 可注入的模型流函数</p></div>
+    <div class="lang-en-only"><p><strong>StreamFn</strong> — injectable model stream function</p></div>
+
+    <div class="lang-zh-only"><p><strong>leafId</strong> — JSONL 会话树当前叶</p></div>
+    <div class="lang-en-only"><p><strong>leafId</strong> — JSONL session tree current leaf</p></div>
+
+    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
+
+    <div class="note">
+      <span class="lang-zh-only">[20.1] 在 ExtensionRunner 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[20.1] At ExtensionRunner stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[20.2] 在 ExtensionRunner 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[20.2] At ExtensionRunner stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[20.3] 在 ExtensionRunner 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[20.3] At ExtensionRunner stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[20.4] 在 ExtensionRunner 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[20.4] At ExtensionRunner stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[20.5] 在 ExtensionRunner 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[20.5] At ExtensionRunner stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[20.6] 在 ExtensionRunner 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[20.6] At ExtensionRunner stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[20.7] 在 ExtensionRunner 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[20.7] At ExtensionRunner stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[20.8] 在 ExtensionRunner 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[20.8] At ExtensionRunner stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+  </section>
+
+  <section class="chap" id="c21">
+    <div class="chap-num">CHAPTER&nbsp;21&nbsp;·&nbsp;EXTENSIONS</div>
+    <h2 class="chap-title lang-zh-only">Pi Packages</h2>
+    <h2 class="chap-title lang-en-only">Pi packages</h2>
+    <p class="chap-en lang-zh-only">npm · git · 可分享的 harness 能力</p>
+    <p class="chap-en lang-en-only">npm · git · shareable harness capabilities</p>
+    <div class="lang-zh-only"><p><code>pi package</code> 命令管理可分享的 harness 能力包——npm 或 git 依赖，把工具+扩展+资源打包分发。</p></div>
+    <div class="lang-en-only"><p><code>pi package</code> manages shareable harness capability bundles — npm or git deps packaging tools+extensions+resources.</p></div>
+
+    <table class="cmp">
+      <thead><tr><th>分发</th><th>格式</th><th>消费者</th></tr></thead>
+      <tbody>
+      <tr><td>npm</td><td>package.json + pi manifest</td><td>pi install</td></tr>
+      <tr><td>git</td><td>repo URL + ref</td><td>pi package add</td></tr>
+      <tr><td>local</td><td>path</td><td>开发调试</td></tr>
+      </tbody>
+    </table>
+
+    <div class="note">
+      <span class="lang-zh-only">扩展生态替代 MCP 市场——类型安全，但门槛是写 TypeScript。</span>
+      <span class="lang-en-only">Extension ecosystem replaces MCP marketplace — type-safe, but requires writing TypeScript.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">本章 (21) 在主线 prompt「npm · git · 可分享的 harness 能力」路径上负责：<strong>Pi Packages</strong>。回到 C02 的 22 站地图定位这一章。</span>
+      <span class="lang-en-only">Chapter (21) on the through-line path handles: <strong>Pi packages</strong>. Return to C02's 22-station map to locate this chapter.</span>
+    </div>
+
+    <table class="cmp">
+      <thead><tr><th>路径</th><th>说明</th></tr></thead>
+      <tbody>
+      <tr><td><code>packages/coding-agent/src/core/extensions/</code></td><td>Extension API</td></tr>
+      <tr><td><code>packages/coding-agent/src/core/extensions/runner.ts</code></td><td>ExtensionRunner</td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">Pi Packages · 实现清单</span><span class="lang-en-only">Pi packages · implementation checklist</span></h3>
+
+    <div class="note">
+      <span class="lang-zh-only">1. 定位生产文件：packages/agent/src/agent-loop.ts</span>
+      <span class="lang-en-only">1. Locate production file: packages/agent/src/agent-loop.ts</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">2. 对照 pi-textbook 同主题 checkpoint</span>
+      <span class="lang-en-only">2. Cross-read matching pi-textbook checkpoint</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">3. 用 --verbose 观察 AgentEvent</span>
+      <span class="lang-en-only">3. Observe AgentEvents with --verbose</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">4. 检查 JSONL 会话文件对应 entry</span>
+      <span class="lang-en-only">4. Inspect matching JSONL session entry</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">5. 阅读 packages/*/test/ 下相关测试</span>
+      <span class="lang-en-only">5. Read related tests under packages/*/test/</span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">附录 · Pi Packages 深度 trace</span><span class="lang-en-only">Appendix · deep trace for Pi packages</span></h3>
+
+    <div class="lang-zh-only"><p>本章 (21) 属于 Phase「扩展」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
+    <div class="lang-en-only"><p>Chapter (21) belongs to Phase «Extensions». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
+
+    <table class="cmp">
+      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
+      <tbody>
+      <tr><td>1</td><td>Pi Packages</td><td>npm · git · 可分享的 harness 能力</td></tr>
+      <tr><td>2</td><td>—</td><td>checkpoint 2</td></tr>
+      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
+      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
+      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
+      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
+      </tbody>
+    </table>
+
+    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// default trace</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 21 · Pi Packages</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 21 · Pi Packages</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 21 · Pi Packages</span></span>
+    </div>
+
+    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
+
+    <div class="lang-zh-only"><p><strong>AgentMessage</strong> — agent-core 内部消息 IR</p></div>
+    <div class="lang-en-only"><p><strong>AgentMessage</strong> — agent-core internal message IR</p></div>
+
+    <div class="lang-zh-only"><p><strong>StreamFn</strong> — 可注入的模型流函数</p></div>
+    <div class="lang-en-only"><p><strong>StreamFn</strong> — injectable model stream function</p></div>
+
+    <div class="lang-zh-only"><p><strong>leafId</strong> — JSONL 会话树当前叶</p></div>
+    <div class="lang-en-only"><p><strong>leafId</strong> — JSONL session tree current leaf</p></div>
+
+    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
+
+    <div class="note">
+      <span class="lang-zh-only">[21.1] 在 Pi Packages 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[21.1] At Pi packages stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[21.2] 在 Pi Packages 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[21.2] At Pi packages stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[21.3] 在 Pi Packages 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[21.3] At Pi packages stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[21.4] 在 Pi Packages 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[21.4] At Pi packages stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[21.5] 在 Pi Packages 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[21.5] At Pi packages stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[21.6] 在 Pi Packages 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[21.6] At Pi packages stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[21.7] 在 Pi Packages 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[21.7] At Pi packages stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[21.8] 在 Pi Packages 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[21.8] At Pi packages stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+  </section>
+
+  <section class="chap" id="c22">
+    <div class="chap-num">CHAPTER&nbsp;22&nbsp;·&nbsp;PERSISTENCE</div>
+    <h2 class="chap-title lang-zh-only">JSONL 会话树</h2>
+    <h2 class="chap-title lang-en-only">JSONL session tree</h2>
+    <p class="chap-en lang-zh-only">parentId · leafId · fork</p>
+    <p class="chap-en lang-en-only">parentId · leafId · fork</p>
+    <div class="lang-zh-only"><p>每个会话是 JSONL 文件：<code>parentId</code> 链构成树，<code>leafId</code> 指向当前叶节点，<code>fork</code> 创建 <code>parentSession</code> 子会话。</p></div>
+    <div class="lang-en-only"><p>Each session is a JSONL file: <code>parentId</code> chain forms tree, <code>leafId</code> points to current leaf, <code>fork</code> creates child with <code>parentSession</code>.</p></div>
+
+    <figure>
+      <div class="figbox"><div class="session-tree">
+      <div>session <code>sess_root</code></div>
+      <div class="st-node">├─ user: 「读取 README.md…」 <code>id=u1</code></div>
+      <div class="st-node">├─ assistant: toolUse read <code>id=a1</code></div>
+      <div class="st-node">├─ toolResult: README fixture <code>id=t1</code></div>
+      <div class="st-node st-leaf">└─ assistant: stop · 最终回答 <code>id=a2</code> ← leafId</div>
+      <div class="st-node" style="margin-top:12px;border-left-color:var(--copper)">fork → session <code>sess_branch</code> (parentSession=sess_root)</div>
+    </div></div>
+      <figcaption>
+        <span class="figid">FIG</span>
+        <span class="lang-zh-only">JSONL 会话树：parentId 链 + leafId 指针 + fork 分支</span>
+        <span class="lang-en-only">JSONL session tree: parentId chain + leafId pointer + fork branch</span>
+      </figcaption>
+    </figure>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/session-manager.ts</span>
+        <span class="src-tag">sm</span>
+      </div>
+      <span class="src-line"><span class="src-kw">export const</span> <span class="src-arg">CURRENT_SESSION_VERSION</span> = <span class="src-num">3</span>;</span>
+      <span class="src-line"><span class="src-kw">export interface</span> <span class="src-cls">SessionMessageEntry</span> {</span>
+      <span class="src-line">  <span class="src-arg">type</span>: <span class="src-str">"message"</span>; <span class="src-arg">parentId</span>: <span class="src-cls">string</span> | <span class="src-kw">null</span>;</span>
+      <span class="src-line">}</span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">主线 prompt 落盘后的 JSONL 行</span><span class="lang-en-only">JSONL lines after through-line prompt</span></h3>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; ~/.pi/sessions/*.jsonl</span>
+        <span class="src-tag">jsonl</span>
+      </div>
+      <span class="src-line">{"type":"session","id":"...","cwd":"/path/to/project"}</span>
+      <span class="src-line">{"type":"message","parentId":null,"message":{"role":"user","content":"读取 README.md..."}}</span>
+      <span class="src-line">{"type":"message","parentId":"...","message":{"role":"assistant","stopReason":"toolUse",...}}</span>
+    </div>
+
+    <table class="cmp">
+      <thead><tr><th>Entry type</th><th>用途</th><th>LLM 可见?</th></tr></thead>
+      <tbody>
+      <tr><td>message</td><td>user/assistant/tool</td><td>✓</td></tr>
+      <tr><td>compaction</td><td>压缩摘要</td><td>✓（替换早期）</td></tr>
+      <tr><td>branch_summary</td><td>fork 摘要</td><td>△</td></tr>
+      <tr><td>model_change</td><td>审计</td><td>✗</td></tr>
+      </tbody>
+    </table>
+
+    <div class="note copper">
+      <span class="lang-zh-only">📘 <strong>pi-textbook checkpoint 10</strong>：Session Tree（<code>session.ts</code>）· 生产映射：<code>packages/coding-agent/src/core/session-manager.ts</code></span>
+      <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 10</strong>: Session Tree (<code>session.ts</code>) · production: <code>packages/coding-agent/src/core/session-manager.ts</code></span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">fork 工作流</span><span class="lang-en-only">Fork workflow</span></h3>
+
+    <div class="lang-zh-only"><p>从任意 message entry 创建 branch_summary + 新 session 文件，parentSession 指向原会话。</p></div>
+    <div class="lang-en-only"><p>From any message entry create branch_summary + new session file with parentSession pointer.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">leafId 语义</span><span class="lang-en-only">leafId semantics</span></h3>
+
+    <div class="lang-zh-only"><p>继续会话时从 leaf 重放 parentId 链到根，重建 AgentMessage[]。</p></div>
+    <div class="lang-en-only"><p>Continue session replays parentId chain from leaf to root, rebuilding AgentMessage[].</p></div>
+
+    <div class="note">
+      <span class="lang-zh-only">本章 (22) 在主线 prompt「parentId · leafId · fork」路径上负责：<strong>JSONL 会话树</strong>。回到 C02 的 22 站地图定位这一章。</span>
+      <span class="lang-en-only">Chapter (22) on the through-line path handles: <strong>JSONL session tree</strong>. Return to C02's 22-station map to locate this chapter.</span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent · chapter 22</span>
+        <span class="src-tag">trace</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// Through-line: parentId · leafId · fork</span></span>
+      <span class="src-line"><span class="src-comment">// Phase: 持久化 / Persistence</span></span>
+      <span class="src-line"><span class="src-kw">await</span> <span class="src-fn">traceTurn</span>({ <span class="src-arg">prompt</span>: <span class="src-str">"README.md"</span> });</span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/session-manager.ts</span>
+        <span class="src-tag">walkthrough</span>
+      </div>
+      <span class="src-line"><span class="src-ln">  1</span> <span class="src-hl">appendFileSync(sessionPath, JSON.stringify(entry))</span></span>
+      <span class="src-line"><span class="src-comment">     // 追加 JSONL 行 / append JSONL line</span></span>
+      <span class="src-line"><span class="src-ln">  2</span> <span class="src-hl">parentId: string | null</span></span>
+      <span class="src-line"><span class="src-comment">     // 树边 / tree edge</span></span>
+      <span class="src-line"><span class="src-ln">  3</span> <span class="src-hl">fork(fromEntryId)</span></span>
+      <span class="src-line"><span class="src-comment">     // 创建分支会话 / create branch session</span></span>
+      <span class="src-line"><span class="src-ln">  4</span> <span class="src-hl">getLeafId()</span></span>
+      <span class="src-line"><span class="src-comment">     // 当前叶指针 / current leaf pointer</span></span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">JSONL 为什么不用 SQLite？</span><span class="lang-en-only">Why JSONL not SQLite?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>可 git diff、可手工编辑、可流式 tail；SQLite 留给扩展 artifact。</p></div><div class="lang-en-only"><p>git diffable, hand-editable, streamable tail; SQLite for extension artifacts.</p></div></div></details>
+
+    <h3 class="sub"><span class="lang-zh-only">附录 · JSONL 会话树 深度 trace</span><span class="lang-en-only">Appendix · deep trace for JSONL session tree</span></h3>
+
+    <div class="lang-zh-only"><p>本章 (22) 属于 Phase「持久化」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
+    <div class="lang-en-only"><p>Chapter (22) belongs to Phase «Persistence». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
+
+    <table class="cmp">
+      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
+      <tbody>
+      <tr><td>1</td><td>SessionManager</td><td>append</td></tr>
+      <tr><td>2</td><td>JSONL</td><td>parentId 写入</td></tr>
+      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
+      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
+      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
+      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
+      </tbody>
+    </table>
+
+    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/session-manager.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// SessionManager</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 22 · JSONL 会话树</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 22 · JSONL 会话树</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 22 · JSONL 会话树</span></span>
+    </div>
+
+    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
+
+    <div class="lang-zh-only"><p><strong>parentId</strong> — JSONL 树边指向父 entry</p></div>
+    <div class="lang-en-only"><p><strong>parentId</strong> — JSONL tree edge to parent entry</p></div>
+
+    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
+
+    <div class="note">
+      <span class="lang-zh-only">[22.1] 在 JSONL 会话树 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[22.1] At JSONL session tree stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[22.2] 在 JSONL 会话树 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[22.2] At JSONL session tree stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[22.3] 在 JSONL 会话树 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[22.3] At JSONL session tree stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[22.4] 在 JSONL 会话树 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[22.4] At JSONL session tree stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[22.5] 在 JSONL 会话树 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[22.5] At JSONL session tree stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[22.6] 在 JSONL 会话树 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[22.6] At JSONL session tree stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[22.7] 在 JSONL 会话树 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[22.7] At JSONL session tree stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[22.8] 在 JSONL 会话树 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[22.8] At JSONL session tree stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+  </section>
+
+  <section class="chap" id="c23">
+    <div class="chap-num">CHAPTER&nbsp;23&nbsp;·&nbsp;PERSISTENCE</div>
+    <h2 class="chap-title lang-zh-only">Compaction 与 Harness</h2>
+    <h2 class="chap-title lang-en-only">Compaction and harness</h2>
+    <p class="chap-en lang-zh-only">上下文压缩 · SQLite lanes</p>
+    <p class="chap-en lang-en-only">context compression · SQLite lanes</p>
+    <div class="lang-zh-only"><p><strong>Compaction</strong>：上下文超阈值时，历史消息<strong>不动</strong>（JSONL 完整保留），但<strong>重建</strong>发给模型的 context——用 LLM 生成摘要替换早期消息。</p></div>
+    <div class="lang-en-only"><p><strong>Compaction</strong>: when context exceeds threshold, history <strong>stays</strong> in JSONL but <strong>rebuilt</strong> context for model — LLM summary replaces early messages.</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/compaction/index.ts</span>
+        <span class="src-tag">compact</span>
+      </div>
+      <span class="src-line"><span class="src-kw">export async function</span> <span class="src-fn">compact</span>(...): <span class="src-cls">Promise</span>&lt;<span class="src-cls">CompactionResult</span>&gt;</span>
+      <span class="src-line"><span class="src-kw">export function</span> <span class="src-fn">shouldCompact</span>(tokens: <span class="src-cls">number</span>): <span class="src-cls">boolean</span></span>
+    </div>
+
+    <div class="stage-purpose">
+      <div class="sp-row">
+        <div class="sp-key"><span class="lang-zh-only">历史</span><span class="lang-en-only">History</span></div>
+        <div class="sp-val"><span class="lang-zh-only">JSONL 永不删</span><span class="lang-en-only">JSONL never deleted</span></div>
+      </div>
+      <div class="sp-row">
+        <div class="sp-key"><span class="lang-zh-only">上下文</span><span class="lang-en-only">Context</span></div>
+        <div class="sp-val"><span class="lang-zh-only">压缩后变短</span><span class="lang-en-only">shorter after compact</span></div>
+      </div>
+      <div class="sp-row">
+        <div class="sp-key"><span class="lang-zh-only">SQLite lanes</span><span class="lang-en-only">SQLite lanes</span></div>
+        <div class="sp-val"><span class="lang-zh-only">扩展可存 artifact 索引</span><span class="lang-en-only">extensions store artifact index</span></div>
+      </div>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">.harness 与 compaction 分工</span><span class="lang-en-only">Harness vs compaction roles</span></h3>
+
+    <div class="lang-zh-only"><p>agent-loop 不管 token 数；AgentSession 在 turn_end 检查 shouldCompact；扩展可在 before_compact 注入结构化摘要。</p></div>
+    <div class="lang-en-only"><p>agent-loop ignores token count; AgentSession checks shouldCompact at turn_end; extensions inject structured summary in before_compact.</p></div>
+
+    <div class="note copper">
+      <span class="lang-zh-only">📘 <strong>pi-textbook checkpoint 11</strong>：Context Compaction（<code>context.ts</code>）· 生产映射：<code>packages/coding-agent/src/core/compaction/</code></span>
+      <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 11</strong>: Context Compaction (<code>context.ts</code>) · production: <code>packages/coding-agent/src/core/compaction/</code></span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">本章 (23) 在主线 prompt「上下文压缩 · SQLite lanes」路径上负责：<strong>Compaction 与 Harness</strong>。回到 C02 的 22 站地图定位这一章。</span>
+      <span class="lang-en-only">Chapter (23) on the through-line path handles: <strong>Compaction and harness</strong>. Return to C02's 22-station map to locate this chapter.</span>
+    </div>
+
+    <table class="cmp">
+      <thead><tr><th>路径</th><th>说明</th></tr></thead>
+      <tbody>
+      <tr><td><code>packages/coding-agent/src/core/session-manager.ts</code></td><td>JSONL 会话树</td></tr>
+      <tr><td><code>packages/coding-agent/src/core/compaction/</code></td><td>上下文压缩</td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">Compaction 与 Harness · 实现清单</span><span class="lang-en-only">Compaction and harness · implementation checklist</span></h3>
+
+    <div class="note">
+      <span class="lang-zh-only">1. 定位生产文件：packages/agent/src/agent-loop.ts</span>
+      <span class="lang-en-only">1. Locate production file: packages/agent/src/agent-loop.ts</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">2. 对照 pi-textbook 同主题 checkpoint</span>
+      <span class="lang-en-only">2. Cross-read matching pi-textbook checkpoint</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">3. 用 --verbose 观察 AgentEvent</span>
+      <span class="lang-en-only">3. Observe AgentEvents with --verbose</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">4. 检查 JSONL 会话文件对应 entry</span>
+      <span class="lang-en-only">4. Inspect matching JSONL session entry</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">5. 阅读 packages/*/test/ 下相关测试</span>
+      <span class="lang-en-only">5. Read related tests under packages/*/test/</span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">附录 · Compaction 与 Harness 深度 trace</span><span class="lang-en-only">Appendix · deep trace for Compaction and harness</span></h3>
+
+    <div class="lang-zh-only"><p>本章 (23) 属于 Phase「持久化」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
+    <div class="lang-en-only"><p>Chapter (23) belongs to Phase «Persistence». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
+
+    <table class="cmp">
+      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
+      <tbody>
+      <tr><td>1</td><td>Compaction 与 Harness</td><td>上下文压缩 · SQLite lanes</td></tr>
+      <tr><td>2</td><td>—</td><td>checkpoint 2</td></tr>
+      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
+      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
+      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
+      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
+      </tbody>
+    </table>
+
+    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/compaction/index.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// compaction</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 23 · Compaction 与 Harness</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 23 · Compaction 与 Harness</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 23 · Compaction 与 Harness</span></span>
+    </div>
+
+    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
+
+    <div class="lang-zh-only"><p><strong>compaction</strong> — 历史保留·上下文重建</p></div>
+    <div class="lang-en-only"><p><strong>compaction</strong> — history kept · context rebuilt</p></div>
+
+    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
+
+    <div class="note">
+      <span class="lang-zh-only">[23.1] 在 Compaction 与 Harness 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[23.1] At Compaction and harness stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[23.2] 在 Compaction 与 Harness 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[23.2] At Compaction and harness stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[23.3] 在 Compaction 与 Harness 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[23.3] At Compaction and harness stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[23.4] 在 Compaction 与 Harness 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[23.4] At Compaction and harness stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[23.5] 在 Compaction 与 Harness 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[23.5] At Compaction and harness stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[23.6] 在 Compaction 与 Harness 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[23.6] At Compaction and harness stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[23.7] 在 Compaction 与 Harness 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[23.7] At Compaction and harness stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[23.8] 在 Compaction 与 Harness 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[23.8] At Compaction and harness stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+  </section>
+
+  <section class="chap" id="c24">
+    <div class="chap-num">CHAPTER&nbsp;24&nbsp;·&nbsp;LANDSCAPE</div>
+    <h2 class="chap-title lang-zh-only">对比 Claude Code / Cursor</h2>
+    <h2 class="chap-title lang-en-only">vs Claude Code / Cursor</h2>
+    <p class="chap-en lang-zh-only">minimal harness 的设计取舍</p>
+    <p class="chap-en lang-en-only">design trade-offs of a minimal harness</p>
+    <div class="lang-zh-only"><p>对比三条路线：Claude Code（密封 CLI + MCP）、Cursor（密封 IDE + 全生态）、Pi（开源 harness + 终端 + JSONL）。</p></div>
+    <div class="lang-en-only"><p>Three routes: Claude Code (sealed CLI + MCP), Cursor (sealed IDE + ecosystem), Pi (open harness + terminal + JSONL).</p></div>
+
+    <table class="cmp">
+      <thead><tr><th>维度</th><th>Claude Code</th><th>Cursor</th><th>Pi</th></tr></thead>
+      <tbody>
+      <tr><td>目标用户</td><td>开箱即用</td><td>IDE 用户</td><td>想读源码的人</td></tr>
+      <tr><td>会话</td><td>专有云</td><td>专有</td><td>本地 JSONL 树</td></tr>
+      <tr><td>扩展</td><td>MCP</td><td>VS Code</td><td>TS Extension API</td></tr>
+      <tr><td>可观测</td><td>低</td><td>低</td><td>高（每事件可 log）</td></tr>
+      <tr><td>主线 prompt 可 trace</td><td>✗</td><td>✗</td><td>✓ --verbose</td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">设计取舍表</span><span class="lang-en-only">Design trade-off table</span></h3>
+
+    <div class="lang-zh-only"><p>Pi 牺牲：一键 MCP 市场、GUI 权限、IDE 集成。Pi 获得：fork 会话、RPC 嵌入、完整事件日志、教学友好的代码体积。</p></div>
+    <div class="lang-en-only"><p>Pi sacrifices: one-click MCP, GUI permissions, IDE integration. Pi gains: fork sessions, RPC embed, full event log, teachable code size.</p></div>
+
+    <div class="note copper">
+      <span class="lang-zh-only">不是「哪个更好」——是「你要闭包体验还是开卷考试」。</span>
+      <span class="lang-en-only">Not «which is better» — «do you want closed-loop UX or open-book exam».</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">本章 (24) 在主线 prompt「minimal harness 的设计取舍」路径上负责：<strong>对比 Claude Code / Cursor</strong>。回到 C02 的 22 站地图定位这一章。</span>
+      <span class="lang-en-only">Chapter (24) on the through-line path handles: <strong>vs Claude Code / Cursor</strong>. Return to C02's 22-station map to locate this chapter.</span>
+    </div>
+
+    <table class="cmp">
+      <thead><tr><th>特性</th><th>Claude Code</th><th>Cursor</th><th>Pi</th></tr></thead>
+      <tbody>
+      <tr><td>MCP 工具市场</td><td>✓</td><td>✓</td><td>✗ (Extension API)</td></tr>
+      <tr><td>子 agent</td><td>✓</td><td>△</td><td>✗ (session fork)</td></tr>
+      <tr><td>Plan 模式</td><td>✓</td><td>✓</td><td>✗</td></tr>
+      <tr><td>JSONL 会话树</td><td>✗</td><td>✗</td><td>✓</td></tr>
+      <tr><td>源码可读</td><td>✗</td><td>✗</td><td>✓</td></tr>
+      <tr><td>--verbose 事件</td><td>✗</td><td>✗</td><td>✓</td></tr>
+      <tr><td>IDE 集成</td><td>△</td><td>✓</td><td>✗</td></tr>
+      <tr><td>OAuth 40+ 模型</td><td>△</td><td>△</td><td>✓</td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">附录 · 对比 Claude Code / Cursor 深度 trace</span><span class="lang-en-only">Appendix · deep trace for vs Claude Code / Cursor</span></h3>
+
+    <div class="lang-zh-only"><p>本章 (24) 属于 Phase「全景」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
+    <div class="lang-en-only"><p>Chapter (24) belongs to Phase «Landscape». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
+
+    <table class="cmp">
+      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
+      <tbody>
+      <tr><td>1</td><td>对比 Claude Code / Cursor</td><td>minimal harness 的设计取舍</td></tr>
+      <tr><td>2</td><td>—</td><td>checkpoint 2</td></tr>
+      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
+      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
+      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
+      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
+      </tbody>
+    </table>
+
+    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// default trace</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 24 · 对比 Claude Code / Cursor</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 24 · 对比 Claude Code / Cursor</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 24 · 对比 Claude Code / Cursor</span></span>
+    </div>
+
+    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
+
+    <div class="lang-zh-only"><p><strong>AgentMessage</strong> — agent-core 内部消息 IR</p></div>
+    <div class="lang-en-only"><p><strong>AgentMessage</strong> — agent-core internal message IR</p></div>
+
+    <div class="lang-zh-only"><p><strong>StreamFn</strong> — 可注入的模型流函数</p></div>
+    <div class="lang-en-only"><p><strong>StreamFn</strong> — injectable model stream function</p></div>
+
+    <div class="lang-zh-only"><p><strong>leafId</strong> — JSONL 会话树当前叶</p></div>
+    <div class="lang-en-only"><p><strong>leafId</strong> — JSONL session tree current leaf</p></div>
+
+    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
+
+    <div class="note">
+      <span class="lang-zh-only">[24.1] 在 对比 Claude Code / Cursor 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[24.1] At vs Claude Code / Cursor stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[24.2] 在 对比 Claude Code / Cursor 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[24.2] At vs Claude Code / Cursor stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[24.3] 在 对比 Claude Code / Cursor 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[24.3] At vs Claude Code / Cursor stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[24.4] 在 对比 Claude Code / Cursor 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[24.4] At vs Claude Code / Cursor stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[24.5] 在 对比 Claude Code / Cursor 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[24.5] At vs Claude Code / Cursor stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[24.6] 在 对比 Claude Code / Cursor 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[24.6] At vs Claude Code / Cursor stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[24.7] 在 对比 Claude Code / Cursor 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[24.7] At vs Claude Code / Cursor stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[24.8] 在 对比 Claude Code / Cursor 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[24.8] At vs Claude Code / Cursor stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+  </section>
+
+  <section class="chap" id="c25">
+    <div class="chap-num">CHAPTER&nbsp;25&nbsp;·&nbsp;LANDSCAPE</div>
+    <h2 class="chap-title lang-zh-only">RPC 与 pi-server</h2>
+    <h2 class="chap-title lang-en-only">RPC and pi-server</h2>
+    <p class="chap-en lang-zh-only">JSONL 进程协议 · CBOR 远程会话</p>
+    <p class="chap-en lang-en-only">JSONL process protocol · CBOR remote sessions</p>
+    <div class="lang-zh-only"><p><code>--mode rpc</code> 把 AgentSession 变成 JSONL 帧协议：stdin 收命令，stdout 吐事件。远程场景用 pi-server + CBOR。</p></div>
+    <div class="lang-en-only"><p><code>--mode rpc</code> turns AgentSession into JSONL frame protocol: stdin commands, stdout events. Remote uses pi-server + CBOR.</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/modes/rpc/</span>
+        <span class="src-tag">rpc</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// {"type":"prompt","text":"读取 README.md..."}</span></span>
+      <span class="src-line"><span class="src-comment">// → AgentEvent stream on stdout</span></span>
+    </div>
+
+    <table class="cmp">
+      <thead><tr><th>模式</th><th>传输</th><th>用例</th></tr></thead>
+      <tbody>
+      <tr><td>rpc</td><td>JSONL stdin/out</td><td>CI · 脚本</td></tr>
+      <tr><td>pi-server</td><td>HTTP + CBOR</td><td>远程 harness</td></tr>
+      <tr><td>interactive</td><td>TUI</td><td>日常开发</td></tr>
+      </tbody>
+    </table>
+
+    <div class="note">
+      <span class="lang-zh-only">本章 (25) 在主线 prompt「JSONL 进程协议 · CBOR 远程会话」路径上负责：<strong>RPC 与 pi-server</strong>。回到 C02 的 22 站地图定位这一章。</span>
+      <span class="lang-en-only">Chapter (25) on the through-line path handles: <strong>RPC and pi-server</strong>. Return to C02's 22-station map to locate this chapter.</span>
+    </div>
+
+    <table class="cmp">
+      <thead><tr><th>路径</th><th>说明</th></tr></thead>
+      <tbody>
+      <tr><td><code>packages/coding-agent/src/modes/rpc/</code></td><td>RPC 模式</td></tr>
+      <tr><td><code>packages/protocol/</code></td><td>JSONL 协议</td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">RPC 与 pi-server · 实现清单</span><span class="lang-en-only">RPC and pi-server · implementation checklist</span></h3>
+
+    <div class="note">
+      <span class="lang-zh-only">1. 定位生产文件：packages/agent/src/agent-loop.ts</span>
+      <span class="lang-en-only">1. Locate production file: packages/agent/src/agent-loop.ts</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">2. 对照 pi-textbook 同主题 checkpoint</span>
+      <span class="lang-en-only">2. Cross-read matching pi-textbook checkpoint</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">3. 用 --verbose 观察 AgentEvent</span>
+      <span class="lang-en-only">3. Observe AgentEvents with --verbose</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">4. 检查 JSONL 会话文件对应 entry</span>
+      <span class="lang-en-only">4. Inspect matching JSONL session entry</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">5. 阅读 packages/*/test/ 下相关测试</span>
+      <span class="lang-en-only">5. Read related tests under packages/*/test/</span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">附录 · RPC 与 pi-server 深度 trace</span><span class="lang-en-only">Appendix · deep trace for RPC and pi-server</span></h3>
+
+    <div class="lang-zh-only"><p>本章 (25) 属于 Phase「全景」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
+    <div class="lang-en-only"><p>Chapter (25) belongs to Phase «Landscape». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
+
+    <table class="cmp">
+      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
+      <tbody>
+      <tr><td>1</td><td>RPC 与 pi-server</td><td>JSONL 进程协议 · CBOR 远程会话</td></tr>
+      <tr><td>2</td><td>—</td><td>checkpoint 2</td></tr>
+      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
+      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
+      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
+      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
+      </tbody>
+    </table>
+
+    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// default trace</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 25 · RPC 与 pi-server</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 25 · RPC 与 pi-server</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 25 · RPC 与 pi-server</span></span>
+    </div>
+
+    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
+
+    <div class="lang-zh-only"><p><strong>AgentMessage</strong> — agent-core 内部消息 IR</p></div>
+    <div class="lang-en-only"><p><strong>AgentMessage</strong> — agent-core internal message IR</p></div>
+
+    <div class="lang-zh-only"><p><strong>StreamFn</strong> — 可注入的模型流函数</p></div>
+    <div class="lang-en-only"><p><strong>StreamFn</strong> — injectable model stream function</p></div>
+
+    <div class="lang-zh-only"><p><strong>leafId</strong> — JSONL 会话树当前叶</p></div>
+    <div class="lang-en-only"><p><strong>leafId</strong> — JSONL session tree current leaf</p></div>
+
+    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
+
+    <div class="note">
+      <span class="lang-zh-only">[25.1] 在 RPC 与 pi-server 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[25.1] At RPC and pi-server stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[25.2] 在 RPC 与 pi-server 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[25.2] At RPC and pi-server stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[25.3] 在 RPC 与 pi-server 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[25.3] At RPC and pi-server stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[25.4] 在 RPC 与 pi-server 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[25.4] At RPC and pi-server stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[25.5] 在 RPC 与 pi-server 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[25.5] At RPC and pi-server stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[25.6] 在 RPC 与 pi-server 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[25.6] At RPC and pi-server stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[25.7] 在 RPC 与 pi-server 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[25.7] At RPC and pi-server stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[25.8] 在 RPC 与 pi-server 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[25.8] At RPC and pi-server stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+  </section>
+
+  <section class="chap" id="c26">
+    <div class="chap-num">CHAPTER&nbsp;26&nbsp;·&nbsp;CODA</div>
+    <h2 class="chap-title lang-zh-only">怎么自己 trace 一轮</h2>
+    <h2 class="chap-title lang-en-only">How to trace a turn yourself</h2>
+    <p class="chap-en lang-zh-only">--verbose · event log · session file</p>
+    <p class="chap-en lang-en-only">--verbose · event log · session file</p>
+    <div class="lang-zh-only"><p>自己 trace 主线 prompt 的三件套：<code>pi --verbose</code> 看 AgentEvent、打开 JSONL 会话文件、对照 pi-textbook workshop 测试。</p></div>
+    <div class="lang-en-only"><p>Trace the through-line yourself: <code>pi --verbose</code> for AgentEvents, open JSONL session file, compare pi-textbook workshop tests.</p></div>
+
+    <div class="ladder">
+      <div class="ladder-step">
+        <div class="ladder-num">01</div>
+        <div class="ladder-body"><span class="lang-zh-only">pi --verbose</span><span class="lang-en-only">stderr 打印完整事件流</span></div>
+      </div>
+      <div class="ladder-step">
+        <div class="ladder-num">02</div>
+        <div class="ladder-body"><span class="lang-zh-only">~/.pi/sessions/</span><span class="lang-en-only">找到最新 .jsonl</span></div>
+      </div>
+      <div class="ladder-step">
+        <div class="ladder-num">03</div>
+        <div class="ladder-body"><span class="lang-zh-only">agent-loop.test.ts</span><span class="lang-en-only">对照单元测试</span></div>
+      </div>
+      <div class="ladder-step">
+        <div class="ladder-num">04</div>
+        <div class="ladder-body"><span class="lang-zh-only">workshop/test/agent-loop.test.ts</span><span class="lang-en-only">pi-textbook 离线复现</span></div>
+      </div>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; terminal</span>
+        <span class="src-tag">verbose</span>
+      </div>
+      <span class="src-line">$ pi --verbose</span>
+      <span class="src-line">$ <span class="src-str">读取 README.md，用一句话告诉我这个项目做什么</span></span>
+      <span class="src-line"><span class="src-comment">// agent_start → turn_start → message_update → ...</span></span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">推荐阅读顺序</span><span class="lang-en-only">Suggested reading order</span></h3>
+
+    <div class="lang-zh-only"><p>1. pi-textbook checkpoint 00 七里程碑 → 2. pi-mono agent-loop.ts runLoop → 3. agent-session.ts prompt() → 4. 本文 C02 22 站地图。</p></div>
+    <div class="lang-en-only"><p>1. pi-textbook cp 00 seven milestones → 2. pi-mono agent-loop.ts runLoop → 3. agent-session.ts prompt() → 4. this article C02 22-station map.</p></div>
+
+    <blockquote class="pull copper">
+      <span class="lang-zh-only">读完之后，用一句话回答：<br>「读取 README.md，用一句话告诉我这个项目做什么」——<br>在 Pi 里，这句话究竟触发了什么？</span>
+      <span class="lang-en-only">After reading, answer in one sentence:<br>«read README.md and tell me what this project does in one sentence» —<br>what exactly does that line trigger in Pi?</span>
+      <cite>Field Note · 10</cite>
+    </blockquote>
+
+    <div class="note">
+      <span class="lang-zh-only">答案应该能指出：AgentSession.prompt → agentLoop → 两次 streamSimple → read tool → JSONL append → TUI message_update。</span>
+      <span class="lang-en-only">Answer should cite: AgentSession.prompt → agentLoop → two streamSimple → read tool → JSONL append → TUI message_update.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">本章 (26) 在主线 prompt「--verbose · event log · session file」路径上负责：<strong>怎么自己 trace 一轮</strong>。回到 C02 的 22 站地图定位这一章。</span>
+      <span class="lang-en-only">Chapter (26) on the through-line path handles: <strong>How to trace a turn yourself</strong>. Return to C02's 22-station map to locate this chapter.</span>
+    </div>
+
+    <table class="cmp">
+      <thead><tr><th>路径</th><th>说明</th></tr></thead>
+      <tbody>
+      <tr><td><code>packages/coding-agent/test/</code></td><td>集成测试</td></tr>
+      <tr><td><code>packages/agent/test/</code></td><td>agent loop 测试</td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">怎么自己 trace 一轮 · 实现清单</span><span class="lang-en-only">How to trace a turn yourself · implementation checklist</span></h3>
+
+    <div class="note">
+      <span class="lang-zh-only">1. 定位生产文件：packages/agent/src/agent-loop.ts</span>
+      <span class="lang-en-only">1. Locate production file: packages/agent/src/agent-loop.ts</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">2. 对照 pi-textbook 同主题 checkpoint</span>
+      <span class="lang-en-only">2. Cross-read matching pi-textbook checkpoint</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">3. 用 --verbose 观察 AgentEvent</span>
+      <span class="lang-en-only">3. Observe AgentEvents with --verbose</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">4. 检查 JSONL 会话文件对应 entry</span>
+      <span class="lang-en-only">4. Inspect matching JSONL session entry</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">5. 阅读 packages/*/test/ 下相关测试</span>
+      <span class="lang-en-only">5. Read related tests under packages/*/test/</span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">附录 · 怎么自己 trace 一轮 深度 trace</span><span class="lang-en-only">Appendix · deep trace for How to trace a turn yourself</span></h3>
+
+    <div class="lang-zh-only"><p>本章 (26) 属于 Phase「Coda」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。</p></div>
+    <div class="lang-en-only"><p>Chapter (26) belongs to Phase «Coda». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.</p></div>
+
+    <table class="cmp">
+      <thead><tr><th>step</th><th>组件</th><th>状态/输出</th></tr></thead>
+      <tbody>
+      <tr><td>1</td><td>怎么自己 trace 一轮</td><td>--verbose · event log · session file</td></tr>
+      <tr><td>2</td><td>—</td><td>checkpoint 2</td></tr>
+      <tr><td>3</td><td>—</td><td>checkpoint 3</td></tr>
+      <tr><td>4</td><td>—</td><td>checkpoint 4</td></tr>
+      <tr><td>5</td><td>—</td><td>checkpoint 5</td></tr>
+      <tr><td>6</td><td>—</td><td>checkpoint 6</td></tr>
+      </tbody>
+    </table>
+
+    <h4 class="sub2"><span class="lang-zh-only">相关源码文件</span><span class="lang-en-only">Related source files</span></h4>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// default trace</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 26 · 怎么自己 trace 一轮</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/test/agent-session.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 集成测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 26 · 怎么自己 trace 一轮</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/test/agent-loop.test.ts</span>
+        <span class="src-tag">ref</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// 教学测试</span></span>
+      <span class="src-line"><span class="src-comment">// chapter 26 · 怎么自己 trace 一轮</span></span>
+    </div>
+
+    <h4 class="sub2"><span class="lang-zh-only">术语表</span><span class="lang-en-only">Glossary</span></h4>
+
+    <div class="lang-zh-only"><p><strong>AgentMessage</strong> — agent-core 内部消息 IR</p></div>
+    <div class="lang-en-only"><p><strong>AgentMessage</strong> — agent-core internal message IR</p></div>
+
+    <div class="lang-zh-only"><p><strong>StreamFn</strong> — 可注入的模型流函数</p></div>
+    <div class="lang-en-only"><p><strong>StreamFn</strong> — injectable model stream function</p></div>
+
+    <div class="lang-zh-only"><p><strong>leafId</strong> — JSONL 会话树当前叶</p></div>
+    <div class="lang-en-only"><p><strong>leafId</strong> — JSONL session tree current leaf</p></div>
+
+    <h4 class="sub2"><span class="lang-zh-only">调试清单</span><span class="lang-en-only">Debug checklist</span></h4>
+
+    <div class="note">
+      <span class="lang-zh-only">[26.1] 在 怎么自己 trace 一轮 阶段：检查 AgentEvent 序列第 1 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[26.1] At How to trace a turn yourself stage: verify AgentEvent sequence item 1 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[26.2] 在 怎么自己 trace 一轮 阶段：检查 AgentEvent 序列第 2 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[26.2] At How to trace a turn yourself stage: verify AgentEvent sequence item 2 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[26.3] 在 怎么自己 trace 一轮 阶段：检查 AgentEvent 序列第 3 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[26.3] At How to trace a turn yourself stage: verify AgentEvent sequence item 3 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[26.4] 在 怎么自己 trace 一轮 阶段：检查 AgentEvent 序列第 4 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[26.4] At How to trace a turn yourself stage: verify AgentEvent sequence item 4 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[26.5] 在 怎么自己 trace 一轮 阶段：检查 AgentEvent 序列第 5 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[26.5] At How to trace a turn yourself stage: verify AgentEvent sequence item 5 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[26.6] 在 怎么自己 trace 一轮 阶段：检查 AgentEvent 序列第 6 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[26.6] At How to trace a turn yourself stage: verify AgentEvent sequence item 6 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[26.7] 在 怎么自己 trace 一轮 阶段：检查 AgentEvent 序列第 7 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[26.7] At How to trace a turn yourself stage: verify AgentEvent sequence item 7 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+
+    <div class="note">
+      <span class="lang-zh-only">[26.8] 在 怎么自己 trace 一轮 阶段：检查 AgentEvent 序列第 8 项是否包含预期字段；对照 JSONL entry parentId 链。</span>
+      <span class="lang-en-only">[26.8] At How to trace a turn yourself stage: verify AgentEvent sequence item 8 has expected fields; match JSONL entry parentId chain.</span>
+    </div>
+  </section>
+
+  <footer class="footer">
+    <div class="ft-rule"><span class="ft-mark">END · FIELD NOTE 10</span></div>
+    <p class="lang-zh-only">这是 Field Note 系列的第十篇。<strong>姐妹篇</strong>:</p>
+    <p class="lang-en-only">Tenth in the Field Note series. <strong>Sister pieces</strong>:</p>
+    <div class="ft-links">
+      <a href="https://ursb.me/immersive/llm-inference-life/">LLM 推理 · 28 站</a>
+      <a href="https://ursb.me/immersive/chromium-renderer/">Chromium · 渲染管线</a>
+      <a href="https://ursb.me/immersive/react-internals/">React · setState 一生</a>
+      <a href="https://ursb.me/immersive/quickjs/">QuickJS · 一行 JS</a>
+    </div>
+    <p class="lang-zh-only" style="margin-top:24px;font-style:italic;color:var(--ink-mute);">"一条用户消息看起来只是终端里的一行字——它真正做的事情，是在六个 npm 包里穿过 26 道工序，在 JSONL 会话树上留下一个可 fork 的节点，然后被 TUI 用 CSI 2026 差分渲染成你看到的 token 流。"</p>
+    <p class="lang-en-only" style="margin-top:24px;font-style:italic;color:var(--ink-mute);">"A user message looks like one line in the terminal. What it really does: pass through 26 stations across six npm packages, leave a forkable node on the JSONL session tree, then get differential-rendered into the token stream you see via CSI 2026."</p>
+    <p style="margin-top:28px;">© 2026 <a href="https://ursb.me">Airing</a> · <span class="lang-zh-only">本文为 Field Note 长文,欢迎转载注明出处</span><span class="lang-en-only">long-form Field Note, attribution appreciated</span></p>
+  </footer>
+
+</div>
+
+
+<script>
+(function() {
+  var zh = document.getElementById('lang-zh');
+  var en = document.getElementById('lang-en');
+  function setLang(lang) {
+    if (lang === 'en') {
+      document.body.classList.add('lang-en');
+      document.documentElement.lang = 'en';
+      en.classList.add('active'); en.setAttribute('aria-pressed', 'true');
+      zh.classList.remove('active'); zh.setAttribute('aria-pressed', 'false');
+    } else {
+      document.body.classList.remove('lang-en');
+      document.documentElement.lang = 'zh-CN';
+      zh.classList.add('active'); zh.setAttribute('aria-pressed', 'true');
+      en.classList.remove('active'); en.setAttribute('aria-pressed', 'false');
+    }
+    try { localStorage.setItem('pi-agent-lang', lang); } catch (e) {}
+  }
+  zh.addEventListener('click', function() { setLang('zh'); });
+  en.addEventListener('click', function() { setLang('en'); });
+  try {
+    var saved = localStorage.getItem('pi-agent-lang');
+    if (saved === 'en') setLang('en');
+  } catch (e) {}
+})();
+
+(function() {
+  var bar = document.getElementById('readProgress');
+  if (!bar) return;
+  function update() {
+    var h = document.documentElement.scrollHeight - window.innerHeight;
+    bar.style.width = (h > 0 ? (window.scrollY / h) * 100 : 0) + '%';
+  }
+  window.addEventListener('scroll', update, { passive: true });
+  update();
+})();
+
+(function() {
+  var cells = document.querySelectorAll('#pbTrack .pb-cell');
+  if (!cells.length) return;
+  var i = -1;
+  function tick() {
+    cells.forEach(function(c, idx) { c.classList.toggle('lit', idx <= i); });
+    i++;
+    if (i >= cells.length + 3) i = -1;
+    setTimeout(tick, 380);
+  }
+  tick();
+  cells.forEach(function(c) {
+    c.addEventListener('click', function() {
+      var target = document.querySelector(c.dataset.jump || '');
+      if (target) target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    });
+  });
+})();
+
+(function () {
+  var sideItems = Array.prototype.map.call(
+    document.querySelectorAll('.toc-side li[data-section]'),
+    function (li) { return { node: li, el: document.getElementById(li.dataset.section) }; }
+  ).filter(function (o) { return o.el; });
+  if (!sideItems.length) return;
+  function update() {
+    var offset = window.innerHeight * 0.32;
+    var activeIdx = 0;
+    for (var i = 0; i < sideItems.length; i++) {
+      if (sideItems[i].el.getBoundingClientRect().top - offset < 0) activeIdx = i;
+    }
+    var activeId = sideItems[activeIdx].el.id;
+    sideItems.forEach(function (o) {
+      o.node.classList.toggle('active', o.el.id === activeId);
+    });
+  }
+  window.addEventListener('scroll', update, { passive: true });
+  window.addEventListener('resize', update);
+  update();
+})();
+</script>
+
+
+<section class="ursb-interactive">
+  <div class="ursb-fbody">
+    <div class="ui-divider"><span class="ui-divider-mark">✦ ✦ ✦</span></div>
+
+    <div class="ui-stats-row">
+      <button class="ui-like" id="uiLikeBtn" type="button" disabled>
+        <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round" stroke-linecap="round" aria-hidden="true">
+          <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/>
+        </svg>
+        <span class="ui-count" id="uiLikeCount">—</span>
+        <span><span lang="zh">点赞</span><span lang="en">Likes</span></span>
+      </button>
+      <div class="ui-views" title="Page views">
+        <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round" stroke-linecap="round" aria-hidden="true">
+          <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/>
+        </svg>
+        <span class="ui-count" id="uiViewCount">—</span>
+        <span><span lang="zh">阅读</span><span lang="en">Reads</span></span>
+      </div>
+      <button class="ui-share" id="uiShareBtn" type="button">
+        <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round" stroke-linecap="round" aria-hidden="true">
+          <path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8"/><polyline points="16 6 12 2 8 6"/><line x1="12" y1="2" x2="12" y2="15"/>
+        </svg>
+        <span class="ui-share-text"><span lang="zh">分享</span><span lang="en">Share</span></span>
+      </button>
+      <div class="ui-online" data-online="page" data-online-template='<span class="ui-online-dot"></span><span class="ui-count">{n}</span><span><span lang="zh">在读</span><span lang="en">reading</span></span>' data-online-min="1" style="display:none"></div>
+    </div>
+
+    <h3 class="ui-section-title">
+      <span lang="zh">留下评论</span><span lang="en">Leave a comment</span>
+    </h3>
+    <form class="ui-comment-form" id="uiCommentForm" autocomplete="off">
+      <div class="ui-form-row">
+        <input type="text" name="nickname" id="uiNickname" required maxlength="40">
+        <input type="email" name="email" id="uiEmail" maxlength="120">
+      </div>
+      <textarea name="content" id="uiContent" required maxlength="2000" rows="4"></textarea>
+      <div class="ui-form-foot">
+        <span class="ui-form-status" id="uiFormStatus"></span>
+        <button type="submit" id="uiSubmitBtn">
+          <span lang="zh">发布评论</span><span lang="en">Post comment</span>
+        </button>
+      </div>
+    </form>
+
+    <h3 class="ui-section-title">
+      <span lang="zh">评论</span><span lang="en">Comments</span>
+      <span id="uiCommentCount" class="ui-count-small">—</span>
+    </h3>
+    <div class="ui-comment-list" id="uiCommentList">
+      <div class="ui-comment-loading">
+        <span lang="zh">加载中…</span><span lang="en">Loading…</span>
+      </div>
+    </div>
+  </div>
+</section>
+
+<script>
+/* ursb.me INTERACTIVE FOOTER — likes / views / comments
+   Talks to https://chat.ursb.me, slug = "note/chromium-renderer" */
+(function() {
+  var API_BASE = 'https://chat.ursb.me';
+  var POST_SLUG = 'note/pi-agent';
+  var ENC = encodeURIComponent(POST_SLUG);
+
+  var likeBtn = document.getElementById('uiLikeBtn');
+  var likeCount = document.getElementById('uiLikeCount');
+  var viewCount = document.getElementById('uiViewCount');
+  var shareBtn = document.getElementById('uiShareBtn');
+  var commentForm = document.getElementById('uiCommentForm');
+  var commentList = document.getElementById('uiCommentList');
+  var commentCount = document.getElementById('uiCommentCount');
+  var formStatus = document.getElementById('uiFormStatus');
+  var submitBtn = document.getElementById('uiSubmitBtn');
+  var nicknameInput = document.getElementById('uiNickname');
+  var emailInput = document.getElementById('uiEmail');
+  var contentInput = document.getElementById('uiContent');
+  if (!likeBtn) return;
+
+  var I18N = {
+    zh: { nicknamePh: '昵称*', emailPh: '邮箱（可选，仅用于回复通知）', contentPh: '说点什么…',
+          posting: '提交中…', posted: '✓ 已发布', postFailed: '✗ 发布失败：',
+          shareCopied: '✓ 已复制链接', loading: '加载中…', empty: '还没有评论，来抢沙发吧。',
+          loadFailed: '评论加载失败', justNow: '刚刚', mAgo: ' 分钟前', hAgo: ' 小时前', dAgo: ' 天前' },
+    en: { nicknamePh: 'Nickname*', emailPh: 'Email (optional, for reply notifications)', contentPh: 'Say something…',
+          posting: 'Posting…', posted: '✓ Posted', postFailed: '✗ Failed: ',
+          shareCopied: '✓ Link copied', loading: 'Loading…', empty: 'Be the first to comment.',
+          loadFailed: 'Failed to load comments', justNow: 'just now', mAgo: 'm ago', hAgo: 'h ago', dAgo: 'd ago' }
+  };
+  function t() {
+    var lang = (document.documentElement.lang || '').toLowerCase();
+    return I18N[lang.indexOf('en') === 0 ? 'en' : 'zh'];
+  }
+  function applyI18n() {
+    var s = t();
+    if (nicknameInput) nicknameInput.placeholder = s.nicknamePh;
+    if (emailInput) emailInput.placeholder = s.emailPh;
+    if (contentInput) contentInput.placeholder = s.contentPh;
+  }
+  applyI18n();
+  new MutationObserver(applyI18n).observe(document.documentElement, { attributes: true, attributeFilter: ['lang'] });
+
+  fetch(API_BASE + '/api/posts/' + ENC + '/view', { method: 'POST' }).catch(function(){});
+
+  fetch(API_BASE + '/api/posts/' + ENC + '/views')
+    .then(function(r) { return r.json(); })
+    .then(function(d) {
+      var pv = (d && (d.pv != null ? d.pv : d.views)) || 0;
+      viewCount.textContent = pv.toLocaleString();
+    })
+    .catch(function() { viewCount.textContent = '—'; });
+
+  fetch(API_BASE + '/api/posts/' + ENC + '/likes')
+    .then(function(r) { return r.json(); })
+    .then(function(d) {
+      likeCount.textContent = ((d && d.count) || 0).toLocaleString();
+      if (d && d.liked) likeBtn.classList.add('liked');
+    })
+    .catch(function() { likeCount.textContent = '—'; })
+    .finally(function() { likeBtn.disabled = false; });
+
+  likeBtn.addEventListener('click', function() {
+    likeBtn.disabled = true;
+    fetch(API_BASE + '/api/posts/' + ENC + '/like', { method: 'POST' })
+      .then(function(r) { return r.json(); })
+      .then(function(d) {
+        likeCount.textContent = ((d && d.count) || 0).toLocaleString();
+        likeBtn.classList.toggle('liked', !!(d && d.liked));
+        if (typeof umami !== 'undefined') umami.track('post-like', { post: POST_SLUG });
+      })
+      .catch(function() {})
+      .finally(function() { likeBtn.disabled = false; });
+  });
+
+  shareBtn.addEventListener('click', function() {
+    var url = window.location.href;
+    var title = document.title;
+    if (navigator.share) { navigator.share({ title: title, url: url }).catch(function(){}); return; }
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(url).then(function() {
+        var label = shareBtn.querySelector('.ui-share-text');
+        var orig = label.innerHTML;
+        label.textContent = t().shareCopied;
+        setTimeout(function() { label.innerHTML = orig; }, 1800);
+      }).catch(function() { window.prompt('Copy URL:', url); });
+    } else { window.prompt('Copy URL:', url); }
+  });
+
+  function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, function(c) {
+      return ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#039;'})[c];
+    });
+  }
+  function fmtDate(s) {
+    if (!s) return '';
+    var d = new Date(s);
+    var diff = (new Date() - d) / 1000;
+    var i18n = t();
+    if (diff < 60) return i18n.justNow;
+    if (diff < 3600) return Math.floor(diff/60) + i18n.mAgo;
+    if (diff < 86400) return Math.floor(diff/3600) + i18n.hAgo;
+    if (diff < 7*86400) return Math.floor(diff/86400) + i18n.dAgo;
+    return d.toLocaleDateString();
+  }
+  function renderComments(comments) {
+    var i18n = t();
+    if (!comments || !comments.length) {
+      commentList.innerHTML = '<div class="ui-comment-empty">' + i18n.empty + '</div>';
+      commentCount.textContent = '(0)';
+      return;
+    }
+    commentCount.textContent = '(' + comments.length + ')';
+    commentList.innerHTML = comments.map(function(c) {
+      return '<div class="ui-comment">' +
+        '<div class="ui-comment-head">' +
+          '<span class="ui-comment-name">' + escapeHtml(c.nickname || 'Anonymous') + '</span>' +
+          '<span class="ui-comment-date">' + escapeHtml(fmtDate(c.created_at || c.createdAt)) + '</span>' +
+        '</div>' +
+        '<div class="ui-comment-body">' + escapeHtml(c.content || '') + '</div>' +
+      '</div>';
+    }).join('');
+  }
+  function loadComments() {
+    fetch(API_BASE + '/api/comments?post_slug=' + encodeURIComponent(POST_SLUG))
+      .then(function(r) { return r.json(); })
+      .then(function(d) {
+        var list = Array.isArray(d) ? d : (d && d.comments) || [];
+        renderComments(list);
+      })
+      .catch(function() {
+        commentList.innerHTML = '<div class="ui-comment-empty">' + t().loadFailed + '</div>';
+      });
+  }
+  loadComments();
+
+  commentForm.addEventListener('submit', function(e) {
+    e.preventDefault();
+    var i18n = t();
+    var payload = {
+      post_slug: POST_SLUG,
+      nickname: (nicknameInput.value || '').trim(),
+      email: (emailInput.value || '').trim() || null,
+      content: (contentInput.value || '').trim(),
+      parent_id: null
+    };
+    if (!payload.nickname || !payload.content) return;
+    submitBtn.disabled = true;
+    formStatus.className = 'ui-form-status';
+    formStatus.textContent = i18n.posting;
+    fetch(API_BASE + '/api/comments', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    })
+      .then(function(r) { return r.json().then(function(j) { return { ok: r.ok, body: j }; }); })
+      .then(function(res) {
+        if (!res.ok) throw new Error((res.body && (res.body.error || res.body.message)) || 'Failed');
+        formStatus.className = 'ui-form-status success';
+        formStatus.textContent = i18n.posted;
+        commentForm.reset();
+        loadComments();
+        if (typeof umami !== 'undefined') umami.track('post-comment', { post: POST_SLUG });
+        setTimeout(function() { formStatus.textContent = ''; formStatus.className = 'ui-form-status'; }, 3000);
+      })
+      .catch(function(err) {
+        formStatus.className = 'ui-form-status error';
+        formStatus.textContent = i18n.postFailed + (err.message || '');
+      })
+      .finally(function() { submitBtn.disabled = false; });
+  });
+})();
+</script>
+
+<!-- Online presence (per-page) -->
+<script>
+(function () {
+  var DOT = '<span class="ui-online-dot"></span>';
+  var N = '<span class="ui-count">{n}</span>';
+  function dual(zh, en) { return '<span lang="zh">' + zh + '</span><span lang="en">' + en + '</span>'; }
+  window.__ONLINE_CONFIG__ = {
+    pageId: 'note/pi-agent',
+    tiers: [
+      { max: 1,   html: '✦ ' + dual('你是此刻唯一在读的人', 'You are the only one reading right now') },
+      { max: 9,   html: DOT + dual('此刻有 ' + N + ' 人在读', N + ' people reading right now') },
+      { max: 19,  html: DOT + dual(N + ' 人正在读这篇', N + ' reading this piece') },
+      { max: 29,  html: DOT + dual('茶座坐满了,' + N + ' 人', 'A full house, ' + N + ' reading') },
+      { max: 99,  html: '🔥 ' + dual(N + ' 人聚在这,人声渐沸', N + ' gathered here, buzzing') },
+      { max: Infinity, html: '🔥 ' + dual(N + ' 人围读!这篇火了', N + ' readers, this is on fire') }
+    ]
+  };
+})();
+</script>
+<script src="/assets/online-presence.js" defer></script>
+
+
+<script>
+/* ====== TOC scroll-spy (added 2026-06) ====== */
+(function () {
+  var sideItems = Array.prototype.map.call(
+    document.querySelectorAll('.toc-side li[data-section]'),
+    function (li) { return { node: li, el: document.getElementById(li.dataset.section) }; }
+  ).filter(function (o) { return o.el; });
+  if (!sideItems.length) return;
+  function update() {
+    var offset = window.innerHeight * 0.32;
+    var activeIdx = 0;
+    for (var i = 0; i < sideItems.length; i++) {
+      if (sideItems[i].el.getBoundingClientRect().top - offset < 0) activeIdx = i;
+    }
+    var activeId = sideItems[activeIdx].el.id;
+    sideItems.forEach(function (o) {
+      o.node.classList.toggle('active', o.el.id === activeId);
+    });
+  }
+  window.addEventListener('scroll', update, { passive: true });
+  window.addEventListener('resize', update);
+  update();
+})();
+</script>
+
+</body>
+
+
+</body>
+</html>

--- a/public/immersive/pi-agent/index.html
+++ b/public/immersive/pi-agent/index.html
@@ -862,6 +862,61 @@
   .pi-svg .svg-box.paper { fill: #f3efe6; stroke: #c7c4ba; }
   .pi-svg .svg-box.muted { fill: #ebe5d8; stroke: #c7c4ba; }
   .pi-svg .svg-arrow { stroke: #1f5c8c; stroke-width: 1.5; marker-end: url(#pi-arr); }
+  .pi-fig.panorama svg { min-width: 100%; }
+  .station-track {
+    margin: 20px 0 28px;
+    border: 1px solid var(--rule);
+    border-radius: 4px;
+    background: var(--paper);
+    overflow: hidden;
+  }
+  .station-track .st-rail {
+    display: grid;
+    grid-template-columns: repeat(11, minmax(72px, 1fr));
+    gap: 0;
+    overflow-x: auto;
+    padding: 0;
+    scrollbar-width: thin;
+  }
+  @media (max-width: 900px) {
+    .station-track .st-rail { grid-template-columns: repeat(11, 88px); }
+  }
+  .station-track .st-cell {
+    border-right: 1px solid var(--rule-soft);
+    border-bottom: 1px solid var(--rule-soft);
+    padding: 12px 8px 10px;
+    text-align: center;
+    background: linear-gradient(180deg, var(--paper) 0%, color-mix(in srgb, var(--st-color) 6%, var(--paper)) 100%);
+    min-height: 88px;
+  }
+  .station-track .st-cell:nth-child(n+12) { border-bottom: none; }
+  .station-track .st-num {
+    font-family: var(--mono); font-size: 18px; font-weight: 700;
+    color: var(--st-color); line-height: 1;
+  }
+  .station-track .st-name {
+    font-family: var(--sans); font-size: 11px; font-weight: 600;
+    color: var(--ink); margin-top: 6px; line-height: 1.25;
+  }
+  .station-track .st-phase {
+    font-family: var(--mono); font-size: 8px; letter-spacing: 0.1em;
+    text-transform: uppercase; color: var(--ink-mute); margin-top: 4px;
+  }
+  .event-flow {
+    border: 1px solid var(--rule); border-radius: 4px;
+    background: var(--paper-2); padding: 4px 0;
+  }
+  .event-flow .ef-row {
+    display: grid; grid-template-columns: 140px 1fr; gap: 16px;
+    padding: 10px 18px; border-bottom: 1px dashed var(--rule-soft);
+    align-items: baseline;
+  }
+  .event-flow .ef-row:last-child { border-bottom: none; }
+  .event-flow .ef-type {
+    font-family: var(--mono); font-size: 11px; font-weight: 600;
+    color: var(--accent); background: var(--accent-pale, #e8f0f8);
+    padding: 3px 8px; border-radius: 3px; display: inline-block;
+  }
   .toc-group[data-phase="heart"] { border-left-color: var(--accent); background: linear-gradient(135deg, rgba(31,92,140,0.04) 0%, var(--paper) 60%); }
   .toc-group[data-phase="llm"] { border-left-color: var(--gpu); background: linear-gradient(135deg, rgba(107,58,163,0.05) 0%, var(--paper) 60%); }
   .toc-group[data-phase="tui"] { border-left-color: var(--asm); background: linear-gradient(135deg, rgba(45,106,79,0.04) 0%, var(--paper) 60%); }
@@ -882,9 +937,6 @@
   }
   .session-tree .st-node { padding: 4px 0 4px 20px; border-left: 2px solid var(--rule); margin-left: 8px; }
   .session-tree .st-leaf { color: var(--accent); font-weight: 700; }
-  .event-flow { font-family: var(--mono); font-size: 11px; }
-  .event-flow .ef-row { display: grid; grid-template-columns: 100px 1fr; gap: 12px; padding: 6px 0; border-bottom: 1px dashed var(--rule-soft); }
-  .event-flow .ef-type { color: var(--accent); font-weight: 600; }
   .milestone-table td.owner-user { color: var(--copper); }
   .milestone-table td.owner-model { color: var(--accent); }
   .milestone-table td.owner-loop { color: var(--gpu); }
@@ -1535,6 +1587,207 @@
     <h3 class="sub"><span class="lang-zh-only">22 站全景（前 22 站）</span><span class="lang-en-only">22-station panorama (first 22)</span></h3>
 
     <figure>
+      <div class="figbox"><div class="pi-fig panorama"><svg viewBox="0 0 1000 270" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true" class="pi-svg">
+  <defs>
+    <marker id="pi-arr" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 Z" fill="#1f5c8c"/>
+    </marker>
+  </defs>
+  <text x="48" y="32" class="svg-label">22 stations · snake timeline · one user message</text>
+  <text x="48" y="52" class="svg-mute">Enter → … → JSONL on disk</text>
+  <line x1="76" y1="95" x2="108" y2="95" stroke="#c7c4ba" stroke-width="1.5"/><line x1="164" y1="95" x2="196" y2="95" stroke="#c7c4ba" stroke-width="1.5"/><line x1="252" y1="95" x2="284" y2="95" stroke="#c7c4ba" stroke-width="1.5"/><line x1="340" y1="95" x2="372" y2="95" stroke="#c7c4ba" stroke-width="1.5"/><line x1="428" y1="95" x2="460" y2="95" stroke="#c7c4ba" stroke-width="1.5"/><line x1="516" y1="95" x2="548" y2="95" stroke="#c7c4ba" stroke-width="1.5"/><line x1="604" y1="95" x2="636" y2="95" stroke="#c7c4ba" stroke-width="1.5"/><line x1="692" y1="95" x2="724" y2="95" stroke="#c7c4ba" stroke-width="1.5"/><line x1="780" y1="95" x2="812" y2="95" stroke="#c7c4ba" stroke-width="1.5"/><line x1="868" y1="95" x2="900" y2="95" stroke="#c7c4ba" stroke-width="1.5"/><path d="M956 95 L980 95 L980 145 L-4 145 L-4 167 L20 167" fill="none" stroke="#c7c4ba" stroke-width="1.5"/><line x1="76" y1="195" x2="108" y2="195" stroke="#c7c4ba" stroke-width="1.5"/><line x1="164" y1="195" x2="196" y2="195" stroke="#c7c4ba" stroke-width="1.5"/><line x1="252" y1="195" x2="284" y2="195" stroke="#c7c4ba" stroke-width="1.5"/><line x1="340" y1="195" x2="372" y2="195" stroke="#c7c4ba" stroke-width="1.5"/><line x1="428" y1="195" x2="460" y2="195" stroke="#c7c4ba" stroke-width="1.5"/><line x1="516" y1="195" x2="548" y2="195" stroke="#c7c4ba" stroke-width="1.5"/><line x1="604" y1="195" x2="636" y2="195" stroke="#c7c4ba" stroke-width="1.5"/><line x1="692" y1="195" x2="724" y2="195" stroke="#c7c4ba" stroke-width="1.5"/><line x1="780" y1="195" x2="812" y2="195" stroke="#c7c4ba" stroke-width="1.5"/><line x1="868" y1="195" x2="900" y2="195" stroke="#c7c4ba" stroke-width="1.5"/>
+  
+  <rect x="20" y="67" width="56" height="56" rx="4" fill="#767c87" opacity="0.12" stroke="#767c87" stroke-width="1.5"/>
+  <text x="48" y="87" text-anchor="middle" class="svg-tiny" fill="#767c87" font-weight="700">01</text>
+  <text x="48" y="105" text-anchor="middle" class="svg-micro">CLI 解析</text>
+  <rect x="108" y="67" width="56" height="56" rx="4" fill="#767c87" opacity="0.12" stroke="#767c87" stroke-width="1.5"/>
+  <text x="136" y="87" text-anchor="middle" class="svg-tiny" fill="#767c87" font-weight="700">02</text>
+  <text x="136" y="105" text-anchor="middle" class="svg-micro">main 启动</text>
+  <rect x="196" y="67" width="56" height="56" rx="4" fill="#767c87" opacity="0.12" stroke="#767c87" stroke-width="1.5"/>
+  <text x="224" y="87" text-anchor="middle" class="svg-tiny" fill="#767c87" font-weight="700">03</text>
+  <text x="224" y="105" text-anchor="middle" class="svg-micro">Session</text>
+  <rect x="284" y="67" width="56" height="56" rx="4" fill="#767c87" opacity="0.12" stroke="#767c87" stroke-width="1.5"/>
+  <text x="312" y="87" text-anchor="middle" class="svg-tiny" fill="#767c87" font-weight="700">04</text>
+  <text x="312" y="105" text-anchor="middle" class="svg-micro">AGENTS.md</text>
+  <rect x="372" y="67" width="56" height="56" rx="4" fill="#1f5c8c" opacity="0.12" stroke="#1f5c8c" stroke-width="1.5"/>
+  <text x="400" y="87" text-anchor="middle" class="svg-tiny" fill="#1f5c8c" font-weight="700">05</text>
+  <text x="400" y="105" text-anchor="middle" class="svg-micro">prompt 入队</text>
+  <rect x="460" y="67" width="56" height="56" rx="4" fill="#1f5c8c" opacity="0.12" stroke="#1f5c8c" stroke-width="1.5"/>
+  <text x="488" y="87" text-anchor="middle" class="svg-tiny" fill="#1f5c8c" font-weight="700">06</text>
+  <text x="488" y="105" text-anchor="middle" class="svg-micro">agent_star</text>
+  <rect x="548" y="67" width="56" height="56" rx="4" fill="#1f5c8c" opacity="0.12" stroke="#1f5c8c" stroke-width="1.5"/>
+  <text x="576" y="87" text-anchor="middle" class="svg-tiny" fill="#1f5c8c" font-weight="700">07</text>
+  <text x="576" y="105" text-anchor="middle" class="svg-micro">turn_start</text>
+  <rect x="636" y="67" width="56" height="56" rx="4" fill="#6b3aa3" opacity="0.12" stroke="#6b3aa3" stroke-width="1.5"/>
+  <text x="664" y="87" text-anchor="middle" class="svg-tiny" fill="#6b3aa3" font-weight="700">08</text>
+  <text x="664" y="105" text-anchor="middle" class="svg-micro">convertToL</text>
+  <rect x="724" y="67" width="56" height="56" rx="4" fill="#6b3aa3" opacity="0.12" stroke="#6b3aa3" stroke-width="1.5"/>
+  <text x="752" y="87" text-anchor="middle" class="svg-tiny" fill="#6b3aa3" font-weight="700">09</text>
+  <text x="752" y="105" text-anchor="middle" class="svg-micro">streamSimp</text>
+  <rect x="812" y="67" width="56" height="56" rx="4" fill="#6b3aa3" opacity="0.12" stroke="#6b3aa3" stroke-width="1.5"/>
+  <text x="840" y="87" text-anchor="middle" class="svg-tiny" fill="#6b3aa3" font-weight="700">10</text>
+  <text x="840" y="105" text-anchor="middle" class="svg-micro">text_delta</text>
+  <rect x="900" y="67" width="56" height="56" rx="4" fill="#6b3aa3" opacity="0.12" stroke="#6b3aa3" stroke-width="1.5"/>
+  <text x="928" y="87" text-anchor="middle" class="svg-tiny" fill="#6b3aa3" font-weight="700">11</text>
+  <text x="928" y="105" text-anchor="middle" class="svg-micro">toolcall_δ</text>
+  <rect x="20" y="167" width="56" height="56" rx="4" fill="#1f5c8c" opacity="0.12" stroke="#1f5c8c" stroke-width="1.5"/>
+  <text x="48" y="187" text-anchor="middle" class="svg-tiny" fill="#1f5c8c" font-weight="700">12</text>
+  <text x="48" y="205" text-anchor="middle" class="svg-micro">toolUse</text>
+  <rect x="108" y="167" width="56" height="56" rx="4" fill="#1f5c8c" opacity="0.12" stroke="#1f5c8c" stroke-width="1.5"/>
+  <text x="136" y="187" text-anchor="middle" class="svg-tiny" fill="#1f5c8c" font-weight="700">13</text>
+  <text x="136" y="205" text-anchor="middle" class="svg-micro">executeToo</text>
+  <rect x="196" y="167" width="56" height="56" rx="4" fill="#2d6a4f" opacity="0.12" stroke="#2d6a4f" stroke-width="1.5"/>
+  <text x="224" y="187" text-anchor="middle" class="svg-tiny" fill="#2d6a4f" font-weight="700">14</text>
+  <text x="224" y="205" text-anchor="middle" class="svg-micro">read READM</text>
+  <rect x="284" y="167" width="56" height="56" rx="4" fill="#2d6a4f" opacity="0.12" stroke="#2d6a4f" stroke-width="1.5"/>
+  <text x="312" y="187" text-anchor="middle" class="svg-tiny" fill="#2d6a4f" font-weight="700">15</text>
+  <text x="312" y="205" text-anchor="middle" class="svg-micro">tool_resul</text>
+  <rect x="372" y="167" width="56" height="56" rx="4" fill="#6b3aa3" opacity="0.12" stroke="#6b3aa3" stroke-width="1.5"/>
+  <text x="400" y="187" text-anchor="middle" class="svg-tiny" fill="#6b3aa3" font-weight="700">16</text>
+  <text x="400" y="205" text-anchor="middle" class="svg-micro">stream #2</text>
+  <rect x="460" y="167" width="56" height="56" rx="4" fill="#6b3aa3" opacity="0.12" stroke="#6b3aa3" stroke-width="1.5"/>
+  <text x="488" y="187" text-anchor="middle" class="svg-tiny" fill="#6b3aa3" font-weight="700">17</text>
+  <text x="488" y="205" text-anchor="middle" class="svg-micro">assistant </text>
+  <rect x="548" y="167" width="56" height="56" rx="4" fill="#1f5c8c" opacity="0.12" stroke="#1f5c8c" stroke-width="1.5"/>
+  <text x="576" y="187" text-anchor="middle" class="svg-tiny" fill="#1f5c8c" font-weight="700">18</text>
+  <text x="576" y="205" text-anchor="middle" class="svg-micro">message_en</text>
+  <rect x="636" y="167" width="56" height="56" rx="4" fill="#b35a1f" opacity="0.12" stroke="#b35a1f" stroke-width="1.5"/>
+  <text x="664" y="187" text-anchor="middle" class="svg-tiny" fill="#b35a1f" font-weight="700">19</text>
+  <text x="664" y="205" text-anchor="middle" class="svg-micro">JSONL appe</text>
+  <rect x="724" y="167" width="56" height="56" rx="4" fill="#3873a3" opacity="0.12" stroke="#3873a3" stroke-width="1.5"/>
+  <text x="752" y="187" text-anchor="middle" class="svg-tiny" fill="#3873a3" font-weight="700">20</text>
+  <text x="752" y="205" text-anchor="middle" class="svg-micro">TUI diff</text>
+  <rect x="812" y="167" width="56" height="56" rx="4" fill="#3873a3" opacity="0.12" stroke="#3873a3" stroke-width="1.5"/>
+  <text x="840" y="187" text-anchor="middle" class="svg-tiny" fill="#3873a3" font-weight="700">21</text>
+  <text x="840" y="205" text-anchor="middle" class="svg-micro">extensions</text>
+  <rect x="900" y="167" width="56" height="56" rx="4" fill="#b35a1f" opacity="0.12" stroke="#b35a1f" stroke-width="1.5"/>
+  <text x="928" y="187" text-anchor="middle" class="svg-tiny" fill="#b35a1f" font-weight="700">22</text>
+  <text x="928" y="205" text-anchor="middle" class="svg-micro">compaction</text>
+  <rect x="48" y="248" width="10" height="10" fill="#767c87" opacity="0.5"/><text x="62" y="257" class="svg-micro">intake</text><rect x="120" y="248" width="10" height="10" fill="#1f5c8c" opacity="0.5"/><text x="134" y="257" class="svg-micro">heart</text><rect x="192" y="248" width="10" height="10" fill="#6b3aa3" opacity="0.5"/><text x="206" y="257" class="svg-micro">llm</text><rect x="264" y="248" width="10" height="10" fill="#2d6a4f" opacity="0.5"/><text x="278" y="257" class="svg-micro">tool</text><rect x="336" y="248" width="10" height="10" fill="#3873a3" opacity="0.5"/><text x="350" y="257" class="svg-micro">terminal</text><rect x="408" y="248" width="10" height="10" fill="#b35a1f" opacity="0.5"/><text x="422" y="257" class="svg-micro">persist</text>
+</svg></div></div>
+      <figcaption>
+        <span class="figid">FIG</span>
+        <span class="lang-zh-only">22 站全景：从 CLI 解析到 compaction 检查的完整蛇形时间线，颜色按 Phase 编码。</span>
+        <span class="lang-en-only">22-station panorama: snake timeline from CLI parse to compaction check, color-coded by phase.</span>
+      </figcaption>
+    </figure>
+
+    <div class="station-track" role="list" aria-label="22 stations">
+      <div class="st-rail">
+      <div class="st-cell" data-phase="intake" style="--st-color:#767c87">
+        <div class="st-num">01</div>
+        <div class="st-name"><span class="lang-zh-only">CLI 解析</span><span class="lang-en-only">cli.ts argv</span></div>
+        <div class="st-phase">intake</div>
+      </div>
+      <div class="st-cell" data-phase="intake" style="--st-color:#767c87">
+        <div class="st-num">02</div>
+        <div class="st-name"><span class="lang-zh-only">main 启动</span><span class="lang-en-only">main.ts boot</span></div>
+        <div class="st-phase">intake</div>
+      </div>
+      <div class="st-cell" data-phase="intake" style="--st-color:#767c87">
+        <div class="st-num">03</div>
+        <div class="st-name"><span class="lang-zh-only">Session</span><span class="lang-en-only">session factory</span></div>
+        <div class="st-phase">intake</div>
+      </div>
+      <div class="st-cell" data-phase="intake" style="--st-color:#767c87">
+        <div class="st-num">04</div>
+        <div class="st-name"><span class="lang-zh-only">AGENTS.md</span><span class="lang-en-only">context stack</span></div>
+        <div class="st-phase">intake</div>
+      </div>
+      <div class="st-cell" data-phase="heart" style="--st-color:#1f5c8c">
+        <div class="st-num">05</div>
+        <div class="st-name"><span class="lang-zh-only">prompt 入队</span><span class="lang-en-only">prompt queued</span></div>
+        <div class="st-phase">heart</div>
+      </div>
+      <div class="st-cell" data-phase="heart" style="--st-color:#1f5c8c">
+        <div class="st-num">06</div>
+        <div class="st-name"><span class="lang-zh-only">agent_start</span><span class="lang-en-only">agent_start</span></div>
+        <div class="st-phase">heart</div>
+      </div>
+      <div class="st-cell" data-phase="heart" style="--st-color:#1f5c8c">
+        <div class="st-num">07</div>
+        <div class="st-name"><span class="lang-zh-only">turn_start</span><span class="lang-en-only">turn_start</span></div>
+        <div class="st-phase">heart</div>
+      </div>
+      <div class="st-cell" data-phase="llm" style="--st-color:#6b3aa3">
+        <div class="st-num">08</div>
+        <div class="st-name"><span class="lang-zh-only">convertToLlm</span><span class="lang-en-only">→ Message[]</span></div>
+        <div class="st-phase">llm</div>
+      </div>
+      <div class="st-cell" data-phase="llm" style="--st-color:#6b3aa3">
+        <div class="st-num">09</div>
+        <div class="st-name"><span class="lang-zh-only">streamSimple</span><span class="lang-en-only">pi-ai stream</span></div>
+        <div class="st-phase">llm</div>
+      </div>
+      <div class="st-cell" data-phase="llm" style="--st-color:#6b3aa3">
+        <div class="st-num">10</div>
+        <div class="st-name"><span class="lang-zh-only">text_delta</span><span class="lang-en-only">token stream</span></div>
+        <div class="st-phase">llm</div>
+      </div>
+      <div class="st-cell" data-phase="llm" style="--st-color:#6b3aa3">
+        <div class="st-num">11</div>
+        <div class="st-name"><span class="lang-zh-only">toolcall_δ</span><span class="lang-en-only">tool assembly</span></div>
+        <div class="st-phase">llm</div>
+      </div>
+      <div class="st-cell" data-phase="heart" style="--st-color:#1f5c8c">
+        <div class="st-num">12</div>
+        <div class="st-name"><span class="lang-zh-only">toolUse</span><span class="lang-en-only">read request</span></div>
+        <div class="st-phase">heart</div>
+      </div>
+      <div class="st-cell" data-phase="heart" style="--st-color:#1f5c8c">
+        <div class="st-num">13</div>
+        <div class="st-name"><span class="lang-zh-only">executeTool</span><span class="lang-en-only">tool dispatch</span></div>
+        <div class="st-phase">heart</div>
+      </div>
+      <div class="st-cell" data-phase="tool" style="--st-color:#2d6a4f">
+        <div class="st-num">14</div>
+        <div class="st-name"><span class="lang-zh-only">read README</span><span class="lang-en-only">filesystem I/O</span></div>
+        <div class="st-phase">tool</div>
+      </div>
+      <div class="st-cell" data-phase="tool" style="--st-color:#2d6a4f">
+        <div class="st-num">15</div>
+        <div class="st-name"><span class="lang-zh-only">tool_result</span><span class="lang-en-only">tool result</span></div>
+        <div class="st-phase">tool</div>
+      </div>
+      <div class="st-cell" data-phase="llm" style="--st-color:#6b3aa3">
+        <div class="st-num">16</div>
+        <div class="st-name"><span class="lang-zh-only">stream #2</span><span class="lang-en-only">turn 2 model</span></div>
+        <div class="st-phase">llm</div>
+      </div>
+      <div class="st-cell" data-phase="llm" style="--st-color:#6b3aa3">
+        <div class="st-num">17</div>
+        <div class="st-name"><span class="lang-zh-only">assistant stop</span><span class="lang-en-only">final answer</span></div>
+        <div class="st-phase">llm</div>
+      </div>
+      <div class="st-cell" data-phase="heart" style="--st-color:#1f5c8c">
+        <div class="st-num">18</div>
+        <div class="st-name"><span class="lang-zh-only">message_end</span><span class="lang-en-only">message_end</span></div>
+        <div class="st-phase">heart</div>
+      </div>
+      <div class="st-cell" data-phase="persist" style="--st-color:#b35a1f">
+        <div class="st-num">19</div>
+        <div class="st-name"><span class="lang-zh-only">JSONL append</span><span class="lang-en-only">JSONL write</span></div>
+        <div class="st-phase">persist</div>
+      </div>
+      <div class="st-cell" data-phase="terminal" style="--st-color:#3873a3">
+        <div class="st-num">20</div>
+        <div class="st-name"><span class="lang-zh-only">TUI diff</span><span class="lang-en-only">diff render</span></div>
+        <div class="st-phase">terminal</div>
+      </div>
+      <div class="st-cell" data-phase="terminal" style="--st-color:#3873a3">
+        <div class="st-num">21</div>
+        <div class="st-name"><span class="lang-zh-only">extensions</span><span class="lang-en-only">extension hooks</span></div>
+        <div class="st-phase">terminal</div>
+      </div>
+      <div class="st-cell" data-phase="persist" style="--st-color:#b35a1f">
+        <div class="st-num">22</div>
+        <div class="st-name"><span class="lang-zh-only">compaction</span><span class="lang-en-only">context check</span></div>
+        <div class="st-phase">persist</div>
+      </div>
+      </div>
+    </div>
+
+    <figure>
       <div class="figbox"><div class="pi-fig wide"><svg viewBox="0 0 720 250" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true" class="pi-svg">
   <defs>
     <marker id="pi-arr" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
@@ -1552,165 +1805,6 @@
         <span class="lang-en-only">22 stations by phase: intake 4, heart 4, LLM 3, terminal 2, persistence 2 — hold this map through the article.</span>
       </figcaption>
     </figure>
-
-    <h4 class="sub2"><span class="lang-zh-only">逐站清单</span><span class="lang-en-only">Station-by-station list</span></h4>
-
-    <div class="ladder">
-      <div class="ld-row">
-        <div class="ld-num">01</div>
-        <div>
-          <div class="ld-name"><span class="lang-zh-only">CLI 解析 argv</span><span class="lang-en-only">cli.ts parses argv</span></div>
-
-        </div>
-      </div>
-      <div class="ld-row">
-        <div class="ld-num">02</div>
-        <div>
-          <div class="ld-name"><span class="lang-zh-only">main 启动</span><span class="lang-en-only">main.ts boot</span></div>
-
-        </div>
-      </div>
-      <div class="ld-row">
-        <div class="ld-num">03</div>
-        <div>
-          <div class="ld-name"><span class="lang-zh-only">createAgentSession</span><span class="lang-en-only">session factory</span></div>
-
-        </div>
-      </div>
-      <div class="ld-row">
-        <div class="ld-num">04</div>
-        <div>
-          <div class="ld-name"><span class="lang-zh-only">ResourceLoader AGENTS.md</span><span class="lang-en-only">context stack</span></div>
-
-        </div>
-      </div>
-      <div class="ld-row">
-        <div class="ld-num">05</div>
-        <div>
-          <div class="ld-name"><span class="lang-zh-only">user message 入队</span><span class="lang-en-only">prompt queued</span></div>
-
-        </div>
-      </div>
-      <div class="ld-row">
-        <div class="ld-num">06</div>
-        <div>
-          <div class="ld-name"><span class="lang-zh-only">agent_start 事件</span><span class="lang-en-only">agent_start event</span></div>
-
-        </div>
-      </div>
-      <div class="ld-row">
-        <div class="ld-num">07</div>
-        <div>
-          <div class="ld-name"><span class="lang-zh-only">turn_start</span><span class="lang-en-only">turn_start</span></div>
-
-        </div>
-      </div>
-      <div class="ld-row">
-        <div class="ld-num">08</div>
-        <div>
-          <div class="ld-name"><span class="lang-zh-only">convertToLlm</span><span class="lang-en-only">AgentMessage → Message[]</span></div>
-
-        </div>
-      </div>
-      <div class="ld-row">
-        <div class="ld-num">09</div>
-        <div>
-          <div class="ld-name"><span class="lang-zh-only">streamSimple</span><span class="lang-en-only">pi-ai stream</span></div>
-
-        </div>
-      </div>
-      <div class="ld-row">
-        <div class="ld-num">10</div>
-        <div>
-          <div class="ld-name"><span class="lang-zh-only">text_delta</span><span class="lang-en-only">token streaming</span></div>
-
-        </div>
-      </div>
-      <div class="ld-row">
-        <div class="ld-num">11</div>
-        <div>
-          <div class="ld-name"><span class="lang-zh-only">toolcall_delta</span><span class="lang-en-only">tool call assembly</span></div>
-
-        </div>
-      </div>
-      <div class="ld-row">
-        <div class="ld-num">12</div>
-        <div>
-          <div class="ld-name"><span class="lang-zh-only">assistant stopReason=toolUse</span><span class="lang-en-only">read tool requested</span></div>
-
-        </div>
-      </div>
-      <div class="ld-row">
-        <div class="ld-num">13</div>
-        <div>
-          <div class="ld-name"><span class="lang-zh-only">executeTool parallel/seq</span><span class="lang-en-only">tool dispatch</span></div>
-
-        </div>
-      </div>
-      <div class="ld-row">
-        <div class="ld-num">14</div>
-        <div>
-          <div class="ld-name"><span class="lang-zh-only">read README.md</span><span class="lang-en-only">filesystem I/O</span></div>
-
-        </div>
-      </div>
-      <div class="ld-row">
-        <div class="ld-num">15</div>
-        <div>
-          <div class="ld-name"><span class="lang-zh-only">tool_result 消息</span><span class="lang-en-only">tool result message</span></div>
-
-        </div>
-      </div>
-      <div class="ld-row">
-        <div class="ld-num">16</div>
-        <div>
-          <div class="ld-name"><span class="lang-zh-only">第二次 streamSimple</span><span class="lang-en-only">turn 2 model call</span></div>
-
-        </div>
-      </div>
-      <div class="ld-row">
-        <div class="ld-num">17</div>
-        <div>
-          <div class="ld-name"><span class="lang-zh-only">最终 assistant stop</span><span class="lang-en-only">final answer</span></div>
-
-        </div>
-      </div>
-      <div class="ld-row">
-        <div class="ld-num">18</div>
-        <div>
-          <div class="ld-name"><span class="lang-zh-only">message_end 事件</span><span class="lang-en-only">message_end</span></div>
-
-        </div>
-      </div>
-      <div class="ld-row">
-        <div class="ld-num">19</div>
-        <div>
-          <div class="ld-name"><span class="lang-zh-only">SessionManager.append</span><span class="lang-en-only">JSONL write</span></div>
-
-        </div>
-      </div>
-      <div class="ld-row">
-        <div class="ld-num">20</div>
-        <div>
-          <div class="ld-name"><span class="lang-zh-only">TUI message_update</span><span class="lang-en-only">diff render</span></div>
-
-        </div>
-      </div>
-      <div class="ld-row">
-        <div class="ld-num">21</div>
-        <div>
-          <div class="ld-name"><span class="lang-zh-only">ExtensionRunner hooks</span><span class="lang-en-only">extension events</span></div>
-
-        </div>
-      </div>
-      <div class="ld-row">
-        <div class="ld-num">22</div>
-        <div>
-          <div class="ld-name"><span class="lang-zh-only">compaction 检查</span><span class="lang-en-only">context check</span></div>
-
-        </div>
-      </div>
-    </div>
 
     <figure>
       <div class="figbox"><div class="event-flow">

--- a/public/immersive/pi-agent/index.html
+++ b/public/immersive/pi-agent/index.html
@@ -1005,6 +1005,143 @@
     font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.18em;
     text-transform: uppercase; color: var(--accent); font-weight: 700; margin-bottom: 8px;
   }
+  .case-study .cs-title {
+    font-family: var(--serif); font-size: 15px; font-weight: 700;
+    margin-bottom: 8px; color: var(--ink);
+  }
+  body.lang-en .case-study .cs-title { font-family: var(--serif-en); }
+  .sec-num {
+    font-family: var(--mono); font-size: 11px; letter-spacing: 0.06em;
+    color: var(--accent); font-weight: 700; margin-right: 6px;
+  }
+  .chap-compass {
+    margin: 0 0 28px; padding: 14px 18px;
+    background: var(--paper-2); border: 1px solid var(--rule);
+    border-left: 3px solid var(--accent); border-radius: 0 4px 4px 0;
+  }
+  .chap-compass .cc-row { display: flex; flex-wrap: wrap; align-items: center; gap: 8px 12px; }
+  .chap-compass .cc-row + .cc-row { margin-top: 10px; padding-top: 10px; border-top: 1px dashed var(--rule-soft); }
+  .chap-compass .cc-phase, .chap-compass .cc-chap, .chap-compass .cc-station {
+    font-family: var(--mono); font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase;
+  }
+  .chap-compass .cc-chap { color: var(--accent); font-weight: 700; }
+  .chap-compass .cc-sep { color: var(--ink-mute); }
+  .chap-compass .cc-forest-label {
+    font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.16em;
+    text-transform: uppercase; color: var(--ink-mute); margin-right: 8px;
+  }
+  .chap-compass .cc-forest-text { font-size: 13px; color: var(--ink-soft); }
+  .chap-compass .cc-links { justify-content: space-between; width: 100%; }
+  .chap-compass .cc-nav {
+    font-size: 12px; color: var(--ink-soft); text-decoration: none;
+    display: inline-flex; align-items: center; gap: 4px; max-width: 42%;
+  }
+  .chap-compass .cc-nav:hover { color: var(--accent); }
+  .chap-compass .cc-nav-num { font-family: var(--mono); font-weight: 700; }
+  .chap-compass .cc-back-map {
+    font-family: var(--mono); font-size: 10px; letter-spacing: 0.12em;
+    text-transform: uppercase; color: var(--copper); text-decoration: none;
+  }
+  .chap-compass .cc-back-map:hover { text-decoration: underline; }
+  .depth-zone {
+    margin: 32px 0 0; padding: 20px 0 0;
+    border-top: 2px solid var(--rule);
+  }
+  .depth-zone-label {
+    font-family: var(--mono); font-size: 10px; letter-spacing: 0.2em;
+    text-transform: uppercase; color: var(--ink-mute); margin-bottom: 20px;
+  }
+  .depth-zone-label .dz-tag {
+    color: var(--copper); font-weight: 700; margin-right: 8px;
+  }
+  .depth-zone h4.depth-sec {
+    font-size: 15px; margin-top: 24px;
+  }
+  .depth-aside-head {
+    margin: 28px 0 12px; padding: 10px 14px;
+    background: var(--paper-2); border: 1px solid var(--rule); border-radius: 4px;
+  }
+  .depth-aside-head .da-tag {
+    font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.16em;
+    text-transform: uppercase; color: var(--copper); font-weight: 700;
+  }
+  .depth-aside-head .da-title { font-size: 14px; font-weight: 600; color: var(--ink); }
+  .forest-overview {
+    margin: 48px 0 56px; padding: 32px 0 40px;
+    border-top: 2px solid var(--ink); border-bottom: 1px solid var(--rule);
+  }
+  .forest-overview .fo-label {
+    font-family: var(--mono); font-size: 10px; letter-spacing: 0.22em;
+    text-transform: uppercase; color: var(--ink-mute); margin-bottom: 12px;
+  }
+  .forest-overview .fo-title {
+    font-family: var(--serif); font-size: 28px; font-weight: 700;
+    margin-bottom: 16px; line-height: 1.2;
+  }
+  body.lang-en .forest-overview .fo-title { font-family: var(--serif-en); }
+  .forest-paths { margin: 28px 0; }
+  .forest-paths .fp-head {
+    font-family: var(--mono); font-size: 10px; letter-spacing: 0.18em;
+    text-transform: uppercase; color: var(--ink-mute); margin-bottom: 14px;
+  }
+  .forest-paths .fp-grid {
+    display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px;
+  }
+  @media (max-width: 800px) {
+    .forest-paths .fp-grid { grid-template-columns: 1fr; }
+  }
+  .forest-paths .fp-card {
+    display: block; padding: 16px 18px;
+    background: var(--paper); border: 1px solid var(--rule);
+    border-radius: 4px; text-decoration: none; color: inherit;
+    transition: border-color 0.15s, box-shadow 0.15s;
+  }
+  .forest-paths .fp-card:hover {
+    border-color: var(--accent); box-shadow: 0 2px 8px rgba(31,92,140,0.08);
+  }
+  .forest-paths .fp-card.fp-highlight { border-left: 3px solid var(--accent); }
+  .forest-paths .fp-tag {
+    font-family: var(--mono); font-size: 9px; letter-spacing: 0.14em;
+    text-transform: uppercase; color: var(--copper); margin-bottom: 6px;
+  }
+  .forest-paths .fp-title { font-size: 14px; font-weight: 700; margin-bottom: 6px; }
+  .forest-paths .fp-desc { font-size: 12px; color: var(--ink-mute); line-height: 1.5; }
+  .forest-overview .fo-legend {
+    margin-top: 24px; padding: 14px 16px;
+    background: var(--paper-2); border-radius: 4px;
+    font-size: 12.5px; color: var(--ink-soft); line-height: 1.6;
+  }
+  .card-filmstrip {
+    position: fixed; top: 0; left: 0; right: 0; z-index: 150;
+    background: rgba(253,251,243,0.96); border-bottom: 1px solid var(--rule);
+    backdrop-filter: blur(8px); transform: translateY(-100%);
+    transition: transform 0.25s ease; pointer-events: none;
+  }
+  .card-filmstrip.is-visible { transform: translateY(0); pointer-events: auto; }
+  .card-filmstrip .cf-inner { max-width: var(--max-w, 720px); margin: 0 auto; padding: 6px 16px 8px; }
+  .card-filmstrip .cf-header {
+    display: flex; justify-content: space-between; align-items: center;
+    font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.14em;
+    text-transform: uppercase; color: var(--ink-mute); margin-bottom: 4px;
+  }
+  .card-filmstrip .cf-header em { color: var(--accent); font-style: normal; font-weight: 700; }
+  .card-filmstrip .cf-track {
+    display: flex; gap: 4px; overflow-x: auto; padding-bottom: 2px;
+    scrollbar-width: thin;
+  }
+  .card-filmstrip .cf-cell {
+    flex: 0 0 auto; min-width: 36px; padding: 4px 6px;
+    text-align: center; text-decoration: none; color: var(--ink-mute);
+    border: 1px solid transparent; border-radius: 3px;
+    font-family: var(--mono); font-size: 10px; transition: all 0.12s;
+  }
+  .card-filmstrip .cf-cell:hover { border-color: var(--rule); color: var(--ink); }
+  .card-filmstrip .cf-cell.active {
+    border-color: var(--accent); background: var(--accent-pale, #e8f0f8);
+    color: var(--accent); font-weight: 700;
+  }
+  body.has-filmstrip { padding-top: 52px; }
+  body.has-filmstrip .ursb-backlink { top: 58px; }
 
 </style>
 <script async defer src="https://analytics.ursb.me/script.js" data-website-id="aa8d5a16-df21-4058-a0a8-0191cdd3798d"></script>
@@ -1098,6 +1235,43 @@
   <span class="sep">/</span>
   <button id="lang-en" aria-pressed="false">EN</button>
 </div>
+
+<nav class="card-filmstrip" id="card-filmstrip" aria-label="26 chapters">
+  <div class="cf-inner">
+    <div class="cf-header">
+      <span><span class="lang-zh-only">主线 · 26 章</span><span class="lang-en-only">Through-line · 26 chapters</span></span>
+      <span><em id="cf-current">C01</em>&nbsp;/&nbsp;26</span>
+    </div>
+    <div class="cf-track" id="cf-track">
+      <a href="#c1" class="cf-cell" data-chap="01"><span class="cf-num">01</span></a>
+      <a href="#c2" class="cf-cell" data-chap="02"><span class="cf-num">02</span></a>
+      <a href="#c3" class="cf-cell" data-chap="03"><span class="cf-num">03</span></a>
+      <a href="#c4" class="cf-cell" data-chap="04"><span class="cf-num">04</span></a>
+      <a href="#c5" class="cf-cell" data-chap="05"><span class="cf-num">05</span></a>
+      <a href="#c6" class="cf-cell" data-chap="06"><span class="cf-num">06</span></a>
+      <a href="#c7" class="cf-cell" data-chap="07"><span class="cf-num">07</span></a>
+      <a href="#c8" class="cf-cell" data-chap="08"><span class="cf-num">08</span></a>
+      <a href="#c9" class="cf-cell" data-chap="09"><span class="cf-num">09</span></a>
+      <a href="#c10" class="cf-cell" data-chap="10"><span class="cf-num">10</span></a>
+      <a href="#c11" class="cf-cell" data-chap="11"><span class="cf-num">11</span></a>
+      <a href="#c12" class="cf-cell" data-chap="12"><span class="cf-num">12</span></a>
+      <a href="#c13" class="cf-cell" data-chap="13"><span class="cf-num">13</span></a>
+      <a href="#c14" class="cf-cell" data-chap="14"><span class="cf-num">14</span></a>
+      <a href="#c15" class="cf-cell" data-chap="15"><span class="cf-num">15</span></a>
+      <a href="#c16" class="cf-cell" data-chap="16"><span class="cf-num">16</span></a>
+      <a href="#c17" class="cf-cell" data-chap="17"><span class="cf-num">17</span></a>
+      <a href="#c18" class="cf-cell" data-chap="18"><span class="cf-num">18</span></a>
+      <a href="#c19" class="cf-cell" data-chap="19"><span class="cf-num">19</span></a>
+      <a href="#c20" class="cf-cell" data-chap="20"><span class="cf-num">20</span></a>
+      <a href="#c21" class="cf-cell" data-chap="21"><span class="cf-num">21</span></a>
+      <a href="#c22" class="cf-cell" data-chap="22"><span class="cf-num">22</span></a>
+      <a href="#c23" class="cf-cell" data-chap="23"><span class="cf-num">23</span></a>
+      <a href="#c24" class="cf-cell" data-chap="24"><span class="cf-num">24</span></a>
+      <a href="#c25" class="cf-cell" data-chap="25"><span class="cf-num">25</span></a>
+      <a href="#c26" class="cf-cell" data-chap="26"><span class="cf-num">26</span></a>
+    </div>
+  </div>
+</nav>
 
 <nav class="toc-side" aria-label="Side contents">
   <div class="toc-label">CONTENTS</div>
@@ -1396,12 +1570,146 @@
     </div>
   </nav>
 
+  <section class="forest-overview" id="forest-overview">
+    <div class="fo-label">
+      <span class="lang-zh-only">OVERVIEW · 森林图</span>
+      <span class="lang-en-only">OVERVIEW · Forest map</span>
+    </div>
+    <h2 class="fo-title lang-zh-only">先见森林，再见树木</h2>
+    <h2 class="fo-title lang-en-only">See the forest before the trees</h2>
+    <div class="lang-zh-only"><p>全文 26 章不是平铺的百科条目，而是一条<strong>固定主线 prompt</strong>从终端回车追到 JSONL 落盘的流水线。下面这张图是望远镜：告诉你 Phase 在哪、章节密度在哪、心脏区（runLoop + tools）在哪。读任何一章前，先看这里的 compass 条（每章顶部）确认自己在全局中的位置。</p></div>
+    <div class="lang-en-only"><p>All 26 chapters are not a flat encyclopedia — they are a pipeline tracing one <strong>fixed through-line prompt</strong> from Enter to JSONL on disk. The diagram below is the telescope: where phases sit, where chapter density peaks, where the heart (runLoop + tools) lives. Before any chapter, check the compass bar at the top to locate yourself in the whole.</p></div>
+    <figure>
+      <div class="figbox"><div class="pi-fig wide panorama"><svg viewBox="0 0 720 290" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true" class="pi-svg">
+  <defs>
+    <marker id="pi-arr" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 Z" fill="#1f5c8c"/>
+    </marker>
+  </defs>
+  <text x="360" y="22" text-anchor="middle" class="svg-label">一条用户消息 · 8 PHASES · 26 CHAPTERS</text>
+
+  <!-- phase columns -->
+  <rect x="16" y="36" width="88" height="200" rx="3" class="svg-box muted"/>
+  <text x="60" y="54" text-anchor="middle" class="svg-micro" font-weight="700">0 引子</text>
+  <text x="60" y="72" text-anchor="middle" class="svg-tiny">C01–02</text>
+  <text x="60" y="100" text-anchor="middle" class="svg-body">心智</text>
+  <text x="60" y="118" text-anchor="middle" class="svg-body">22 站图</text>
+
+  <rect x="108" y="36" width="72" height="200" rx="3" class="svg-box paper"/>
+  <text x="144" y="54" text-anchor="middle" class="svg-micro" font-weight="700">· 背景</text>
+  <text x="144" y="72" text-anchor="middle" class="svg-tiny">C03–05</text>
+
+  <rect x="184" y="36" width="72" height="200" rx="3" class="svg-box accent"/>
+  <text x="220" y="54" text-anchor="middle" class="svg-micro" font-weight="700">I 入口</text>
+  <text x="220" y="72" text-anchor="middle" class="svg-tiny">C06–08</text>
+  <text x="220" y="100" text-anchor="middle" class="svg-body">CLI</text>
+  <text x="220" y="118" text-anchor="middle" class="svg-body">Session</text>
+
+  <rect x="260" y="36" width="88" height="200" rx="3" fill="#fde8e4" stroke="#c3573a" stroke-width="1.5"/>
+  <text x="304" y="54" text-anchor="middle" class="svg-micro" font-weight="700" fill="#c3573a">II 心脏</text>
+  <text x="304" y="72" text-anchor="middle" class="svg-tiny">C09–13</text>
+  <text x="304" y="100" text-anchor="middle" class="svg-body">runLoop</text>
+  <text x="304" y="118" text-anchor="middle" class="svg-body">tools</text>
+  <text x="304" y="136" text-anchor="middle" class="svg-body">events</text>
+
+  <rect x="352" y="36" width="72" height="200" rx="3" class="svg-box gpu"/>
+  <text x="388" y="54" text-anchor="middle" class="svg-micro" font-weight="700">III LLM</text>
+  <text x="388" y="72" text-anchor="middle" class="svg-tiny">C14–16</text>
+
+  <rect x="428" y="36" width="72" height="200" rx="3" class="svg-box asm"/>
+  <text x="464" y="54" text-anchor="middle" class="svg-micro" font-weight="700">IV 终端</text>
+  <text x="464" y="72" text-anchor="middle" class="svg-tiny">C17–18</text>
+
+  <rect x="504" y="36" width="72" height="200" rx="3" class="svg-box copper"/>
+  <text x="540" y="54" text-anchor="middle" class="svg-micro" font-weight="700">V 扩展</text>
+  <text x="540" y="72" text-anchor="middle" class="svg-tiny">C19–21</text>
+
+  <rect x="580" y="36" width="60" height="200" rx="3" class="svg-box muted"/>
+  <text x="610" y="54" text-anchor="middle" class="svg-micro" font-weight="700">VI</text>
+  <text x="610" y="72" text-anchor="middle" class="svg-tiny">C22–23</text>
+
+  <rect x="644" y="36" width="60" height="200" rx="3" class="svg-box paper"/>
+  <text x="674" y="54" text-anchor="middle" class="svg-micro" font-weight="700">VII</text>
+  <text x="674" y="72" text-anchor="middle" class="svg-tiny">C24–25</text>
+
+  <!-- through-line arrow -->
+  <path d="M40 250 L680 250" stroke="#1f5c8c" stroke-width="2" marker-end="url(#pi-arr)"/>
+  <text x="360" y="272" text-anchor="middle" class="svg-mute">Enter → agentLoop ×2 → read → stop → JSONL → TUI diff</text>
+
+  <!-- highlight heart -->
+  <rect x="268" y="148" width="72" height="28" rx="2" fill="none" stroke="#c3573a" stroke-width="2" stroke-dasharray="4 2"/>
+  <text x="304" y="166" text-anchor="middle" class="svg-micro" fill="#c3573a">主线最密区</text>
+</svg></div></div>
+      <figcaption>
+        <span class="figid">FIG</span>
+        <span class="lang-zh-only">森林图：8 个 Phase 把 26 章串成一条线；Phase II（心脏）是 runLoop 与工具执行最密集的区域。</span>
+        <span class="lang-en-only">Forest map: 8 phases string 26 chapters; Phase II (Heart) is the densest runLoop + tool region.</span>
+      </figcaption>
+    </figure>
+    <div class="forest-paths">
+      <div class="fp-head">
+        <span class="lang-zh-only">三条阅读路径</span>
+        <span class="lang-en-only">Three reading paths</span>
+      </div>
+      <div class="fp-grid">
+        <a href="#c2" class="fp-card">
+          <div class="fp-tag lang-zh-only">路径 A · 先看森林</div>
+          <div class="fp-tag lang-en-only">Path A · Forest first</div>
+          <div class="fp-title lang-zh-only">C02 22 站全景 → 按需跳章</div>
+          <div class="fp-title lang-en-only">C02 22-station map → jump as needed</div>
+          <div class="fp-desc lang-zh-only">适合已懂 agent 基础、想先建立全局心智模型的读者。</div>
+          <div class="fp-desc lang-en-only">For readers who know agent basics and want the global map first.</div>
+        </a>
+        <a href="#c7" class="fp-card fp-highlight">
+          <div class="fp-tag lang-zh-only">路径 B · 直奔心脏</div>
+          <div class="fp-tag lang-en-only">Path B · Straight to heart</div>
+          <div class="fp-title lang-zh-only">C07 AgentSession → C10 runLoop → C14 pi-ai</div>
+          <div class="fp-title lang-en-only">C07 AgentSession → C10 runLoop → C14 pi-ai</div>
+          <div class="fp-desc lang-zh-only">最短源码路径：从 prompt() 追到 streamSimple()。</div>
+          <div class="fp-desc lang-en-only">Shortest source path: prompt() to streamSimple().</div>
+        </a>
+        <a href="#c26" class="fp-card">
+          <div class="fp-tag lang-zh-only">路径 C · 动手 trace</div>
+          <div class="fp-tag lang-en-only">Path C · Hands-on trace</div>
+          <div class="fp-title lang-zh-only">pi-textbook cp00 → --verbose → JSONL</div>
+          <div class="fp-title lang-en-only">pi-textbook cp00 → --verbose → JSONL</div>
+          <div class="fp-desc lang-zh-only">边跑 checkpoint 边对照本文章节，最后读 C26 自查清单。</div>
+          <div class="fp-desc lang-en-only">Run checkpoints alongside chapters; finish with C26 checklist.</div>
+        </a>
+      </div>
+    </div>
+    <div class="fo-legend">
+      <span class="lang-zh-only"><strong>标题层级约定：</strong>每章仅一个 <code>h2</code> 章标题；正文小节为 <code>C07.1</code> 式编号；「深度细读」块内为 <code>C07.4+</code>，FAQ / Case Study 不再占用标题层级。</span>
+      <span class="lang-en-only"><strong>Heading convention:</strong> one <code>h2</code> chapter title; body sections numbered <code>C07.1</code>; deep-dive block uses <code>C07.4+</code>; FAQ / Case Study use labels, not headings.</span>
+    </div>
+  </section>
+
   <section class="chap" id="c1">
     <div class="chap-num">CHAPTER&nbsp;01&nbsp;·&nbsp;引子</div>
     <h2 class="chap-title lang-zh-only">Harness 不是 Product</h2>
     <h2 class="chap-title lang-en-only">Harness is not a product</h2>
     <p class="chap-en lang-zh-only">agent 产品战争里的第三条路</p>
     <p class="chap-en lang-en-only">a third path in the agent product war</p>
+    <nav class="chap-compass" aria-label="Chapter 01 navigation">
+      <div class="cc-row cc-loc">
+        <span class="cc-phase"><span class="lang-zh-only">引子</span><span class="lang-en-only">Prologue</span></span>
+        <span class="cc-sep">·</span>
+        <span class="cc-chap">C01 / 26</span>
+        <span class="cc-sep">·</span>
+        <span class="cc-station"><span class="lang-zh-only">站 00 · 心智</span><span class="lang-en-only">St. 00 · mindset</span></span>
+      </div>
+      <div class="cc-row cc-forest">
+        <span class="cc-forest-label lang-zh-only">你在森林的这里</span>
+        <span class="cc-forest-label lang-en-only">You are here</span>
+        <span class="cc-forest-text lang-zh-only">森林入口：先建立 harness 心智</span>
+        <span class="cc-forest-text lang-en-only">Forest entry: harness mindset first</span>
+      </div>
+      <div class="cc-row cc-links">
+        <span class="cc-nav cc-empty"></span>
+        <a class="cc-back-map" href="#forest-overview"><span class="lang-zh-only">↑ 回到总览</span><span class="lang-en-only">↑ Forest map</span></a>
+        <a class="cc-nav cc-next" href="#c2"><span class="cc-nav-num">C02</span> <span class="lang-zh-only">一条消息的 22 站</span><span class="lang-en-only">22 stations for one message</span> <span class="cc-arrow">→</span></a>
+      </div>
+    </nav>
     <aside class="stage-why-care lang-zh-only">
       <div class="swc-label">为什么这一段对你来说很重要</div>
       <p><span class="swc-pill ">直觉</span><span>Pi 把 agent 编排写成可读的 TypeScript 环，而不是黑盒产品。</span></p>
@@ -1489,7 +1797,7 @@
       <span class="src-line">}</span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">为什么「最小」是特性而不是缺陷</span><span class="lang-en-only">Why "minimal" is a feature, not a bug</span></h3>
+    <h3 class="sub"><span class="sec-num">C01.1</span> <span class="lang-zh-only">为什么「最小」是特性而不是缺陷</span><span class="lang-en-only">Why "minimal" is a feature, not a bug</span></h3>
 
     <div class="lang-zh-only"><p>密封产品的复杂度藏在黑盒里：你不知道 steering 消息如何插队、compaction 的精确阈值、tool 并行策略。Pi 把这三件事写进 <code>agent-loop.ts</code> 和 <code>agent-session.ts</code>，用单元测试锁住行为。你可以 fork pi-mono 换工具、写扩展注入 lint、用 <code>--mode rpc</code> 嵌进 CI。</p></div>
     <div class="lang-en-only"><p>Sealed products hide complexity. Pi writes steering, compaction, and tool parallelism into <code>agent-loop.ts</code> and <code>agent-session.ts</code>, locked by tests. Fork pi-mono, swap tools, inject lint via extensions, embed with <code>--mode rpc</code>.</p></div>
@@ -1571,7 +1879,7 @@
       </figcaption>
     </figure>
 
-    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">交叉引用</span><span class="lang-en-only">Cross-ref</span></span> <span class="da-title lang-zh-only">pi-textbook checkpoint</span><span class="da-title lang-en-only">pi-textbook checkpoint</span></div>    <table class="cmp">
       <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
       <tbody>
       <tr><td>cp 00</td><td>一次 README 读取的七个里程碑</td><td><code>prologue.ts</code></td><td><code>packages/coding-agent/src/main.ts · packages/agent/src/agent-loop.ts</code></td></tr>
@@ -1581,12 +1889,14 @@
 
     <div class="case-study">
       <div class="cs-tag">CASE STUDY</div>
-      <h4 class="sub2"><span class="lang-zh-only">从 Claude Code 迁移到 Pi</span><span class="lang-en-only">Migrating from Claude Code to Pi</span></h4>
+      <div class="cs-title"><span class="lang-zh-only">从 Claude Code 迁移到 Pi</span><span class="lang-en-only">Migrating from Claude Code to Pi</span></div>
       <div class="lang-zh-only"><p>Claude Code 把编排藏在产品里；Pi 把编排写在 agent-loop.ts。迁移的第一步不是换 CLI，而是跑通 pi-textbook checkpoint 00 的七里程碑，建立事件心智模型。</p></div>
       <div class="lang-en-only"><p>Claude Code hides orchestration in the product; Pi writes it in agent-loop.ts. Migration starts not with a new CLI but checkpoint 00's seven milestones — building an event mental model.</p></div>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">Harness 哲学：主线 prompt 如何穿过此模块</span><span class="lang-en-only">Harness 哲学: through-line crossing</span></h3>
+    <div class="depth-zone" data-chapter="C01"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C01.4+</span><span class="lang-en-only">Deep dive · C01.4+</span></div>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C01.4</span> <span class="lang-zh-only">主线 prompt 如何穿过此模块</span><span class="lang-en-only">through-line crossing</span></h4>
 
     <div class="lang-zh-only"><p>用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/agent/src/agent-loop.ts</code> 定义了此阶段的类型契约与副作用边界。</p></div>
     <div class="lang-en-only"><p>After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/agent/src/agent-loop.ts</code> defines type contracts and side-effect boundaries here.</p></div>
@@ -1600,7 +1910,7 @@
     <div class="lang-zh-only"><p>pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。</p></div>
     <div class="lang-en-only"><p>Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">Harness 哲学：关键函数与数据流</span><span class="lang-en-only">Harness 哲学: key functions and data flow</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C01.5</span> <span class="lang-zh-only">关键函数与数据流</span><span class="lang-en-only">key functions and data flow</span></h4>
 
     <div class="lang-zh-only"><p><code>agent-loop.ts</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。</p></div>
     <div class="lang-en-only"><p><code>async</code> functions in <code>agent-loop.ts</code> are usually IO boundaries: disk, network, or subprocess.</p></div>
@@ -1614,7 +1924,7 @@
     <div class="lang-zh-only"><p>对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。</p></div>
     <div class="lang-en-only"><p>Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">Harness 哲学：与 agent-loop 的接口</span><span class="lang-en-only">Harness 哲学: interface with agent-loop</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C01.6</span> <span class="lang-zh-only">与 agent-loop 的接口</span><span class="lang-en-only">interface with agent-loop</span></h4>
 
     <div class="lang-zh-only"><p><code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。</p></div>
     <div class="lang-en-only"><p><code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc.</p></div>
@@ -1628,6 +1938,20 @@
     <div class="lang-zh-only"><p>--verbose 模式下 stderr 事件类型可回溯到 <code>packages/agent/src/agent-loop.ts</code> 的具体行。</p></div>
     <div class="lang-en-only"><p>Under --verbose, stderr event types trace to lines in <code>packages/agent/src/agent-loop.ts</code>.</p></div>
 
+    <h4 class="sub2 depth-sec"><span class="sec-num">C01.7</span> <span class="lang-zh-only">读完后应能回答的 5 个问题 · Harness 不是 Product</span><span class="lang-en-only">Five questions you should answer after reading · Harness 不是 Product</span></h4>
+
+    <div class="lang-zh-only"><p>① 主线 prompt 进入本章模块时，第一个被调用的 <code>export</code> 函数是什么？② 它 emit 的第一个 AgentEvent 类型是什么？③ 若在此层抛错，TUI 会卡在什么状态？④ 对应的 pi-textbook checkpoint 测试命令是什么？⑤ <code>packages/agent/src/agent-loop.ts</code> 中哪一行最值得打断点？</p></div>
+    <div class="lang-en-only"><p>① First <code>export</code> called when through-line enters this module? ② First AgentEvent type emitted? ③ If this layer throws, what TUI state stalls? ④ Matching pi-textbook checkpoint test command? ⑤ Best breakpoint line in <code>packages/agent/src/agent-loop.ts</code>?</p></div>
+
+    <div class="lang-zh-only"><p>不要一次读完整个文件。用「从测试入手」法：先 <code>npm test -- &lt;matching-test&gt;</code>，看失败断言指向哪行，再读那一行上下游 30 行。生产 pi-mono 的测试覆盖率在 agent-loop 与 session-manager 最高——优先读测试。</p></div>
+    <div class="lang-en-only"><p>Don't read whole files at once. «Test-first» method: run <code>npm test -- &lt;matching-test&gt;</code>, see which assertion fails, read ±30 lines around that line. Highest test coverage in agent-loop and session-manager — read tests first.</p></div>
+
+    <div class="lang-zh-only"><p>对照本文 TRACE 盒与 <code>--verbose</code> stderr：每个 event type 应在源码中有且仅有一处「决策点」——若找不到，说明事件在更上层（AgentSession）或更下层（pi-ai adapter）合并发出。</p></div>
+    <div class="lang-en-only"><p>Cross-check TRACE box with <code>--verbose</code> stderr: each event type should have exactly one «decision point» in source — if missing, event is merged upstream (AgentSession) or downstream (pi-ai adapter).</p></div>
+
+    <div class="lang-zh-only"><p>进阶：用 <code>git blame packages/agent/src/agent-loop.ts</code> 看最近改动——Pi 的 harness 接口仍在活跃演进，注释可能落后于 <code>AgentLoopConfig</code> 类型定义。类型即文档。</p></div>
+    <div class="lang-en-only"><p>Advanced: <code>git blame packages/agent/src/agent-loop.ts</code> for recent changes — Pi harness APIs still evolve; comments may lag <code>AgentLoopConfig</code> types. Types are the doc.</p></div>
+
     <div class="trace-box">
       <div class="tb-tag">TRACE · station 00</div>
       <div class="lang-zh-only"><p>Station 00：harness 心智，尚未 read。</p></div>
@@ -1636,7 +1960,7 @@
 
     <div class="case-study">
       <div class="cs-tag">CASE STUDY</div>
-      <h4 class="sub2"><span class="lang-zh-only">迁移到 Pi</span><span class="lang-en-only">Migrate to Pi</span></h4>
+      <div class="cs-title"><span class="lang-zh-only">迁移到 Pi</span><span class="lang-en-only">Migrate to Pi</span></div>
       <div class="lang-zh-only"><p>跑 checkpoint 00 再对照 AgentSession.prompt()。</p></div>
       <div class="lang-en-only"><p>Run checkpoint 00 then compare AgentSession.prompt().</p></div>
     </div>
@@ -1650,7 +1974,7 @@
       <span class="src-line"><span class="src-line"><span class="src-kw">export function</span> <span class="src-fn">agentLoop</span>(...)</span></span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">交叉引用</span><span class="lang-en-only">Cross-ref</span></span> <span class="da-title lang-zh-only">pi-textbook checkpoint</span><span class="da-title lang-en-only">pi-textbook checkpoint</span></div>    <table class="cmp">
       <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
       <tbody>
       <tr><td>cp 00</td><td>一次 README 读取的七个里程碑</td><td><code>prologue.ts</code></td><td><code>packages/coding-agent/src/main.ts · packages/agent/src/agent-loop.ts</code></td></tr>
@@ -1658,13 +1982,26 @@
       </tbody>
     </table>
 
-    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">附录</span><span class="lang-en-only">Appendix</span></span> <span class="da-title lang-zh-only">常见问题</span><span class="da-title lang-en-only">FAQ</span></div>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">Pi 是产品还是库？</span><span class="lang-en-only">Product or library?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>CLI + 可嵌入库。</p></div><div class="lang-en-only"><p>CLI plus embeddable libs.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">为何不 fork Claude Code？</span><span class="lang-en-only">Why not fork Claude Code?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>闭源，无法审计 agentLoop。</p></div><div class="lang-en-only"><p>Closed source.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">读完 C01？</span><span class="lang-en-only">After C01?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>克隆 pi 与 pi-textbook。</p></div><div class="lang-en-only"><p>Clone pi and pi-textbook.</p></div></div></details>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C01.8</span> <span class="lang-zh-only">打开源码：packages/agent/src/agent-loop.ts</span><span class="lang-en-only">Open source: packages/agent/src/agent-loop.ts</span></h4>
+
+    <div class="lang-zh-only"><p>本章主线 prompt 经过此模块时，请在 pi-mono 打开 <code>packages/agent/src/agent-loop.ts</code>，搜索 <code>export</code> 与测试文件中的同名场景。对照 pi-textbook 对应 checkpoint 的 workshop 测试——先让测试绿，再读生产实现。</p></div>
+    <div class="lang-en-only"><p>When the through-line prompt crosses this module, open <code>packages/agent/src/agent-loop.ts</code> in pi-mono, search <code>export</code> and matching test scenarios. Cross-read the pi-textbook checkpoint workshop test — green test first, then production.</p></div>
+
+    <div class="lang-zh-only"><p>建议命令：<code>cd packages/agent && npm test -- agent-loop</code>（路径因章而异）。测试文件是行为契约的executable spec，比注释更可靠。</p></div>
+    <div class="lang-en-only"><p>Suggested: <code>cd packages/agent && npm test -- agent-loop</code> (path varies). Tests are executable specs of behavior contracts — more reliable than comments.</p></div>
+
+    <div class="lang-zh-only"><p>用 <code>--verbose</code> 跑一轮主线 prompt，把 stderr event 类型与源码中的 <code>emit</code> 调用逐行对齐——这是本文 C26 推荐的 trace 方法。</p></div>
+    <div class="lang-en-only"><p>Run the through-line with <code>--verbose</code>, align stderr event types with <code>emit</code> calls in source — the trace method recommended in C26.</p></div>
+
+    </div>
   </section>
 
   <section class="chap" id="c2">
@@ -1673,6 +2010,26 @@
     <h2 class="chap-title lang-en-only">22 stations for one message</h2>
     <p class="chap-en lang-zh-only">从回车到 JSONL 的全景图</p>
     <p class="chap-en lang-en-only">from Enter to JSONL, the full map</p>
+    <nav class="chap-compass" aria-label="Chapter 02 navigation">
+      <div class="cc-row cc-loc">
+        <span class="cc-phase"><span class="lang-zh-only">引子</span><span class="lang-en-only">Prologue</span></span>
+        <span class="cc-sep">·</span>
+        <span class="cc-chap">C02 / 26</span>
+        <span class="cc-sep">·</span>
+        <span class="cc-station"><span class="lang-zh-only">站 01–22 · 全景</span><span class="lang-en-only">St. 01–22 · map</span></span>
+      </div>
+      <div class="cc-row cc-forest">
+        <span class="cc-forest-label lang-zh-only">你在森林的这里</span>
+        <span class="cc-forest-label lang-en-only">You are here</span>
+        <span class="cc-forest-text lang-zh-only">望远镜：22 站 + 7 里程碑总览</span>
+        <span class="cc-forest-text lang-en-only">Telescope: 22 stations + 7 milestones</span>
+      </div>
+      <div class="cc-row cc-links">
+        <a class="cc-nav cc-prev" href="#c1"><span class="cc-arrow">←</span> <span class="cc-nav-num">C01</span> <span class="lang-zh-only">Harness 不是 Product</span><span class="lang-en-only">Harness is not a product</span></a>
+        <a class="cc-back-map" href="#forest-overview"><span class="lang-zh-only">↑ 回到总览</span><span class="lang-en-only">↑ Forest map</span></a>
+        <a class="cc-nav cc-next" href="#c3"><span class="cc-nav-num">C03</span> <span class="lang-zh-only">pi-mono 家谱</span><span class="lang-en-only">The pi-mono family tree</span> <span class="cc-arrow">→</span></a>
+      </div>
+    </nav>
     <aside class="stage-why-care lang-zh-only">
       <div class="swc-label">为什么这一段对你来说很重要</div>
       <p><span class="swc-pill ">直觉</span><span>22 站地图是整篇文章骨架。</span></p>
@@ -1708,7 +2065,7 @@
     <div class="lang-zh-only"><p>按下回车之后，<code>读取 README.md，用一句话告诉我这个项目做什么</code> 不是直接发给 LLM——它要先变成 <code>AgentMessage</code>，穿过 <code>AgentSession.prompt()</code>，触发 <code>agentLoop()</code>，在 <code>runLoop</code> 的双环里转两圈 model stream，中间插一次 <code>read</code> 工具，最后才在 TUI 里滚动、在 JSONL 里落盘。</p></div>
     <div class="lang-en-only"><p>After Enter, <code>read README.md and tell me what this project does in one sentence</code> does not go straight to the LLM — it becomes an <code>AgentMessage</code>, passes through <code>AgentSession.prompt()</code>, triggers <code>agentLoop()</code>, spins two model streams in <code>runLoop</code>'s twin loops with a <code>read</code> tool in between, then scrolls in the TUI and lands on disk as JSONL.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">七个里程碑 · pi-textbook 序章</span><span class="lang-en-only">Seven milestones · pi-textbook prologue</span></h3>
+    <h3 class="sub"><span class="sec-num">C02.1</span> <span class="lang-zh-only">七个里程碑 · pi-textbook 序章</span><span class="lang-en-only">Seven milestones · pi-textbook prologue</span></h3>
 
     <div class="lang-zh-only"><p>pi-textbook 用离线 <code>ScriptedModel</code> 固定了主线 prompt 的七步 trace。生产代码 <code>agent-loop.ts</code> 产生语义等价但事件更细的事件流。</p></div>
     <div class="lang-en-only"><p>pi-textbook fixes a seven-step trace for the through-line prompt with offline <code>ScriptedModel</code>. Production <code>agent-loop.ts</code> emits semantically equivalent but finer-grained events.</p></div>
@@ -1764,7 +2121,7 @@
       </figcaption>
     </figure>
 
-    <h3 class="sub"><span class="lang-zh-only">22 站全景（前 22 站）</span><span class="lang-en-only">22-station panorama (first 22)</span></h3>
+    <h3 class="sub"><span class="sec-num">C02.2</span> <span class="lang-zh-only">22 站全景（前 22 站）</span><span class="lang-en-only">22-station panorama (first 22)</span></h3>
 
     <figure>
       <div class="figbox"><div class="pi-fig panorama"><svg viewBox="0 0 1000 270" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true" class="pi-svg">
@@ -2056,7 +2413,9 @@
       <cite>Field Note · 10</cite>
     </blockquote>
 
-    <h3 class="sub"><span class="lang-zh-only">回车到第一次 stream</span><span class="lang-en-only">Enter to first stream</span></h3>
+    <div class="depth-zone" data-chapter="C02"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C02.4+</span><span class="lang-en-only">Deep dive · C02.4+</span></div>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C02.4</span> <span class="lang-zh-only">回车到第一次 stream</span><span class="lang-en-only">Enter to first stream</span></h4>
 
     <div class="lang-zh-only"><p>站 01–06：shell 回车 → cli.ts → main.ts → createAgentSession() → prompt() 将「读取 README.md，用一句话告诉我这个项目做什么」变为 AgentMessage 并写 JSONL。</p></div>
     <div class="lang-en-only"><p>Stations 01–06: Enter → cli.ts → main.ts → createAgentSession() → prompt() turns «read README.md and tell me what this project does in one sentence» into AgentMessage + JSONL.</p></div>
@@ -2070,7 +2429,7 @@
     <div class="lang-zh-only"><p>owner=loop 站 07–11：executeToolCalls → packages/coding-agent/src/core/tools/read.ts createReadTool。</p></div>
     <div class="lang-en-only"><p>owner=loop 07–11: executeToolCalls → createReadTool in read.ts.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">工具结果到第二次 stream</span><span class="lang-en-only">To second stream</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C02.5</span> <span class="lang-zh-only">工具结果到第二次 stream</span><span class="lang-en-only">To second stream</span></h4>
 
     <div class="lang-zh-only"><p>toolResult push 后 convertToLlm(messages) 转 Message[]；第二次 streamAssistantResponse。</p></div>
     <div class="lang-en-only"><p>After toolResult, convertToLlm to Message[]; second streamAssistantResponse.</p></div>
@@ -2081,7 +2440,7 @@
     <div class="lang-zh-only"><p>turn_end 携带 toolResults；无 follow-up 时 agent_end。</p></div>
     <div class="lang-en-only"><p>turn_end carries toolResults; agent_end without follow-up.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">七里程碑映射</span><span class="lang-en-only">Milestone map</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C02.6</span> <span class="lang-zh-only">七里程碑映射</span><span class="lang-en-only">Milestone map</span></h4>
 
     <div class="lang-zh-only"><p>01 user_message↔01–04；03 assistant(toolUse)↔06；04–05 tool↔07–12；07 stop↔15–18。</p></div>
     <div class="lang-en-only"><p>01 user↔01–04; 03 toolUse↔06; 04–05 tool↔07–12; 07 stop↔15–18.</p></div>
@@ -2089,13 +2448,27 @@
     <div class="lang-zh-only"><p>站 19–22：扩展 hook、compaction 检查、TUI flush、leafId——短任务可能 noop。</p></div>
     <div class="lang-en-only"><p>19–22: extension hooks, compaction, TUI flush, leafId — may noop on short task.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">如何读后续章</span><span class="lang-en-only">Read later chapters</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C02.7</span> <span class="lang-zh-only">如何读后续章</span><span class="lang-en-only">Read later chapters</span></h4>
 
     <div class="lang-zh-only"><p>C06↔03–05；C07↔05–08；C10↔09–11；C14↔14–16。</p></div>
     <div class="lang-en-only"><p>C06↔03–05; C07↔05–08; C10↔09–11; C14↔14–16.</p></div>
 
     <div class="lang-zh-only"><p>验收：pi --verbose 事件序列应对齐 prologue.ts 类型顺序。</p></div>
     <div class="lang-en-only"><p>Acceptance: pi --verbose event types mirror prologue.ts order.</p></div>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C02.8</span> <span class="lang-zh-only">读完后应能回答的 5 个问题 · 一条消息的 22 站</span><span class="lang-en-only">Five questions you should answer after reading · 一条消息的 22 站</span></h4>
+
+    <div class="lang-zh-only"><p>① 主线 prompt 进入本章模块时，第一个被调用的 <code>export</code> 函数是什么？② 它 emit 的第一个 AgentEvent 类型是什么？③ 若在此层抛错，TUI 会卡在什么状态？④ 对应的 pi-textbook checkpoint 测试命令是什么？⑤ <code>packages/coding-agent/src/main.ts</code> 中哪一行最值得打断点？</p></div>
+    <div class="lang-en-only"><p>① First <code>export</code> called when through-line enters this module? ② First AgentEvent type emitted? ③ If this layer throws, what TUI state stalls? ④ Matching pi-textbook checkpoint test command? ⑤ Best breakpoint line in <code>packages/coding-agent/src/main.ts</code>?</p></div>
+
+    <div class="lang-zh-only"><p>不要一次读完整个文件。用「从测试入手」法：先 <code>npm test -- &lt;matching-test&gt;</code>，看失败断言指向哪行，再读那一行上下游 30 行。生产 pi-mono 的测试覆盖率在 agent-loop 与 session-manager 最高——优先读测试。</p></div>
+    <div class="lang-en-only"><p>Don't read whole files at once. «Test-first» method: run <code>npm test -- &lt;matching-test&gt;</code>, see which assertion fails, read ±30 lines around that line. Highest test coverage in agent-loop and session-manager — read tests first.</p></div>
+
+    <div class="lang-zh-only"><p>对照本文 TRACE 盒与 <code>--verbose</code> stderr：每个 event type 应在源码中有且仅有一处「决策点」——若找不到，说明事件在更上层（AgentSession）或更下层（pi-ai adapter）合并发出。</p></div>
+    <div class="lang-en-only"><p>Cross-check TRACE box with <code>--verbose</code> stderr: each event type should have exactly one «decision point» in source — if missing, event is merged upstream (AgentSession) or downstream (pi-ai adapter).</p></div>
+
+    <div class="lang-zh-only"><p>进阶：用 <code>git blame packages/coding-agent/src/main.ts</code> 看最近改动——Pi 的 harness 接口仍在活跃演进，注释可能落后于 <code>AgentLoopConfig</code> 类型定义。类型即文档。</p></div>
+    <div class="lang-en-only"><p>Advanced: <code>git blame packages/coding-agent/src/main.ts</code> for recent changes — Pi harness APIs still evolve; comments may lag <code>AgentLoopConfig</code> types. Types are the doc.</p></div>
 
     <div class="trace-box">
       <div class="tb-tag">TRACE · station 01</div>
@@ -2121,20 +2494,33 @@
       <span class="src-line"><span class="src-line">  <span class="src-kw">while</span> (hasMoreToolCalls || pendingMessages.length) {</span></span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">交叉引用</span><span class="lang-en-only">Cross-ref</span></span> <span class="da-title lang-zh-only">pi-textbook checkpoint</span><span class="da-title lang-en-only">pi-textbook checkpoint</span></div>    <table class="cmp">
       <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
       <tbody>
       <tr><td>cp 00</td><td>一次 README 读取的七个里程碑</td><td><code>prologue.ts</code></td><td><code>packages/coding-agent/src/main.ts · packages/agent/src/agent-loop.ts</code></td></tr>
       </tbody>
     </table>
 
-    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">附录</span><span class="lang-en-only">Appendix</span></span> <span class="da-title lang-zh-only">常见问题</span><span class="da-title lang-en-only">FAQ</span></div>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">22 vs 26？</span><span class="lang-en-only">22 vs 26?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>章含背景 C03–C05 与全景 C24–C25。</p></div><div class="lang-en-only"><p>Chapters include background and landscape.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">owner 从哪来？</span><span class="lang-en-only">owner?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>prologue.ts trace 约定。</p></div><div class="lang-en-only"><p>prologue.ts trace convention.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">如何验证？</span><span class="lang-en-only">Verify?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>对照 coding-agent package.json 版本。</p></div><div class="lang-en-only"><p>Match coding-agent version.</p></div></div></details>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C02.9</span> <span class="lang-zh-only">打开源码：packages/coding-agent/src/main.ts</span><span class="lang-en-only">Open source: packages/coding-agent/src/main.ts</span></h4>
+
+    <div class="lang-zh-only"><p>本章主线 prompt 经过此模块时，请在 pi-mono 打开 <code>packages/coding-agent/src/main.ts</code>，搜索 <code>export</code> 与测试文件中的同名场景。对照 pi-textbook 对应 checkpoint 的 workshop 测试——先让测试绿，再读生产实现。</p></div>
+    <div class="lang-en-only"><p>When the through-line prompt crosses this module, open <code>packages/coding-agent/src/main.ts</code> in pi-mono, search <code>export</code> and matching test scenarios. Cross-read the pi-textbook checkpoint workshop test — green test first, then production.</p></div>
+
+    <div class="lang-zh-only"><p>建议命令：<code>cd packages/agent && npm test -- agent-loop</code>（路径因章而异）。测试文件是行为契约的executable spec，比注释更可靠。</p></div>
+    <div class="lang-en-only"><p>Suggested: <code>cd packages/agent && npm test -- agent-loop</code> (path varies). Tests are executable specs of behavior contracts — more reliable than comments.</p></div>
+
+    <div class="lang-zh-only"><p>用 <code>--verbose</code> 跑一轮主线 prompt，把 stderr event 类型与源码中的 <code>emit</code> 调用逐行对齐——这是本文 C26 推荐的 trace 方法。</p></div>
+    <div class="lang-en-only"><p>Run the through-line with <code>--verbose</code>, align stderr event types with <code>emit</code> calls in source — the trace method recommended in C26.</p></div>
+
+    </div>
   </section>
 
   <section class="chap" id="c3">
@@ -2143,6 +2529,26 @@
     <h2 class="chap-title lang-en-only">The pi-mono family tree</h2>
     <p class="chap-en lang-zh-only">Mario Zechner 与 earendil-works</p>
     <p class="chap-en lang-en-only">Mario Zechner and earendil-works</p>
+    <nav class="chap-compass" aria-label="Chapter 03 navigation">
+      <div class="cc-row cc-loc">
+        <span class="cc-phase"><span class="lang-zh-only">背景</span><span class="lang-en-only">Background</span></span>
+        <span class="cc-sep">·</span>
+        <span class="cc-chap">C03 / 26</span>
+        <span class="cc-sep">·</span>
+        <span class="cc-station"><span class="lang-zh-only">—</span><span class="lang-en-only">—</span></span>
+      </div>
+      <div class="cc-row cc-forest">
+        <span class="cc-forest-label lang-zh-only">你在森林的这里</span>
+        <span class="cc-forest-label lang-en-only">You are here</span>
+        <span class="cc-forest-text lang-zh-only">树根：pi-mono 家谱</span>
+        <span class="cc-forest-text lang-en-only">Roots: pi-mono family tree</span>
+      </div>
+      <div class="cc-row cc-links">
+        <a class="cc-nav cc-prev" href="#c2"><span class="cc-arrow">←</span> <span class="cc-nav-num">C02</span> <span class="lang-zh-only">一条消息的 22 站</span><span class="lang-en-only">22 stations for one message</span></a>
+        <a class="cc-back-map" href="#forest-overview"><span class="lang-zh-only">↑ 回到总览</span><span class="lang-en-only">↑ Forest map</span></a>
+        <a class="cc-nav cc-next" href="#c4"><span class="cc-nav-num">C04</span> <span class="lang-zh-only">六层蛋糕</span><span class="lang-en-only">The six-layer cake</span> <span class="cc-arrow">→</span></a>
+      </div>
+    </nav>
     <aside class="stage-why-care lang-zh-only">
       <div class="swc-label">为什么这一段对你来说很重要</div>
       <p><span class="swc-pill ">直觉</span><span>pi-mono 家谱 决定你如何理解 Pi 在此层的机制。</span></p>
@@ -2178,7 +2584,7 @@
     <div class="lang-zh-only"><p>pi-mono 是 Mario Zechner（Badlogic Games，libGDX 作者）在 earendil-works 组织下的 monorepo。它不是「又一个 ChatGPT 套壳」——而是一套可 fork 的 agent harness，npm 发布六个包。</p></div>
     <div class="lang-en-only"><p>pi-mono is Mario Zechner's (Badlogic Games, libGDX author) monorepo under earendil-works. Not another ChatGPT wrapper — a forkable agent harness published as six npm packages.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">仓库拓扑</span><span class="lang-en-only">Repository topology</span></h3>
+    <h3 class="sub"><span class="sec-num">C03.1</span> <span class="lang-zh-only">仓库拓扑</span><span class="lang-en-only">Repository topology</span></h3>
 
     <div class="src-stack">
       <div class="src-h">
@@ -2206,7 +2612,7 @@
       </tbody>
     </table>
 
-    <h3 class="sub"><span class="lang-zh-only">与 pi-textbook 的关系</span><span class="lang-en-only">Relationship to pi-textbook</span></h3>
+    <h3 class="sub"><span class="sec-num">C03.2</span> <span class="lang-zh-only">与 pi-textbook 的关系</span><span class="lang-en-only">Relationship to pi-textbook</span></h3>
 
     <div class="lang-zh-only"><p>pi-textbook 把生产代码<strong>降维</strong>成 15 个 checkpoint 的可运行 workshop。每个 checkpoint 对应 pi-mono 里一个真实目录，但剥离了 OAuth、40+ provider、TUI 差分渲染等生产复杂度。</p></div>
     <div class="lang-en-only"><p>pi-textbook <strong>reduces</strong> production code into 15 runnable workshop checkpoints. Each maps to a real pi-mono directory, stripped of OAuth, 40+ providers, TUI diff rendering, etc.</p></div>
@@ -2309,7 +2715,9 @@
       </figcaption>
     </figure>
 
-    <h3 class="sub"><span class="lang-zh-only">pi-mono 家谱：主线 prompt 如何穿过此模块</span><span class="lang-en-only">pi-mono 家谱: through-line crossing</span></h3>
+    <div class="depth-zone" data-chapter="C03"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C03.4+</span><span class="lang-en-only">Deep dive · C03.4+</span></div>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C03.4</span> <span class="lang-zh-only">主线 prompt 如何穿过此模块</span><span class="lang-en-only">through-line crossing</span></h4>
 
     <div class="lang-zh-only"><p>用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>pi-mono/package.json</code> 定义了此阶段的类型契约与副作用边界。</p></div>
     <div class="lang-en-only"><p>After «<code>read README.md and tell me what this project does in one sentence</code>», <code>pi-mono/package.json</code> defines type contracts and side-effect boundaries here.</p></div>
@@ -2323,7 +2731,7 @@
     <div class="lang-zh-only"><p>pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。</p></div>
     <div class="lang-en-only"><p>Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">pi-mono 家谱：关键函数与数据流</span><span class="lang-en-only">pi-mono 家谱: key functions and data flow</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C03.5</span> <span class="lang-zh-only">关键函数与数据流</span><span class="lang-en-only">key functions and data flow</span></h4>
 
     <div class="lang-zh-only"><p><code>package.json</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。</p></div>
     <div class="lang-en-only"><p><code>async</code> functions in <code>package.json</code> are usually IO boundaries: disk, network, or subprocess.</p></div>
@@ -2337,7 +2745,7 @@
     <div class="lang-zh-only"><p>对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。</p></div>
     <div class="lang-en-only"><p>Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">pi-mono 家谱：与 agent-loop 的接口</span><span class="lang-en-only">pi-mono 家谱: interface with agent-loop</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C03.6</span> <span class="lang-zh-only">与 agent-loop 的接口</span><span class="lang-en-only">interface with agent-loop</span></h4>
 
     <div class="lang-zh-only"><p><code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。</p></div>
     <div class="lang-en-only"><p><code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc.</p></div>
@@ -2351,7 +2759,7 @@
     <div class="lang-zh-only"><p>--verbose 模式下 stderr 事件类型可回溯到 <code>pi-mono/package.json</code> 的具体行。</p></div>
     <div class="lang-en-only"><p>Under --verbose, stderr event types trace to lines in <code>pi-mono/package.json</code>.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">pi-mono 家谱：设计权衡与常见坑</span><span class="lang-en-only">pi-mono 家谱: trade-offs and pitfalls</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C03.7</span> <span class="lang-zh-only">设计权衡与常见坑</span><span class="lang-en-only">trade-offs and pitfalls</span></h4>
 
     <div class="lang-zh-only"><p>显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。</p></div>
     <div class="lang-en-only"><p>Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union.</p></div>
@@ -2365,6 +2773,20 @@
     <div class="lang-zh-only"><p>对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。</p></div>
     <div class="lang-en-only"><p>vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable.</p></div>
 
+    <h4 class="sub2 depth-sec"><span class="sec-num">C03.8</span> <span class="lang-zh-only">读完后应能回答的 5 个问题 · pi-mono 家谱</span><span class="lang-en-only">Five questions you should answer after reading · pi-mono 家谱</span></h4>
+
+    <div class="lang-zh-only"><p>① 主线 prompt 进入本章模块时，第一个被调用的 <code>export</code> 函数是什么？② 它 emit 的第一个 AgentEvent 类型是什么？③ 若在此层抛错，TUI 会卡在什么状态？④ 对应的 pi-textbook checkpoint 测试命令是什么？⑤ <code>packages/agent/src/agent-loop.ts</code> 中哪一行最值得打断点？</p></div>
+    <div class="lang-en-only"><p>① First <code>export</code> called when through-line enters this module? ② First AgentEvent type emitted? ③ If this layer throws, what TUI state stalls? ④ Matching pi-textbook checkpoint test command? ⑤ Best breakpoint line in <code>packages/agent/src/agent-loop.ts</code>?</p></div>
+
+    <div class="lang-zh-only"><p>不要一次读完整个文件。用「从测试入手」法：先 <code>npm test -- &lt;matching-test&gt;</code>，看失败断言指向哪行，再读那一行上下游 30 行。生产 pi-mono 的测试覆盖率在 agent-loop 与 session-manager 最高——优先读测试。</p></div>
+    <div class="lang-en-only"><p>Don't read whole files at once. «Test-first» method: run <code>npm test -- &lt;matching-test&gt;</code>, see which assertion fails, read ±30 lines around that line. Highest test coverage in agent-loop and session-manager — read tests first.</p></div>
+
+    <div class="lang-zh-only"><p>对照本文 TRACE 盒与 <code>--verbose</code> stderr：每个 event type 应在源码中有且仅有一处「决策点」——若找不到，说明事件在更上层（AgentSession）或更下层（pi-ai adapter）合并发出。</p></div>
+    <div class="lang-en-only"><p>Cross-check TRACE box with <code>--verbose</code> stderr: each event type should have exactly one «decision point» in source — if missing, event is merged upstream (AgentSession) or downstream (pi-ai adapter).</p></div>
+
+    <div class="lang-zh-only"><p>进阶：用 <code>git blame packages/agent/src/agent-loop.ts</code> 看最近改动——Pi 的 harness 接口仍在活跃演进，注释可能落后于 <code>AgentLoopConfig</code> 类型定义。类型即文档。</p></div>
+    <div class="lang-en-only"><p>Advanced: <code>git blame packages/agent/src/agent-loop.ts</code> for recent changes — Pi harness APIs still evolve; comments may lag <code>AgentLoopConfig</code> types. Types are the doc.</p></div>
+
     <div class="src-stack">
       <div class="src-h">
         <span>SOURCE &nbsp;·&nbsp; pi-mono/package.json</span>
@@ -2374,20 +2796,33 @@
       <span class="src-line"><span class="src-line"><span class="src-comment">// through-line: README.md</span></span></span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">交叉引用</span><span class="lang-en-only">Cross-ref</span></span> <span class="da-title lang-zh-only">pi-textbook checkpoint</span><span class="da-title lang-en-only">pi-textbook checkpoint</span></div>    <table class="cmp">
       <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
       <tbody>
       <tr><td>cp 13</td><td>Composition Root</td><td><code>composition-root</code></td><td><code>packages/coding-agent/src/core/agent-session.ts · sdk.ts</code></td></tr>
       </tbody>
     </table>
 
-    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">附录</span><span class="lang-en-only">Appendix</span></span> <span class="da-title lang-zh-only">常见问题</span><span class="da-title lang-en-only">FAQ</span></div>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">pi-mono 家谱最关键文件？</span><span class="lang-en-only">Key file?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p><code>pi-mono/package.json</code>。</p></div><div class="lang-en-only"><p><code>pi-mono/package.json</code>.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">如何单测？</span><span class="lang-en-only">Unit test?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>mock StreamFn 或 ScriptedModel。</p></div><div class="lang-en-only"><p>mock StreamFn or ScriptedModel.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">与 textbook 差异？</span><span class="lang-en-only">vs textbook?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>生产含 OAuth/TUI/40+ providers。</p></div><div class="lang-en-only"><p>Production adds OAuth/TUI/40+ providers.</p></div></div></details>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C03.9</span> <span class="lang-zh-only">打开源码：package.json</span><span class="lang-en-only">Open source: package.json</span></h4>
+
+    <div class="lang-zh-only"><p>本章主线 prompt 经过此模块时，请在 pi-mono 打开 <code>package.json</code>，搜索 <code>export</code> 与测试文件中的同名场景。对照 pi-textbook 对应 checkpoint 的 workshop 测试——先让测试绿，再读生产实现。</p></div>
+    <div class="lang-en-only"><p>When the through-line prompt crosses this module, open <code>package.json</code> in pi-mono, search <code>export</code> and matching test scenarios. Cross-read the pi-textbook checkpoint workshop test — green test first, then production.</p></div>
+
+    <div class="lang-zh-only"><p>建议命令：<code>cd packages/agent && npm test -- agent-loop</code>（路径因章而异）。测试文件是行为契约的executable spec，比注释更可靠。</p></div>
+    <div class="lang-en-only"><p>Suggested: <code>cd packages/agent && npm test -- agent-loop</code> (path varies). Tests are executable specs of behavior contracts — more reliable than comments.</p></div>
+
+    <div class="lang-zh-only"><p>用 <code>--verbose</code> 跑一轮主线 prompt，把 stderr event 类型与源码中的 <code>emit</code> 调用逐行对齐——这是本文 C26 推荐的 trace 方法。</p></div>
+    <div class="lang-en-only"><p>Run the through-line with <code>--verbose</code>, align stderr event types with <code>emit</code> calls in source — the trace method recommended in C26.</p></div>
+
+    </div>
   </section>
 
   <section class="chap" id="c4">
@@ -2396,6 +2831,26 @@
     <h2 class="chap-title lang-en-only">The six-layer cake</h2>
     <p class="chap-en lang-zh-only">agent-core · ai · tui · coding-agent</p>
     <p class="chap-en lang-en-only">agent-core · ai · tui · coding-agent</p>
+    <nav class="chap-compass" aria-label="Chapter 04 navigation">
+      <div class="cc-row cc-loc">
+        <span class="cc-phase"><span class="lang-zh-only">背景</span><span class="lang-en-only">Background</span></span>
+        <span class="cc-sep">·</span>
+        <span class="cc-chap">C04 / 26</span>
+        <span class="cc-sep">·</span>
+        <span class="cc-station"><span class="lang-zh-only">—</span><span class="lang-en-only">—</span></span>
+      </div>
+      <div class="cc-row cc-forest">
+        <span class="cc-forest-label lang-zh-only">你在森林的这里</span>
+        <span class="cc-forest-label lang-en-only">You are here</span>
+        <span class="cc-forest-text lang-zh-only">六层蛋糕：依赖方向</span>
+        <span class="cc-forest-text lang-en-only">Six-layer cake: dependency flow</span>
+      </div>
+      <div class="cc-row cc-links">
+        <a class="cc-nav cc-prev" href="#c3"><span class="cc-arrow">←</span> <span class="cc-nav-num">C03</span> <span class="lang-zh-only">pi-mono 家谱</span><span class="lang-en-only">The pi-mono family tree</span></a>
+        <a class="cc-back-map" href="#forest-overview"><span class="lang-zh-only">↑ 回到总览</span><span class="lang-en-only">↑ Forest map</span></a>
+        <a class="cc-nav cc-next" href="#c5"><span class="cc-nav-num">C05</span> <span class="lang-zh-only">故意不做的功能</span><span class="lang-en-only">Intentionally missing features</span> <span class="cc-arrow">→</span></a>
+      </div>
+    </nav>
     <aside class="stage-why-care lang-zh-only">
       <div class="swc-label">为什么这一段对你来说很重要</div>
       <p><span class="swc-pill ">直觉</span><span>六层蛋糕 决定你如何理解 Pi 在此层的机制。</span></p>
@@ -2431,7 +2886,7 @@
     <div class="lang-zh-only"><p>主线 prompt <code>读取 README.md，用一句话告诉我这个项目做什么</code> 从 L6 进入，在 L5 循环，L4 调模型，L3 渲染，L2/L1 只在 RPC 模式参与。</p></div>
     <div class="lang-en-only"><p>Through-line prompt enters at L6, loops in L5, calls model at L4, renders at L3; L2/L1 only in RPC mode.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">六层蛋糕</span><span class="lang-en-only">Six-layer cake</span></h3>
+    <h3 class="sub"><span class="sec-num">C04.1</span> <span class="lang-zh-only">六层蛋糕</span><span class="lang-en-only">Six-layer cake</span></h3>
 
     <figure>
       <div class="figbox"><div class="pi-fig"><svg viewBox="0 0 720 300" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true" class="pi-svg">
@@ -2545,7 +3000,7 @@
       <span class="src-line"><span class="src-str">"name"</span>: <span class="src-str">"@earendil-works/pi-ai"</span>,</span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">边界纪律</span><span class="lang-en-only">Boundary discipline</span></h3>
+    <h3 class="sub"><span class="sec-num">C04.2</span> <span class="lang-zh-only">边界纪律</span><span class="lang-en-only">Boundary discipline</span></h3>
 
     <div class="lang-zh-only"><p><code>AgentMessage</code> 在整个 agent-core 内流通；只在 <code>streamAssistantResponse</code> 调用点通过 <code>convertToLlm</code> 变成 pi-ai 的 <code>Message[]</code>。这条边界是 pi-textbook checkpoint 03 的核心教训。</p></div>
     <div class="lang-en-only"><p><code>AgentMessage</code> flows through agent-core; only at <code>streamAssistantResponse</code> does <code>convertToLlm</code> produce pi-ai <code>Message[]</code>. Core lesson of textbook checkpoint 03.</p></div>
@@ -2570,7 +3025,9 @@
       <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 13</strong>: Composition Root (<code>composition-root</code>) · production: <code>packages/coding-agent/src/core/agent-session.ts · sdk.ts</code></span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">六层蛋糕：主线 prompt 如何穿过此模块</span><span class="lang-en-only">六层蛋糕: through-line crossing</span></h3>
+    <div class="depth-zone" data-chapter="C04"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C04.4+</span><span class="lang-en-only">Deep dive · C04.4+</span></div>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C04.4</span> <span class="lang-zh-only">主线 prompt 如何穿过此模块</span><span class="lang-en-only">through-line crossing</span></h4>
 
     <div class="lang-zh-only"><p>用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/agent/package.json</code> 定义了此阶段的类型契约与副作用边界。</p></div>
     <div class="lang-en-only"><p>After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/agent/package.json</code> defines type contracts and side-effect boundaries here.</p></div>
@@ -2584,7 +3041,7 @@
     <div class="lang-zh-only"><p>pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。</p></div>
     <div class="lang-en-only"><p>Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">六层蛋糕：关键函数与数据流</span><span class="lang-en-only">六层蛋糕: key functions and data flow</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C04.5</span> <span class="lang-zh-only">关键函数与数据流</span><span class="lang-en-only">key functions and data flow</span></h4>
 
     <div class="lang-zh-only"><p><code>package.json</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。</p></div>
     <div class="lang-en-only"><p><code>async</code> functions in <code>package.json</code> are usually IO boundaries: disk, network, or subprocess.</p></div>
@@ -2598,7 +3055,7 @@
     <div class="lang-zh-only"><p>对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。</p></div>
     <div class="lang-en-only"><p>Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">六层蛋糕：与 agent-loop 的接口</span><span class="lang-en-only">六层蛋糕: interface with agent-loop</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C04.6</span> <span class="lang-zh-only">与 agent-loop 的接口</span><span class="lang-en-only">interface with agent-loop</span></h4>
 
     <div class="lang-zh-only"><p><code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。</p></div>
     <div class="lang-en-only"><p><code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc.</p></div>
@@ -2612,7 +3069,7 @@
     <div class="lang-zh-only"><p>--verbose 模式下 stderr 事件类型可回溯到 <code>packages/agent/package.json</code> 的具体行。</p></div>
     <div class="lang-en-only"><p>Under --verbose, stderr event types trace to lines in <code>packages/agent/package.json</code>.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">六层蛋糕：设计权衡与常见坑</span><span class="lang-en-only">六层蛋糕: trade-offs and pitfalls</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C04.7</span> <span class="lang-zh-only">设计权衡与常见坑</span><span class="lang-en-only">trade-offs and pitfalls</span></h4>
 
     <div class="lang-zh-only"><p>显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。</p></div>
     <div class="lang-en-only"><p>Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union.</p></div>
@@ -2626,6 +3083,20 @@
     <div class="lang-zh-only"><p>对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。</p></div>
     <div class="lang-en-only"><p>vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable.</p></div>
 
+    <h4 class="sub2 depth-sec"><span class="sec-num">C04.8</span> <span class="lang-zh-only">读完后应能回答的 5 个问题 · 六层蛋糕</span><span class="lang-en-only">Five questions you should answer after reading · 六层蛋糕</span></h4>
+
+    <div class="lang-zh-only"><p>① 主线 prompt 进入本章模块时，第一个被调用的 <code>export</code> 函数是什么？② 它 emit 的第一个 AgentEvent 类型是什么？③ 若在此层抛错，TUI 会卡在什么状态？④ 对应的 pi-textbook checkpoint 测试命令是什么？⑤ <code>packages/agent/src/agent-loop.ts</code> 中哪一行最值得打断点？</p></div>
+    <div class="lang-en-only"><p>① First <code>export</code> called when through-line enters this module? ② First AgentEvent type emitted? ③ If this layer throws, what TUI state stalls? ④ Matching pi-textbook checkpoint test command? ⑤ Best breakpoint line in <code>packages/agent/src/agent-loop.ts</code>?</p></div>
+
+    <div class="lang-zh-only"><p>不要一次读完整个文件。用「从测试入手」法：先 <code>npm test -- &lt;matching-test&gt;</code>，看失败断言指向哪行，再读那一行上下游 30 行。生产 pi-mono 的测试覆盖率在 agent-loop 与 session-manager 最高——优先读测试。</p></div>
+    <div class="lang-en-only"><p>Don't read whole files at once. «Test-first» method: run <code>npm test -- &lt;matching-test&gt;</code>, see which assertion fails, read ±30 lines around that line. Highest test coverage in agent-loop and session-manager — read tests first.</p></div>
+
+    <div class="lang-zh-only"><p>对照本文 TRACE 盒与 <code>--verbose</code> stderr：每个 event type 应在源码中有且仅有一处「决策点」——若找不到，说明事件在更上层（AgentSession）或更下层（pi-ai adapter）合并发出。</p></div>
+    <div class="lang-en-only"><p>Cross-check TRACE box with <code>--verbose</code> stderr: each event type should have exactly one «decision point» in source — if missing, event is merged upstream (AgentSession) or downstream (pi-ai adapter).</p></div>
+
+    <div class="lang-zh-only"><p>进阶：用 <code>git blame packages/agent/src/agent-loop.ts</code> 看最近改动——Pi 的 harness 接口仍在活跃演进，注释可能落后于 <code>AgentLoopConfig</code> 类型定义。类型即文档。</p></div>
+    <div class="lang-en-only"><p>Advanced: <code>git blame packages/agent/src/agent-loop.ts</code> for recent changes — Pi harness APIs still evolve; comments may lag <code>AgentLoopConfig</code> types. Types are the doc.</p></div>
+
     <div class="src-stack">
       <div class="src-h">
         <span>SOURCE &nbsp;·&nbsp; packages/agent/package.json</span>
@@ -2635,7 +3106,7 @@
       <span class="src-line"><span class="src-line"><span class="src-comment">// through-line: README.md</span></span></span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">交叉引用</span><span class="lang-en-only">Cross-ref</span></span> <span class="da-title lang-zh-only">pi-textbook checkpoint</span><span class="da-title lang-en-only">pi-textbook checkpoint</span></div>    <table class="cmp">
       <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
       <tbody>
       <tr><td>cp 03</td><td>Message IR</td><td><code>types.ts</code></td><td><code>packages/agent/src/types.ts · packages/coding-agent/src/core/messages.ts</code></td></tr>
@@ -2643,13 +3114,26 @@
       </tbody>
     </table>
 
-    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">附录</span><span class="lang-en-only">Appendix</span></span> <span class="da-title lang-zh-only">常见问题</span><span class="da-title lang-en-only">FAQ</span></div>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">六层蛋糕最关键文件？</span><span class="lang-en-only">Key file?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p><code>packages/agent/package.json</code>。</p></div><div class="lang-en-only"><p><code>packages/agent/package.json</code>.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">如何单测？</span><span class="lang-en-only">Unit test?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>mock StreamFn 或 ScriptedModel。</p></div><div class="lang-en-only"><p>mock StreamFn or ScriptedModel.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">与 textbook 差异？</span><span class="lang-en-only">vs textbook?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>生产含 OAuth/TUI/40+ providers。</p></div><div class="lang-en-only"><p>Production adds OAuth/TUI/40+ providers.</p></div></div></details>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C04.9</span> <span class="lang-zh-only">打开源码：packages/agent/package.json</span><span class="lang-en-only">Open source: packages/agent/package.json</span></h4>
+
+    <div class="lang-zh-only"><p>本章主线 prompt 经过此模块时，请在 pi-mono 打开 <code>packages/agent/package.json</code>，搜索 <code>export</code> 与测试文件中的同名场景。对照 pi-textbook 对应 checkpoint 的 workshop 测试——先让测试绿，再读生产实现。</p></div>
+    <div class="lang-en-only"><p>When the through-line prompt crosses this module, open <code>packages/agent/package.json</code> in pi-mono, search <code>export</code> and matching test scenarios. Cross-read the pi-textbook checkpoint workshop test — green test first, then production.</p></div>
+
+    <div class="lang-zh-only"><p>建议命令：<code>cd packages/agent && npm test -- agent-loop</code>（路径因章而异）。测试文件是行为契约的executable spec，比注释更可靠。</p></div>
+    <div class="lang-en-only"><p>Suggested: <code>cd packages/agent && npm test -- agent-loop</code> (path varies). Tests are executable specs of behavior contracts — more reliable than comments.</p></div>
+
+    <div class="lang-zh-only"><p>用 <code>--verbose</code> 跑一轮主线 prompt，把 stderr event 类型与源码中的 <code>emit</code> 调用逐行对齐——这是本文 C26 推荐的 trace 方法。</p></div>
+    <div class="lang-en-only"><p>Run the through-line with <code>--verbose</code>, align stderr event types with <code>emit</code> calls in source — the trace method recommended in C26.</p></div>
+
+    </div>
   </section>
 
   <section class="chap" id="c5">
@@ -2658,6 +3142,26 @@
     <h2 class="chap-title lang-en-only">Intentionally missing features</h2>
     <p class="chap-en lang-zh-only">No MCP · No sub-agents · No plan mode</p>
     <p class="chap-en lang-en-only">No MCP · No sub-agents · No plan mode</p>
+    <nav class="chap-compass" aria-label="Chapter 05 navigation">
+      <div class="cc-row cc-loc">
+        <span class="cc-phase"><span class="lang-zh-only">背景</span><span class="lang-en-only">Background</span></span>
+        <span class="cc-sep">·</span>
+        <span class="cc-chap">C05 / 26</span>
+        <span class="cc-sep">·</span>
+        <span class="cc-station"><span class="lang-zh-only">—</span><span class="lang-en-only">—</span></span>
+      </div>
+      <div class="cc-row cc-forest">
+        <span class="cc-forest-label lang-zh-only">你在森林的这里</span>
+        <span class="cc-forest-label lang-en-only">You are here</span>
+        <span class="cc-forest-text lang-zh-only">边界：故意不做的功能</span>
+        <span class="cc-forest-text lang-en-only">Boundary: intentionally omitted</span>
+      </div>
+      <div class="cc-row cc-links">
+        <a class="cc-nav cc-prev" href="#c4"><span class="cc-arrow">←</span> <span class="cc-nav-num">C04</span> <span class="lang-zh-only">六层蛋糕</span><span class="lang-en-only">The six-layer cake</span></a>
+        <a class="cc-back-map" href="#forest-overview"><span class="lang-zh-only">↑ 回到总览</span><span class="lang-en-only">↑ Forest map</span></a>
+        <a class="cc-nav cc-next" href="#c6"><span class="cc-nav-num">C06</span> <span class="lang-zh-only">CLI 启动链</span><span class="lang-en-only">CLI boot chain</span> <span class="cc-arrow">→</span></a>
+      </div>
+    </nav>
     <aside class="stage-why-care lang-zh-only">
       <div class="swc-label">为什么这一段对你来说很重要</div>
       <p><span class="swc-pill ">直觉</span><span>Pi README 明确列出 No MCP / No sub-agents / No plan mode——这是边界声明，不是遗漏。</span></p>
@@ -2704,12 +3208,12 @@
       </tbody>
     </table>
 
-    <h3 class="sub"><span class="lang-zh-only">为什么 No MCP</span><span class="lang-en-only">Why no MCP</span></h3>
+    <h3 class="sub"><span class="sec-num">C05.1</span> <span class="lang-zh-only">为什么 No MCP</span><span class="lang-en-only">Why no MCP</span></h3>
 
     <div class="lang-zh-only"><p>MCP 把工具发现协议化，但 Pi 选择 <code>registerTool</code> + npm/git 扩展包——类型安全、可测试、与 agent loop 同进程。代价是生态不互通 Claude Desktop 的 MCP 市场。</p></div>
     <div class="lang-en-only"><p>MCP protocolizes tool discovery; Pi chooses <code>registerTool</code> + npm/git extension packages — type-safe, testable, same process as agent loop. Cost: no interchange with Claude Desktop's MCP marketplace.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">为什么 No sub-agents</span><span class="lang-en-only">Why no sub-agents</span></h3>
+    <h3 class="sub"><span class="sec-num">C05.2</span> <span class="lang-zh-only">为什么 No sub-agents</span><span class="lang-en-only">Why no sub-agents</span></h3>
 
     <div class="lang-zh-only"><p>子 agent 本质是嵌套 agentLoop + 独立 context。Pi 用 <strong>session fork</strong>（JSONL parentSession）+ <strong>RPC 模式</strong> 达到类似效果，但不隐藏嵌套层。</p></div>
     <div class="lang-en-only"><p>Sub-agents are nested agentLoop + isolated context. Pi achieves similar via <strong>session fork</strong> (JSONL parentSession) + <strong>RPC mode</strong> without hiding the nesting.</p></div>
@@ -2725,7 +3229,9 @@
       <cite>Field Note · 10</cite>
     </blockquote>
 
-    <h3 class="sub"><span class="lang-zh-only">为什么 No MCP</span><span class="lang-en-only">Why no MCP</span></h3>
+    <div class="depth-zone" data-chapter="C05"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C05.4+</span><span class="lang-en-only">Deep dive · C05.4+</span></div>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C05.4</span> <span class="lang-zh-only">为什么 No MCP</span><span class="lang-en-only">Why no MCP</span></h4>
 
     <div class="lang-zh-only"><p><code>packages/coding-agent/README.md</code> 第 498 行：<strong>No MCP</strong>。Mario 的博客解释：MCP 把工具发现协议化，但 Pi 选择 <code>registerTool</code> + Skills + npm/git 扩展包。</p></div>
     <div class="lang-en-only"><p><code>packages/coding-agent/README.md</code> line 498: <strong>No MCP</strong>. Mario's blog: MCP protocolizes tool discovery; Pi chooses <code>registerTool</code> + Skills + npm/git extension packages.</p></div>
@@ -2739,7 +3245,7 @@
     <div class="lang-zh-only"><p>扩展路径：<code>examples/extensions/</code> 可添加 MCP；<code>plan-mode/</code> 示例展示 extension 实现产品功能。</p></div>
     <div class="lang-en-only"><p>Extension path: <code>examples/extensions/</code> can add MCP; <code>plan-mode/</code> shows product features via extensions.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">为什么 No sub-agents</span><span class="lang-en-only">Why no sub-agents</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C05.5</span> <span class="lang-zh-only">为什么 No sub-agents</span><span class="lang-en-only">Why no sub-agents</span></h4>
 
     <div class="lang-zh-only"><p>README 第 500 行：可用 tmux spawn 多个 pi 实例，或用 extension 自建，或安装第三方 pi package。</p></div>
     <div class="lang-en-only"><p>README line 500: spawn pi via tmux, build with extensions, or install third-party pi packages.</p></div>
@@ -2753,7 +3259,7 @@
     <div class="lang-zh-only"><p><code>packages/client</code> 的 <code>acquireSession</code> exclusive lease 防止并发写同一会话。</p></div>
     <div class="lang-en-only"><p><code>packages/client</code> <code>acquireSession</code> exclusive lease prevents concurrent session writes.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">为什么 No plan mode</span><span class="lang-en-only">Why no plan mode</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C05.6</span> <span class="lang-zh-only">为什么 No plan mode</span><span class="lang-en-only">Why no plan mode</span></h4>
 
     <div class="lang-zh-only"><p>README 第 504 行：把计划写进文件、用 extension 实现、或安装 package。<code>examples/extensions/plan-mode/</code> 提供 <code>/plan</code> 与 <code>Ctrl+Alt+P</code>。</p></div>
     <div class="lang-en-only"><p>README line 504: write plans to files, use extensions, or install packages. <code>plan-mode/</code> provides <code>/plan</code> and <code>Ctrl+Alt+P</code>.</p></div>
@@ -2764,7 +3270,7 @@
     <div class="lang-zh-only"><p>对主线 prompt：模型可直接 toolUse read，无需先进入 plan 只读阶段。</p></div>
     <div class="lang-en-only"><p>Through-line: model can toolUse read directly — no plan-only phase.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">故意不做 = 可观测性预算</span><span class="lang-en-only">Omissions = observability budget</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C05.7</span> <span class="lang-zh-only">故意不做 = 可观测性预算</span><span class="lang-en-only">Omissions = observability budget</span></h4>
 
     <div class="lang-zh-only"><p>每省略一个产品功能，就少一层黑盒。Pi 用 <code>--verbose</code> 事件 + 开源 <code>agent-loop.ts</code> 补偿 IDE 集成缺失。</p></div>
     <div class="lang-en-only"><p>Each omitted feature removes a black box. Pi compensates with <code>--verbose</code> events and open <code>agent-loop.ts</code>.</p></div>
@@ -2772,13 +3278,27 @@
     <div class="lang-zh-only"><p>对比 Claude Code Plan 模式：用户看不见 plan 状态机；Pi plan-mode extension 仍走 <code>ExtensionRunner</code> 事件。</p></div>
     <div class="lang-en-only"><p>vs Claude Code Plan: users cannot see state machine; Pi plan-mode extension still emits via <code>ExtensionRunner</code>.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">主线 prompt 在「故意不做」语境下</span><span class="lang-en-only">Through-line under omissions</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C05.8</span> <span class="lang-zh-only">主线 prompt 在「故意不做」语境下</span><span class="lang-en-only">Through-line under omissions</span></h4>
 
     <div class="lang-zh-only"><p>主线只需 read + summarize——恰好是 Pi 默认 tool 集的最小闭环。</p></div>
     <div class="lang-en-only"><p>Through-line needs only read + summarize — Pi default tool set minimal loop.</p></div>
 
     <div class="lang-zh-only"><p>若 fork Pi 加 MCP：改动 <code>ExtensionRunner</code> + tool registry，不必 fork <code>agent-loop.ts</code>。</p></div>
     <div class="lang-en-only"><p>Forking to add MCP: change <code>ExtensionRunner</code> + tool registry, not <code>agent-loop.ts</code>.</p></div>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C05.9</span> <span class="lang-zh-only">读完后应能回答的 5 个问题 · 故意不做的功能</span><span class="lang-en-only">Five questions you should answer after reading · 故意不做的功能</span></h4>
+
+    <div class="lang-zh-only"><p>① 主线 prompt 进入本章模块时，第一个被调用的 <code>export</code> 函数是什么？② 它 emit 的第一个 AgentEvent 类型是什么？③ 若在此层抛错，TUI 会卡在什么状态？④ 对应的 pi-textbook checkpoint 测试命令是什么？⑤ <code>packages/agent/src/agent-loop.ts</code> 中哪一行最值得打断点？</p></div>
+    <div class="lang-en-only"><p>① First <code>export</code> called when through-line enters this module? ② First AgentEvent type emitted? ③ If this layer throws, what TUI state stalls? ④ Matching pi-textbook checkpoint test command? ⑤ Best breakpoint line in <code>packages/agent/src/agent-loop.ts</code>?</p></div>
+
+    <div class="lang-zh-only"><p>不要一次读完整个文件。用「从测试入手」法：先 <code>npm test -- &lt;matching-test&gt;</code>，看失败断言指向哪行，再读那一行上下游 30 行。生产 pi-mono 的测试覆盖率在 agent-loop 与 session-manager 最高——优先读测试。</p></div>
+    <div class="lang-en-only"><p>Don't read whole files at once. «Test-first» method: run <code>npm test -- &lt;matching-test&gt;</code>, see which assertion fails, read ±30 lines around that line. Highest test coverage in agent-loop and session-manager — read tests first.</p></div>
+
+    <div class="lang-zh-only"><p>对照本文 TRACE 盒与 <code>--verbose</code> stderr：每个 event type 应在源码中有且仅有一处「决策点」——若找不到，说明事件在更上层（AgentSession）或更下层（pi-ai adapter）合并发出。</p></div>
+    <div class="lang-en-only"><p>Cross-check TRACE box with <code>--verbose</code> stderr: each event type should have exactly one «decision point» in source — if missing, event is merged upstream (AgentSession) or downstream (pi-ai adapter).</p></div>
+
+    <div class="lang-zh-only"><p>进阶：用 <code>git blame packages/agent/src/agent-loop.ts</code> 看最近改动——Pi 的 harness 接口仍在活跃演进，注释可能落后于 <code>AgentLoopConfig</code> 类型定义。类型即文档。</p></div>
+    <div class="lang-en-only"><p>Advanced: <code>git blame packages/agent/src/agent-loop.ts</code> for recent changes — Pi harness APIs still evolve; comments may lag <code>AgentLoopConfig</code> types. Types are the doc.</p></div>
 
     <div class="src-stack">
       <div class="src-h">
@@ -2790,7 +3310,7 @@
       <span class="src-line"><span class="src-line"><span class="src-str">**No plan mode.**</span> Write plans to files ...</span></span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">交叉引用</span><span class="lang-en-only">Cross-ref</span></span> <span class="da-title lang-zh-only">pi-textbook checkpoint</span><span class="da-title lang-en-only">pi-textbook checkpoint</span></div>    <table class="cmp">
       <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
       <tbody>
       <tr><td>cp 12</td><td>Resources + Extensions</td><td><code>resources-extensions</code></td><td><code>packages/coding-agent/src/core/extensions/ · resource-loader.ts</code></td></tr>
@@ -2798,13 +3318,26 @@
       </tbody>
     </table>
 
-    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">附录</span><span class="lang-en-only">Appendix</span></span> <span class="da-title lang-zh-only">常见问题</span><span class="da-title lang-en-only">FAQ</span></div>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">Pi 永远不会有 MCP 吗？</span><span class="lang-en-only">Will Pi never have MCP?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>核心不做一等协议；社区 extension 可加。</p></div><div class="lang-en-only"><p>Not first-class in core; community extensions can add it.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">session fork 和 sub-agent 有何不同？</span><span class="lang-en-only">fork vs sub-agent?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>fork 显式 JSONL 树 + parentSession。</p></div><div class="lang-en-only"><p>fork has explicit JSONL tree + parentSession.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">plan-mode 示例在哪？</span><span class="lang-en-only">plan-mode example?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p><code>examples/extensions/plan-mode/</code>。</p></div><div class="lang-en-only"><p><code>examples/extensions/plan-mode/</code>.</p></div></div></details>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C05.10</span> <span class="lang-zh-only">打开源码：packages/coding-agent/README.md</span><span class="lang-en-only">Open source: packages/coding-agent/README.md</span></h4>
+
+    <div class="lang-zh-only"><p>本章主线 prompt 经过此模块时，请在 pi-mono 打开 <code>packages/coding-agent/README.md</code>，搜索 <code>export</code> 与测试文件中的同名场景。对照 pi-textbook 对应 checkpoint 的 workshop 测试——先让测试绿，再读生产实现。</p></div>
+    <div class="lang-en-only"><p>When the through-line prompt crosses this module, open <code>packages/coding-agent/README.md</code> in pi-mono, search <code>export</code> and matching test scenarios. Cross-read the pi-textbook checkpoint workshop test — green test first, then production.</p></div>
+
+    <div class="lang-zh-only"><p>建议命令：<code>cd packages/agent && npm test -- agent-loop</code>（路径因章而异）。测试文件是行为契约的executable spec，比注释更可靠。</p></div>
+    <div class="lang-en-only"><p>Suggested: <code>cd packages/agent && npm test -- agent-loop</code> (path varies). Tests are executable specs of behavior contracts — more reliable than comments.</p></div>
+
+    <div class="lang-zh-only"><p>用 <code>--verbose</code> 跑一轮主线 prompt，把 stderr event 类型与源码中的 <code>emit</code> 调用逐行对齐——这是本文 C26 推荐的 trace 方法。</p></div>
+    <div class="lang-en-only"><p>Run the through-line with <code>--verbose</code>, align stderr event types with <code>emit</code> calls in source — the trace method recommended in C26.</p></div>
+
+    </div>
   </section>
 
   <section class="chap" id="c6">
@@ -2813,6 +3346,26 @@
     <h2 class="chap-title lang-en-only">CLI boot chain</h2>
     <p class="chap-en lang-zh-only">cli.ts → main.ts → createAgentSession</p>
     <p class="chap-en lang-en-only">cli.ts → main.ts → createAgentSession</p>
+    <nav class="chap-compass" aria-label="Chapter 06 navigation">
+      <div class="cc-row cc-loc">
+        <span class="cc-phase"><span class="lang-zh-only">Phase I · 入口</span><span class="lang-en-only">Phase I · Intake</span></span>
+        <span class="cc-sep">·</span>
+        <span class="cc-chap">C06 / 26</span>
+        <span class="cc-sep">·</span>
+        <span class="cc-station"><span class="lang-zh-only">站 01–03</span><span class="lang-en-only">St. 01–03</span></span>
+      </div>
+      <div class="cc-row cc-forest">
+        <span class="cc-forest-label lang-zh-only">你在森林的这里</span>
+        <span class="cc-forest-label lang-en-only">You are here</span>
+        <span class="cc-forest-text lang-zh-only">CLI 启动 → createAgentSession</span>
+        <span class="cc-forest-text lang-en-only">CLI boot → createAgentSession</span>
+      </div>
+      <div class="cc-row cc-links">
+        <a class="cc-nav cc-prev" href="#c5"><span class="cc-arrow">←</span> <span class="cc-nav-num">C05</span> <span class="lang-zh-only">故意不做的功能</span><span class="lang-en-only">Intentionally missing features</span></a>
+        <a class="cc-back-map" href="#forest-overview"><span class="lang-zh-only">↑ 回到总览</span><span class="lang-en-only">↑ Forest map</span></a>
+        <a class="cc-nav cc-next" href="#c7"><span class="cc-nav-num">C07</span> <span class="lang-zh-only">AgentSession 编排</span><span class="lang-en-only">AgentSession orchestration</span> <span class="cc-arrow">→</span></a>
+      </div>
+    </nav>
     <aside class="stage-why-care lang-zh-only">
       <div class="swc-label">为什么这一段对你来说很重要</div>
       <p><span class="swc-pill ">直觉</span><span>CLI 启动 决定你如何理解 Pi 在此层的机制。</span></p>
@@ -2914,7 +3467,7 @@
       </div>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">Case study：第一次启动</span><span class="lang-en-only">Case study: first boot</span></h3>
+    <h3 class="sub"><span class="sec-num">C06.1</span> <span class="lang-zh-only">Case study：第一次启动</span><span class="lang-en-only">Case study: first boot</span></h3>
 
     <div class="lang-zh-only"><p>冷启动时 <code>ModelRegistry</code> 读取 <code>models.generated.ts</code>，<code>ResourceLoader</code> 扫描 AGENTS.md 栈，<code>SessionManager</code> 创建新 JSONL 文件。用户尚未输入主线 prompt，但 harness 已就绪。</p></div>
     <div class="lang-en-only"><p>On cold boot <code>ModelRegistry</code> reads <code>models.generated.ts</code>, <code>ResourceLoader</code> scans AGENTS.md stack, <code>SessionManager</code> creates new JSONL. User hasn't typed the through-line prompt yet, but harness is ready.</p></div>
@@ -2924,7 +3477,9 @@
       <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 13</strong>: Composition Root (<code>composition-root</code>) · production: <code>packages/coding-agent/src/core/agent-session.ts · sdk.ts</code></span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">CLI 启动：主线 prompt 如何穿过此模块</span><span class="lang-en-only">CLI 启动: through-line crossing</span></h3>
+    <div class="depth-zone" data-chapter="C06"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C06.4+</span><span class="lang-en-only">Deep dive · C06.4+</span></div>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C06.4</span> <span class="lang-zh-only">主线 prompt 如何穿过此模块</span><span class="lang-en-only">through-line crossing</span></h4>
 
     <div class="lang-zh-only"><p>用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/coding-agent/src/cli.ts</code> 定义了此阶段的类型契约与副作用边界。</p></div>
     <div class="lang-en-only"><p>After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/coding-agent/src/cli.ts</code> defines type contracts and side-effect boundaries here.</p></div>
@@ -2938,7 +3493,7 @@
     <div class="lang-zh-only"><p>pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。</p></div>
     <div class="lang-en-only"><p>Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">CLI 启动：关键函数与数据流</span><span class="lang-en-only">CLI 启动: key functions and data flow</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C06.5</span> <span class="lang-zh-only">关键函数与数据流</span><span class="lang-en-only">key functions and data flow</span></h4>
 
     <div class="lang-zh-only"><p><code>cli.ts</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。</p></div>
     <div class="lang-en-only"><p><code>async</code> functions in <code>cli.ts</code> are usually IO boundaries: disk, network, or subprocess.</p></div>
@@ -2952,7 +3507,7 @@
     <div class="lang-zh-only"><p>对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。</p></div>
     <div class="lang-en-only"><p>Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">CLI 启动：与 agent-loop 的接口</span><span class="lang-en-only">CLI 启动: interface with agent-loop</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C06.6</span> <span class="lang-zh-only">与 agent-loop 的接口</span><span class="lang-en-only">interface with agent-loop</span></h4>
 
     <div class="lang-zh-only"><p><code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。</p></div>
     <div class="lang-en-only"><p><code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc.</p></div>
@@ -2966,7 +3521,7 @@
     <div class="lang-zh-only"><p>--verbose 模式下 stderr 事件类型可回溯到 <code>packages/coding-agent/src/cli.ts</code> 的具体行。</p></div>
     <div class="lang-en-only"><p>Under --verbose, stderr event types trace to lines in <code>packages/coding-agent/src/cli.ts</code>.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">CLI 启动：设计权衡与常见坑</span><span class="lang-en-only">CLI 启动: trade-offs and pitfalls</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C06.7</span> <span class="lang-zh-only">设计权衡与常见坑</span><span class="lang-en-only">trade-offs and pitfalls</span></h4>
 
     <div class="lang-zh-only"><p>显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。</p></div>
     <div class="lang-en-only"><p>Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union.</p></div>
@@ -2979,6 +3534,20 @@
 
     <div class="lang-zh-only"><p>对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。</p></div>
     <div class="lang-en-only"><p>vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable.</p></div>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C06.8</span> <span class="lang-zh-only">读完后应能回答的 5 个问题 · CLI 启动链</span><span class="lang-en-only">Five questions you should answer after reading · CLI 启动链</span></h4>
+
+    <div class="lang-zh-only"><p>① 主线 prompt 进入本章模块时，第一个被调用的 <code>export</code> 函数是什么？② 它 emit 的第一个 AgentEvent 类型是什么？③ 若在此层抛错，TUI 会卡在什么状态？④ 对应的 pi-textbook checkpoint 测试命令是什么？⑤ <code>packages/coding-agent/src/cli.ts</code> 中哪一行最值得打断点？</p></div>
+    <div class="lang-en-only"><p>① First <code>export</code> called when through-line enters this module? ② First AgentEvent type emitted? ③ If this layer throws, what TUI state stalls? ④ Matching pi-textbook checkpoint test command? ⑤ Best breakpoint line in <code>packages/coding-agent/src/cli.ts</code>?</p></div>
+
+    <div class="lang-zh-only"><p>不要一次读完整个文件。用「从测试入手」法：先 <code>npm test -- &lt;matching-test&gt;</code>，看失败断言指向哪行，再读那一行上下游 30 行。生产 pi-mono 的测试覆盖率在 agent-loop 与 session-manager 最高——优先读测试。</p></div>
+    <div class="lang-en-only"><p>Don't read whole files at once. «Test-first» method: run <code>npm test -- &lt;matching-test&gt;</code>, see which assertion fails, read ±30 lines around that line. Highest test coverage in agent-loop and session-manager — read tests first.</p></div>
+
+    <div class="lang-zh-only"><p>对照本文 TRACE 盒与 <code>--verbose</code> stderr：每个 event type 应在源码中有且仅有一处「决策点」——若找不到，说明事件在更上层（AgentSession）或更下层（pi-ai adapter）合并发出。</p></div>
+    <div class="lang-en-only"><p>Cross-check TRACE box with <code>--verbose</code> stderr: each event type should have exactly one «decision point» in source — if missing, event is merged upstream (AgentSession) or downstream (pi-ai adapter).</p></div>
+
+    <div class="lang-zh-only"><p>进阶：用 <code>git blame packages/coding-agent/src/cli.ts</code> 看最近改动——Pi 的 harness 接口仍在活跃演进，注释可能落后于 <code>AgentLoopConfig</code> 类型定义。类型即文档。</p></div>
+    <div class="lang-en-only"><p>Advanced: <code>git blame packages/coding-agent/src/cli.ts</code> for recent changes — Pi harness APIs still evolve; comments may lag <code>AgentLoopConfig</code> types. Types are the doc.</p></div>
 
     <div class="trace-box">
       <div class="tb-tag">TRACE · station 06</div>
@@ -2995,20 +3564,33 @@
       <span class="src-line"><span class="src-line"><span class="src-comment">// through-line: README.md</span></span></span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">交叉引用</span><span class="lang-en-only">Cross-ref</span></span> <span class="da-title lang-zh-only">pi-textbook checkpoint</span><span class="da-title lang-en-only">pi-textbook checkpoint</span></div>    <table class="cmp">
       <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
       <tbody>
       <tr><td>cp 13</td><td>Composition Root</td><td><code>composition-root</code></td><td><code>packages/coding-agent/src/core/agent-session.ts · sdk.ts</code></td></tr>
       </tbody>
     </table>
 
-    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">附录</span><span class="lang-en-only">Appendix</span></span> <span class="da-title lang-zh-only">常见问题</span><span class="da-title lang-en-only">FAQ</span></div>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">CLI 启动最关键文件？</span><span class="lang-en-only">Key file?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p><code>packages/coding-agent/src/cli.ts</code>。</p></div><div class="lang-en-only"><p><code>packages/coding-agent/src/cli.ts</code>.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">如何单测？</span><span class="lang-en-only">Unit test?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>mock StreamFn 或 ScriptedModel。</p></div><div class="lang-en-only"><p>mock StreamFn or ScriptedModel.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">与 textbook 差异？</span><span class="lang-en-only">vs textbook?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>生产含 OAuth/TUI/40+ providers。</p></div><div class="lang-en-only"><p>Production adds OAuth/TUI/40+ providers.</p></div></div></details>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C06.9</span> <span class="lang-zh-only">打开源码：packages/coding-agent/src/cli.ts</span><span class="lang-en-only">Open source: packages/coding-agent/src/cli.ts</span></h4>
+
+    <div class="lang-zh-only"><p>本章主线 prompt 经过此模块时，请在 pi-mono 打开 <code>packages/coding-agent/src/cli.ts</code>，搜索 <code>export</code> 与测试文件中的同名场景。对照 pi-textbook 对应 checkpoint 的 workshop 测试——先让测试绿，再读生产实现。</p></div>
+    <div class="lang-en-only"><p>When the through-line prompt crosses this module, open <code>packages/coding-agent/src/cli.ts</code> in pi-mono, search <code>export</code> and matching test scenarios. Cross-read the pi-textbook checkpoint workshop test — green test first, then production.</p></div>
+
+    <div class="lang-zh-only"><p>建议命令：<code>cd packages/agent && npm test -- agent-loop</code>（路径因章而异）。测试文件是行为契约的executable spec，比注释更可靠。</p></div>
+    <div class="lang-en-only"><p>Suggested: <code>cd packages/agent && npm test -- agent-loop</code> (path varies). Tests are executable specs of behavior contracts — more reliable than comments.</p></div>
+
+    <div class="lang-zh-only"><p>用 <code>--verbose</code> 跑一轮主线 prompt，把 stderr event 类型与源码中的 <code>emit</code> 调用逐行对齐——这是本文 C26 推荐的 trace 方法。</p></div>
+    <div class="lang-en-only"><p>Run the through-line with <code>--verbose</code>, align stderr event types with <code>emit</code> calls in source — the trace method recommended in C26.</p></div>
+
+    </div>
   </section>
 
   <section class="chap" id="c7">
@@ -3017,6 +3599,26 @@
     <h2 class="chap-title lang-en-only">AgentSession orchestration</h2>
     <p class="chap-en lang-zh-only">唯一的中枢调度器</p>
     <p class="chap-en lang-en-only">the single orchestration hub</p>
+    <nav class="chap-compass" aria-label="Chapter 07 navigation">
+      <div class="cc-row cc-loc">
+        <span class="cc-phase"><span class="lang-zh-only">Phase I · 入口</span><span class="lang-en-only">Phase I · Intake</span></span>
+        <span class="cc-sep">·</span>
+        <span class="cc-chap">C07 / 26</span>
+        <span class="cc-sep">·</span>
+        <span class="cc-station"><span class="lang-zh-only">站 04–06</span><span class="lang-en-only">St. 04–06</span></span>
+      </div>
+      <div class="cc-row cc-forest">
+        <span class="cc-forest-label lang-zh-only">你在森林的这里</span>
+        <span class="cc-forest-label lang-en-only">You are here</span>
+        <span class="cc-forest-text lang-zh-only">中枢：AgentSession.prompt()</span>
+        <span class="cc-forest-text lang-en-only">Hub: AgentSession.prompt()</span>
+      </div>
+      <div class="cc-row cc-links">
+        <a class="cc-nav cc-prev" href="#c6"><span class="cc-arrow">←</span> <span class="cc-nav-num">C06</span> <span class="lang-zh-only">CLI 启动链</span><span class="lang-en-only">CLI boot chain</span></a>
+        <a class="cc-back-map" href="#forest-overview"><span class="lang-zh-only">↑ 回到总览</span><span class="lang-en-only">↑ Forest map</span></a>
+        <a class="cc-nav cc-next" href="#c8"><span class="cc-nav-num">C08</span> <span class="lang-zh-only">AGENTS.md 上下文栈</span><span class="lang-en-only">The AGENTS.md context stack</span> <span class="cc-arrow">→</span></a>
+      </div>
+    </nav>
     <aside class="stage-why-care lang-zh-only">
       <div class="swc-label">为什么这一段对你来说很重要</div>
       <p><span class="swc-pill ">直觉</span><span>AgentSession 决定你如何理解 Pi 在此层的机制。</span></p>
@@ -3075,7 +3677,7 @@
       <figcaption><span class="figid">EVT</span><span class="lang-zh-only">AgentEvent 流 · 主线 prompt</span><span class="lang-en-only">AgentEvent stream · through-line prompt</span></figcaption>
     </figure>
 
-    <h3 class="sub"><span class="lang-zh-only">AgentSession 职责矩阵</span><span class="lang-en-only">AgentSession responsibility matrix</span></h3>
+    <h3 class="sub"><span class="sec-num">C07.1</span> <span class="lang-zh-only">AgentSession 职责矩阵</span><span class="lang-en-only">AgentSession responsibility matrix</span></h3>
 
     <table class="cmp">
       <thead><tr><th>职责</th><th>类/模块</th><th>主线时刻</th></tr></thead>
@@ -3088,7 +3690,7 @@
       </tbody>
     </table>
 
-    <h3 class="sub"><span class="lang-zh-only">与 agent-core 的分工</span><span class="lang-en-only">Split with agent-core</span></h3>
+    <h3 class="sub"><span class="sec-num">C07.2</span> <span class="lang-zh-only">与 agent-core 的分工</span><span class="lang-en-only">Split with agent-core</span></h3>
 
     <div class="lang-zh-only"><p><code>AgentSession</code> 拥有 I/O 和持久化；<code>agentLoop</code> 是纯函数式循环，不知道 JSONL 和 TUI 的存在。测试 agent loop 不需要启动终端。</p></div>
     <div class="lang-en-only"><p><code>AgentSession</code> owns I/O and persistence; <code>agentLoop</code> is a pure loop unaware of JSONL and TUI. Testing agent loop needs no terminal.</p></div>
@@ -3123,7 +3725,7 @@
       <span class="src-line"><span class="src-comment">     // 事件泵 → JSONL + TUI / event pump → JSONL + TUI</span></span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">交叉引用</span><span class="lang-en-only">Cross-ref</span></span> <span class="da-title lang-zh-only">pi-textbook checkpoint</span><span class="da-title lang-en-only">pi-textbook checkpoint</span></div>    <table class="cmp">
       <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
       <tbody>
       <tr><td>cp 09</td><td>Stateful Agent</td><td><code>stateful-agent</code></td><td><code>packages/agent/src/agent.ts</code></td></tr>
@@ -3131,7 +3733,9 @@
       </tbody>
     </table>
 
-    <h3 class="sub"><span class="lang-zh-only">AgentSession：主线 prompt 如何穿过此模块</span><span class="lang-en-only">AgentSession: through-line crossing</span></h3>
+    <div class="depth-zone" data-chapter="C07"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C07.4+</span><span class="lang-en-only">Deep dive · C07.4+</span></div>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C07.4</span> <span class="lang-zh-only">主线 prompt 如何穿过此模块</span><span class="lang-en-only">through-line crossing</span></h4>
 
     <div class="lang-zh-only"><p>用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/coding-agent/src/core/agent-session.ts</code> 定义了此阶段的类型契约与副作用边界。</p></div>
     <div class="lang-en-only"><p>After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/coding-agent/src/core/agent-session.ts</code> defines type contracts and side-effect boundaries here.</p></div>
@@ -3145,7 +3749,7 @@
     <div class="lang-zh-only"><p>pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。</p></div>
     <div class="lang-en-only"><p>Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">AgentSession：关键函数与数据流</span><span class="lang-en-only">AgentSession: key functions and data flow</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C07.5</span> <span class="lang-zh-only">关键函数与数据流</span><span class="lang-en-only">key functions and data flow</span></h4>
 
     <div class="lang-zh-only"><p><code>agent-session.ts</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。</p></div>
     <div class="lang-en-only"><p><code>async</code> functions in <code>agent-session.ts</code> are usually IO boundaries: disk, network, or subprocess.</p></div>
@@ -3159,7 +3763,7 @@
     <div class="lang-zh-only"><p>对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。</p></div>
     <div class="lang-en-only"><p>Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">AgentSession：与 agent-loop 的接口</span><span class="lang-en-only">AgentSession: interface with agent-loop</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C07.6</span> <span class="lang-zh-only">与 agent-loop 的接口</span><span class="lang-en-only">interface with agent-loop</span></h4>
 
     <div class="lang-zh-only"><p><code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。</p></div>
     <div class="lang-en-only"><p><code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc.</p></div>
@@ -3173,7 +3777,7 @@
     <div class="lang-zh-only"><p>--verbose 模式下 stderr 事件类型可回溯到 <code>packages/coding-agent/src/core/agent-session.ts</code> 的具体行。</p></div>
     <div class="lang-en-only"><p>Under --verbose, stderr event types trace to lines in <code>packages/coding-agent/src/core/agent-session.ts</code>.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">AgentSession：设计权衡与常见坑</span><span class="lang-en-only">AgentSession: trade-offs and pitfalls</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C07.7</span> <span class="lang-zh-only">设计权衡与常见坑</span><span class="lang-en-only">trade-offs and pitfalls</span></h4>
 
     <div class="lang-zh-only"><p>显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。</p></div>
     <div class="lang-en-only"><p>Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union.</p></div>
@@ -3186,6 +3790,20 @@
 
     <div class="lang-zh-only"><p>对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。</p></div>
     <div class="lang-en-only"><p>vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable.</p></div>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C07.8</span> <span class="lang-zh-only">读完后应能回答的 5 个问题 · AgentSession 编排</span><span class="lang-en-only">Five questions you should answer after reading · AgentSession 编排</span></h4>
+
+    <div class="lang-zh-only"><p>① 主线 prompt 进入本章模块时，第一个被调用的 <code>export</code> 函数是什么？② 它 emit 的第一个 AgentEvent 类型是什么？③ 若在此层抛错，TUI 会卡在什么状态？④ 对应的 pi-textbook checkpoint 测试命令是什么？⑤ <code>packages/coding-agent/src/core/agent-session.ts</code> 中哪一行最值得打断点？</p></div>
+    <div class="lang-en-only"><p>① First <code>export</code> called when through-line enters this module? ② First AgentEvent type emitted? ③ If this layer throws, what TUI state stalls? ④ Matching pi-textbook checkpoint test command? ⑤ Best breakpoint line in <code>packages/coding-agent/src/core/agent-session.ts</code>?</p></div>
+
+    <div class="lang-zh-only"><p>不要一次读完整个文件。用「从测试入手」法：先 <code>npm test -- &lt;matching-test&gt;</code>，看失败断言指向哪行，再读那一行上下游 30 行。生产 pi-mono 的测试覆盖率在 agent-loop 与 session-manager 最高——优先读测试。</p></div>
+    <div class="lang-en-only"><p>Don't read whole files at once. «Test-first» method: run <code>npm test -- &lt;matching-test&gt;</code>, see which assertion fails, read ±30 lines around that line. Highest test coverage in agent-loop and session-manager — read tests first.</p></div>
+
+    <div class="lang-zh-only"><p>对照本文 TRACE 盒与 <code>--verbose</code> stderr：每个 event type 应在源码中有且仅有一处「决策点」——若找不到，说明事件在更上层（AgentSession）或更下层（pi-ai adapter）合并发出。</p></div>
+    <div class="lang-en-only"><p>Cross-check TRACE box with <code>--verbose</code> stderr: each event type should have exactly one «decision point» in source — if missing, event is merged upstream (AgentSession) or downstream (pi-ai adapter).</p></div>
+
+    <div class="lang-zh-only"><p>进阶：用 <code>git blame packages/coding-agent/src/core/agent-session.ts</code> 看最近改动——Pi 的 harness 接口仍在活跃演进，注释可能落后于 <code>AgentLoopConfig</code> 类型定义。类型即文档。</p></div>
+    <div class="lang-en-only"><p>Advanced: <code>git blame packages/coding-agent/src/core/agent-session.ts</code> for recent changes — Pi harness APIs still evolve; comments may lag <code>AgentLoopConfig</code> types. Types are the doc.</p></div>
 
     <div class="trace-box">
       <div class="tb-tag">TRACE · station 07</div>
@@ -3202,7 +3820,7 @@
       <span class="src-line"><span class="src-line"><span class="src-comment">// through-line: README.md</span></span></span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">交叉引用</span><span class="lang-en-only">Cross-ref</span></span> <span class="da-title lang-zh-only">pi-textbook checkpoint</span><span class="da-title lang-en-only">pi-textbook checkpoint</span></div>    <table class="cmp">
       <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
       <tbody>
       <tr><td>cp 09</td><td>Stateful Agent</td><td><code>stateful-agent</code></td><td><code>packages/agent/src/agent.ts</code></td></tr>
@@ -3210,13 +3828,37 @@
       </tbody>
     </table>
 
-    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">附录</span><span class="lang-en-only">Appendix</span></span> <span class="da-title lang-zh-only">常见问题</span><span class="da-title lang-en-only">FAQ</span></div>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">AgentSession最关键文件？</span><span class="lang-en-only">Key file?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p><code>packages/coding-agent/src/core/agent-session.ts</code>。</p></div><div class="lang-en-only"><p><code>packages/coding-agent/src/core/agent-session.ts</code>.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">如何单测？</span><span class="lang-en-only">Unit test?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>mock StreamFn 或 ScriptedModel。</p></div><div class="lang-en-only"><p>mock StreamFn or ScriptedModel.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">与 textbook 差异？</span><span class="lang-en-only">vs textbook?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>生产含 OAuth/TUI/40+ providers。</p></div><div class="lang-en-only"><p>Production adds OAuth/TUI/40+ providers.</p></div></div></details>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C07.9</span> <span class="lang-zh-only">prompt() 到 agentLoop 的逐步 trace</span><span class="lang-en-only">Step-by-step trace from prompt() to agentLoop</span></h4>
+
+    <div class="lang-zh-only"><p><code>AgentSession.prompt(text)</code> 首先构造 <code>createUserMessage(text)</code>，类型为 <code>AgentMessage</code> 而非 pi-ai 的 <code>Message</code>。这是 checkpoint 03 与 09 的分水岭：在 agent-core 内永远操作 AgentMessage，只在 <code>streamAssistantResponse</code> 边界调用 <code>convertToLlm</code>。</p></div>
+    <div class="lang-en-only"><p><code>AgentSession.prompt(text)</code> first builds <code>createUserMessage(text)</code> as <code>AgentMessage</code>, not pi-ai <code>Message</code>. Checkpoint 03/09 watershed: AgentMessage inside agent-core; <code>convertToLlm</code> only at <code>streamAssistantResponse</code>.</p></div>
+
+    <div class="lang-zh-only"><p>随后 <code>runLoop</code> 把 userMsg 推入 pending queue，emit <code>turn_start</code> → <code>message_start</code>。若 SessionManager 已绑定，同一事件流会触发 JSONL append——因此 TUI 与磁盘是<strong>同一事件的两个订阅者</strong>，不是两条路径。</p></div>
+    <div class="lang-en-only"><p>Then <code>runLoop</code> pushes userMsg to pending queue, emits <code>turn_start</code> → <code>message_start</code>. With SessionManager bound, the same stream triggers JSONL append — TUI and disk are <strong>two subscribers to one event bus</strong>, not two paths.</p></div>
+
+    <div class="lang-zh-only"><p>主线 prompt 的第一圈 model stream 在 <code>agent-loop.ts</code> 的 inner loop 启动；当 <code>stopReason=toolUse</code> 时，outer loop 不退出，而是进入 tool batch。读 README 的 <code>read</code> 在此执行——cwd 相对路径由 coding-agent 的 tool registry 解析。</p></div>
+    <div class="lang-en-only"><p>First model stream for the through-line starts in agent-loop's inner loop; when <code>stopReason=toolUse</code>, outer loop continues into tool batch. <code>read</code> for README runs here — cwd-relative paths resolved by coding-agent tool registry.</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/agent-session.ts</span>
+        <span class="src-tag">walkthrough</span>
+      </div>
+      <span class="src-line">      <span class="src-line"><span class="src-kw">async</span> <span class="src-fn">prompt</span>(<span class="src-arg">text</span>: <span class="src-cls">string</span>) {</span></span>
+      <span class="src-line">      <span class="src-line">  <span class="src-kw">const</span> userMsg = <span class="src-fn">createUserMessage</span>(text);</span></span>
+      <span class="src-line">      <span class="src-line">  <span class="src-kw">await</span> <span class="src-fn">this.runLoop</span>([userMsg]);</span></span>
+      <span class="src-line">      <span class="src-line">}</span></span>
+    </div>
+
+    </div>
   </section>
 
   <section class="chap" id="c8">
@@ -3225,6 +3867,26 @@
     <h2 class="chap-title lang-en-only">The AGENTS.md context stack</h2>
     <p class="chap-en lang-zh-only">从 ~/.pi 到项目根的指令叠加</p>
     <p class="chap-en lang-en-only">instructions stacked from ~/.pi to project root</p>
+    <nav class="chap-compass" aria-label="Chapter 08 navigation">
+      <div class="cc-row cc-loc">
+        <span class="cc-phase"><span class="lang-zh-only">Phase I · 入口</span><span class="lang-en-only">Phase I · Intake</span></span>
+        <span class="cc-sep">·</span>
+        <span class="cc-chap">C08 / 26</span>
+        <span class="cc-sep">·</span>
+        <span class="cc-station"><span class="lang-zh-only">站 07</span><span class="lang-en-only">St. 07</span></span>
+      </div>
+      <div class="cc-row cc-forest">
+        <span class="cc-forest-label lang-zh-only">你在森林的这里</span>
+        <span class="cc-forest-label lang-en-only">You are here</span>
+        <span class="cc-forest-text lang-zh-only">上下文栈：AGENTS.md 叠加</span>
+        <span class="cc-forest-text lang-en-only">Context stack: AGENTS.md layers</span>
+      </div>
+      <div class="cc-row cc-links">
+        <a class="cc-nav cc-prev" href="#c7"><span class="cc-arrow">←</span> <span class="cc-nav-num">C07</span> <span class="lang-zh-only">AgentSession 编排</span><span class="lang-en-only">AgentSession orchestration</span></a>
+        <a class="cc-back-map" href="#forest-overview"><span class="lang-zh-only">↑ 回到总览</span><span class="lang-en-only">↑ Forest map</span></a>
+        <a class="cc-nav cc-next" href="#c9"><span class="cc-nav-num">C09</span> <span class="lang-zh-only">两层消息模型</span><span class="lang-en-only">Two-layer message model</span> <span class="cc-arrow">→</span></a>
+      </div>
+    </nav>
     <aside class="stage-why-care lang-zh-only">
       <div class="swc-label">为什么这一段对你来说很重要</div>
       <p><span class="swc-pill ">直觉</span><span>AGENTS.md 栈 决定你如何理解 Pi 在此层的机制。</span></p>
@@ -3317,7 +3979,7 @@
       </div>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">主线 prompt 时的 context 长什么样</span><span class="lang-en-only">What context looks like at through-line prompt</span></h3>
+    <h3 class="sub"><span class="sec-num">C08.1</span> <span class="lang-zh-only">主线 prompt 时的 context 长什么样</span><span class="lang-en-only">What context looks like at through-line prompt</span></h3>
 
     <div class="lang-zh-only"><p>模型看到的不是裸的「读取 README」——而是 <code>system: [AGENTS.md 栈] + user: 读取 README.md…</code>。工具 schema 也在 system 或 tools 参数里。</p></div>
     <div class="lang-en-only"><p>Model sees not bare «read README» but <code>system: [AGENTS.md stack] + user: read README.md…</code>. Tool schemas live in system or tools param.</p></div>
@@ -3327,7 +3989,9 @@
       <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 12</strong>: Resources + Extensions (<code>resources-extensions</code>) · production: <code>packages/coding-agent/src/core/extensions/ · resource-loader.ts</code></span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">AGENTS.md 栈：主线 prompt 如何穿过此模块</span><span class="lang-en-only">AGENTS.md 栈: through-line crossing</span></h3>
+    <div class="depth-zone" data-chapter="C08"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C08.4+</span><span class="lang-en-only">Deep dive · C08.4+</span></div>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C08.4</span> <span class="lang-zh-only">主线 prompt 如何穿过此模块</span><span class="lang-en-only">through-line crossing</span></h4>
 
     <div class="lang-zh-only"><p>用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/coding-agent/src/core/resource-loader.ts</code> 定义了此阶段的类型契约与副作用边界。</p></div>
     <div class="lang-en-only"><p>After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/coding-agent/src/core/resource-loader.ts</code> defines type contracts and side-effect boundaries here.</p></div>
@@ -3341,7 +4005,7 @@
     <div class="lang-zh-only"><p>pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。</p></div>
     <div class="lang-en-only"><p>Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">AGENTS.md 栈：关键函数与数据流</span><span class="lang-en-only">AGENTS.md 栈: key functions and data flow</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C08.5</span> <span class="lang-zh-only">关键函数与数据流</span><span class="lang-en-only">key functions and data flow</span></h4>
 
     <div class="lang-zh-only"><p><code>resource-loader.ts</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。</p></div>
     <div class="lang-en-only"><p><code>async</code> functions in <code>resource-loader.ts</code> are usually IO boundaries: disk, network, or subprocess.</p></div>
@@ -3355,7 +4019,7 @@
     <div class="lang-zh-only"><p>对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。</p></div>
     <div class="lang-en-only"><p>Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">AGENTS.md 栈：与 agent-loop 的接口</span><span class="lang-en-only">AGENTS.md 栈: interface with agent-loop</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C08.6</span> <span class="lang-zh-only">与 agent-loop 的接口</span><span class="lang-en-only">interface with agent-loop</span></h4>
 
     <div class="lang-zh-only"><p><code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。</p></div>
     <div class="lang-en-only"><p><code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc.</p></div>
@@ -3369,7 +4033,7 @@
     <div class="lang-zh-only"><p>--verbose 模式下 stderr 事件类型可回溯到 <code>packages/coding-agent/src/core/resource-loader.ts</code> 的具体行。</p></div>
     <div class="lang-en-only"><p>Under --verbose, stderr event types trace to lines in <code>packages/coding-agent/src/core/resource-loader.ts</code>.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">AGENTS.md 栈：设计权衡与常见坑</span><span class="lang-en-only">AGENTS.md 栈: trade-offs and pitfalls</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C08.7</span> <span class="lang-zh-only">设计权衡与常见坑</span><span class="lang-en-only">trade-offs and pitfalls</span></h4>
 
     <div class="lang-zh-only"><p>显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。</p></div>
     <div class="lang-en-only"><p>Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union.</p></div>
@@ -3382,6 +4046,20 @@
 
     <div class="lang-zh-only"><p>对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。</p></div>
     <div class="lang-en-only"><p>vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable.</p></div>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C08.8</span> <span class="lang-zh-only">读完后应能回答的 5 个问题 · AGENTS.md 上下文栈</span><span class="lang-en-only">Five questions you should answer after reading · AGENTS.md 上下文栈</span></h4>
+
+    <div class="lang-zh-only"><p>① 主线 prompt 进入本章模块时，第一个被调用的 <code>export</code> 函数是什么？② 它 emit 的第一个 AgentEvent 类型是什么？③ 若在此层抛错，TUI 会卡在什么状态？④ 对应的 pi-textbook checkpoint 测试命令是什么？⑤ <code>packages/agent/src/agent-loop.ts</code> 中哪一行最值得打断点？</p></div>
+    <div class="lang-en-only"><p>① First <code>export</code> called when through-line enters this module? ② First AgentEvent type emitted? ③ If this layer throws, what TUI state stalls? ④ Matching pi-textbook checkpoint test command? ⑤ Best breakpoint line in <code>packages/agent/src/agent-loop.ts</code>?</p></div>
+
+    <div class="lang-zh-only"><p>不要一次读完整个文件。用「从测试入手」法：先 <code>npm test -- &lt;matching-test&gt;</code>，看失败断言指向哪行，再读那一行上下游 30 行。生产 pi-mono 的测试覆盖率在 agent-loop 与 session-manager 最高——优先读测试。</p></div>
+    <div class="lang-en-only"><p>Don't read whole files at once. «Test-first» method: run <code>npm test -- &lt;matching-test&gt;</code>, see which assertion fails, read ±30 lines around that line. Highest test coverage in agent-loop and session-manager — read tests first.</p></div>
+
+    <div class="lang-zh-only"><p>对照本文 TRACE 盒与 <code>--verbose</code> stderr：每个 event type 应在源码中有且仅有一处「决策点」——若找不到，说明事件在更上层（AgentSession）或更下层（pi-ai adapter）合并发出。</p></div>
+    <div class="lang-en-only"><p>Cross-check TRACE box with <code>--verbose</code> stderr: each event type should have exactly one «decision point» in source — if missing, event is merged upstream (AgentSession) or downstream (pi-ai adapter).</p></div>
+
+    <div class="lang-zh-only"><p>进阶：用 <code>git blame packages/agent/src/agent-loop.ts</code> 看最近改动——Pi 的 harness 接口仍在活跃演进，注释可能落后于 <code>AgentLoopConfig</code> 类型定义。类型即文档。</p></div>
+    <div class="lang-en-only"><p>Advanced: <code>git blame packages/agent/src/agent-loop.ts</code> for recent changes — Pi harness APIs still evolve; comments may lag <code>AgentLoopConfig</code> types. Types are the doc.</p></div>
 
     <div class="trace-box">
       <div class="tb-tag">TRACE · station 08</div>
@@ -3398,20 +4076,33 @@
       <span class="src-line"><span class="src-line"><span class="src-comment">// through-line: README.md</span></span></span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">交叉引用</span><span class="lang-en-only">Cross-ref</span></span> <span class="da-title lang-zh-only">pi-textbook checkpoint</span><span class="da-title lang-en-only">pi-textbook checkpoint</span></div>    <table class="cmp">
       <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
       <tbody>
       <tr><td>cp 12</td><td>Resources + Extensions</td><td><code>resources-extensions</code></td><td><code>packages/coding-agent/src/core/extensions/ · resource-loader.ts</code></td></tr>
       </tbody>
     </table>
 
-    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">附录</span><span class="lang-en-only">Appendix</span></span> <span class="da-title lang-zh-only">常见问题</span><span class="da-title lang-en-only">FAQ</span></div>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">AGENTS.md 栈最关键文件？</span><span class="lang-en-only">Key file?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p><code>packages/coding-agent/src/core/resource-loader.ts</code>。</p></div><div class="lang-en-only"><p><code>packages/coding-agent/src/core/resource-loader.ts</code>.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">如何单测？</span><span class="lang-en-only">Unit test?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>mock StreamFn 或 ScriptedModel。</p></div><div class="lang-en-only"><p>mock StreamFn or ScriptedModel.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">与 textbook 差异？</span><span class="lang-en-only">vs textbook?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>生产含 OAuth/TUI/40+ providers。</p></div><div class="lang-en-only"><p>Production adds OAuth/TUI/40+ providers.</p></div></div></details>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C08.9</span> <span class="lang-zh-only">打开源码：packages/coding-agent/src/core/resource-loader.ts</span><span class="lang-en-only">Open source: packages/coding-agent/src/core/resource-loader.ts</span></h4>
+
+    <div class="lang-zh-only"><p>本章主线 prompt 经过此模块时，请在 pi-mono 打开 <code>packages/coding-agent/src/core/resource-loader.ts</code>，搜索 <code>export</code> 与测试文件中的同名场景。对照 pi-textbook 对应 checkpoint 的 workshop 测试——先让测试绿，再读生产实现。</p></div>
+    <div class="lang-en-only"><p>When the through-line prompt crosses this module, open <code>packages/coding-agent/src/core/resource-loader.ts</code> in pi-mono, search <code>export</code> and matching test scenarios. Cross-read the pi-textbook checkpoint workshop test — green test first, then production.</p></div>
+
+    <div class="lang-zh-only"><p>建议命令：<code>cd packages/agent && npm test -- agent-loop</code>（路径因章而异）。测试文件是行为契约的executable spec，比注释更可靠。</p></div>
+    <div class="lang-en-only"><p>Suggested: <code>cd packages/agent && npm test -- agent-loop</code> (path varies). Tests are executable specs of behavior contracts — more reliable than comments.</p></div>
+
+    <div class="lang-zh-only"><p>用 <code>--verbose</code> 跑一轮主线 prompt，把 stderr event 类型与源码中的 <code>emit</code> 调用逐行对齐——这是本文 C26 推荐的 trace 方法。</p></div>
+    <div class="lang-en-only"><p>Run the through-line with <code>--verbose</code>, align stderr event types with <code>emit</code> calls in source — the trace method recommended in C26.</p></div>
+
+    </div>
   </section>
 
   <section class="chap" id="c9">
@@ -3420,6 +4111,26 @@
     <h2 class="chap-title lang-en-only">Two-layer message model</h2>
     <p class="chap-en lang-zh-only">AgentMessage ≠ Message</p>
     <p class="chap-en lang-en-only">AgentMessage ≠ Message</p>
+    <nav class="chap-compass" aria-label="Chapter 09 navigation">
+      <div class="cc-row cc-loc">
+        <span class="cc-phase"><span class="lang-zh-only">Phase II · 心脏</span><span class="lang-en-only">Phase II · Heart</span></span>
+        <span class="cc-sep">·</span>
+        <span class="cc-chap">C09 / 26</span>
+        <span class="cc-sep">·</span>
+        <span class="cc-station"><span class="lang-zh-only">站 08–09</span><span class="lang-en-only">St. 08–09</span></span>
+      </div>
+      <div class="cc-row cc-forest">
+        <span class="cc-forest-label lang-zh-only">你在森林的这里</span>
+        <span class="cc-forest-label lang-en-only">You are here</span>
+        <span class="cc-forest-text lang-zh-only">消息 IR：AgentMessage ≠ Message</span>
+        <span class="cc-forest-text lang-en-only">Message IR: AgentMessage ≠ Message</span>
+      </div>
+      <div class="cc-row cc-links">
+        <a class="cc-nav cc-prev" href="#c8"><span class="cc-arrow">←</span> <span class="cc-nav-num">C08</span> <span class="lang-zh-only">AGENTS.md 上下文栈</span><span class="lang-en-only">The AGENTS.md context stack</span></a>
+        <a class="cc-back-map" href="#forest-overview"><span class="lang-zh-only">↑ 回到总览</span><span class="lang-en-only">↑ Forest map</span></a>
+        <a class="cc-nav cc-next" href="#c10"><span class="cc-nav-num">C10</span> <span class="lang-zh-only">runLoop 双环</span><span class="lang-en-only">The runLoop twin loops</span> <span class="cc-arrow">→</span></a>
+      </div>
+    </nav>
     <aside class="stage-why-care lang-zh-only">
       <div class="swc-label">为什么这一段对你来说很重要</div>
       <p><span class="swc-pill ">直觉</span><span>消息模型 决定你如何理解 Pi 在此层的机制。</span></p>
@@ -3482,7 +4193,7 @@
       <span class="src-line"><span class="src-kw">export function</span> <span class="src-fn">convertToLlm</span>(<span class="src-arg">messages</span>: <span class="src-cls">AgentMessage</span>[]): <span class="src-cls">Message</span>[]</span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">三层 canonical transcript</span><span class="lang-en-only">Three-layer canonical transcript</span></h3>
+    <h3 class="sub"><span class="sec-num">C09.1</span> <span class="lang-zh-only">三层 canonical transcript</span><span class="lang-en-only">Three-layer canonical transcript</span></h3>
 
     <div class="lang-zh-only"><p>pi-textbook checkpoint 03 强调：transcript 是<strong>唯一真相源</strong>；LLM 请求是投影；TUI 是另一个投影。fork 会话时只复制 AgentMessage 链。</p></div>
     <div class="lang-en-only"><p>Textbook checkpoint 03: transcript is the <strong>single source of truth</strong>; LLM request is a projection; TUI is another. Session fork copies AgentMessage chain only.</p></div>
@@ -3534,7 +4245,9 @@
       <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 03</strong>: Message IR (<code>types.ts</code>) · production: <code>packages/agent/src/types.ts · packages/coding-agent/src/core/messages.ts</code></span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">消息模型：主线 prompt 如何穿过此模块</span><span class="lang-en-only">消息模型: through-line crossing</span></h3>
+    <div class="depth-zone" data-chapter="C09"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C09.4+</span><span class="lang-en-only">Deep dive · C09.4+</span></div>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C09.4</span> <span class="lang-zh-only">主线 prompt 如何穿过此模块</span><span class="lang-en-only">through-line crossing</span></h4>
 
     <div class="lang-zh-only"><p>用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/agent/src/types.ts</code> 定义了此阶段的类型契约与副作用边界。</p></div>
     <div class="lang-en-only"><p>After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/agent/src/types.ts</code> defines type contracts and side-effect boundaries here.</p></div>
@@ -3548,7 +4261,7 @@
     <div class="lang-zh-only"><p>pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。</p></div>
     <div class="lang-en-only"><p>Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">消息模型：关键函数与数据流</span><span class="lang-en-only">消息模型: key functions and data flow</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C09.5</span> <span class="lang-zh-only">关键函数与数据流</span><span class="lang-en-only">key functions and data flow</span></h4>
 
     <div class="lang-zh-only"><p><code>types.ts</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。</p></div>
     <div class="lang-en-only"><p><code>async</code> functions in <code>types.ts</code> are usually IO boundaries: disk, network, or subprocess.</p></div>
@@ -3562,7 +4275,7 @@
     <div class="lang-zh-only"><p>对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。</p></div>
     <div class="lang-en-only"><p>Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">消息模型：与 agent-loop 的接口</span><span class="lang-en-only">消息模型: interface with agent-loop</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C09.6</span> <span class="lang-zh-only">与 agent-loop 的接口</span><span class="lang-en-only">interface with agent-loop</span></h4>
 
     <div class="lang-zh-only"><p><code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。</p></div>
     <div class="lang-en-only"><p><code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc.</p></div>
@@ -3576,7 +4289,7 @@
     <div class="lang-zh-only"><p>--verbose 模式下 stderr 事件类型可回溯到 <code>packages/agent/src/types.ts</code> 的具体行。</p></div>
     <div class="lang-en-only"><p>Under --verbose, stderr event types trace to lines in <code>packages/agent/src/types.ts</code>.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">消息模型：设计权衡与常见坑</span><span class="lang-en-only">消息模型: trade-offs and pitfalls</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C09.7</span> <span class="lang-zh-only">设计权衡与常见坑</span><span class="lang-en-only">trade-offs and pitfalls</span></h4>
 
     <div class="lang-zh-only"><p>显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。</p></div>
     <div class="lang-en-only"><p>Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union.</p></div>
@@ -3589,6 +4302,20 @@
 
     <div class="lang-zh-only"><p>对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。</p></div>
     <div class="lang-en-only"><p>vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable.</p></div>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C09.8</span> <span class="lang-zh-only">读完后应能回答的 5 个问题 · 两层消息模型</span><span class="lang-en-only">Five questions you should answer after reading · 两层消息模型</span></h4>
+
+    <div class="lang-zh-only"><p>① 主线 prompt 进入本章模块时，第一个被调用的 <code>export</code> 函数是什么？② 它 emit 的第一个 AgentEvent 类型是什么？③ 若在此层抛错，TUI 会卡在什么状态？④ 对应的 pi-textbook checkpoint 测试命令是什么？⑤ <code>packages/agent/src/agent-loop.ts</code> 中哪一行最值得打断点？</p></div>
+    <div class="lang-en-only"><p>① First <code>export</code> called when through-line enters this module? ② First AgentEvent type emitted? ③ If this layer throws, what TUI state stalls? ④ Matching pi-textbook checkpoint test command? ⑤ Best breakpoint line in <code>packages/agent/src/agent-loop.ts</code>?</p></div>
+
+    <div class="lang-zh-only"><p>不要一次读完整个文件。用「从测试入手」法：先 <code>npm test -- &lt;matching-test&gt;</code>，看失败断言指向哪行，再读那一行上下游 30 行。生产 pi-mono 的测试覆盖率在 agent-loop 与 session-manager 最高——优先读测试。</p></div>
+    <div class="lang-en-only"><p>Don't read whole files at once. «Test-first» method: run <code>npm test -- &lt;matching-test&gt;</code>, see which assertion fails, read ±30 lines around that line. Highest test coverage in agent-loop and session-manager — read tests first.</p></div>
+
+    <div class="lang-zh-only"><p>对照本文 TRACE 盒与 <code>--verbose</code> stderr：每个 event type 应在源码中有且仅有一处「决策点」——若找不到，说明事件在更上层（AgentSession）或更下层（pi-ai adapter）合并发出。</p></div>
+    <div class="lang-en-only"><p>Cross-check TRACE box with <code>--verbose</code> stderr: each event type should have exactly one «decision point» in source — if missing, event is merged upstream (AgentSession) or downstream (pi-ai adapter).</p></div>
+
+    <div class="lang-zh-only"><p>进阶：用 <code>git blame packages/agent/src/agent-loop.ts</code> 看最近改动——Pi 的 harness 接口仍在活跃演进，注释可能落后于 <code>AgentLoopConfig</code> 类型定义。类型即文档。</p></div>
+    <div class="lang-en-only"><p>Advanced: <code>git blame packages/agent/src/agent-loop.ts</code> for recent changes — Pi harness APIs still evolve; comments may lag <code>AgentLoopConfig</code> types. Types are the doc.</p></div>
 
     <div class="trace-box">
       <div class="tb-tag">TRACE · station 09</div>
@@ -3605,20 +4332,33 @@
       <span class="src-line"><span class="src-line"><span class="src-comment">// through-line: README.md</span></span></span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">交叉引用</span><span class="lang-en-only">Cross-ref</span></span> <span class="da-title lang-zh-only">pi-textbook checkpoint</span><span class="da-title lang-en-only">pi-textbook checkpoint</span></div>    <table class="cmp">
       <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
       <tbody>
       <tr><td>cp 03</td><td>Message IR</td><td><code>types.ts</code></td><td><code>packages/agent/src/types.ts · packages/coding-agent/src/core/messages.ts</code></td></tr>
       </tbody>
     </table>
 
-    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">附录</span><span class="lang-en-only">Appendix</span></span> <span class="da-title lang-zh-only">常见问题</span><span class="da-title lang-en-only">FAQ</span></div>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">消息模型最关键文件？</span><span class="lang-en-only">Key file?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p><code>packages/agent/src/types.ts</code>。</p></div><div class="lang-en-only"><p><code>packages/agent/src/types.ts</code>.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">如何单测？</span><span class="lang-en-only">Unit test?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>mock StreamFn 或 ScriptedModel。</p></div><div class="lang-en-only"><p>mock StreamFn or ScriptedModel.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">与 textbook 差异？</span><span class="lang-en-only">vs textbook?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>生产含 OAuth/TUI/40+ providers。</p></div><div class="lang-en-only"><p>Production adds OAuth/TUI/40+ providers.</p></div></div></details>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C09.9</span> <span class="lang-zh-only">打开源码：packages/agent/src/types.ts</span><span class="lang-en-only">Open source: packages/agent/src/types.ts</span></h4>
+
+    <div class="lang-zh-only"><p>本章主线 prompt 经过此模块时，请在 pi-mono 打开 <code>packages/agent/src/types.ts</code>，搜索 <code>export</code> 与测试文件中的同名场景。对照 pi-textbook 对应 checkpoint 的 workshop 测试——先让测试绿，再读生产实现。</p></div>
+    <div class="lang-en-only"><p>When the through-line prompt crosses this module, open <code>packages/agent/src/types.ts</code> in pi-mono, search <code>export</code> and matching test scenarios. Cross-read the pi-textbook checkpoint workshop test — green test first, then production.</p></div>
+
+    <div class="lang-zh-only"><p>建议命令：<code>cd packages/agent && npm test -- agent-loop</code>（路径因章而异）。测试文件是行为契约的executable spec，比注释更可靠。</p></div>
+    <div class="lang-en-only"><p>Suggested: <code>cd packages/agent && npm test -- agent-loop</code> (path varies). Tests are executable specs of behavior contracts — more reliable than comments.</p></div>
+
+    <div class="lang-zh-only"><p>用 <code>--verbose</code> 跑一轮主线 prompt，把 stderr event 类型与源码中的 <code>emit</code> 调用逐行对齐——这是本文 C26 推荐的 trace 方法。</p></div>
+    <div class="lang-en-only"><p>Run the through-line with <code>--verbose</code>, align stderr event types with <code>emit</code> calls in source — the trace method recommended in C26.</p></div>
+
+    </div>
   </section>
 
   <section class="chap" id="c10">
@@ -3627,6 +4367,26 @@
     <h2 class="chap-title lang-en-only">The runLoop twin loops</h2>
     <p class="chap-en lang-zh-only">outer follow-up · inner tool batch</p>
     <p class="chap-en lang-en-only">outer follow-up · inner tool batch</p>
+    <nav class="chap-compass" aria-label="Chapter 10 navigation">
+      <div class="cc-row cc-loc">
+        <span class="cc-phase"><span class="lang-zh-only">Phase II · 心脏</span><span class="lang-en-only">Phase II · Heart</span></span>
+        <span class="cc-sep">·</span>
+        <span class="cc-chap">C10 / 26</span>
+        <span class="cc-sep">·</span>
+        <span class="cc-station"><span class="lang-zh-only">站 10–11</span><span class="lang-en-only">St. 10–11</span></span>
+      </div>
+      <div class="cc-row cc-forest">
+        <span class="cc-forest-label lang-zh-only">你在森林的这里</span>
+        <span class="cc-forest-label lang-en-only">You are here</span>
+        <span class="cc-forest-text lang-zh-only">双环：follow-up × tool batch</span>
+        <span class="cc-forest-text lang-en-only">Twin loops: follow-up × tool batch</span>
+      </div>
+      <div class="cc-row cc-links">
+        <a class="cc-nav cc-prev" href="#c9"><span class="cc-arrow">←</span> <span class="cc-nav-num">C09</span> <span class="lang-zh-only">两层消息模型</span><span class="lang-en-only">Two-layer message model</span></a>
+        <a class="cc-back-map" href="#forest-overview"><span class="lang-zh-only">↑ 回到总览</span><span class="lang-en-only">↑ Forest map</span></a>
+        <a class="cc-nav cc-next" href="#c11"><span class="cc-nav-num">C11</span> <span class="lang-zh-only">Steering 与 Follow-up</span><span class="lang-en-only">Steering and follow-up</span> <span class="cc-arrow">→</span></a>
+      </div>
+    </nav>
     <aside class="stage-why-care lang-zh-only">
       <div class="swc-label">为什么这一段对你来说很重要</div>
       <p><span class="swc-pill ">直觉</span><span>runLoop 双环 决定你如何理解 Pi 在此层的机制。</span></p>
@@ -3676,7 +4436,7 @@
       <span class="src-line">}</span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">主线 prompt 的两圈 model stream</span><span class="lang-en-only">Two model streams for through-line prompt</span></h3>
+    <h3 class="sub"><span class="sec-num">C10.1</span> <span class="lang-zh-only">主线 prompt 的两圈 model stream</span><span class="lang-en-only">Two model streams for through-line prompt</span></h3>
 
     <figure>
       <div class="figbox"><div class="pi-fig"><svg viewBox="0 0 720 250" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true" class="pi-svg">
@@ -3785,14 +4545,16 @@
       <span class="src-line"><span class="src-comment">     // 执行 read 等 / execute read etc</span></span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">交叉引用</span><span class="lang-en-only">Cross-ref</span></span> <span class="da-title lang-zh-only">pi-textbook checkpoint</span><span class="da-title lang-en-only">pi-textbook checkpoint</span></div>    <table class="cmp">
       <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
       <tbody>
       <tr><td>cp 07</td><td>Agent Loop</td><td><code>agent-loop.ts</code></td><td><code>packages/agent/src/agent-loop.ts</code></td></tr>
       </tbody>
     </table>
 
-    <h3 class="sub"><span class="lang-zh-only">runLoop 双环：主线 prompt 如何穿过此模块</span><span class="lang-en-only">runLoop 双环: through-line crossing</span></h3>
+    <div class="depth-zone" data-chapter="C10"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C10.4+</span><span class="lang-en-only">Deep dive · C10.4+</span></div>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C10.4</span> <span class="lang-zh-only">主线 prompt 如何穿过此模块</span><span class="lang-en-only">through-line crossing</span></h4>
 
     <div class="lang-zh-only"><p>用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/agent/src/agent-loop.ts</code> 定义了此阶段的类型契约与副作用边界。</p></div>
     <div class="lang-en-only"><p>After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/agent/src/agent-loop.ts</code> defines type contracts and side-effect boundaries here.</p></div>
@@ -3806,7 +4568,7 @@
     <div class="lang-zh-only"><p>pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。</p></div>
     <div class="lang-en-only"><p>Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">runLoop 双环：关键函数与数据流</span><span class="lang-en-only">runLoop 双环: key functions and data flow</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C10.5</span> <span class="lang-zh-only">关键函数与数据流</span><span class="lang-en-only">key functions and data flow</span></h4>
 
     <div class="lang-zh-only"><p><code>agent-loop.ts</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。</p></div>
     <div class="lang-en-only"><p><code>async</code> functions in <code>agent-loop.ts</code> are usually IO boundaries: disk, network, or subprocess.</p></div>
@@ -3820,7 +4582,7 @@
     <div class="lang-zh-only"><p>对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。</p></div>
     <div class="lang-en-only"><p>Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">runLoop 双环：与 agent-loop 的接口</span><span class="lang-en-only">runLoop 双环: interface with agent-loop</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C10.6</span> <span class="lang-zh-only">与 agent-loop 的接口</span><span class="lang-en-only">interface with agent-loop</span></h4>
 
     <div class="lang-zh-only"><p><code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。</p></div>
     <div class="lang-en-only"><p><code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc.</p></div>
@@ -3834,7 +4596,7 @@
     <div class="lang-zh-only"><p>--verbose 模式下 stderr 事件类型可回溯到 <code>packages/agent/src/agent-loop.ts</code> 的具体行。</p></div>
     <div class="lang-en-only"><p>Under --verbose, stderr event types trace to lines in <code>packages/agent/src/agent-loop.ts</code>.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">runLoop 双环：设计权衡与常见坑</span><span class="lang-en-only">runLoop 双环: trade-offs and pitfalls</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C10.7</span> <span class="lang-zh-only">设计权衡与常见坑</span><span class="lang-en-only">trade-offs and pitfalls</span></h4>
 
     <div class="lang-zh-only"><p>显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。</p></div>
     <div class="lang-en-only"><p>Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union.</p></div>
@@ -3847,6 +4609,20 @@
 
     <div class="lang-zh-only"><p>对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。</p></div>
     <div class="lang-en-only"><p>vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable.</p></div>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C10.8</span> <span class="lang-zh-only">读完后应能回答的 5 个问题 · runLoop 双环</span><span class="lang-en-only">Five questions you should answer after reading · runLoop 双环</span></h4>
+
+    <div class="lang-zh-only"><p>① 主线 prompt 进入本章模块时，第一个被调用的 <code>export</code> 函数是什么？② 它 emit 的第一个 AgentEvent 类型是什么？③ 若在此层抛错，TUI 会卡在什么状态？④ 对应的 pi-textbook checkpoint 测试命令是什么？⑤ <code>packages/agent/src/agent-loop.ts</code> 中哪一行最值得打断点？</p></div>
+    <div class="lang-en-only"><p>① First <code>export</code> called when through-line enters this module? ② First AgentEvent type emitted? ③ If this layer throws, what TUI state stalls? ④ Matching pi-textbook checkpoint test command? ⑤ Best breakpoint line in <code>packages/agent/src/agent-loop.ts</code>?</p></div>
+
+    <div class="lang-zh-only"><p>不要一次读完整个文件。用「从测试入手」法：先 <code>npm test -- &lt;matching-test&gt;</code>，看失败断言指向哪行，再读那一行上下游 30 行。生产 pi-mono 的测试覆盖率在 agent-loop 与 session-manager 最高——优先读测试。</p></div>
+    <div class="lang-en-only"><p>Don't read whole files at once. «Test-first» method: run <code>npm test -- &lt;matching-test&gt;</code>, see which assertion fails, read ±30 lines around that line. Highest test coverage in agent-loop and session-manager — read tests first.</p></div>
+
+    <div class="lang-zh-only"><p>对照本文 TRACE 盒与 <code>--verbose</code> stderr：每个 event type 应在源码中有且仅有一处「决策点」——若找不到，说明事件在更上层（AgentSession）或更下层（pi-ai adapter）合并发出。</p></div>
+    <div class="lang-en-only"><p>Cross-check TRACE box with <code>--verbose</code> stderr: each event type should have exactly one «decision point» in source — if missing, event is merged upstream (AgentSession) or downstream (pi-ai adapter).</p></div>
+
+    <div class="lang-zh-only"><p>进阶：用 <code>git blame packages/agent/src/agent-loop.ts</code> 看最近改动——Pi 的 harness 接口仍在活跃演进，注释可能落后于 <code>AgentLoopConfig</code> 类型定义。类型即文档。</p></div>
+    <div class="lang-en-only"><p>Advanced: <code>git blame packages/agent/src/agent-loop.ts</code> for recent changes — Pi harness APIs still evolve; comments may lag <code>AgentLoopConfig</code> types. Types are the doc.</p></div>
 
     <div class="trace-box">
       <div class="tb-tag">TRACE · station 10</div>
@@ -3863,20 +4639,46 @@
       <span class="src-line"><span class="src-line">  <span class="src-kw">while</span> (hasMoreToolCalls || pendingMessages.length) {</span></span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">交叉引用</span><span class="lang-en-only">Cross-ref</span></span> <span class="da-title lang-zh-only">pi-textbook checkpoint</span><span class="da-title lang-en-only">pi-textbook checkpoint</span></div>    <table class="cmp">
       <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
       <tbody>
       <tr><td>cp 07</td><td>Agent Loop</td><td><code>agent-loop.ts</code></td><td><code>packages/agent/src/agent-loop.ts</code></td></tr>
       </tbody>
     </table>
 
-    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">附录</span><span class="lang-en-only">Appendix</span></span> <span class="da-title lang-zh-only">常见问题</span><span class="da-title lang-en-only">FAQ</span></div>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">runLoop 双环最关键文件？</span><span class="lang-en-only">Key file?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p><code>packages/agent/src/agent-loop.ts</code>。</p></div><div class="lang-en-only"><p><code>packages/agent/src/agent-loop.ts</code>.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">如何单测？</span><span class="lang-en-only">Unit test?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>mock StreamFn 或 ScriptedModel。</p></div><div class="lang-en-only"><p>mock StreamFn or ScriptedModel.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">与 textbook 差异？</span><span class="lang-en-only">vs textbook?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>生产含 OAuth/TUI/40+ providers。</p></div><div class="lang-en-only"><p>Production adds OAuth/TUI/40+ providers.</p></div></div></details>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C10.9</span> <span class="lang-zh-only">双环状态机：用主线 prompt 走一遍</span><span class="lang-en-only">Twin-loop state machine walked with through-line prompt</span></h4>
+
+    <div class="lang-zh-only"><p>外环条件：<code>while (true)</code> 检查 follow-up 队列与 steering 注入。主线 prompt 首次进入时 follow-up 为空，但 steering 可能在 tool 执行中被用户插入——这是 Pi 与「一次性 completion API」的本质差异。</p></div>
+    <div class="lang-en-only"><p>Outer loop: <code>while (true)</code> checks follow-up queue and steering. First through-line entry has empty follow-up, but steering may inject during tool execution — Pi's essential difference from one-shot completion APIs.</p></div>
+
+    <div class="lang-zh-only"><p>内环条件：<code>while (hasMoreToolCalls || pendingMessages.length)</code>。第一圈 model 返回 toolUse(read) 后，<code>hasMoreToolCalls</code> 为真，内环继续而不回到用户。第二圈 model 收到 tool result 后 <code>stopReason=stop</code>，内环退出，外环检查无 follow-up 后 agent_end。</p></div>
+    <div class="lang-en-only"><p>Inner loop: <code>while (hasMoreToolCalls || pendingMessages.length)</code>. After turn-1 toolUse(read), inner loop continues. Turn-2 stop ends inner loop; outer loop exits with agent_end when no follow-up.</p></div>
+
+    <div class="lang-zh-only"><p>理解双环的最快方法：在 pi-textbook checkpoint 07 的测试里给 <code>ScriptedModel</code> 固定两轮响应，对照 <code>--verbose</code> stderr 的 event 顺序——应看到两次 <code>model_start</code> 夹一次 <code>tool_execution_*</code>。</p></div>
+    <div class="lang-en-only"><p>Fastest way to grok twin loops: fix two-turn responses in textbook cp07's <code>ScriptedModel</code>, compare with <code>--verbose</code> stderr — expect two <code>model_start</code> bracketing one <code>tool_execution_*</code>.</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
+        <span class="src-tag">loop</span>
+      </div>
+      <span class="src-line">      <span class="src-line"><span class="src-kw">while</span> (<span class="src-lit">true</span>) { <span class="src-comment">// outer: follow-up</span></span></span>
+      <span class="src-line">      <span class="src-line">  <span class="src-kw">while</span> (hasMoreToolCalls || pendingMessages.length) { <span class="src-comment">// inner</span></span></span>
+      <span class="src-line">      <span class="src-line">    <span class="src-kw">await</span> <span class="src-fn">streamAssistantResponse</span>(...);</span></span>
+      <span class="src-line">      <span class="src-line">    <span class="src-kw">await</span> <span class="src-fn">executeToolCalls</span>(...);</span></span>
+      <span class="src-line">      <span class="src-line">  }</span></span>
+      <span class="src-line">      <span class="src-line">}</span></span>
+    </div>
+
+    </div>
   </section>
 
   <section class="chap" id="c11">
@@ -3885,6 +4687,26 @@
     <h2 class="chap-title lang-en-only">Steering and follow-up</h2>
     <p class="chap-en lang-zh-only">运行中插队与结束后续</p>
     <p class="chap-en lang-en-only">mid-run injection and post-stop follow-up</p>
+    <nav class="chap-compass" aria-label="Chapter 11 navigation">
+      <div class="cc-row cc-loc">
+        <span class="cc-phase"><span class="lang-zh-only">Phase II · 心脏</span><span class="lang-en-only">Phase II · Heart</span></span>
+        <span class="cc-sep">·</span>
+        <span class="cc-chap">C11 / 26</span>
+        <span class="cc-sep">·</span>
+        <span class="cc-station"><span class="lang-zh-only">站 12</span><span class="lang-en-only">St. 12</span></span>
+      </div>
+      <div class="cc-row cc-forest">
+        <span class="cc-forest-label lang-zh-only">你在森林的这里</span>
+        <span class="cc-forest-label lang-en-only">You are here</span>
+        <span class="cc-forest-text lang-zh-only">插队：steering / follow-up</span>
+        <span class="cc-forest-text lang-en-only">Injection: steering / follow-up</span>
+      </div>
+      <div class="cc-row cc-links">
+        <a class="cc-nav cc-prev" href="#c10"><span class="cc-arrow">←</span> <span class="cc-nav-num">C10</span> <span class="lang-zh-only">runLoop 双环</span><span class="lang-en-only">The runLoop twin loops</span></a>
+        <a class="cc-back-map" href="#forest-overview"><span class="lang-zh-only">↑ 回到总览</span><span class="lang-en-only">↑ Forest map</span></a>
+        <a class="cc-nav cc-next" href="#c12"><span class="cc-nav-num">C12</span> <span class="lang-zh-only">Tool 执行管线</span><span class="lang-en-only">Tool execution pipeline</span> <span class="cc-arrow">→</span></a>
+      </div>
+    </nav>
     <aside class="stage-why-care lang-zh-only">
       <div class="swc-label">为什么这一段对你来说很重要</div>
       <p><span class="swc-pill ">直觉</span><span>Steering 在 tool 执行期间插队；Follow-up 在 agent 将停时续聊。</span></p>
@@ -3940,7 +4762,7 @@
       </tbody>
     </table>
 
-    <h3 class="sub"><span class="lang-zh-only">Case study：read 中途改主意</span><span class="lang-en-only">Case study: change mind mid-read</span></h3>
+    <h3 class="sub"><span class="sec-num">C11.1</span> <span class="lang-zh-only">Case study：read 中途改主意</span><span class="lang-en-only">Case study: change mind mid-read</span></h3>
 
     <div class="lang-zh-only"><p>用户发出主线 prompt 后，模型开始 toolUse read；用户在 TUI 里输入 steering「先列出目录」。内环在 executeTool 前收到 pendingMessages，注入 user 消息，可能改变 tool 选择。</p></div>
     <div class="lang-en-only"><p>After through-line prompt, model starts toolUse read; user steers «list directory first». Inner loop receives pendingMessages before executeTool, may change tool choice.</p></div>
@@ -3950,7 +4772,9 @@
       <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 09</strong>: Stateful Agent (<code>stateful-agent</code>) · production: <code>packages/agent/src/agent.ts</code></span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">Steering：内环插队语义</span><span class="lang-en-only">Steering: inner-loop injection</span></h3>
+    <div class="depth-zone" data-chapter="C11"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C11.4+</span><span class="lang-en-only">Deep dive · C11.4+</span></div>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C11.4</span> <span class="lang-zh-only">内环插队语义</span><span class="lang-en-only">inner-loop injection</span></h4>
 
     <div class="lang-zh-only"><p>runLoop 内环每次迭代末尾调用 getSteeringMessages（agent-loop.ts 259 行）。返回的 AgentMessage[] 在下一次 streamAssistantResponse 之前 push 进 context。</p></div>
     <div class="lang-en-only"><p>Inner loop calls getSteeringMessages (line 259). AgentMessage[] pushed before next streamAssistantResponse.</p></div>
@@ -3964,7 +4788,7 @@
     <div class="lang-zh-only"><p>场景：read 执行中用户输入「先 ls」——steering 在 tool batch 完成后、下次 LLM 前注入。</p></div>
     <div class="lang-en-only"><p>Scenario: while read runs, user types «ls first» — steering injects after tool batch.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">Follow-up：外环续聊语义</span><span class="lang-en-only">Follow-up: outer-loop continuation</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C11.5</span> <span class="lang-zh-only">外环续聊语义</span><span class="lang-en-only">outer-loop continuation</span></h4>
 
     <div class="lang-zh-only"><p>内环结束后外环检查 getFollowUpMessages（263 行）。非空则 pendingMessages 并 continue 外环。</p></div>
     <div class="lang-en-only"><p>Outer loop checks getFollowUpMessages (line 263). Non-empty continues outer loop.</p></div>
@@ -3975,7 +4799,7 @@
     <div class="lang-zh-only"><p>与 steering 区别：follow-up 在 agent would stop 时；steering 在 still running 时。</p></div>
     <div class="lang-en-only"><p>vs steering: follow-up when would stop; steering while still running.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">AgentSession 与 Agent 的分工</span><span class="lang-en-only">AgentSession vs Agent</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C11.6</span> <span class="lang-zh-only">AgentSession 与 Agent 的分工</span><span class="lang-en-only">AgentSession vs Agent</span></h4>
 
     <div class="lang-zh-only"><p>AgentSession 维护 _steeringMessages / _followUpMessages；构造 AgentLoopConfig 时绑定 drain。</p></div>
     <div class="lang-en-only"><p>AgentSession maintains queues; binds drain when building AgentLoopConfig.</p></div>
@@ -3986,7 +4810,7 @@
     <div class="lang-zh-only"><p>interactive-mode.ts 4303 行合并队列状态渲染 footer。</p></div>
     <div class="lang-en-only"><p>interactive-mode.ts line 4303 merges queue state in footer.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">QueueMode 与并发</span><span class="lang-en-only">QueueMode and concurrency</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C11.7</span> <span class="lang-zh-only">QueueMode 与并发</span><span class="lang-en-only">QueueMode and concurrency</span></h4>
 
     <div class="lang-zh-only"><p>types.ts 导出 QueueMode 控制排队策略。</p></div>
     <div class="lang-en-only"><p>types.ts exports QueueMode for queue policy.</p></div>
@@ -3997,10 +4821,24 @@
     <div class="lang-zh-only"><p>abort：AgentSession.abort() 1561 行调用 agent.abort()。</p></div>
     <div class="lang-en-only"><p>Abort: AgentSession.abort() line 1561 calls agent.abort().</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">主线 prompt 下的 steering/follow-up</span><span class="lang-en-only">On through-line</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C11.8</span> <span class="lang-zh-only">主线 prompt 下的 steering/follow-up</span><span class="lang-en-only">On through-line</span></h4>
 
     <div class="lang-zh-only"><p>默认 README 任务不触发 steering；测试 mock getSteeringMessages 观察内环注入。</p></div>
     <div class="lang-en-only"><p>Default README task does not steer; mock getSteeringMessages to test injection.</p></div>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C11.9</span> <span class="lang-zh-only">读完后应能回答的 5 个问题 · Steering 与 Follow-up</span><span class="lang-en-only">Five questions you should answer after reading · Steering 与 Follow-up</span></h4>
+
+    <div class="lang-zh-only"><p>① 主线 prompt 进入本章模块时，第一个被调用的 <code>export</code> 函数是什么？② 它 emit 的第一个 AgentEvent 类型是什么？③ 若在此层抛错，TUI 会卡在什么状态？④ 对应的 pi-textbook checkpoint 测试命令是什么？⑤ <code>packages/agent/src/agent-loop.ts</code> 中哪一行最值得打断点？</p></div>
+    <div class="lang-en-only"><p>① First <code>export</code> called when through-line enters this module? ② First AgentEvent type emitted? ③ If this layer throws, what TUI state stalls? ④ Matching pi-textbook checkpoint test command? ⑤ Best breakpoint line in <code>packages/agent/src/agent-loop.ts</code>?</p></div>
+
+    <div class="lang-zh-only"><p>不要一次读完整个文件。用「从测试入手」法：先 <code>npm test -- &lt;matching-test&gt;</code>，看失败断言指向哪行，再读那一行上下游 30 行。生产 pi-mono 的测试覆盖率在 agent-loop 与 session-manager 最高——优先读测试。</p></div>
+    <div class="lang-en-only"><p>Don't read whole files at once. «Test-first» method: run <code>npm test -- &lt;matching-test&gt;</code>, see which assertion fails, read ±30 lines around that line. Highest test coverage in agent-loop and session-manager — read tests first.</p></div>
+
+    <div class="lang-zh-only"><p>对照本文 TRACE 盒与 <code>--verbose</code> stderr：每个 event type 应在源码中有且仅有一处「决策点」——若找不到，说明事件在更上层（AgentSession）或更下层（pi-ai adapter）合并发出。</p></div>
+    <div class="lang-en-only"><p>Cross-check TRACE box with <code>--verbose</code> stderr: each event type should have exactly one «decision point» in source — if missing, event is merged upstream (AgentSession) or downstream (pi-ai adapter).</p></div>
+
+    <div class="lang-zh-only"><p>进阶：用 <code>git blame packages/agent/src/agent-loop.ts</code> 看最近改动——Pi 的 harness 接口仍在活跃演进，注释可能落后于 <code>AgentLoopConfig</code> 类型定义。类型即文档。</p></div>
+    <div class="lang-en-only"><p>Advanced: <code>git blame packages/agent/src/agent-loop.ts</code> for recent changes — Pi harness APIs still evolve; comments may lag <code>AgentLoopConfig</code> types. Types are the doc.</p></div>
 
     <div class="trace-box">
       <div class="tb-tag">TRACE · station 10</div>
@@ -4026,20 +4864,33 @@
       <span class="src-line"><span class="src-line"><span class="src-fn">getFollowUpMessages</span>: <span class="src-kw">async</span> () => <span class="src-kw">this</span>.followUpQueue.<span class="src-fn">drain</span>(),</span></span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">交叉引用</span><span class="lang-en-only">Cross-ref</span></span> <span class="da-title lang-zh-only">pi-textbook checkpoint</span><span class="da-title lang-en-only">pi-textbook checkpoint</span></div>    <table class="cmp">
       <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
       <tbody>
       <tr><td>cp 09</td><td>Stateful Agent</td><td><code>stateful-agent</code></td><td><code>packages/agent/src/agent.ts</code></td></tr>
       </tbody>
     </table>
 
-    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">附录</span><span class="lang-en-only">Appendix</span></span> <span class="da-title lang-zh-only">常见问题</span><span class="da-title lang-en-only">FAQ</span></div>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">steering 和 follow-up 能否同时排队？</span><span class="lang-en-only">Both queue?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>可以；pendingMessageCount 1540 行返回两者之和。</p></div><div class="lang-en-only"><p>Yes; pendingMessageCount sums both.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">steering 会打断 bash 吗？</span><span class="lang-en-only">Interrupt bash?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>不立即；在当前 tool batch 完成后注入。</p></div><div class="lang-en-only"><p>Not immediately; after tool batch.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">extension 如何注入 steering？</span><span class="lang-en-only">Extension steer?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>通过 ExtensionActions queue 方法。</p></div><div class="lang-en-only"><p>Via ExtensionActions queue methods.</p></div></div></details>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C11.10</span> <span class="lang-zh-only">打开源码：packages/agent/src/agent-loop.ts</span><span class="lang-en-only">Open source: packages/agent/src/agent-loop.ts</span></h4>
+
+    <div class="lang-zh-only"><p>本章主线 prompt 经过此模块时，请在 pi-mono 打开 <code>packages/agent/src/agent-loop.ts</code>，搜索 <code>export</code> 与测试文件中的同名场景。对照 pi-textbook 对应 checkpoint 的 workshop 测试——先让测试绿，再读生产实现。</p></div>
+    <div class="lang-en-only"><p>When the through-line prompt crosses this module, open <code>packages/agent/src/agent-loop.ts</code> in pi-mono, search <code>export</code> and matching test scenarios. Cross-read the pi-textbook checkpoint workshop test — green test first, then production.</p></div>
+
+    <div class="lang-zh-only"><p>建议命令：<code>cd packages/agent && npm test -- agent-loop</code>（路径因章而异）。测试文件是行为契约的executable spec，比注释更可靠。</p></div>
+    <div class="lang-en-only"><p>Suggested: <code>cd packages/agent && npm test -- agent-loop</code> (path varies). Tests are executable specs of behavior contracts — more reliable than comments.</p></div>
+
+    <div class="lang-zh-only"><p>用 <code>--verbose</code> 跑一轮主线 prompt，把 stderr event 类型与源码中的 <code>emit</code> 调用逐行对齐——这是本文 C26 推荐的 trace 方法。</p></div>
+    <div class="lang-en-only"><p>Run the through-line with <code>--verbose</code>, align stderr event types with <code>emit</code> calls in source — the trace method recommended in C26.</p></div>
+
+    </div>
   </section>
 
   <section class="chap" id="c12">
@@ -4048,6 +4899,26 @@
     <h2 class="chap-title lang-en-only">Tool execution pipeline</h2>
     <p class="chap-en lang-zh-only">parallel vs sequential · length 截断</p>
     <p class="chap-en lang-en-only">parallel vs sequential · length truncation</p>
+    <nav class="chap-compass" aria-label="Chapter 12 navigation">
+      <div class="cc-row cc-loc">
+        <span class="cc-phase"><span class="lang-zh-only">Phase II · 心脏</span><span class="lang-en-only">Phase II · Heart</span></span>
+        <span class="cc-sep">·</span>
+        <span class="cc-chap">C12 / 26</span>
+        <span class="cc-sep">·</span>
+        <span class="cc-station"><span class="lang-zh-only">站 13–14</span><span class="lang-en-only">St. 13–14</span></span>
+      </div>
+      <div class="cc-row cc-forest">
+        <span class="cc-forest-label lang-zh-only">你在森林的这里</span>
+        <span class="cc-forest-label lang-en-only">You are here</span>
+        <span class="cc-forest-text lang-zh-only">工具：read README · 截断</span>
+        <span class="cc-forest-text lang-en-only">Tools: read README · truncation</span>
+      </div>
+      <div class="cc-row cc-links">
+        <a class="cc-nav cc-prev" href="#c11"><span class="cc-arrow">←</span> <span class="cc-nav-num">C11</span> <span class="lang-zh-only">Steering 与 Follow-up</span><span class="lang-en-only">Steering and follow-up</span></a>
+        <a class="cc-back-map" href="#forest-overview"><span class="lang-zh-only">↑ 回到总览</span><span class="lang-en-only">↑ Forest map</span></a>
+        <a class="cc-nav cc-next" href="#c13"><span class="cc-nav-num">C13</span> <span class="lang-zh-only">事件总线</span><span class="lang-en-only">The event bus</span> <span class="cc-arrow">→</span></a>
+      </div>
+    </nav>
     <aside class="stage-why-care lang-zh-only">
       <div class="swc-label">为什么这一段对你来说很重要</div>
       <p><span class="swc-pill ">直觉</span><span>Tool 管线 决定你如何理解 Pi 在此层的机制。</span></p>
@@ -4109,7 +4980,7 @@
       </tbody>
     </table>
 
-    <h3 class="sub"><span class="lang-zh-only">read README 的完整路径</span><span class="lang-en-only">Full path of read README</span></h3>
+    <h3 class="sub"><span class="sec-num">C12.1</span> <span class="lang-zh-only">read README 的完整路径</span><span class="lang-en-only">Full path of read README</span></h3>
 
     <div class="ladder">
       <div class="ld-row">
@@ -4159,7 +5030,9 @@
       <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 08</strong>: Coding Tools (<code>coding-tools</code>) · production: <code>packages/coding-agent/src/core/tools/index.ts</code></span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">Tool 管线：主线 prompt 如何穿过此模块</span><span class="lang-en-only">Tool 管线: through-line crossing</span></h3>
+    <div class="depth-zone" data-chapter="C12"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C12.4+</span><span class="lang-en-only">Deep dive · C12.4+</span></div>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C12.4</span> <span class="lang-zh-only">主线 prompt 如何穿过此模块</span><span class="lang-en-only">through-line crossing</span></h4>
 
     <div class="lang-zh-only"><p>用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/coding-agent/src/core/tools/read.ts</code> 定义了此阶段的类型契约与副作用边界。</p></div>
     <div class="lang-en-only"><p>After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/coding-agent/src/core/tools/read.ts</code> defines type contracts and side-effect boundaries here.</p></div>
@@ -4173,7 +5046,7 @@
     <div class="lang-zh-only"><p>pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。</p></div>
     <div class="lang-en-only"><p>Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">Tool 管线：关键函数与数据流</span><span class="lang-en-only">Tool 管线: key functions and data flow</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C12.5</span> <span class="lang-zh-only">关键函数与数据流</span><span class="lang-en-only">key functions and data flow</span></h4>
 
     <div class="lang-zh-only"><p><code>read.ts</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。</p></div>
     <div class="lang-en-only"><p><code>async</code> functions in <code>read.ts</code> are usually IO boundaries: disk, network, or subprocess.</p></div>
@@ -4187,7 +5060,7 @@
     <div class="lang-zh-only"><p>对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。</p></div>
     <div class="lang-en-only"><p>Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">Tool 管线：与 agent-loop 的接口</span><span class="lang-en-only">Tool 管线: interface with agent-loop</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C12.6</span> <span class="lang-zh-only">与 agent-loop 的接口</span><span class="lang-en-only">interface with agent-loop</span></h4>
 
     <div class="lang-zh-only"><p><code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。</p></div>
     <div class="lang-en-only"><p><code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc.</p></div>
@@ -4201,7 +5074,7 @@
     <div class="lang-zh-only"><p>--verbose 模式下 stderr 事件类型可回溯到 <code>packages/coding-agent/src/core/tools/read.ts</code> 的具体行。</p></div>
     <div class="lang-en-only"><p>Under --verbose, stderr event types trace to lines in <code>packages/coding-agent/src/core/tools/read.ts</code>.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">Tool 管线：设计权衡与常见坑</span><span class="lang-en-only">Tool 管线: trade-offs and pitfalls</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C12.7</span> <span class="lang-zh-only">设计权衡与常见坑</span><span class="lang-en-only">trade-offs and pitfalls</span></h4>
 
     <div class="lang-zh-only"><p>显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。</p></div>
     <div class="lang-en-only"><p>Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union.</p></div>
@@ -4214,6 +5087,20 @@
 
     <div class="lang-zh-only"><p>对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。</p></div>
     <div class="lang-en-only"><p>vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable.</p></div>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C12.8</span> <span class="lang-zh-only">读完后应能回答的 5 个问题 · Tool 执行管线</span><span class="lang-en-only">Five questions you should answer after reading · Tool 执行管线</span></h4>
+
+    <div class="lang-zh-only"><p>① 主线 prompt 进入本章模块时，第一个被调用的 <code>export</code> 函数是什么？② 它 emit 的第一个 AgentEvent 类型是什么？③ 若在此层抛错，TUI 会卡在什么状态？④ 对应的 pi-textbook checkpoint 测试命令是什么？⑤ <code>packages/coding-agent/src/core/tools/read.ts</code> 中哪一行最值得打断点？</p></div>
+    <div class="lang-en-only"><p>① First <code>export</code> called when through-line enters this module? ② First AgentEvent type emitted? ③ If this layer throws, what TUI state stalls? ④ Matching pi-textbook checkpoint test command? ⑤ Best breakpoint line in <code>packages/coding-agent/src/core/tools/read.ts</code>?</p></div>
+
+    <div class="lang-zh-only"><p>不要一次读完整个文件。用「从测试入手」法：先 <code>npm test -- &lt;matching-test&gt;</code>，看失败断言指向哪行，再读那一行上下游 30 行。生产 pi-mono 的测试覆盖率在 agent-loop 与 session-manager 最高——优先读测试。</p></div>
+    <div class="lang-en-only"><p>Don't read whole files at once. «Test-first» method: run <code>npm test -- &lt;matching-test&gt;</code>, see which assertion fails, read ±30 lines around that line. Highest test coverage in agent-loop and session-manager — read tests first.</p></div>
+
+    <div class="lang-zh-only"><p>对照本文 TRACE 盒与 <code>--verbose</code> stderr：每个 event type 应在源码中有且仅有一处「决策点」——若找不到，说明事件在更上层（AgentSession）或更下层（pi-ai adapter）合并发出。</p></div>
+    <div class="lang-en-only"><p>Cross-check TRACE box with <code>--verbose</code> stderr: each event type should have exactly one «decision point» in source — if missing, event is merged upstream (AgentSession) or downstream (pi-ai adapter).</p></div>
+
+    <div class="lang-zh-only"><p>进阶：用 <code>git blame packages/coding-agent/src/core/tools/read.ts</code> 看最近改动——Pi 的 harness 接口仍在活跃演进，注释可能落后于 <code>AgentLoopConfig</code> 类型定义。类型即文档。</p></div>
+    <div class="lang-en-only"><p>Advanced: <code>git blame packages/coding-agent/src/core/tools/read.ts</code> for recent changes — Pi harness APIs still evolve; comments may lag <code>AgentLoopConfig</code> types. Types are the doc.</p></div>
 
     <div class="trace-box">
       <div class="tb-tag">TRACE · station 12</div>
@@ -4230,7 +5117,7 @@
       <span class="src-line"><span class="src-line"><span class="src-comment">// through-line: README.md</span></span></span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">交叉引用</span><span class="lang-en-only">Cross-ref</span></span> <span class="da-title lang-zh-only">pi-textbook checkpoint</span><span class="da-title lang-en-only">pi-textbook checkpoint</span></div>    <table class="cmp">
       <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
       <tbody>
       <tr><td>cp 06</td><td>Tool Contract</td><td><code>tool-contract</code></td><td><code>packages/agent/src/agent-loop.ts · packages/coding-agent/src/core/tools/</code></td></tr>
@@ -4238,13 +5125,26 @@
       </tbody>
     </table>
 
-    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">附录</span><span class="lang-en-only">Appendix</span></span> <span class="da-title lang-zh-only">常见问题</span><span class="da-title lang-en-only">FAQ</span></div>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">Tool 管线最关键文件？</span><span class="lang-en-only">Key file?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p><code>packages/coding-agent/src/core/tools/read.ts</code>。</p></div><div class="lang-en-only"><p><code>packages/coding-agent/src/core/tools/read.ts</code>.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">如何单测？</span><span class="lang-en-only">Unit test?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>mock StreamFn 或 ScriptedModel。</p></div><div class="lang-en-only"><p>mock StreamFn or ScriptedModel.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">与 textbook 差异？</span><span class="lang-en-only">vs textbook?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>生产含 OAuth/TUI/40+ providers。</p></div><div class="lang-en-only"><p>Production adds OAuth/TUI/40+ providers.</p></div></div></details>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C12.9</span> <span class="lang-zh-only">打开源码：packages/coding-agent/src/core/tools/read.ts</span><span class="lang-en-only">Open source: packages/coding-agent/src/core/tools/read.ts</span></h4>
+
+    <div class="lang-zh-only"><p>本章主线 prompt 经过此模块时，请在 pi-mono 打开 <code>packages/coding-agent/src/core/tools/read.ts</code>，搜索 <code>export</code> 与测试文件中的同名场景。对照 pi-textbook 对应 checkpoint 的 workshop 测试——先让测试绿，再读生产实现。</p></div>
+    <div class="lang-en-only"><p>When the through-line prompt crosses this module, open <code>packages/coding-agent/src/core/tools/read.ts</code> in pi-mono, search <code>export</code> and matching test scenarios. Cross-read the pi-textbook checkpoint workshop test — green test first, then production.</p></div>
+
+    <div class="lang-zh-only"><p>建议命令：<code>cd packages/agent && npm test -- agent-loop</code>（路径因章而异）。测试文件是行为契约的executable spec，比注释更可靠。</p></div>
+    <div class="lang-en-only"><p>Suggested: <code>cd packages/agent && npm test -- agent-loop</code> (path varies). Tests are executable specs of behavior contracts — more reliable than comments.</p></div>
+
+    <div class="lang-zh-only"><p>用 <code>--verbose</code> 跑一轮主线 prompt，把 stderr event 类型与源码中的 <code>emit</code> 调用逐行对齐——这是本文 C26 推荐的 trace 方法。</p></div>
+    <div class="lang-en-only"><p>Run the through-line with <code>--verbose</code>, align stderr event types with <code>emit</code> calls in source — the trace method recommended in C26.</p></div>
+
+    </div>
   </section>
 
   <section class="chap" id="c13">
@@ -4253,6 +5153,26 @@
     <h2 class="chap-title lang-en-only">The event bus</h2>
     <p class="chap-en lang-zh-only">message_update 如何驱动 TUI</p>
     <p class="chap-en lang-en-only">how message_update drives the TUI</p>
+    <nav class="chap-compass" aria-label="Chapter 13 navigation">
+      <div class="cc-row cc-loc">
+        <span class="cc-phase"><span class="lang-zh-only">Phase II · 心脏</span><span class="lang-en-only">Phase II · Heart</span></span>
+        <span class="cc-sep">·</span>
+        <span class="cc-chap">C13 / 26</span>
+        <span class="cc-sep">·</span>
+        <span class="cc-station"><span class="lang-zh-only">站 15</span><span class="lang-en-only">St. 15</span></span>
+      </div>
+      <div class="cc-row cc-forest">
+        <span class="cc-forest-label lang-zh-only">你在森林的这里</span>
+        <span class="cc-forest-label lang-en-only">You are here</span>
+        <span class="cc-forest-text lang-zh-only">事件总线 → TUI 燃料</span>
+        <span class="cc-forest-text lang-en-only">Event bus → TUI fuel</span>
+      </div>
+      <div class="cc-row cc-links">
+        <a class="cc-nav cc-prev" href="#c12"><span class="cc-arrow">←</span> <span class="cc-nav-num">C12</span> <span class="lang-zh-only">Tool 执行管线</span><span class="lang-en-only">Tool execution pipeline</span></a>
+        <a class="cc-back-map" href="#forest-overview"><span class="lang-zh-only">↑ 回到总览</span><span class="lang-en-only">↑ Forest map</span></a>
+        <a class="cc-nav cc-next" href="#c14"><span class="cc-nav-num">C14</span> <span class="lang-zh-only">pi-ai 提供商抽象</span><span class="lang-en-only">pi-ai provider abstraction</span> <span class="cc-arrow">→</span></a>
+      </div>
+    </nav>
     <aside class="stage-why-care lang-zh-only">
       <div class="swc-label">为什么这一段对你来说很重要</div>
       <p><span class="swc-pill ">直觉</span><span>事件总线 决定你如何理解 Pi 在此层的机制。</span></p>
@@ -4314,7 +5234,7 @@
       <span class="src-line">  | { <span class="src-arg">type</span>: <span class="src-str">"tool_execution_start"</span>; ... };</span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">主线一轮的事件顺序</span><span class="lang-en-only">Event order for one through-line turn</span></h3>
+    <h3 class="sub"><span class="sec-num">C13.1</span> <span class="lang-zh-only">主线一轮的事件顺序</span><span class="lang-en-only">Event order for one through-line turn</span></h3>
 
     <div class="lang-zh-only"><p>简化版：agent_start → turn_start → message_start(user) → message_end(user) → message_update×N → message_end(assistant) → tool_execution_* → message_update×M → message_end(assistant) → turn_end → agent_end。</p></div>
     <div class="lang-en-only"><p>Simplified: agent_start → turn_start → message_start(user) → … → agent_end.</p></div>
@@ -4343,7 +5263,9 @@
       <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 02</strong>: EventStream (<code>event-stream.ts</code>) · production: <code>packages/ai/src/utils/event-stream.ts</code></span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">事件总线：主线 prompt 如何穿过此模块</span><span class="lang-en-only">事件总线: through-line crossing</span></h3>
+    <div class="depth-zone" data-chapter="C13"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C13.4+</span><span class="lang-en-only">Deep dive · C13.4+</span></div>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C13.4</span> <span class="lang-zh-only">主线 prompt 如何穿过此模块</span><span class="lang-en-only">through-line crossing</span></h4>
 
     <div class="lang-zh-only"><p>用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/coding-agent/src/core/agent-session.ts</code> 定义了此阶段的类型契约与副作用边界。</p></div>
     <div class="lang-en-only"><p>After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/coding-agent/src/core/agent-session.ts</code> defines type contracts and side-effect boundaries here.</p></div>
@@ -4357,7 +5279,7 @@
     <div class="lang-zh-only"><p>pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。</p></div>
     <div class="lang-en-only"><p>Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">事件总线：关键函数与数据流</span><span class="lang-en-only">事件总线: key functions and data flow</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C13.5</span> <span class="lang-zh-only">关键函数与数据流</span><span class="lang-en-only">key functions and data flow</span></h4>
 
     <div class="lang-zh-only"><p><code>agent-session.ts</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。</p></div>
     <div class="lang-en-only"><p><code>async</code> functions in <code>agent-session.ts</code> are usually IO boundaries: disk, network, or subprocess.</p></div>
@@ -4371,7 +5293,7 @@
     <div class="lang-zh-only"><p>对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。</p></div>
     <div class="lang-en-only"><p>Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">事件总线：与 agent-loop 的接口</span><span class="lang-en-only">事件总线: interface with agent-loop</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C13.6</span> <span class="lang-zh-only">与 agent-loop 的接口</span><span class="lang-en-only">interface with agent-loop</span></h4>
 
     <div class="lang-zh-only"><p><code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。</p></div>
     <div class="lang-en-only"><p><code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc.</p></div>
@@ -4385,7 +5307,7 @@
     <div class="lang-zh-only"><p>--verbose 模式下 stderr 事件类型可回溯到 <code>packages/coding-agent/src/core/agent-session.ts</code> 的具体行。</p></div>
     <div class="lang-en-only"><p>Under --verbose, stderr event types trace to lines in <code>packages/coding-agent/src/core/agent-session.ts</code>.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">事件总线：设计权衡与常见坑</span><span class="lang-en-only">事件总线: trade-offs and pitfalls</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C13.7</span> <span class="lang-zh-only">设计权衡与常见坑</span><span class="lang-en-only">trade-offs and pitfalls</span></h4>
 
     <div class="lang-zh-only"><p>显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。</p></div>
     <div class="lang-en-only"><p>Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union.</p></div>
@@ -4398,6 +5320,20 @@
 
     <div class="lang-zh-only"><p>对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。</p></div>
     <div class="lang-en-only"><p>vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable.</p></div>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C13.8</span> <span class="lang-zh-only">读完后应能回答的 5 个问题 · 事件总线</span><span class="lang-en-only">Five questions you should answer after reading · 事件总线</span></h4>
+
+    <div class="lang-zh-only"><p>① 主线 prompt 进入本章模块时，第一个被调用的 <code>export</code> 函数是什么？② 它 emit 的第一个 AgentEvent 类型是什么？③ 若在此层抛错，TUI 会卡在什么状态？④ 对应的 pi-textbook checkpoint 测试命令是什么？⑤ <code>packages/agent/src/agent-loop.ts</code> 中哪一行最值得打断点？</p></div>
+    <div class="lang-en-only"><p>① First <code>export</code> called when through-line enters this module? ② First AgentEvent type emitted? ③ If this layer throws, what TUI state stalls? ④ Matching pi-textbook checkpoint test command? ⑤ Best breakpoint line in <code>packages/agent/src/agent-loop.ts</code>?</p></div>
+
+    <div class="lang-zh-only"><p>不要一次读完整个文件。用「从测试入手」法：先 <code>npm test -- &lt;matching-test&gt;</code>，看失败断言指向哪行，再读那一行上下游 30 行。生产 pi-mono 的测试覆盖率在 agent-loop 与 session-manager 最高——优先读测试。</p></div>
+    <div class="lang-en-only"><p>Don't read whole files at once. «Test-first» method: run <code>npm test -- &lt;matching-test&gt;</code>, see which assertion fails, read ±30 lines around that line. Highest test coverage in agent-loop and session-manager — read tests first.</p></div>
+
+    <div class="lang-zh-only"><p>对照本文 TRACE 盒与 <code>--verbose</code> stderr：每个 event type 应在源码中有且仅有一处「决策点」——若找不到，说明事件在更上层（AgentSession）或更下层（pi-ai adapter）合并发出。</p></div>
+    <div class="lang-en-only"><p>Cross-check TRACE box with <code>--verbose</code> stderr: each event type should have exactly one «decision point» in source — if missing, event is merged upstream (AgentSession) or downstream (pi-ai adapter).</p></div>
+
+    <div class="lang-zh-only"><p>进阶：用 <code>git blame packages/agent/src/agent-loop.ts</code> 看最近改动——Pi 的 harness 接口仍在活跃演进，注释可能落后于 <code>AgentLoopConfig</code> 类型定义。类型即文档。</p></div>
+    <div class="lang-en-only"><p>Advanced: <code>git blame packages/agent/src/agent-loop.ts</code> for recent changes — Pi harness APIs still evolve; comments may lag <code>AgentLoopConfig</code> types. Types are the doc.</p></div>
 
     <div class="trace-box">
       <div class="tb-tag">TRACE · station 13</div>
@@ -4414,20 +5350,33 @@
       <span class="src-line"><span class="src-line"><span class="src-comment">// through-line: README.md</span></span></span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">交叉引用</span><span class="lang-en-only">Cross-ref</span></span> <span class="da-title lang-zh-only">pi-textbook checkpoint</span><span class="da-title lang-en-only">pi-textbook checkpoint</span></div>    <table class="cmp">
       <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
       <tbody>
       <tr><td>cp 09</td><td>Stateful Agent</td><td><code>stateful-agent</code></td><td><code>packages/agent/src/agent.ts</code></td></tr>
       </tbody>
     </table>
 
-    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">附录</span><span class="lang-en-only">Appendix</span></span> <span class="da-title lang-zh-only">常见问题</span><span class="da-title lang-en-only">FAQ</span></div>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">事件总线最关键文件？</span><span class="lang-en-only">Key file?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p><code>packages/coding-agent/src/core/agent-session.ts</code>。</p></div><div class="lang-en-only"><p><code>packages/coding-agent/src/core/agent-session.ts</code>.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">如何单测？</span><span class="lang-en-only">Unit test?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>mock StreamFn 或 ScriptedModel。</p></div><div class="lang-en-only"><p>mock StreamFn or ScriptedModel.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">与 textbook 差异？</span><span class="lang-en-only">vs textbook?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>生产含 OAuth/TUI/40+ providers。</p></div><div class="lang-en-only"><p>Production adds OAuth/TUI/40+ providers.</p></div></div></details>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C13.9</span> <span class="lang-zh-only">打开源码：packages/agent/src/types.ts</span><span class="lang-en-only">Open source: packages/agent/src/types.ts</span></h4>
+
+    <div class="lang-zh-only"><p>本章主线 prompt 经过此模块时，请在 pi-mono 打开 <code>packages/agent/src/types.ts</code>，搜索 <code>export</code> 与测试文件中的同名场景。对照 pi-textbook 对应 checkpoint 的 workshop 测试——先让测试绿，再读生产实现。</p></div>
+    <div class="lang-en-only"><p>When the through-line prompt crosses this module, open <code>packages/agent/src/types.ts</code> in pi-mono, search <code>export</code> and matching test scenarios. Cross-read the pi-textbook checkpoint workshop test — green test first, then production.</p></div>
+
+    <div class="lang-zh-only"><p>建议命令：<code>cd packages/agent && npm test -- agent-loop</code>（路径因章而异）。测试文件是行为契约的executable spec，比注释更可靠。</p></div>
+    <div class="lang-en-only"><p>Suggested: <code>cd packages/agent && npm test -- agent-loop</code> (path varies). Tests are executable specs of behavior contracts — more reliable than comments.</p></div>
+
+    <div class="lang-zh-only"><p>用 <code>--verbose</code> 跑一轮主线 prompt，把 stderr event 类型与源码中的 <code>emit</code> 调用逐行对齐——这是本文 C26 推荐的 trace 方法。</p></div>
+    <div class="lang-en-only"><p>Run the through-line with <code>--verbose</code>, align stderr event types with <code>emit</code> calls in source — the trace method recommended in C26.</p></div>
+
+    </div>
   </section>
 
   <section class="chap" id="c14">
@@ -4436,6 +5385,26 @@
     <h2 class="chap-title lang-en-only">pi-ai provider abstraction</h2>
     <p class="chap-en lang-zh-only">Models · createProvider · streamSimple</p>
     <p class="chap-en lang-en-only">Models · createProvider · streamSimple</p>
+    <nav class="chap-compass" aria-label="Chapter 14 navigation">
+      <div class="cc-row cc-loc">
+        <span class="cc-phase"><span class="lang-zh-only">Phase III · LLM</span><span class="lang-en-only">Phase III · LLM</span></span>
+        <span class="cc-sep">·</span>
+        <span class="cc-chap">C14 / 26</span>
+        <span class="cc-sep">·</span>
+        <span class="cc-station"><span class="lang-zh-only">站 16</span><span class="lang-en-only">St. 16</span></span>
+      </div>
+      <div class="cc-row cc-forest">
+        <span class="cc-forest-label lang-zh-only">你在森林的这里</span>
+        <span class="cc-forest-label lang-en-only">You are here</span>
+        <span class="cc-forest-text lang-zh-only">pi-ai：provider 抽象</span>
+        <span class="cc-forest-text lang-en-only">pi-ai: provider abstraction</span>
+      </div>
+      <div class="cc-row cc-links">
+        <a class="cc-nav cc-prev" href="#c13"><span class="cc-arrow">←</span> <span class="cc-nav-num">C13</span> <span class="lang-zh-only">事件总线</span><span class="lang-en-only">The event bus</span></a>
+        <a class="cc-back-map" href="#forest-overview"><span class="lang-zh-only">↑ 回到总览</span><span class="lang-en-only">↑ Forest map</span></a>
+        <a class="cc-nav cc-next" href="#c15"><span class="cc-nav-num">C15</span> <span class="lang-zh-only">流式 EventStream</span><span class="lang-en-only">Streaming EventStream</span> <span class="cc-arrow">→</span></a>
+      </div>
+    </nav>
     <aside class="stage-why-care lang-zh-only">
       <div class="swc-label">为什么这一段对你来说很重要</div>
       <p><span class="swc-pill ">直觉</span><span>pi-ai 提供商 决定你如何理解 Pi 在此层的机制。</span></p>
@@ -4501,7 +5470,9 @@
       <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 05</strong>: Provider Adapter (<code>provider-adapter.ts</code>) · production: <code>packages/ai/src/api/*.ts · packages/ai/src/models.ts</code></span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">pi-ai 提供商：主线 prompt 如何穿过此模块</span><span class="lang-en-only">pi-ai 提供商: through-line crossing</span></h3>
+    <div class="depth-zone" data-chapter="C14"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C14.4+</span><span class="lang-en-only">Deep dive · C14.4+</span></div>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C14.4</span> <span class="lang-zh-only">主线 prompt 如何穿过此模块</span><span class="lang-en-only">through-line crossing</span></h4>
 
     <div class="lang-zh-only"><p>用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/ai/src/models.ts</code> 定义了此阶段的类型契约与副作用边界。</p></div>
     <div class="lang-en-only"><p>After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/ai/src/models.ts</code> defines type contracts and side-effect boundaries here.</p></div>
@@ -4515,7 +5486,7 @@
     <div class="lang-zh-only"><p>pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。</p></div>
     <div class="lang-en-only"><p>Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">pi-ai 提供商：关键函数与数据流</span><span class="lang-en-only">pi-ai 提供商: key functions and data flow</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C14.5</span> <span class="lang-zh-only">关键函数与数据流</span><span class="lang-en-only">key functions and data flow</span></h4>
 
     <div class="lang-zh-only"><p><code>models.ts</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。</p></div>
     <div class="lang-en-only"><p><code>async</code> functions in <code>models.ts</code> are usually IO boundaries: disk, network, or subprocess.</p></div>
@@ -4529,7 +5500,7 @@
     <div class="lang-zh-only"><p>对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。</p></div>
     <div class="lang-en-only"><p>Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">pi-ai 提供商：与 agent-loop 的接口</span><span class="lang-en-only">pi-ai 提供商: interface with agent-loop</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C14.6</span> <span class="lang-zh-only">与 agent-loop 的接口</span><span class="lang-en-only">interface with agent-loop</span></h4>
 
     <div class="lang-zh-only"><p><code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。</p></div>
     <div class="lang-en-only"><p><code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc.</p></div>
@@ -4543,7 +5514,7 @@
     <div class="lang-zh-only"><p>--verbose 模式下 stderr 事件类型可回溯到 <code>packages/ai/src/models.ts</code> 的具体行。</p></div>
     <div class="lang-en-only"><p>Under --verbose, stderr event types trace to lines in <code>packages/ai/src/models.ts</code>.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">pi-ai 提供商：设计权衡与常见坑</span><span class="lang-en-only">pi-ai 提供商: trade-offs and pitfalls</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C14.7</span> <span class="lang-zh-only">设计权衡与常见坑</span><span class="lang-en-only">trade-offs and pitfalls</span></h4>
 
     <div class="lang-zh-only"><p>显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。</p></div>
     <div class="lang-en-only"><p>Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union.</p></div>
@@ -4556,6 +5527,20 @@
 
     <div class="lang-zh-only"><p>对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。</p></div>
     <div class="lang-en-only"><p>vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable.</p></div>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C14.8</span> <span class="lang-zh-only">读完后应能回答的 5 个问题 · pi-ai 提供商抽象</span><span class="lang-en-only">Five questions you should answer after reading · pi-ai 提供商抽象</span></h4>
+
+    <div class="lang-zh-only"><p>① 主线 prompt 进入本章模块时，第一个被调用的 <code>export</code> 函数是什么？② 它 emit 的第一个 AgentEvent 类型是什么？③ 若在此层抛错，TUI 会卡在什么状态？④ 对应的 pi-textbook checkpoint 测试命令是什么？⑤ <code>packages/ai/src/api/stream-simple.ts</code> 中哪一行最值得打断点？</p></div>
+    <div class="lang-en-only"><p>① First <code>export</code> called when through-line enters this module? ② First AgentEvent type emitted? ③ If this layer throws, what TUI state stalls? ④ Matching pi-textbook checkpoint test command? ⑤ Best breakpoint line in <code>packages/ai/src/api/stream-simple.ts</code>?</p></div>
+
+    <div class="lang-zh-only"><p>不要一次读完整个文件。用「从测试入手」法：先 <code>npm test -- &lt;matching-test&gt;</code>，看失败断言指向哪行，再读那一行上下游 30 行。生产 pi-mono 的测试覆盖率在 agent-loop 与 session-manager 最高——优先读测试。</p></div>
+    <div class="lang-en-only"><p>Don't read whole files at once. «Test-first» method: run <code>npm test -- &lt;matching-test&gt;</code>, see which assertion fails, read ±30 lines around that line. Highest test coverage in agent-loop and session-manager — read tests first.</p></div>
+
+    <div class="lang-zh-only"><p>对照本文 TRACE 盒与 <code>--verbose</code> stderr：每个 event type 应在源码中有且仅有一处「决策点」——若找不到，说明事件在更上层（AgentSession）或更下层（pi-ai adapter）合并发出。</p></div>
+    <div class="lang-en-only"><p>Cross-check TRACE box with <code>--verbose</code> stderr: each event type should have exactly one «decision point» in source — if missing, event is merged upstream (AgentSession) or downstream (pi-ai adapter).</p></div>
+
+    <div class="lang-zh-only"><p>进阶：用 <code>git blame packages/ai/src/api/stream-simple.ts</code> 看最近改动——Pi 的 harness 接口仍在活跃演进，注释可能落后于 <code>AgentLoopConfig</code> 类型定义。类型即文档。</p></div>
+    <div class="lang-en-only"><p>Advanced: <code>git blame packages/ai/src/api/stream-simple.ts</code> for recent changes — Pi harness APIs still evolve; comments may lag <code>AgentLoopConfig</code> types. Types are the doc.</p></div>
 
     <div class="trace-box">
       <div class="tb-tag">TRACE · station 14</div>
@@ -4572,20 +5557,30 @@
       <span class="src-line"><span class="src-line"><span class="src-comment">// through-line: README.md</span></span></span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">交叉引用</span><span class="lang-en-only">Cross-ref</span></span> <span class="da-title lang-zh-only">pi-textbook checkpoint</span><span class="da-title lang-en-only">pi-textbook checkpoint</span></div>    <table class="cmp">
       <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
       <tbody>
       <tr><td>cp 05</td><td>Provider Adapter</td><td><code>provider-adapter.ts</code></td><td><code>packages/ai/src/api/*.ts · packages/ai/src/models.ts</code></td></tr>
       </tbody>
     </table>
 
-    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">附录</span><span class="lang-en-only">Appendix</span></span> <span class="da-title lang-zh-only">常见问题</span><span class="da-title lang-en-only">FAQ</span></div>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">pi-ai 提供商最关键文件？</span><span class="lang-en-only">Key file?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p><code>packages/ai/src/models.ts</code>。</p></div><div class="lang-en-only"><p><code>packages/ai/src/models.ts</code>.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">如何单测？</span><span class="lang-en-only">Unit test?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>mock StreamFn 或 ScriptedModel。</p></div><div class="lang-en-only"><p>mock StreamFn or ScriptedModel.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">与 textbook 差异？</span><span class="lang-en-only">vs textbook?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>生产含 OAuth/TUI/40+ providers。</p></div><div class="lang-en-only"><p>Production adds OAuth/TUI/40+ providers.</p></div></div></details>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C14.9</span> <span class="lang-zh-only">streamSimple 如何吃掉 convertToLlm 的输出</span><span class="lang-en-only">How streamSimple consumes convertToLlm output</span></h4>
+
+    <div class="lang-zh-only"><p><code>convertToLlm(messages: AgentMessage[])</code> 产出 pi-ai 的 <code>Message[]</code>，其中 tool result 已折叠为 provider 特定格式。Anthropic 与 OpenAI 的 tool 块形状不同——pi-ai 的 adapter 层负责这一转换，agent-core 不应 import provider 细节。</p></div>
+    <div class="lang-en-only"><p><code>convertToLlm(messages: AgentMessage[])</code> yields pi-ai <code>Message[]</code> with tool results folded to provider format. Anthropic vs OpenAI tool blocks differ — pi-ai adapters handle this; agent-core must not import provider details.</p></div>
+
+    <div class="lang-zh-only"><p><code>streamSimple(model, messages, tools)</code> 返回 <code>EventStream</code>：先过程项（text_delta、toolcall_delta），后终态（done + usage）。TUI 只订阅 message_update；SessionManager 在 message_end 落盘——两者消费同一 stream 的不同阶段。</p></div>
+    <div class="lang-en-only"><p><code>streamSimple(model, messages, tools)</code> returns <code>EventStream</code>: process items first (text_delta, toolcall_delta), terminal state last (done + usage). TUI subscribes to message_update; SessionManager persists at message_end.</p></div>
+
+    </div>
   </section>
 
   <section class="chap" id="c15">
@@ -4594,6 +5589,26 @@
     <h2 class="chap-title lang-en-only">Streaming EventStream</h2>
     <p class="chap-en lang-zh-only">text_delta · toolcall_delta · done</p>
     <p class="chap-en lang-en-only">text_delta · toolcall_delta · done</p>
+    <nav class="chap-compass" aria-label="Chapter 15 navigation">
+      <div class="cc-row cc-loc">
+        <span class="cc-phase"><span class="lang-zh-only">Phase III · LLM</span><span class="lang-en-only">Phase III · LLM</span></span>
+        <span class="cc-sep">·</span>
+        <span class="cc-chap">C15 / 26</span>
+        <span class="cc-sep">·</span>
+        <span class="cc-station"><span class="lang-zh-only">站 17</span><span class="lang-en-only">St. 17</span></span>
+      </div>
+      <div class="cc-row cc-forest">
+        <span class="cc-forest-label lang-zh-only">你在森林的这里</span>
+        <span class="cc-forest-label lang-en-only">You are here</span>
+        <span class="cc-forest-text lang-zh-only">流式：text_delta / toolcall_delta</span>
+        <span class="cc-forest-text lang-en-only">Streaming: text_delta / toolcall_delta</span>
+      </div>
+      <div class="cc-row cc-links">
+        <a class="cc-nav cc-prev" href="#c14"><span class="cc-arrow">←</span> <span class="cc-nav-num">C14</span> <span class="lang-zh-only">pi-ai 提供商抽象</span><span class="lang-en-only">pi-ai provider abstraction</span></a>
+        <a class="cc-back-map" href="#forest-overview"><span class="lang-zh-only">↑ 回到总览</span><span class="lang-en-only">↑ Forest map</span></a>
+        <a class="cc-nav cc-next" href="#c16"><span class="cc-nav-num">C16</span> <span class="lang-zh-only">认证与模型目录</span><span class="lang-en-only">Auth and model catalog</span> <span class="cc-arrow">→</span></a>
+      </div>
+    </nav>
     <aside class="stage-why-care lang-zh-only">
       <div class="swc-label">为什么这一段对你来说很重要</div>
       <p><span class="swc-pill ">直觉</span><span>EventStream 是 pi-ai 与 agent-loop 之间的异步泵——token 与终态同流交付。</span></p>
@@ -4654,7 +5669,9 @@
       <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 02</strong>: EventStream (<code>event-stream.ts</code>) · production: <code>packages/ai/src/utils/event-stream.ts</code></span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">EventStream 核心语义</span><span class="lang-en-only">EventStream core semantics</span></h3>
+    <div class="depth-zone" data-chapter="C15"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C15.4+</span><span class="lang-en-only">Deep dive · C15.4+</span></div>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C15.4</span> <span class="lang-zh-only">EventStream 核心语义</span><span class="lang-en-only">EventStream core semantics</span></h4>
 
     <div class="lang-zh-only"><p>packages/ai/src/utils/event-stream.ts：泛型 EventStream<T,R>，构造时传入 isComplete 与 extractResult。</p></div>
     <div class="lang-en-only"><p>packages/ai/src/utils/event-stream.ts: generic EventStream<T,R> with isComplete and extractResult at construction.</p></div>
@@ -4668,7 +5685,7 @@
     <div class="lang-zh-only"><p>AssistantMessageEventStream 子类：isComplete 当 type===done 或 error；extractResult 返回 message 或抛错。</p></div>
     <div class="lang-en-only"><p>AssistantMessageEventStream: isComplete on done/error; extractResult returns message or throws.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">主线 prompt 上的流事件类型</span><span class="lang-en-only">Stream events on through-line</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C15.5</span> <span class="lang-zh-only">主线 prompt 上的流事件类型</span><span class="lang-en-only">Stream events on through-line</span></h4>
 
     <div class="lang-zh-only"><p>第一次 stream（toolUse）：text_delta 可能为空或极短；toolcall_delta 累积 read 参数；done 时 stopReason=toolUse。</p></div>
     <div class="lang-en-only"><p>First stream (toolUse): short text_delta; toolcall_delta accumulates read args; done with stopReason=toolUse.</p></div>
@@ -4679,7 +5696,7 @@
     <div class="lang-zh-only"><p>streamAssistantResponse 把 LLM EventStream 事件映射为 AgentEvent message_update。</p></div>
     <div class="lang-en-only"><p>streamAssistantResponse maps LLM EventStream events to AgentEvent message_update.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">agent-loop 侧的 EventStream</span><span class="lang-en-only">Agent-side EventStream</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C15.6</span> <span class="lang-zh-only">agent-loop 侧的 EventStream</span><span class="lang-en-only">Agent-side EventStream</span></h4>
 
     <div class="lang-zh-only"><p>createAgentStream（agent-loop.ts 145 行）：isComplete 当 type===agent_end；extractResult 返回 messages 数组。</p></div>
     <div class="lang-en-only"><p>createAgentStream (line 145): isComplete on agent_end; extractResult returns messages array.</p></div>
@@ -4690,7 +5707,7 @@
     <div class="lang-zh-only"><p>end(result) 手动 resolve——用于 abort 或错误路径提前结束。</p></div>
     <div class="lang-en-only"><p>end(result) manually resolves — for abort or error early termination.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">背压与 TUI 消费</span><span class="lang-en-only">Backpressure and TUI consumption</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C15.7</span> <span class="lang-zh-only">背压与 TUI 消费</span><span class="lang-en-only">Backpressure and TUI consumption</span></h4>
 
     <div class="lang-zh-only"><p>EventStream 无界队列：高速 token 时 TUI diff 渲染可能落后；TuiMainScreen firstChanged/lastChanged 优化重绘区间。</p></div>
     <div class="lang-en-only"><p>Unbounded queue: TUI diff may lag on fast tokens; TuiMainScreen firstChanged/lastChanged optimizes redraw.</p></div>
@@ -4698,13 +5715,27 @@
     <div class="lang-zh-only"><p>message_update 携带 partial content；message_end 携带完整 AssistantMessage。</p></div>
     <div class="lang-en-only"><p>message_update carries partial content; message_end carries full AssistantMessage.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">与 textbook checkpoint 02 对照</span><span class="lang-en-only">vs textbook checkpoint 02</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C15.8</span> <span class="lang-zh-only">与 textbook checkpoint 02 对照</span><span class="lang-en-only">vs textbook checkpoint 02</span></h4>
 
     <div class="lang-zh-only"><p>textbook event-stream.ts 教学「过程项与终态同时交付」——生产代码在 streamSimple 与 agentLoop 两层复用同一模式。</p></div>
     <div class="lang-en-only"><p>Textbook checkpoint 02 teaches simultaneous partial and terminal delivery — production reuses pattern in streamSimple and agentLoop.</p></div>
 
     <div class="lang-zh-only"><p>测试：用 ScriptedModel 注入固定 delta 序列，断言 message_update 次数与顺序。</p></div>
     <div class="lang-en-only"><p>Test: ScriptedModel injects fixed delta sequence; assert message_update count and order.</p></div>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C15.9</span> <span class="lang-zh-only">读完后应能回答的 5 个问题 · 流式 EventStream</span><span class="lang-en-only">Five questions you should answer after reading · 流式 EventStream</span></h4>
+
+    <div class="lang-zh-only"><p>① 主线 prompt 进入本章模块时，第一个被调用的 <code>export</code> 函数是什么？② 它 emit 的第一个 AgentEvent 类型是什么？③ 若在此层抛错，TUI 会卡在什么状态？④ 对应的 pi-textbook checkpoint 测试命令是什么？⑤ <code>packages/agent/src/agent-loop.ts</code> 中哪一行最值得打断点？</p></div>
+    <div class="lang-en-only"><p>① First <code>export</code> called when through-line enters this module? ② First AgentEvent type emitted? ③ If this layer throws, what TUI state stalls? ④ Matching pi-textbook checkpoint test command? ⑤ Best breakpoint line in <code>packages/agent/src/agent-loop.ts</code>?</p></div>
+
+    <div class="lang-zh-only"><p>不要一次读完整个文件。用「从测试入手」法：先 <code>npm test -- &lt;matching-test&gt;</code>，看失败断言指向哪行，再读那一行上下游 30 行。生产 pi-mono 的测试覆盖率在 agent-loop 与 session-manager 最高——优先读测试。</p></div>
+    <div class="lang-en-only"><p>Don't read whole files at once. «Test-first» method: run <code>npm test -- &lt;matching-test&gt;</code>, see which assertion fails, read ±30 lines around that line. Highest test coverage in agent-loop and session-manager — read tests first.</p></div>
+
+    <div class="lang-zh-only"><p>对照本文 TRACE 盒与 <code>--verbose</code> stderr：每个 event type 应在源码中有且仅有一处「决策点」——若找不到，说明事件在更上层（AgentSession）或更下层（pi-ai adapter）合并发出。</p></div>
+    <div class="lang-en-only"><p>Cross-check TRACE box with <code>--verbose</code> stderr: each event type should have exactly one «decision point» in source — if missing, event is merged upstream (AgentSession) or downstream (pi-ai adapter).</p></div>
+
+    <div class="lang-zh-only"><p>进阶：用 <code>git blame packages/agent/src/agent-loop.ts</code> 看最近改动——Pi 的 harness 接口仍在活跃演进，注释可能落后于 <code>AgentLoopConfig</code> 类型定义。类型即文档。</p></div>
+    <div class="lang-en-only"><p>Advanced: <code>git blame packages/agent/src/agent-loop.ts</code> for recent changes — Pi harness APIs still evolve; comments may lag <code>AgentLoopConfig</code> types. Types are the doc.</p></div>
 
     <div class="trace-box">
       <div class="tb-tag">TRACE · station 15</div>
@@ -4722,20 +5753,33 @@
       <span class="src-line"><span class="src-line">  <span class="src-kw">if</span> (<span class="src-kw">this</span>.isComplete(event)) { <span class="src-kw">this</span>.done = <span class="src-num">true</span>; ... }</span></span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">交叉引用</span><span class="lang-en-only">Cross-ref</span></span> <span class="da-title lang-zh-only">pi-textbook checkpoint</span><span class="da-title lang-en-only">pi-textbook checkpoint</span></div>    <table class="cmp">
       <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
       <tbody>
       <tr><td>cp 02</td><td>EventStream</td><td><code>event-stream.ts</code></td><td><code>packages/ai/src/utils/event-stream.ts</code></td></tr>
       </tbody>
     </table>
 
-    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">附录</span><span class="lang-en-only">Appendix</span></span> <span class="da-title lang-zh-only">常见问题</span><span class="da-title lang-en-only">FAQ</span></div>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">EventStream 会丢事件吗？</span><span class="lang-en-only">Drop events?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>push 在 done 后忽略；正常路径不丢。</p></div><div class="lang-en-only"><p>push ignores after done; normal path does not drop.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">agent_end 与 done 区别？</span><span class="lang-en-only">agent_end vs done?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>agent_end 是 AgentEvent；done 是 LLM AssistantMessageEvent。</p></div><div class="lang-en-only"><p>agent_end is AgentEvent; done is LLM AssistantMessageEvent.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">如何 mock 流？</span><span class="lang-en-only">Mock stream?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>ScriptedModel 或自定义 StreamFn 返回预置 EventStream。</p></div><div class="lang-en-only"><p>ScriptedModel or custom StreamFn returning preset EventStream.</p></div></div></details>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C15.10</span> <span class="lang-zh-only">打开源码：packages/ai/src/utils/event-stream.ts</span><span class="lang-en-only">Open source: packages/ai/src/utils/event-stream.ts</span></h4>
+
+    <div class="lang-zh-only"><p>本章主线 prompt 经过此模块时，请在 pi-mono 打开 <code>packages/ai/src/utils/event-stream.ts</code>，搜索 <code>export</code> 与测试文件中的同名场景。对照 pi-textbook 对应 checkpoint 的 workshop 测试——先让测试绿，再读生产实现。</p></div>
+    <div class="lang-en-only"><p>When the through-line prompt crosses this module, open <code>packages/ai/src/utils/event-stream.ts</code> in pi-mono, search <code>export</code> and matching test scenarios. Cross-read the pi-textbook checkpoint workshop test — green test first, then production.</p></div>
+
+    <div class="lang-zh-only"><p>建议命令：<code>cd packages/agent && npm test -- agent-loop</code>（路径因章而异）。测试文件是行为契约的executable spec，比注释更可靠。</p></div>
+    <div class="lang-en-only"><p>Suggested: <code>cd packages/agent && npm test -- agent-loop</code> (path varies). Tests are executable specs of behavior contracts — more reliable than comments.</p></div>
+
+    <div class="lang-zh-only"><p>用 <code>--verbose</code> 跑一轮主线 prompt，把 stderr event 类型与源码中的 <code>emit</code> 调用逐行对齐——这是本文 C26 推荐的 trace 方法。</p></div>
+    <div class="lang-en-only"><p>Run the through-line with <code>--verbose</code>, align stderr event types with <code>emit</code> calls in source — the trace method recommended in C26.</p></div>
+
+    </div>
   </section>
 
   <section class="chap" id="c16">
@@ -4744,6 +5788,26 @@
     <h2 class="chap-title lang-en-only">Auth and model catalog</h2>
     <p class="chap-en lang-zh-only">40+ providers · OAuth · models.generated.ts</p>
     <p class="chap-en lang-en-only">40+ providers · OAuth · models.generated.ts</p>
+    <nav class="chap-compass" aria-label="Chapter 16 navigation">
+      <div class="cc-row cc-loc">
+        <span class="cc-phase"><span class="lang-zh-only">Phase III · LLM</span><span class="lang-en-only">Phase III · LLM</span></span>
+        <span class="cc-sep">·</span>
+        <span class="cc-chap">C16 / 26</span>
+        <span class="cc-sep">·</span>
+        <span class="cc-station"><span class="lang-zh-only">站 18</span><span class="lang-en-only">St. 18</span></span>
+      </div>
+      <div class="cc-row cc-forest">
+        <span class="cc-forest-label lang-zh-only">你在森林的这里</span>
+        <span class="cc-forest-label lang-en-only">You are here</span>
+        <span class="cc-forest-text lang-zh-only">认证与模型目录</span>
+        <span class="cc-forest-text lang-en-only">Auth and model catalog</span>
+      </div>
+      <div class="cc-row cc-links">
+        <a class="cc-nav cc-prev" href="#c15"><span class="cc-arrow">←</span> <span class="cc-nav-num">C15</span> <span class="lang-zh-only">流式 EventStream</span><span class="lang-en-only">Streaming EventStream</span></a>
+        <a class="cc-back-map" href="#forest-overview"><span class="lang-zh-only">↑ 回到总览</span><span class="lang-en-only">↑ Forest map</span></a>
+        <a class="cc-nav cc-next" href="#c17"><span class="cc-nav-num">C17</span> <span class="lang-zh-only">差分渲染 TUI</span><span class="lang-en-only">Differential-render TUI</span> <span class="cc-arrow">→</span></a>
+      </div>
+    </nav>
     <aside class="stage-why-care lang-zh-only">
       <div class="swc-label">为什么这一段对你来说很重要</div>
       <p><span class="swc-pill ">直觉</span><span>models.generated.ts 聚合 40+ provider 的模型目录——OAuth 与 API key 分流。</span></p>
@@ -4802,7 +5866,9 @@
       </div>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">模型目录生成管线</span><span class="lang-en-only">Model catalog pipeline</span></h3>
+    <div class="depth-zone" data-chapter="C16"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C16.4+</span><span class="lang-en-only">Deep dive · C16.4+</span></div>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C16.4</span> <span class="lang-zh-only">模型目录生成管线</span><span class="lang-en-only">Model catalog pipeline</span></h4>
 
     <div class="lang-zh-only"><p>packages/ai/src/models.generated.ts 头部注释：auto-generated by scripts/generate-models.ts，勿手改。</p></div>
     <div class="lang-en-only"><p>models.generated.ts header: auto-generated by generate-models.ts, do not edit manually.</p></div>
@@ -4813,7 +5879,7 @@
     <div class="lang-zh-only"><p>每个 Model 含 id、provider、contextWindow、maxTokens、cost、reasoning 支持等字段。</p></div>
     <div class="lang-en-only"><p>Each Model has id, provider, contextWindow, maxTokens, cost, reasoning support.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">认证路径</span><span class="lang-en-only">Auth paths</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C16.5</span> <span class="lang-zh-only">认证路径</span><span class="lang-en-only">Auth paths</span></h4>
 
     <div class="lang-zh-only"><p>packages/ai/src/oauth.ts 与 bun-oauth.ts 处理交互式 OAuth（GitHub Copilot、OpenAI Codex 等）。</p></div>
     <div class="lang-en-only"><p>oauth.ts and bun-oauth.ts handle interactive OAuth for Copilot, Codex, etc.</p></div>
@@ -4824,7 +5890,7 @@
     <div class="lang-zh-only"><p>agent-session.ts formatNoApiKeyFoundMessage 在冷启动无 key 时给出 auth-guidance。</p></div>
     <div class="lang-en-only"><p>formatNoApiKeyFoundMessage gives auth-guidance on cold start without key.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">主线 prompt 的模型选择</span><span class="lang-en-only">Model selection for through-line</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C16.6</span> <span class="lang-zh-only">主线 prompt 的模型选择</span><span class="lang-en-only">Model selection for through-line</span></h4>
 
     <div class="lang-zh-only"><p>CLI --model provider/id 或交互式 /model 选择；model_change entry 写入 JSONL。</p></div>
     <div class="lang-en-only"><p>CLI --model provider/id or /model picker; model_change entry in JSONL.</p></div>
@@ -4835,7 +5901,7 @@
     <div class="lang-zh-only"><p>换模型不丢会话：SessionManager 保留历史，新 model_change entry 标记切换点。</p></div>
     <div class="lang-en-only"><p>Model switch preserves session: model_change entry marks switch point.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">ModelRegistry 运行时</span><span class="lang-en-only">ModelRegistry runtime</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C16.7</span> <span class="lang-zh-only">ModelRegistry 运行时</span><span class="lang-en-only">ModelRegistry runtime</span></h4>
 
     <div class="lang-zh-only"><p>coding-agent ModelRegistry 读取 generated  catalog，合并用户 settings 与 extension 贡献的 provider config。</p></div>
     <div class="lang-en-only"><p>ModelRegistry reads generated catalog, merges user settings and extension provider configs.</p></div>
@@ -4843,10 +5909,24 @@
     <div class="lang-zh-only"><p>modelsAreEqual 用于避免重复 emit model_select 事件。</p></div>
     <div class="lang-en-only"><p>modelsAreEqual avoids duplicate model_select events.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">与 textbook checkpoint 05 对照</span><span class="lang-en-only">vs textbook checkpoint 05</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C16.8</span> <span class="lang-zh-only">与 textbook checkpoint 05 对照</span><span class="lang-en-only">vs textbook checkpoint 05</span></h4>
 
     <div class="lang-zh-only"><p>textbook Provider Adapter 教 SSE→统一事件；生产 pi-ai api/*.ts 实现各厂商 adapter。</p></div>
     <div class="lang-en-only"><p>Textbook checkpoint 05 teaches SSE→unified events; production api/*.ts implements per-vendor adapters.</p></div>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C16.9</span> <span class="lang-zh-only">读完后应能回答的 5 个问题 · 认证与模型目录</span><span class="lang-en-only">Five questions you should answer after reading · 认证与模型目录</span></h4>
+
+    <div class="lang-zh-only"><p>① 主线 prompt 进入本章模块时，第一个被调用的 <code>export</code> 函数是什么？② 它 emit 的第一个 AgentEvent 类型是什么？③ 若在此层抛错，TUI 会卡在什么状态？④ 对应的 pi-textbook checkpoint 测试命令是什么？⑤ <code>packages/agent/src/agent-loop.ts</code> 中哪一行最值得打断点？</p></div>
+    <div class="lang-en-only"><p>① First <code>export</code> called when through-line enters this module? ② First AgentEvent type emitted? ③ If this layer throws, what TUI state stalls? ④ Matching pi-textbook checkpoint test command? ⑤ Best breakpoint line in <code>packages/agent/src/agent-loop.ts</code>?</p></div>
+
+    <div class="lang-zh-only"><p>不要一次读完整个文件。用「从测试入手」法：先 <code>npm test -- &lt;matching-test&gt;</code>，看失败断言指向哪行，再读那一行上下游 30 行。生产 pi-mono 的测试覆盖率在 agent-loop 与 session-manager 最高——优先读测试。</p></div>
+    <div class="lang-en-only"><p>Don't read whole files at once. «Test-first» method: run <code>npm test -- &lt;matching-test&gt;</code>, see which assertion fails, read ±30 lines around that line. Highest test coverage in agent-loop and session-manager — read tests first.</p></div>
+
+    <div class="lang-zh-only"><p>对照本文 TRACE 盒与 <code>--verbose</code> stderr：每个 event type 应在源码中有且仅有一处「决策点」——若找不到，说明事件在更上层（AgentSession）或更下层（pi-ai adapter）合并发出。</p></div>
+    <div class="lang-en-only"><p>Cross-check TRACE box with <code>--verbose</code> stderr: each event type should have exactly one «decision point» in source — if missing, event is merged upstream (AgentSession) or downstream (pi-ai adapter).</p></div>
+
+    <div class="lang-zh-only"><p>进阶：用 <code>git blame packages/agent/src/agent-loop.ts</code> 看最近改动——Pi 的 harness 接口仍在活跃演进，注释可能落后于 <code>AgentLoopConfig</code> 类型定义。类型即文档。</p></div>
+    <div class="lang-en-only"><p>Advanced: <code>git blame packages/agent/src/agent-loop.ts</code> for recent changes — Pi harness APIs still evolve; comments may lag <code>AgentLoopConfig</code> types. Types are the doc.</p></div>
 
     <div class="trace-box">
       <div class="tb-tag">TRACE · station 16</div>
@@ -4863,20 +5943,33 @@
       <span class="src-line"><span class="src-line"><span class="src-kw">export const</span> <span class="src-arg">MODELS</span> = { ... <span class="src-num">40</span>+ providers ... };</span></span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">交叉引用</span><span class="lang-en-only">Cross-ref</span></span> <span class="da-title lang-zh-only">pi-textbook checkpoint</span><span class="da-title lang-en-only">pi-textbook checkpoint</span></div>    <table class="cmp">
       <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
       <tbody>
       <tr><td>cp 05</td><td>Provider Adapter</td><td><code>provider-adapter.ts</code></td><td><code>packages/ai/src/api/*.ts · packages/ai/src/models.ts</code></td></tr>
       </tbody>
     </table>
 
-    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">附录</span><span class="lang-en-only">Appendix</span></span> <span class="da-title lang-zh-only">常见问题</span><span class="da-title lang-en-only">FAQ</span></div>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">如何添加新 provider？</span><span class="lang-en-only">Add provider?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>在 pi-ai providers/ 加 models 文件并跑 generate-models。</p></div><div class="lang-en-only"><p>Add models file under providers/ and run generate-models.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">OAuth 失败怎么办？</span><span class="lang-en-only">OAuth fails?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>检查 bun-oauth 回调与 ~/.pi 凭据存储。</p></div><div class="lang-en-only"><p>Check bun-oauth callback and ~/.pi credential storage.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">默认模型在哪设？</span><span class="lang-en-only">Default model?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>settings.json 与 CLI --model。</p></div><div class="lang-en-only"><p>settings.json and CLI --model.</p></div></div></details>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C16.10</span> <span class="lang-zh-only">打开源码：packages/ai/src/models.generated.ts</span><span class="lang-en-only">Open source: packages/ai/src/models.generated.ts</span></h4>
+
+    <div class="lang-zh-only"><p>本章主线 prompt 经过此模块时，请在 pi-mono 打开 <code>packages/ai/src/models.generated.ts</code>，搜索 <code>export</code> 与测试文件中的同名场景。对照 pi-textbook 对应 checkpoint 的 workshop 测试——先让测试绿，再读生产实现。</p></div>
+    <div class="lang-en-only"><p>When the through-line prompt crosses this module, open <code>packages/ai/src/models.generated.ts</code> in pi-mono, search <code>export</code> and matching test scenarios. Cross-read the pi-textbook checkpoint workshop test — green test first, then production.</p></div>
+
+    <div class="lang-zh-only"><p>建议命令：<code>cd packages/agent && npm test -- agent-loop</code>（路径因章而异）。测试文件是行为契约的executable spec，比注释更可靠。</p></div>
+    <div class="lang-en-only"><p>Suggested: <code>cd packages/agent && npm test -- agent-loop</code> (path varies). Tests are executable specs of behavior contracts — more reliable than comments.</p></div>
+
+    <div class="lang-zh-only"><p>用 <code>--verbose</code> 跑一轮主线 prompt，把 stderr event 类型与源码中的 <code>emit</code> 调用逐行对齐——这是本文 C26 推荐的 trace 方法。</p></div>
+    <div class="lang-en-only"><p>Run the through-line with <code>--verbose</code>, align stderr event types with <code>emit</code> calls in source — the trace method recommended in C26.</p></div>
+
+    </div>
   </section>
 
   <section class="chap" id="c17">
@@ -4885,6 +5978,26 @@
     <h2 class="chap-title lang-en-only">Differential-render TUI</h2>
     <p class="chap-en lang-zh-only">CSI 2026 · firstChanged → lastChanged</p>
     <p class="chap-en lang-en-only">CSI 2026 · firstChanged → lastChanged</p>
+    <nav class="chap-compass" aria-label="Chapter 17 navigation">
+      <div class="cc-row cc-loc">
+        <span class="cc-phase"><span class="lang-zh-only">Phase IV · 终端</span><span class="lang-en-only">Phase IV · Terminal</span></span>
+        <span class="cc-sep">·</span>
+        <span class="cc-chap">C17 / 26</span>
+        <span class="cc-sep">·</span>
+        <span class="cc-station"><span class="lang-zh-only">站 19</span><span class="lang-en-only">St. 19</span></span>
+      </div>
+      <div class="cc-row cc-forest">
+        <span class="cc-forest-label lang-zh-only">你在森林的这里</span>
+        <span class="cc-forest-label lang-en-only">You are here</span>
+        <span class="cc-forest-text lang-zh-only">CSI 2026 差分渲染</span>
+        <span class="cc-forest-text lang-en-only">CSI 2026 differential render</span>
+      </div>
+      <div class="cc-row cc-links">
+        <a class="cc-nav cc-prev" href="#c16"><span class="cc-arrow">←</span> <span class="cc-nav-num">C16</span> <span class="lang-zh-only">认证与模型目录</span><span class="lang-en-only">Auth and model catalog</span></a>
+        <a class="cc-back-map" href="#forest-overview"><span class="lang-zh-only">↑ 回到总览</span><span class="lang-en-only">↑ Forest map</span></a>
+        <a class="cc-nav cc-next" href="#c18"><span class="cc-nav-num">C18</span> <span class="lang-zh-only">Interactive Mode</span><span class="lang-en-only">Interactive mode</span> <span class="cc-arrow">→</span></a>
+      </div>
+    </nav>
     <aside class="stage-why-care lang-zh-only">
       <div class="swc-label">为什么这一段对你来说很重要</div>
       <p><span class="swc-pill ">直觉</span><span>差分 TUI 决定你如何理解 Pi 在此层的机制。</span></p>
@@ -4938,7 +6051,7 @@
       </tbody>
     </table>
 
-    <h3 class="sub"><span class="lang-zh-only">message_update → 像素</span><span class="lang-en-only">message_update → pixels</span></h3>
+    <h3 class="sub"><span class="sec-num">C17.1</span> <span class="lang-zh-only">message_update → 像素</span><span class="lang-en-only">message_update → pixels</span></h3>
 
     <div class="lang-zh-only"><p>AgentSession 把 message_update 交给 interactive mode → TUI 组件树 → Markdown 增量解析 → 终端 write。</p></div>
     <div class="lang-en-only"><p>AgentSession hands message_update to interactive mode → TUI component tree → incremental Markdown → terminal write.</p></div>
@@ -4975,7 +6088,9 @@
       </figcaption>
     </figure>
 
-    <h3 class="sub"><span class="lang-zh-only">差分 TUI：主线 prompt 如何穿过此模块</span><span class="lang-en-only">差分 TUI: through-line crossing</span></h3>
+    <div class="depth-zone" data-chapter="C17"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C17.4+</span><span class="lang-en-only">Deep dive · C17.4+</span></div>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C17.4</span> <span class="lang-zh-only">主线 prompt 如何穿过此模块</span><span class="lang-en-only">through-line crossing</span></h4>
 
     <div class="lang-zh-only"><p>用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/tui/src/tui-main-screen.ts</code> 定义了此阶段的类型契约与副作用边界。</p></div>
     <div class="lang-en-only"><p>After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/tui/src/tui-main-screen.ts</code> defines type contracts and side-effect boundaries here.</p></div>
@@ -4989,7 +6104,7 @@
     <div class="lang-zh-only"><p>pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。</p></div>
     <div class="lang-en-only"><p>Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">差分 TUI：关键函数与数据流</span><span class="lang-en-only">差分 TUI: key functions and data flow</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C17.5</span> <span class="lang-zh-only">关键函数与数据流</span><span class="lang-en-only">key functions and data flow</span></h4>
 
     <div class="lang-zh-only"><p><code>tui-main-screen.ts</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。</p></div>
     <div class="lang-en-only"><p><code>async</code> functions in <code>tui-main-screen.ts</code> are usually IO boundaries: disk, network, or subprocess.</p></div>
@@ -5003,7 +6118,7 @@
     <div class="lang-zh-only"><p>对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。</p></div>
     <div class="lang-en-only"><p>Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">差分 TUI：与 agent-loop 的接口</span><span class="lang-en-only">差分 TUI: interface with agent-loop</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C17.6</span> <span class="lang-zh-only">与 agent-loop 的接口</span><span class="lang-en-only">interface with agent-loop</span></h4>
 
     <div class="lang-zh-only"><p><code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。</p></div>
     <div class="lang-en-only"><p><code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc.</p></div>
@@ -5017,7 +6132,7 @@
     <div class="lang-zh-only"><p>--verbose 模式下 stderr 事件类型可回溯到 <code>packages/tui/src/tui-main-screen.ts</code> 的具体行。</p></div>
     <div class="lang-en-only"><p>Under --verbose, stderr event types trace to lines in <code>packages/tui/src/tui-main-screen.ts</code>.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">差分 TUI：设计权衡与常见坑</span><span class="lang-en-only">差分 TUI: trade-offs and pitfalls</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C17.7</span> <span class="lang-zh-only">设计权衡与常见坑</span><span class="lang-en-only">trade-offs and pitfalls</span></h4>
 
     <div class="lang-zh-only"><p>显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。</p></div>
     <div class="lang-en-only"><p>Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union.</p></div>
@@ -5030,6 +6145,20 @@
 
     <div class="lang-zh-only"><p>对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。</p></div>
     <div class="lang-en-only"><p>vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable.</p></div>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C17.8</span> <span class="lang-zh-only">读完后应能回答的 5 个问题 · 差分渲染 TUI</span><span class="lang-en-only">Five questions you should answer after reading · 差分渲染 TUI</span></h4>
+
+    <div class="lang-zh-only"><p>① 主线 prompt 进入本章模块时，第一个被调用的 <code>export</code> 函数是什么？② 它 emit 的第一个 AgentEvent 类型是什么？③ 若在此层抛错，TUI 会卡在什么状态？④ 对应的 pi-textbook checkpoint 测试命令是什么？⑤ <code>packages/tui/src/terminal.ts</code> 中哪一行最值得打断点？</p></div>
+    <div class="lang-en-only"><p>① First <code>export</code> called when through-line enters this module? ② First AgentEvent type emitted? ③ If this layer throws, what TUI state stalls? ④ Matching pi-textbook checkpoint test command? ⑤ Best breakpoint line in <code>packages/tui/src/terminal.ts</code>?</p></div>
+
+    <div class="lang-zh-only"><p>不要一次读完整个文件。用「从测试入手」法：先 <code>npm test -- &lt;matching-test&gt;</code>，看失败断言指向哪行，再读那一行上下游 30 行。生产 pi-mono 的测试覆盖率在 agent-loop 与 session-manager 最高——优先读测试。</p></div>
+    <div class="lang-en-only"><p>Don't read whole files at once. «Test-first» method: run <code>npm test -- &lt;matching-test&gt;</code>, see which assertion fails, read ±30 lines around that line. Highest test coverage in agent-loop and session-manager — read tests first.</p></div>
+
+    <div class="lang-zh-only"><p>对照本文 TRACE 盒与 <code>--verbose</code> stderr：每个 event type 应在源码中有且仅有一处「决策点」——若找不到，说明事件在更上层（AgentSession）或更下层（pi-ai adapter）合并发出。</p></div>
+    <div class="lang-en-only"><p>Cross-check TRACE box with <code>--verbose</code> stderr: each event type should have exactly one «decision point» in source — if missing, event is merged upstream (AgentSession) or downstream (pi-ai adapter).</p></div>
+
+    <div class="lang-zh-only"><p>进阶：用 <code>git blame packages/tui/src/terminal.ts</code> 看最近改动——Pi 的 harness 接口仍在活跃演进，注释可能落后于 <code>AgentLoopConfig</code> 类型定义。类型即文档。</p></div>
+    <div class="lang-en-only"><p>Advanced: <code>git blame packages/tui/src/terminal.ts</code> for recent changes — Pi harness APIs still evolve; comments may lag <code>AgentLoopConfig</code> types. Types are the doc.</p></div>
 
     <div class="trace-box">
       <div class="tb-tag">TRACE · station 17</div>
@@ -5046,13 +6175,26 @@
       <span class="src-line"><span class="src-line"><span class="src-kw">let</span> <span class="src-arg">lastChanged</span> = -<span class="src-num">1</span>;</span></span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">附录</span><span class="lang-en-only">Appendix</span></span> <span class="da-title lang-zh-only">常见问题</span><span class="da-title lang-en-only">FAQ</span></div>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">差分 TUI最关键文件？</span><span class="lang-en-only">Key file?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p><code>packages/tui/src/tui-main-screen.ts</code>。</p></div><div class="lang-en-only"><p><code>packages/tui/src/tui-main-screen.ts</code>.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">如何单测？</span><span class="lang-en-only">Unit test?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>mock StreamFn 或 ScriptedModel。</p></div><div class="lang-en-only"><p>mock StreamFn or ScriptedModel.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">与 textbook 差异？</span><span class="lang-en-only">vs textbook?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>生产含 OAuth/TUI/40+ providers。</p></div><div class="lang-en-only"><p>Production adds OAuth/TUI/40+ providers.</p></div></div></details>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C17.9</span> <span class="lang-zh-only">打开源码：packages/tui/src/terminal.ts</span><span class="lang-en-only">Open source: packages/tui/src/terminal.ts</span></h4>
+
+    <div class="lang-zh-only"><p>本章主线 prompt 经过此模块时，请在 pi-mono 打开 <code>packages/tui/src/terminal.ts</code>，搜索 <code>export</code> 与测试文件中的同名场景。对照 pi-textbook 对应 checkpoint 的 workshop 测试——先让测试绿，再读生产实现。</p></div>
+    <div class="lang-en-only"><p>When the through-line prompt crosses this module, open <code>packages/tui/src/terminal.ts</code> in pi-mono, search <code>export</code> and matching test scenarios. Cross-read the pi-textbook checkpoint workshop test — green test first, then production.</p></div>
+
+    <div class="lang-zh-only"><p>建议命令：<code>cd packages/agent && npm test -- agent-loop</code>（路径因章而异）。测试文件是行为契约的executable spec，比注释更可靠。</p></div>
+    <div class="lang-en-only"><p>Suggested: <code>cd packages/agent && npm test -- agent-loop</code> (path varies). Tests are executable specs of behavior contracts — more reliable than comments.</p></div>
+
+    <div class="lang-zh-only"><p>用 <code>--verbose</code> 跑一轮主线 prompt，把 stderr event 类型与源码中的 <code>emit</code> 调用逐行对齐——这是本文 C26 推荐的 trace 方法。</p></div>
+    <div class="lang-en-only"><p>Run the through-line with <code>--verbose</code>, align stderr event types with <code>emit</code> calls in source — the trace method recommended in C26.</p></div>
+
+    </div>
   </section>
 
   <section class="chap" id="c18">
@@ -5061,6 +6203,26 @@
     <h2 class="chap-title lang-en-only">Interactive mode</h2>
     <p class="chap-en lang-zh-only">Editor · Markdown · tool renderers</p>
     <p class="chap-en lang-en-only">Editor · Markdown · tool renderers</p>
+    <nav class="chap-compass" aria-label="Chapter 18 navigation">
+      <div class="cc-row cc-loc">
+        <span class="cc-phase"><span class="lang-zh-only">Phase IV · 终端</span><span class="lang-en-only">Phase IV · Terminal</span></span>
+        <span class="cc-sep">·</span>
+        <span class="cc-chap">C18 / 26</span>
+        <span class="cc-sep">·</span>
+        <span class="cc-station"><span class="lang-zh-only">站 20</span><span class="lang-en-only">St. 20</span></span>
+      </div>
+      <div class="cc-row cc-forest">
+        <span class="cc-forest-label lang-zh-only">你在森林的这里</span>
+        <span class="cc-forest-label lang-en-only">You are here</span>
+        <span class="cc-forest-text lang-zh-only">Interactive：Editor + Markdown</span>
+        <span class="cc-forest-text lang-en-only">Interactive: Editor + Markdown</span>
+      </div>
+      <div class="cc-row cc-links">
+        <a class="cc-nav cc-prev" href="#c17"><span class="cc-arrow">←</span> <span class="cc-nav-num">C17</span> <span class="lang-zh-only">差分渲染 TUI</span><span class="lang-en-only">Differential-render TUI</span></a>
+        <a class="cc-back-map" href="#forest-overview"><span class="lang-zh-only">↑ 回到总览</span><span class="lang-en-only">↑ Forest map</span></a>
+        <a class="cc-nav cc-next" href="#c19"><span class="cc-nav-num">C19</span> <span class="lang-zh-only">Extension API 面</span><span class="lang-en-only">Extension API surface</span> <span class="cc-arrow">→</span></a>
+      </div>
+    </nav>
     <aside class="stage-why-care lang-zh-only">
       <div class="swc-label">为什么这一段对你来说很重要</div>
       <p><span class="swc-pill ">直觉</span><span>Interactive Mode 决定你如何理解 Pi 在此层的机制。</span></p>
@@ -5119,7 +6281,9 @@
       </div>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">Interactive Mode：主线 prompt 如何穿过此模块</span><span class="lang-en-only">Interactive Mode: through-line crossing</span></h3>
+    <div class="depth-zone" data-chapter="C18"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C18.4+</span><span class="lang-en-only">Deep dive · C18.4+</span></div>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C18.4</span> <span class="lang-zh-only">主线 prompt 如何穿过此模块</span><span class="lang-en-only">through-line crossing</span></h4>
 
     <div class="lang-zh-only"><p>用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/coding-agent/src/modes/interactive/interactive-mode.ts</code> 定义了此阶段的类型契约与副作用边界。</p></div>
     <div class="lang-en-only"><p>After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/coding-agent/src/modes/interactive/interactive-mode.ts</code> defines type contracts and side-effect boundaries here.</p></div>
@@ -5133,7 +6297,7 @@
     <div class="lang-zh-only"><p>pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。</p></div>
     <div class="lang-en-only"><p>Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">Interactive Mode：关键函数与数据流</span><span class="lang-en-only">Interactive Mode: key functions and data flow</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C18.5</span> <span class="lang-zh-only">关键函数与数据流</span><span class="lang-en-only">key functions and data flow</span></h4>
 
     <div class="lang-zh-only"><p><code>interactive-mode.ts</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。</p></div>
     <div class="lang-en-only"><p><code>async</code> functions in <code>interactive-mode.ts</code> are usually IO boundaries: disk, network, or subprocess.</p></div>
@@ -5147,7 +6311,7 @@
     <div class="lang-zh-only"><p>对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。</p></div>
     <div class="lang-en-only"><p>Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">Interactive Mode：与 agent-loop 的接口</span><span class="lang-en-only">Interactive Mode: interface with agent-loop</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C18.6</span> <span class="lang-zh-only">与 agent-loop 的接口</span><span class="lang-en-only">interface with agent-loop</span></h4>
 
     <div class="lang-zh-only"><p><code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。</p></div>
     <div class="lang-en-only"><p><code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc.</p></div>
@@ -5161,7 +6325,7 @@
     <div class="lang-zh-only"><p>--verbose 模式下 stderr 事件类型可回溯到 <code>packages/coding-agent/src/modes/interactive/interactive-mode.ts</code> 的具体行。</p></div>
     <div class="lang-en-only"><p>Under --verbose, stderr event types trace to lines in <code>packages/coding-agent/src/modes/interactive/interactive-mode.ts</code>.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">Interactive Mode：设计权衡与常见坑</span><span class="lang-en-only">Interactive Mode: trade-offs and pitfalls</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C18.7</span> <span class="lang-zh-only">设计权衡与常见坑</span><span class="lang-en-only">trade-offs and pitfalls</span></h4>
 
     <div class="lang-zh-only"><p>显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。</p></div>
     <div class="lang-en-only"><p>Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union.</p></div>
@@ -5175,7 +6339,7 @@
     <div class="lang-zh-only"><p>对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。</p></div>
     <div class="lang-en-only"><p>vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">Interactive Mode：深度走读清单</span><span class="lang-en-only">Interactive Mode: deep walk checklist</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C18.8</span> <span class="lang-zh-only">深度走读清单</span><span class="lang-en-only">deep walk checklist</span></h4>
 
     <div class="lang-zh-only"><p>① 打开 <code>packages/coding-agent/src/modes/interactive/interactive-mode.ts</code>；② 从 export 符号跟踪 README 路径调用链；③ 标注每个 await 的 IO 类型。</p></div>
     <div class="lang-en-only"><p>① Open <code>packages/coding-agent/src/modes/interactive/interactive-mode.ts</code>; ② trace README call chain from exports; ③ label each await's IO type.</p></div>
@@ -5188,6 +6352,20 @@
 
     <div class="lang-zh-only"><p>将观察结果与 pi-textbook workshop 的 checkpoint 测试输出 diff。</p></div>
     <div class="lang-en-only"><p>Diff observations against pi-textbook workshop checkpoint test output.</p></div>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C18.9</span> <span class="lang-zh-only">读完后应能回答的 5 个问题 · Interactive Mode</span><span class="lang-en-only">Five questions you should answer after reading · Interactive Mode</span></h4>
+
+    <div class="lang-zh-only"><p>① 主线 prompt 进入本章模块时，第一个被调用的 <code>export</code> 函数是什么？② 它 emit 的第一个 AgentEvent 类型是什么？③ 若在此层抛错，TUI 会卡在什么状态？④ 对应的 pi-textbook checkpoint 测试命令是什么？⑤ <code>packages/agent/src/agent-loop.ts</code> 中哪一行最值得打断点？</p></div>
+    <div class="lang-en-only"><p>① First <code>export</code> called when through-line enters this module? ② First AgentEvent type emitted? ③ If this layer throws, what TUI state stalls? ④ Matching pi-textbook checkpoint test command? ⑤ Best breakpoint line in <code>packages/agent/src/agent-loop.ts</code>?</p></div>
+
+    <div class="lang-zh-only"><p>不要一次读完整个文件。用「从测试入手」法：先 <code>npm test -- &lt;matching-test&gt;</code>，看失败断言指向哪行，再读那一行上下游 30 行。生产 pi-mono 的测试覆盖率在 agent-loop 与 session-manager 最高——优先读测试。</p></div>
+    <div class="lang-en-only"><p>Don't read whole files at once. «Test-first» method: run <code>npm test -- &lt;matching-test&gt;</code>, see which assertion fails, read ±30 lines around that line. Highest test coverage in agent-loop and session-manager — read tests first.</p></div>
+
+    <div class="lang-zh-only"><p>对照本文 TRACE 盒与 <code>--verbose</code> stderr：每个 event type 应在源码中有且仅有一处「决策点」——若找不到，说明事件在更上层（AgentSession）或更下层（pi-ai adapter）合并发出。</p></div>
+    <div class="lang-en-only"><p>Cross-check TRACE box with <code>--verbose</code> stderr: each event type should have exactly one «decision point» in source — if missing, event is merged upstream (AgentSession) or downstream (pi-ai adapter).</p></div>
+
+    <div class="lang-zh-only"><p>进阶：用 <code>git blame packages/agent/src/agent-loop.ts</code> 看最近改动——Pi 的 harness 接口仍在活跃演进，注释可能落后于 <code>AgentLoopConfig</code> 类型定义。类型即文档。</p></div>
+    <div class="lang-en-only"><p>Advanced: <code>git blame packages/agent/src/agent-loop.ts</code> for recent changes — Pi harness APIs still evolve; comments may lag <code>AgentLoopConfig</code> types. Types are the doc.</p></div>
 
     <div class="trace-box">
       <div class="tb-tag">TRACE · station 18</div>
@@ -5204,13 +6382,26 @@
       <span class="src-line"><span class="src-line"><span class="src-comment">// through-line: README.md</span></span></span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">附录</span><span class="lang-en-only">Appendix</span></span> <span class="da-title lang-zh-only">常见问题</span><span class="da-title lang-en-only">FAQ</span></div>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">Interactive Mode最关键文件？</span><span class="lang-en-only">Key file?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p><code>packages/coding-agent/src/modes/interactive/interactive-mode.ts</code>。</p></div><div class="lang-en-only"><p><code>packages/coding-agent/src/modes/interactive/interactive-mode.ts</code>.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">如何单测？</span><span class="lang-en-only">Unit test?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>mock StreamFn 或 ScriptedModel。</p></div><div class="lang-en-only"><p>mock StreamFn or ScriptedModel.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">与 textbook 差异？</span><span class="lang-en-only">vs textbook?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>生产含 OAuth/TUI/40+ providers。</p></div><div class="lang-en-only"><p>Production adds OAuth/TUI/40+ providers.</p></div></div></details>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C18.10</span> <span class="lang-zh-only">打开源码：packages/tui/src/components/editor.ts</span><span class="lang-en-only">Open source: packages/tui/src/components/editor.ts</span></h4>
+
+    <div class="lang-zh-only"><p>本章主线 prompt 经过此模块时，请在 pi-mono 打开 <code>packages/tui/src/components/editor.ts</code>，搜索 <code>export</code> 与测试文件中的同名场景。对照 pi-textbook 对应 checkpoint 的 workshop 测试——先让测试绿，再读生产实现。</p></div>
+    <div class="lang-en-only"><p>When the through-line prompt crosses this module, open <code>packages/tui/src/components/editor.ts</code> in pi-mono, search <code>export</code> and matching test scenarios. Cross-read the pi-textbook checkpoint workshop test — green test first, then production.</p></div>
+
+    <div class="lang-zh-only"><p>建议命令：<code>cd packages/agent && npm test -- agent-loop</code>（路径因章而异）。测试文件是行为契约的executable spec，比注释更可靠。</p></div>
+    <div class="lang-en-only"><p>Suggested: <code>cd packages/agent && npm test -- agent-loop</code> (path varies). Tests are executable specs of behavior contracts — more reliable than comments.</p></div>
+
+    <div class="lang-zh-only"><p>用 <code>--verbose</code> 跑一轮主线 prompt，把 stderr event 类型与源码中的 <code>emit</code> 调用逐行对齐——这是本文 C26 推荐的 trace 方法。</p></div>
+    <div class="lang-en-only"><p>Run the through-line with <code>--verbose</code>, align stderr event types with <code>emit</code> calls in source — the trace method recommended in C26.</p></div>
+
+    </div>
   </section>
 
   <section class="chap" id="c19">
@@ -5219,6 +6410,26 @@
     <h2 class="chap-title lang-en-only">Extension API surface</h2>
     <p class="chap-en lang-zh-only">registerTool · registerCommand · events</p>
     <p class="chap-en lang-en-only">registerTool · registerCommand · events</p>
+    <nav class="chap-compass" aria-label="Chapter 19 navigation">
+      <div class="cc-row cc-loc">
+        <span class="cc-phase"><span class="lang-zh-only">Phase V · 扩展</span><span class="lang-en-only">Phase V · Extensions</span></span>
+        <span class="cc-sep">·</span>
+        <span class="cc-chap">C19 / 26</span>
+        <span class="cc-sep">·</span>
+        <span class="cc-station"><span class="lang-zh-only">—</span><span class="lang-en-only">—</span></span>
+      </div>
+      <div class="cc-row cc-forest">
+        <span class="cc-forest-label lang-zh-only">你在森林的这里</span>
+        <span class="cc-forest-label lang-en-only">You are here</span>
+        <span class="cc-forest-text lang-zh-only">Extension API 面</span>
+        <span class="cc-forest-text lang-en-only">Extension API surface</span>
+      </div>
+      <div class="cc-row cc-links">
+        <a class="cc-nav cc-prev" href="#c18"><span class="cc-arrow">←</span> <span class="cc-nav-num">C18</span> <span class="lang-zh-only">Interactive Mode</span><span class="lang-en-only">Interactive mode</span></a>
+        <a class="cc-back-map" href="#forest-overview"><span class="lang-zh-only">↑ 回到总览</span><span class="lang-en-only">↑ Forest map</span></a>
+        <a class="cc-nav cc-next" href="#c20"><span class="cc-nav-num">C20</span> <span class="lang-zh-only">ExtensionRunner</span><span class="lang-en-only">ExtensionRunner</span> <span class="cc-arrow">→</span></a>
+      </div>
+    </nav>
     <aside class="stage-why-care lang-zh-only">
       <div class="swc-label">为什么这一段对你来说很重要</div>
       <p><span class="swc-pill ">直觉</span><span>Extension API 决定你如何理解 Pi 在此层的机制。</span></p>
@@ -5310,7 +6521,9 @@
       <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 12</strong>: Resources + Extensions (<code>resources-extensions</code>) · production: <code>packages/coding-agent/src/core/extensions/ · resource-loader.ts</code></span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">Extension API：主线 prompt 如何穿过此模块</span><span class="lang-en-only">Extension API: through-line crossing</span></h3>
+    <div class="depth-zone" data-chapter="C19"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C19.4+</span><span class="lang-en-only">Deep dive · C19.4+</span></div>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C19.4</span> <span class="lang-zh-only">主线 prompt 如何穿过此模块</span><span class="lang-en-only">through-line crossing</span></h4>
 
     <div class="lang-zh-only"><p>用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/coding-agent/src/core/extensions/types.ts</code> 定义了此阶段的类型契约与副作用边界。</p></div>
     <div class="lang-en-only"><p>After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/coding-agent/src/core/extensions/types.ts</code> defines type contracts and side-effect boundaries here.</p></div>
@@ -5324,7 +6537,7 @@
     <div class="lang-zh-only"><p>pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。</p></div>
     <div class="lang-en-only"><p>Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">Extension API：关键函数与数据流</span><span class="lang-en-only">Extension API: key functions and data flow</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C19.5</span> <span class="lang-zh-only">关键函数与数据流</span><span class="lang-en-only">key functions and data flow</span></h4>
 
     <div class="lang-zh-only"><p><code>types.ts</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。</p></div>
     <div class="lang-en-only"><p><code>async</code> functions in <code>types.ts</code> are usually IO boundaries: disk, network, or subprocess.</p></div>
@@ -5338,7 +6551,7 @@
     <div class="lang-zh-only"><p>对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。</p></div>
     <div class="lang-en-only"><p>Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">Extension API：与 agent-loop 的接口</span><span class="lang-en-only">Extension API: interface with agent-loop</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C19.6</span> <span class="lang-zh-only">与 agent-loop 的接口</span><span class="lang-en-only">interface with agent-loop</span></h4>
 
     <div class="lang-zh-only"><p><code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。</p></div>
     <div class="lang-en-only"><p><code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc.</p></div>
@@ -5352,7 +6565,7 @@
     <div class="lang-zh-only"><p>--verbose 模式下 stderr 事件类型可回溯到 <code>packages/coding-agent/src/core/extensions/types.ts</code> 的具体行。</p></div>
     <div class="lang-en-only"><p>Under --verbose, stderr event types trace to lines in <code>packages/coding-agent/src/core/extensions/types.ts</code>.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">Extension API：设计权衡与常见坑</span><span class="lang-en-only">Extension API: trade-offs and pitfalls</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C19.7</span> <span class="lang-zh-only">设计权衡与常见坑</span><span class="lang-en-only">trade-offs and pitfalls</span></h4>
 
     <div class="lang-zh-only"><p>显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。</p></div>
     <div class="lang-en-only"><p>Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union.</p></div>
@@ -5365,6 +6578,20 @@
 
     <div class="lang-zh-only"><p>对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。</p></div>
     <div class="lang-en-only"><p>vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable.</p></div>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C19.8</span> <span class="lang-zh-only">读完后应能回答的 5 个问题 · Extension API 面</span><span class="lang-en-only">Five questions you should answer after reading · Extension API 面</span></h4>
+
+    <div class="lang-zh-only"><p>① 主线 prompt 进入本章模块时，第一个被调用的 <code>export</code> 函数是什么？② 它 emit 的第一个 AgentEvent 类型是什么？③ 若在此层抛错，TUI 会卡在什么状态？④ 对应的 pi-textbook checkpoint 测试命令是什么？⑤ <code>packages/agent/src/agent-loop.ts</code> 中哪一行最值得打断点？</p></div>
+    <div class="lang-en-only"><p>① First <code>export</code> called when through-line enters this module? ② First AgentEvent type emitted? ③ If this layer throws, what TUI state stalls? ④ Matching pi-textbook checkpoint test command? ⑤ Best breakpoint line in <code>packages/agent/src/agent-loop.ts</code>?</p></div>
+
+    <div class="lang-zh-only"><p>不要一次读完整个文件。用「从测试入手」法：先 <code>npm test -- &lt;matching-test&gt;</code>，看失败断言指向哪行，再读那一行上下游 30 行。生产 pi-mono 的测试覆盖率在 agent-loop 与 session-manager 最高——优先读测试。</p></div>
+    <div class="lang-en-only"><p>Don't read whole files at once. «Test-first» method: run <code>npm test -- &lt;matching-test&gt;</code>, see which assertion fails, read ±30 lines around that line. Highest test coverage in agent-loop and session-manager — read tests first.</p></div>
+
+    <div class="lang-zh-only"><p>对照本文 TRACE 盒与 <code>--verbose</code> stderr：每个 event type 应在源码中有且仅有一处「决策点」——若找不到，说明事件在更上层（AgentSession）或更下层（pi-ai adapter）合并发出。</p></div>
+    <div class="lang-en-only"><p>Cross-check TRACE box with <code>--verbose</code> stderr: each event type should have exactly one «decision point» in source — if missing, event is merged upstream (AgentSession) or downstream (pi-ai adapter).</p></div>
+
+    <div class="lang-zh-only"><p>进阶：用 <code>git blame packages/agent/src/agent-loop.ts</code> 看最近改动——Pi 的 harness 接口仍在活跃演进，注释可能落后于 <code>AgentLoopConfig</code> 类型定义。类型即文档。</p></div>
+    <div class="lang-en-only"><p>Advanced: <code>git blame packages/agent/src/agent-loop.ts</code> for recent changes — Pi harness APIs still evolve; comments may lag <code>AgentLoopConfig</code> types. Types are the doc.</p></div>
 
     <div class="trace-box">
       <div class="tb-tag">TRACE · station 19</div>
@@ -5381,20 +6608,33 @@
       <span class="src-line"><span class="src-line"><span class="src-comment">// through-line: README.md</span></span></span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">交叉引用</span><span class="lang-en-only">Cross-ref</span></span> <span class="da-title lang-zh-only">pi-textbook checkpoint</span><span class="da-title lang-en-only">pi-textbook checkpoint</span></div>    <table class="cmp">
       <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
       <tbody>
       <tr><td>cp 12</td><td>Resources + Extensions</td><td><code>resources-extensions</code></td><td><code>packages/coding-agent/src/core/extensions/ · resource-loader.ts</code></td></tr>
       </tbody>
     </table>
 
-    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">附录</span><span class="lang-en-only">Appendix</span></span> <span class="da-title lang-zh-only">常见问题</span><span class="da-title lang-en-only">FAQ</span></div>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">Extension API最关键文件？</span><span class="lang-en-only">Key file?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p><code>packages/coding-agent/src/core/extensions/types.ts</code>。</p></div><div class="lang-en-only"><p><code>packages/coding-agent/src/core/extensions/types.ts</code>.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">如何单测？</span><span class="lang-en-only">Unit test?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>mock StreamFn 或 ScriptedModel。</p></div><div class="lang-en-only"><p>mock StreamFn or ScriptedModel.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">与 textbook 差异？</span><span class="lang-en-only">vs textbook?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>生产含 OAuth/TUI/40+ providers。</p></div><div class="lang-en-only"><p>Production adds OAuth/TUI/40+ providers.</p></div></div></details>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C19.9</span> <span class="lang-zh-only">打开源码：packages/coding-agent/src/core/extensions/types.ts</span><span class="lang-en-only">Open source: packages/coding-agent/src/core/extensions/types.ts</span></h4>
+
+    <div class="lang-zh-only"><p>本章主线 prompt 经过此模块时，请在 pi-mono 打开 <code>packages/coding-agent/src/core/extensions/types.ts</code>，搜索 <code>export</code> 与测试文件中的同名场景。对照 pi-textbook 对应 checkpoint 的 workshop 测试——先让测试绿，再读生产实现。</p></div>
+    <div class="lang-en-only"><p>When the through-line prompt crosses this module, open <code>packages/coding-agent/src/core/extensions/types.ts</code> in pi-mono, search <code>export</code> and matching test scenarios. Cross-read the pi-textbook checkpoint workshop test — green test first, then production.</p></div>
+
+    <div class="lang-zh-only"><p>建议命令：<code>cd packages/agent && npm test -- agent-loop</code>（路径因章而异）。测试文件是行为契约的executable spec，比注释更可靠。</p></div>
+    <div class="lang-en-only"><p>Suggested: <code>cd packages/agent && npm test -- agent-loop</code> (path varies). Tests are executable specs of behavior contracts — more reliable than comments.</p></div>
+
+    <div class="lang-zh-only"><p>用 <code>--verbose</code> 跑一轮主线 prompt，把 stderr event 类型与源码中的 <code>emit</code> 调用逐行对齐——这是本文 C26 推荐的 trace 方法。</p></div>
+    <div class="lang-en-only"><p>Run the through-line with <code>--verbose</code>, align stderr event types with <code>emit</code> calls in source — the trace method recommended in C26.</p></div>
+
+    </div>
   </section>
 
   <section class="chap" id="c20">
@@ -5403,6 +6643,26 @@
     <h2 class="chap-title lang-en-only">ExtensionRunner</h2>
     <p class="chap-en lang-zh-only">jiti 加载 · 事件合并 · hook 注入</p>
     <p class="chap-en lang-en-only">jiti load · event merge · hook injection</p>
+    <nav class="chap-compass" aria-label="Chapter 20 navigation">
+      <div class="cc-row cc-loc">
+        <span class="cc-phase"><span class="lang-zh-only">Phase V · 扩展</span><span class="lang-en-only">Phase V · Extensions</span></span>
+        <span class="cc-sep">·</span>
+        <span class="cc-chap">C20 / 26</span>
+        <span class="cc-sep">·</span>
+        <span class="cc-station"><span class="lang-zh-only">—</span><span class="lang-en-only">—</span></span>
+      </div>
+      <div class="cc-row cc-forest">
+        <span class="cc-forest-label lang-zh-only">你在森林的这里</span>
+        <span class="cc-forest-label lang-en-only">You are here</span>
+        <span class="cc-forest-text lang-zh-only">ExtensionRunner · jiti</span>
+        <span class="cc-forest-text lang-en-only">ExtensionRunner · jiti</span>
+      </div>
+      <div class="cc-row cc-links">
+        <a class="cc-nav cc-prev" href="#c19"><span class="cc-arrow">←</span> <span class="cc-nav-num">C19</span> <span class="lang-zh-only">Extension API 面</span><span class="lang-en-only">Extension API surface</span></a>
+        <a class="cc-back-map" href="#forest-overview"><span class="lang-zh-only">↑ 回到总览</span><span class="lang-en-only">↑ Forest map</span></a>
+        <a class="cc-nav cc-next" href="#c21"><span class="cc-nav-num">C21</span> <span class="lang-zh-only">Pi Packages</span><span class="lang-en-only">Pi packages</span> <span class="cc-arrow">→</span></a>
+      </div>
+    </nav>
     <aside class="stage-why-care lang-zh-only">
       <div class="swc-label">为什么这一段对你来说很重要</div>
       <p><span class="swc-pill ">直觉</span><span>ExtensionRunner 决定你如何理解 Pi 在此层的机制。</span></p>
@@ -5448,7 +6708,7 @@
       <span class="src-line">}</span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">事件合并语义</span><span class="lang-en-only">Event merge semantics</span></h3>
+    <h3 class="sub"><span class="sec-num">C20.1</span> <span class="lang-zh-only">事件合并语义</span><span class="lang-en-only">Event merge semantics</span></h3>
 
     <div class="lang-zh-only"><p>多个扩展可订阅同一事件；Runner 按加载顺序调用；<code>before_compact</code> 可返回修改后的 summary。</p></div>
     <div class="lang-en-only"><p>Multiple extensions can subscribe; Runner calls in load order; <code>before_compact</code> can return modified summary.</p></div>
@@ -5458,7 +6718,9 @@
       <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 13</strong>: Composition Root (<code>composition-root</code>) · production: <code>packages/coding-agent/src/core/agent-session.ts · sdk.ts</code></span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">ExtensionRunner：主线 prompt 如何穿过此模块</span><span class="lang-en-only">ExtensionRunner: through-line crossing</span></h3>
+    <div class="depth-zone" data-chapter="C20"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C20.4+</span><span class="lang-en-only">Deep dive · C20.4+</span></div>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C20.4</span> <span class="lang-zh-only">主线 prompt 如何穿过此模块</span><span class="lang-en-only">through-line crossing</span></h4>
 
     <div class="lang-zh-only"><p>用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/coding-agent/src/core/extensions/runner.ts</code> 定义了此阶段的类型契约与副作用边界。</p></div>
     <div class="lang-en-only"><p>After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/coding-agent/src/core/extensions/runner.ts</code> defines type contracts and side-effect boundaries here.</p></div>
@@ -5472,7 +6734,7 @@
     <div class="lang-zh-only"><p>pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。</p></div>
     <div class="lang-en-only"><p>Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">ExtensionRunner：关键函数与数据流</span><span class="lang-en-only">ExtensionRunner: key functions and data flow</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C20.5</span> <span class="lang-zh-only">关键函数与数据流</span><span class="lang-en-only">key functions and data flow</span></h4>
 
     <div class="lang-zh-only"><p><code>runner.ts</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。</p></div>
     <div class="lang-en-only"><p><code>async</code> functions in <code>runner.ts</code> are usually IO boundaries: disk, network, or subprocess.</p></div>
@@ -5486,7 +6748,7 @@
     <div class="lang-zh-only"><p>对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。</p></div>
     <div class="lang-en-only"><p>Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">ExtensionRunner：与 agent-loop 的接口</span><span class="lang-en-only">ExtensionRunner: interface with agent-loop</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C20.6</span> <span class="lang-zh-only">与 agent-loop 的接口</span><span class="lang-en-only">interface with agent-loop</span></h4>
 
     <div class="lang-zh-only"><p><code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。</p></div>
     <div class="lang-en-only"><p><code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc.</p></div>
@@ -5500,7 +6762,7 @@
     <div class="lang-zh-only"><p>--verbose 模式下 stderr 事件类型可回溯到 <code>packages/coding-agent/src/core/extensions/runner.ts</code> 的具体行。</p></div>
     <div class="lang-en-only"><p>Under --verbose, stderr event types trace to lines in <code>packages/coding-agent/src/core/extensions/runner.ts</code>.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">ExtensionRunner：设计权衡与常见坑</span><span class="lang-en-only">ExtensionRunner: trade-offs and pitfalls</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C20.7</span> <span class="lang-zh-only">设计权衡与常见坑</span><span class="lang-en-only">trade-offs and pitfalls</span></h4>
 
     <div class="lang-zh-only"><p>显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。</p></div>
     <div class="lang-en-only"><p>Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union.</p></div>
@@ -5514,7 +6776,7 @@
     <div class="lang-zh-only"><p>对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。</p></div>
     <div class="lang-en-only"><p>vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">ExtensionRunner：深度走读清单</span><span class="lang-en-only">ExtensionRunner: deep walk checklist</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C20.8</span> <span class="lang-zh-only">深度走读清单</span><span class="lang-en-only">deep walk checklist</span></h4>
 
     <div class="lang-zh-only"><p>① 打开 <code>packages/coding-agent/src/core/extensions/runner.ts</code>；② 从 export 符号跟踪 README 路径调用链；③ 标注每个 await 的 IO 类型。</p></div>
     <div class="lang-en-only"><p>① Open <code>packages/coding-agent/src/core/extensions/runner.ts</code>; ② trace README call chain from exports; ③ label each await's IO type.</p></div>
@@ -5527,6 +6789,20 @@
 
     <div class="lang-zh-only"><p>将观察结果与 pi-textbook workshop 的 checkpoint 测试输出 diff。</p></div>
     <div class="lang-en-only"><p>Diff observations against pi-textbook workshop checkpoint test output.</p></div>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C20.9</span> <span class="lang-zh-only">读完后应能回答的 5 个问题 · ExtensionRunner</span><span class="lang-en-only">Five questions you should answer after reading · ExtensionRunner</span></h4>
+
+    <div class="lang-zh-only"><p>① 主线 prompt 进入本章模块时，第一个被调用的 <code>export</code> 函数是什么？② 它 emit 的第一个 AgentEvent 类型是什么？③ 若在此层抛错，TUI 会卡在什么状态？④ 对应的 pi-textbook checkpoint 测试命令是什么？⑤ <code>packages/agent/src/agent-loop.ts</code> 中哪一行最值得打断点？</p></div>
+    <div class="lang-en-only"><p>① First <code>export</code> called when through-line enters this module? ② First AgentEvent type emitted? ③ If this layer throws, what TUI state stalls? ④ Matching pi-textbook checkpoint test command? ⑤ Best breakpoint line in <code>packages/agent/src/agent-loop.ts</code>?</p></div>
+
+    <div class="lang-zh-only"><p>不要一次读完整个文件。用「从测试入手」法：先 <code>npm test -- &lt;matching-test&gt;</code>，看失败断言指向哪行，再读那一行上下游 30 行。生产 pi-mono 的测试覆盖率在 agent-loop 与 session-manager 最高——优先读测试。</p></div>
+    <div class="lang-en-only"><p>Don't read whole files at once. «Test-first» method: run <code>npm test -- &lt;matching-test&gt;</code>, see which assertion fails, read ±30 lines around that line. Highest test coverage in agent-loop and session-manager — read tests first.</p></div>
+
+    <div class="lang-zh-only"><p>对照本文 TRACE 盒与 <code>--verbose</code> stderr：每个 event type 应在源码中有且仅有一处「决策点」——若找不到，说明事件在更上层（AgentSession）或更下层（pi-ai adapter）合并发出。</p></div>
+    <div class="lang-en-only"><p>Cross-check TRACE box with <code>--verbose</code> stderr: each event type should have exactly one «decision point» in source — if missing, event is merged upstream (AgentSession) or downstream (pi-ai adapter).</p></div>
+
+    <div class="lang-zh-only"><p>进阶：用 <code>git blame packages/agent/src/agent-loop.ts</code> 看最近改动——Pi 的 harness 接口仍在活跃演进，注释可能落后于 <code>AgentLoopConfig</code> 类型定义。类型即文档。</p></div>
+    <div class="lang-en-only"><p>Advanced: <code>git blame packages/agent/src/agent-loop.ts</code> for recent changes — Pi harness APIs still evolve; comments may lag <code>AgentLoopConfig</code> types. Types are the doc.</p></div>
 
     <div class="trace-box">
       <div class="tb-tag">TRACE · station 20</div>
@@ -5543,7 +6819,7 @@
       <span class="src-line"><span class="src-line"><span class="src-comment">/** executes extensions and manages lifecycle */</span></span></span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">交叉引用</span><span class="lang-en-only">Cross-ref</span></span> <span class="da-title lang-zh-only">pi-textbook checkpoint</span><span class="da-title lang-en-only">pi-textbook checkpoint</span></div>    <table class="cmp">
       <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
       <tbody>
       <tr><td>cp 12</td><td>Resources + Extensions</td><td><code>resources-extensions</code></td><td><code>packages/coding-agent/src/core/extensions/ · resource-loader.ts</code></td></tr>
@@ -5551,13 +6827,26 @@
       </tbody>
     </table>
 
-    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">附录</span><span class="lang-en-only">Appendix</span></span> <span class="da-title lang-zh-only">常见问题</span><span class="da-title lang-en-only">FAQ</span></div>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">ExtensionRunner最关键文件？</span><span class="lang-en-only">Key file?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p><code>packages/coding-agent/src/core/extensions/runner.ts</code>。</p></div><div class="lang-en-only"><p><code>packages/coding-agent/src/core/extensions/runner.ts</code>.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">如何单测？</span><span class="lang-en-only">Unit test?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>mock StreamFn 或 ScriptedModel。</p></div><div class="lang-en-only"><p>mock StreamFn or ScriptedModel.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">与 textbook 差异？</span><span class="lang-en-only">vs textbook?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>生产含 OAuth/TUI/40+ providers。</p></div><div class="lang-en-only"><p>Production adds OAuth/TUI/40+ providers.</p></div></div></details>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C20.10</span> <span class="lang-zh-only">打开源码：packages/coding-agent/src/core/extensions/runner.ts</span><span class="lang-en-only">Open source: packages/coding-agent/src/core/extensions/runner.ts</span></h4>
+
+    <div class="lang-zh-only"><p>本章主线 prompt 经过此模块时，请在 pi-mono 打开 <code>packages/coding-agent/src/core/extensions/runner.ts</code>，搜索 <code>export</code> 与测试文件中的同名场景。对照 pi-textbook 对应 checkpoint 的 workshop 测试——先让测试绿，再读生产实现。</p></div>
+    <div class="lang-en-only"><p>When the through-line prompt crosses this module, open <code>packages/coding-agent/src/core/extensions/runner.ts</code> in pi-mono, search <code>export</code> and matching test scenarios. Cross-read the pi-textbook checkpoint workshop test — green test first, then production.</p></div>
+
+    <div class="lang-zh-only"><p>建议命令：<code>cd packages/agent && npm test -- agent-loop</code>（路径因章而异）。测试文件是行为契约的executable spec，比注释更可靠。</p></div>
+    <div class="lang-en-only"><p>Suggested: <code>cd packages/agent && npm test -- agent-loop</code> (path varies). Tests are executable specs of behavior contracts — more reliable than comments.</p></div>
+
+    <div class="lang-zh-only"><p>用 <code>--verbose</code> 跑一轮主线 prompt，把 stderr event 类型与源码中的 <code>emit</code> 调用逐行对齐——这是本文 C26 推荐的 trace 方法。</p></div>
+    <div class="lang-en-only"><p>Run the through-line with <code>--verbose</code>, align stderr event types with <code>emit</code> calls in source — the trace method recommended in C26.</p></div>
+
+    </div>
   </section>
 
   <section class="chap" id="c21">
@@ -5566,6 +6855,26 @@
     <h2 class="chap-title lang-en-only">Pi packages</h2>
     <p class="chap-en lang-zh-only">npm · git · 可分享的 harness 能力</p>
     <p class="chap-en lang-en-only">npm · git · shareable harness capabilities</p>
+    <nav class="chap-compass" aria-label="Chapter 21 navigation">
+      <div class="cc-row cc-loc">
+        <span class="cc-phase"><span class="lang-zh-only">Phase V · 扩展</span><span class="lang-en-only">Phase V · Extensions</span></span>
+        <span class="cc-sep">·</span>
+        <span class="cc-chap">C21 / 26</span>
+        <span class="cc-sep">·</span>
+        <span class="cc-station"><span class="lang-zh-only">—</span><span class="lang-en-only">—</span></span>
+      </div>
+      <div class="cc-row cc-forest">
+        <span class="cc-forest-label lang-zh-only">你在森林的这里</span>
+        <span class="cc-forest-label lang-en-only">You are here</span>
+        <span class="cc-forest-text lang-zh-only">Pi Packages 分享 harness</span>
+        <span class="cc-forest-text lang-en-only">Pi Packages share harness</span>
+      </div>
+      <div class="cc-row cc-links">
+        <a class="cc-nav cc-prev" href="#c20"><span class="cc-arrow">←</span> <span class="cc-nav-num">C20</span> <span class="lang-zh-only">ExtensionRunner</span><span class="lang-en-only">ExtensionRunner</span></a>
+        <a class="cc-back-map" href="#forest-overview"><span class="lang-zh-only">↑ 回到总览</span><span class="lang-en-only">↑ Forest map</span></a>
+        <a class="cc-nav cc-next" href="#c22"><span class="cc-nav-num">C22</span> <span class="lang-zh-only">JSONL 会话树</span><span class="lang-en-only">JSONL session tree</span> <span class="cc-arrow">→</span></a>
+      </div>
+    </nav>
     <aside class="stage-why-care lang-zh-only">
       <div class="swc-label">为什么这一段对你来说很重要</div>
       <p><span class="swc-pill ">直觉</span><span>Pi Packages 决定你如何理解 Pi 在此层的机制。</span></p>
@@ -5615,7 +6924,9 @@
       <span class="lang-en-only">Extension ecosystem replaces MCP marketplace — type-safe, but requires writing TypeScript.</span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">Pi Packages：主线 prompt 如何穿过此模块</span><span class="lang-en-only">Pi Packages: through-line crossing</span></h3>
+    <div class="depth-zone" data-chapter="C21"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C21.4+</span><span class="lang-en-only">Deep dive · C21.4+</span></div>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C21.4</span> <span class="lang-zh-only">主线 prompt 如何穿过此模块</span><span class="lang-en-only">through-line crossing</span></h4>
 
     <div class="lang-zh-only"><p>用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/coding-agent/src/core/package-manager.ts</code> 定义了此阶段的类型契约与副作用边界。</p></div>
     <div class="lang-en-only"><p>After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/coding-agent/src/core/package-manager.ts</code> defines type contracts and side-effect boundaries here.</p></div>
@@ -5629,7 +6940,7 @@
     <div class="lang-zh-only"><p>pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。</p></div>
     <div class="lang-en-only"><p>Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">Pi Packages：关键函数与数据流</span><span class="lang-en-only">Pi Packages: key functions and data flow</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C21.5</span> <span class="lang-zh-only">关键函数与数据流</span><span class="lang-en-only">key functions and data flow</span></h4>
 
     <div class="lang-zh-only"><p><code>package-manager.ts</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。</p></div>
     <div class="lang-en-only"><p><code>async</code> functions in <code>package-manager.ts</code> are usually IO boundaries: disk, network, or subprocess.</p></div>
@@ -5643,7 +6954,7 @@
     <div class="lang-zh-only"><p>对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。</p></div>
     <div class="lang-en-only"><p>Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">Pi Packages：与 agent-loop 的接口</span><span class="lang-en-only">Pi Packages: interface with agent-loop</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C21.6</span> <span class="lang-zh-only">与 agent-loop 的接口</span><span class="lang-en-only">interface with agent-loop</span></h4>
 
     <div class="lang-zh-only"><p><code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。</p></div>
     <div class="lang-en-only"><p><code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc.</p></div>
@@ -5657,7 +6968,7 @@
     <div class="lang-zh-only"><p>--verbose 模式下 stderr 事件类型可回溯到 <code>packages/coding-agent/src/core/package-manager.ts</code> 的具体行。</p></div>
     <div class="lang-en-only"><p>Under --verbose, stderr event types trace to lines in <code>packages/coding-agent/src/core/package-manager.ts</code>.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">Pi Packages：设计权衡与常见坑</span><span class="lang-en-only">Pi Packages: trade-offs and pitfalls</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C21.7</span> <span class="lang-zh-only">设计权衡与常见坑</span><span class="lang-en-only">trade-offs and pitfalls</span></h4>
 
     <div class="lang-zh-only"><p>显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。</p></div>
     <div class="lang-en-only"><p>Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union.</p></div>
@@ -5671,7 +6982,7 @@
     <div class="lang-zh-only"><p>对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。</p></div>
     <div class="lang-en-only"><p>vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">Pi Packages：深度走读清单</span><span class="lang-en-only">Pi Packages: deep walk checklist</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C21.8</span> <span class="lang-zh-only">深度走读清单</span><span class="lang-en-only">deep walk checklist</span></h4>
 
     <div class="lang-zh-only"><p>① 打开 <code>packages/coding-agent/src/core/package-manager.ts</code>；② 从 export 符号跟踪 README 路径调用链；③ 标注每个 await 的 IO 类型。</p></div>
     <div class="lang-en-only"><p>① Open <code>packages/coding-agent/src/core/package-manager.ts</code>; ② trace README call chain from exports; ③ label each await's IO type.</p></div>
@@ -5684,6 +6995,20 @@
 
     <div class="lang-zh-only"><p>将观察结果与 pi-textbook workshop 的 checkpoint 测试输出 diff。</p></div>
     <div class="lang-en-only"><p>Diff observations against pi-textbook workshop checkpoint test output.</p></div>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C21.9</span> <span class="lang-zh-only">读完后应能回答的 5 个问题 · Pi Packages</span><span class="lang-en-only">Five questions you should answer after reading · Pi Packages</span></h4>
+
+    <div class="lang-zh-only"><p>① 主线 prompt 进入本章模块时，第一个被调用的 <code>export</code> 函数是什么？② 它 emit 的第一个 AgentEvent 类型是什么？③ 若在此层抛错，TUI 会卡在什么状态？④ 对应的 pi-textbook checkpoint 测试命令是什么？⑤ <code>packages/agent/src/agent-loop.ts</code> 中哪一行最值得打断点？</p></div>
+    <div class="lang-en-only"><p>① First <code>export</code> called when through-line enters this module? ② First AgentEvent type emitted? ③ If this layer throws, what TUI state stalls? ④ Matching pi-textbook checkpoint test command? ⑤ Best breakpoint line in <code>packages/agent/src/agent-loop.ts</code>?</p></div>
+
+    <div class="lang-zh-only"><p>不要一次读完整个文件。用「从测试入手」法：先 <code>npm test -- &lt;matching-test&gt;</code>，看失败断言指向哪行，再读那一行上下游 30 行。生产 pi-mono 的测试覆盖率在 agent-loop 与 session-manager 最高——优先读测试。</p></div>
+    <div class="lang-en-only"><p>Don't read whole files at once. «Test-first» method: run <code>npm test -- &lt;matching-test&gt;</code>, see which assertion fails, read ±30 lines around that line. Highest test coverage in agent-loop and session-manager — read tests first.</p></div>
+
+    <div class="lang-zh-only"><p>对照本文 TRACE 盒与 <code>--verbose</code> stderr：每个 event type 应在源码中有且仅有一处「决策点」——若找不到，说明事件在更上层（AgentSession）或更下层（pi-ai adapter）合并发出。</p></div>
+    <div class="lang-en-only"><p>Cross-check TRACE box with <code>--verbose</code> stderr: each event type should have exactly one «decision point» in source — if missing, event is merged upstream (AgentSession) or downstream (pi-ai adapter).</p></div>
+
+    <div class="lang-zh-only"><p>进阶：用 <code>git blame packages/agent/src/agent-loop.ts</code> 看最近改动——Pi 的 harness 接口仍在活跃演进，注释可能落后于 <code>AgentLoopConfig</code> 类型定义。类型即文档。</p></div>
+    <div class="lang-en-only"><p>Advanced: <code>git blame packages/agent/src/agent-loop.ts</code> for recent changes — Pi harness APIs still evolve; comments may lag <code>AgentLoopConfig</code> types. Types are the doc.</p></div>
 
     <div class="trace-box">
       <div class="tb-tag">TRACE · station 21</div>
@@ -5700,20 +7025,33 @@
       <span class="src-line"><span class="src-line"><span class="src-comment">// through-line: README.md</span></span></span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">交叉引用</span><span class="lang-en-only">Cross-ref</span></span> <span class="da-title lang-zh-only">pi-textbook checkpoint</span><span class="da-title lang-en-only">pi-textbook checkpoint</span></div>    <table class="cmp">
       <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
       <tbody>
       <tr><td>cp 12</td><td>Resources + Extensions</td><td><code>resources-extensions</code></td><td><code>packages/coding-agent/src/core/extensions/ · resource-loader.ts</code></td></tr>
       </tbody>
     </table>
 
-    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">附录</span><span class="lang-en-only">Appendix</span></span> <span class="da-title lang-zh-only">常见问题</span><span class="da-title lang-en-only">FAQ</span></div>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">Pi Packages最关键文件？</span><span class="lang-en-only">Key file?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p><code>packages/coding-agent/src/core/package-manager.ts</code>。</p></div><div class="lang-en-only"><p><code>packages/coding-agent/src/core/package-manager.ts</code>.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">如何单测？</span><span class="lang-en-only">Unit test?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>mock StreamFn 或 ScriptedModel。</p></div><div class="lang-en-only"><p>mock StreamFn or ScriptedModel.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">与 textbook 差异？</span><span class="lang-en-only">vs textbook?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>生产含 OAuth/TUI/40+ providers。</p></div><div class="lang-en-only"><p>Production adds OAuth/TUI/40+ providers.</p></div></div></details>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C21.10</span> <span class="lang-zh-only">打开源码：packages/coding-agent/src/core/extensions/loader.ts</span><span class="lang-en-only">Open source: packages/coding-agent/src/core/extensions/loader.ts</span></h4>
+
+    <div class="lang-zh-only"><p>本章主线 prompt 经过此模块时，请在 pi-mono 打开 <code>packages/coding-agent/src/core/extensions/loader.ts</code>，搜索 <code>export</code> 与测试文件中的同名场景。对照 pi-textbook 对应 checkpoint 的 workshop 测试——先让测试绿，再读生产实现。</p></div>
+    <div class="lang-en-only"><p>When the through-line prompt crosses this module, open <code>packages/coding-agent/src/core/extensions/loader.ts</code> in pi-mono, search <code>export</code> and matching test scenarios. Cross-read the pi-textbook checkpoint workshop test — green test first, then production.</p></div>
+
+    <div class="lang-zh-only"><p>建议命令：<code>cd packages/agent && npm test -- agent-loop</code>（路径因章而异）。测试文件是行为契约的executable spec，比注释更可靠。</p></div>
+    <div class="lang-en-only"><p>Suggested: <code>cd packages/agent && npm test -- agent-loop</code> (path varies). Tests are executable specs of behavior contracts — more reliable than comments.</p></div>
+
+    <div class="lang-zh-only"><p>用 <code>--verbose</code> 跑一轮主线 prompt，把 stderr event 类型与源码中的 <code>emit</code> 调用逐行对齐——这是本文 C26 推荐的 trace 方法。</p></div>
+    <div class="lang-en-only"><p>Run the through-line with <code>--verbose</code>, align stderr event types with <code>emit</code> calls in source — the trace method recommended in C26.</p></div>
+
+    </div>
   </section>
 
   <section class="chap" id="c22">
@@ -5722,6 +7060,26 @@
     <h2 class="chap-title lang-en-only">JSONL session tree</h2>
     <p class="chap-en lang-zh-only">parentId · leafId · fork</p>
     <p class="chap-en lang-en-only">parentId · leafId · fork</p>
+    <nav class="chap-compass" aria-label="Chapter 22 navigation">
+      <div class="cc-row cc-loc">
+        <span class="cc-phase"><span class="lang-zh-only">Phase VI · 持久化</span><span class="lang-en-only">Phase VI · Persistence</span></span>
+        <span class="cc-sep">·</span>
+        <span class="cc-chap">C22 / 26</span>
+        <span class="cc-sep">·</span>
+        <span class="cc-station"><span class="lang-zh-only">站 21</span><span class="lang-en-only">St. 21</span></span>
+      </div>
+      <div class="cc-row cc-forest">
+        <span class="cc-forest-label lang-zh-only">你在森林的这里</span>
+        <span class="cc-forest-label lang-en-only">You are here</span>
+        <span class="cc-forest-text lang-zh-only">JSONL 会话树落盘</span>
+        <span class="cc-forest-text lang-en-only">JSONL session tree on disk</span>
+      </div>
+      <div class="cc-row cc-links">
+        <a class="cc-nav cc-prev" href="#c21"><span class="cc-arrow">←</span> <span class="cc-nav-num">C21</span> <span class="lang-zh-only">Pi Packages</span><span class="lang-en-only">Pi packages</span></a>
+        <a class="cc-back-map" href="#forest-overview"><span class="lang-zh-only">↑ 回到总览</span><span class="lang-en-only">↑ Forest map</span></a>
+        <a class="cc-nav cc-next" href="#c23"><span class="cc-nav-num">C23</span> <span class="lang-zh-only">Compaction 与 Harness</span><span class="lang-en-only">Compaction and harness</span> <span class="cc-arrow">→</span></a>
+      </div>
+    </nav>
     <aside class="stage-why-care lang-zh-only">
       <div class="swc-label">为什么这一段对你来说很重要</div>
       <p><span class="swc-pill ">直觉</span><span>JSONL 会话树 决定你如何理解 Pi 在此层的机制。</span></p>
@@ -5799,7 +7157,7 @@
       <span class="src-line">}</span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">主线 prompt 落盘后的 JSONL 行</span><span class="lang-en-only">JSONL lines after through-line prompt</span></h3>
+    <h3 class="sub"><span class="sec-num">C22.1</span> <span class="lang-zh-only">主线 prompt 落盘后的 JSONL 行</span><span class="lang-en-only">JSONL lines after through-line prompt</span></h3>
 
     <div class="src-stack">
       <div class="src-h">
@@ -5841,14 +7199,16 @@
       <span class="src-line"><span class="src-comment">     // 当前叶指针 / current leaf</span></span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">交叉引用</span><span class="lang-en-only">Cross-ref</span></span> <span class="da-title lang-zh-only">pi-textbook checkpoint</span><span class="da-title lang-en-only">pi-textbook checkpoint</span></div>    <table class="cmp">
       <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
       <tbody>
       <tr><td>cp 10</td><td>Session Tree</td><td><code>session.ts</code></td><td><code>packages/coding-agent/src/core/session-manager.ts</code></td></tr>
       </tbody>
     </table>
 
-    <h3 class="sub"><span class="lang-zh-only">JSONL 会话树：主线 prompt 如何穿过此模块</span><span class="lang-en-only">JSONL 会话树: through-line crossing</span></h3>
+    <div class="depth-zone" data-chapter="C22"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C22.4+</span><span class="lang-en-only">Deep dive · C22.4+</span></div>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C22.4</span> <span class="lang-zh-only">主线 prompt 如何穿过此模块</span><span class="lang-en-only">through-line crossing</span></h4>
 
     <div class="lang-zh-only"><p>用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/coding-agent/src/core/session-manager.ts</code> 定义了此阶段的类型契约与副作用边界。</p></div>
     <div class="lang-en-only"><p>After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/coding-agent/src/core/session-manager.ts</code> defines type contracts and side-effect boundaries here.</p></div>
@@ -5862,7 +7222,7 @@
     <div class="lang-zh-only"><p>pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。</p></div>
     <div class="lang-en-only"><p>Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">JSONL 会话树：关键函数与数据流</span><span class="lang-en-only">JSONL 会话树: key functions and data flow</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C22.5</span> <span class="lang-zh-only">关键函数与数据流</span><span class="lang-en-only">key functions and data flow</span></h4>
 
     <div class="lang-zh-only"><p><code>session-manager.ts</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。</p></div>
     <div class="lang-en-only"><p><code>async</code> functions in <code>session-manager.ts</code> are usually IO boundaries: disk, network, or subprocess.</p></div>
@@ -5876,7 +7236,7 @@
     <div class="lang-zh-only"><p>对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。</p></div>
     <div class="lang-en-only"><p>Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">JSONL 会话树：与 agent-loop 的接口</span><span class="lang-en-only">JSONL 会话树: interface with agent-loop</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C22.6</span> <span class="lang-zh-only">与 agent-loop 的接口</span><span class="lang-en-only">interface with agent-loop</span></h4>
 
     <div class="lang-zh-only"><p><code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。</p></div>
     <div class="lang-en-only"><p><code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc.</p></div>
@@ -5890,7 +7250,7 @@
     <div class="lang-zh-only"><p>--verbose 模式下 stderr 事件类型可回溯到 <code>packages/coding-agent/src/core/session-manager.ts</code> 的具体行。</p></div>
     <div class="lang-en-only"><p>Under --verbose, stderr event types trace to lines in <code>packages/coding-agent/src/core/session-manager.ts</code>.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">JSONL 会话树：设计权衡与常见坑</span><span class="lang-en-only">JSONL 会话树: trade-offs and pitfalls</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C22.7</span> <span class="lang-zh-only">设计权衡与常见坑</span><span class="lang-en-only">trade-offs and pitfalls</span></h4>
 
     <div class="lang-zh-only"><p>显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。</p></div>
     <div class="lang-en-only"><p>Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union.</p></div>
@@ -5903,6 +7263,20 @@
 
     <div class="lang-zh-only"><p>对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。</p></div>
     <div class="lang-en-only"><p>vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable.</p></div>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C22.8</span> <span class="lang-zh-only">读完后应能回答的 5 个问题 · JSONL 会话树</span><span class="lang-en-only">Five questions you should answer after reading · JSONL 会话树</span></h4>
+
+    <div class="lang-zh-only"><p>① 主线 prompt 进入本章模块时，第一个被调用的 <code>export</code> 函数是什么？② 它 emit 的第一个 AgentEvent 类型是什么？③ 若在此层抛错，TUI 会卡在什么状态？④ 对应的 pi-textbook checkpoint 测试命令是什么？⑤ <code>packages/coding-agent/src/core/session-manager.ts</code> 中哪一行最值得打断点？</p></div>
+    <div class="lang-en-only"><p>① First <code>export</code> called when through-line enters this module? ② First AgentEvent type emitted? ③ If this layer throws, what TUI state stalls? ④ Matching pi-textbook checkpoint test command? ⑤ Best breakpoint line in <code>packages/coding-agent/src/core/session-manager.ts</code>?</p></div>
+
+    <div class="lang-zh-only"><p>不要一次读完整个文件。用「从测试入手」法：先 <code>npm test -- &lt;matching-test&gt;</code>，看失败断言指向哪行，再读那一行上下游 30 行。生产 pi-mono 的测试覆盖率在 agent-loop 与 session-manager 最高——优先读测试。</p></div>
+    <div class="lang-en-only"><p>Don't read whole files at once. «Test-first» method: run <code>npm test -- &lt;matching-test&gt;</code>, see which assertion fails, read ±30 lines around that line. Highest test coverage in agent-loop and session-manager — read tests first.</p></div>
+
+    <div class="lang-zh-only"><p>对照本文 TRACE 盒与 <code>--verbose</code> stderr：每个 event type 应在源码中有且仅有一处「决策点」——若找不到，说明事件在更上层（AgentSession）或更下层（pi-ai adapter）合并发出。</p></div>
+    <div class="lang-en-only"><p>Cross-check TRACE box with <code>--verbose</code> stderr: each event type should have exactly one «decision point» in source — if missing, event is merged upstream (AgentSession) or downstream (pi-ai adapter).</p></div>
+
+    <div class="lang-zh-only"><p>进阶：用 <code>git blame packages/coding-agent/src/core/session-manager.ts</code> 看最近改动——Pi 的 harness 接口仍在活跃演进，注释可能落后于 <code>AgentLoopConfig</code> 类型定义。类型即文档。</p></div>
+    <div class="lang-en-only"><p>Advanced: <code>git blame packages/coding-agent/src/core/session-manager.ts</code> for recent changes — Pi harness APIs still evolve; comments may lag <code>AgentLoopConfig</code> types. Types are the doc.</p></div>
 
     <div class="trace-box">
       <div class="tb-tag">TRACE · station 22</div>
@@ -5919,20 +7293,30 @@
       <span class="src-line"><span class="src-line"><span class="src-arg">parentId</span>: <span class="src-cls">string</span> | <span class="src-cls">null</span>;</span></span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">交叉引用</span><span class="lang-en-only">Cross-ref</span></span> <span class="da-title lang-zh-only">pi-textbook checkpoint</span><span class="da-title lang-en-only">pi-textbook checkpoint</span></div>    <table class="cmp">
       <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
       <tbody>
       <tr><td>cp 10</td><td>Session Tree</td><td><code>session.ts</code></td><td><code>packages/coding-agent/src/core/session-manager.ts</code></td></tr>
       </tbody>
     </table>
 
-    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">附录</span><span class="lang-en-only">Appendix</span></span> <span class="da-title lang-zh-only">常见问题</span><span class="da-title lang-en-only">FAQ</span></div>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">JSONL 会话树最关键文件？</span><span class="lang-en-only">Key file?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p><code>packages/coding-agent/src/core/session-manager.ts</code>。</p></div><div class="lang-en-only"><p><code>packages/coding-agent/src/core/session-manager.ts</code>.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">如何单测？</span><span class="lang-en-only">Unit test?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>mock StreamFn 或 ScriptedModel。</p></div><div class="lang-en-only"><p>mock StreamFn or ScriptedModel.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">与 textbook 差异？</span><span class="lang-en-only">vs textbook?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>生产含 OAuth/TUI/40+ providers。</p></div><div class="lang-en-only"><p>Production adds OAuth/TUI/40+ providers.</p></div></div></details>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C22.9</span> <span class="lang-zh-only">JSONL 一行究竟长什么样</span><span class="lang-en-only">What one JSONL line actually looks like</span></h4>
+
+    <div class="lang-zh-only"><p>每条 entry 含 <code>id</code>、<code>parentId</code>、<code>type</code>、<code>message</code> 或 <code>event</code> 载荷。主线 prompt 的第一行 user entry 的 <code>parentId</code> 指向 session 根或上一 leaf；assistant toolUse 行的 <code>parentId</code> 指向 user entry——形成树而非链表。</p></div>
+    <div class="lang-en-only"><p>Each entry has <code>id</code>, <code>parentId</code>, <code>type</code>, and <code>message</code> or <code>event</code> payload. First user entry's <code>parentId</code> points to session root or prior leaf; assistant toolUse points to user entry — a tree, not a linked list.</p></div>
+
+    <div class="lang-zh-only"><p><code>fork(fromEntryId)</code> 创建新 session 文件，复制祖先链到切点，后续 append 挂在新分支上。这是 Pi 替代 sub-agent 的方式：不是进程内 spawn，而是<strong>会话树分支</strong>。</p></div>
+    <div class="lang-en-only"><p><code>fork(fromEntryId)</code> creates a new session file, copies ancestor chain to cut point; subsequent appends hang on the new branch. Pi's sub-agent alternative: <strong>session tree branch</strong>, not in-process spawn.</p></div>
+
+    </div>
   </section>
 
   <section class="chap" id="c23">
@@ -5941,6 +7325,26 @@
     <h2 class="chap-title lang-en-only">Compaction and harness</h2>
     <p class="chap-en lang-zh-only">上下文压缩 · SQLite lanes</p>
     <p class="chap-en lang-en-only">context compression · SQLite lanes</p>
+    <nav class="chap-compass" aria-label="Chapter 23 navigation">
+      <div class="cc-row cc-loc">
+        <span class="cc-phase"><span class="lang-zh-only">Phase VI · 持久化</span><span class="lang-en-only">Phase VI · Persistence</span></span>
+        <span class="cc-sep">·</span>
+        <span class="cc-chap">C23 / 26</span>
+        <span class="cc-sep">·</span>
+        <span class="cc-station"><span class="lang-zh-only">站 22</span><span class="lang-en-only">St. 22</span></span>
+      </div>
+      <div class="cc-row cc-forest">
+        <span class="cc-forest-label lang-zh-only">你在森林的这里</span>
+        <span class="cc-forest-label lang-en-only">You are here</span>
+        <span class="cc-forest-text lang-zh-only">Compaction 压缩上下文</span>
+        <span class="cc-forest-text lang-en-only">Compaction compresses context</span>
+      </div>
+      <div class="cc-row cc-links">
+        <a class="cc-nav cc-prev" href="#c22"><span class="cc-arrow">←</span> <span class="cc-nav-num">C22</span> <span class="lang-zh-only">JSONL 会话树</span><span class="lang-en-only">JSONL session tree</span></a>
+        <a class="cc-back-map" href="#forest-overview"><span class="lang-zh-only">↑ 回到总览</span><span class="lang-en-only">↑ Forest map</span></a>
+        <a class="cc-nav cc-next" href="#c24"><span class="cc-nav-num">C24</span> <span class="lang-zh-only">对比 Claude Code / Cursor</span><span class="lang-en-only">vs Claude Code / Cursor</span> <span class="cc-arrow">→</span></a>
+      </div>
+    </nav>
     <aside class="stage-why-care lang-zh-only">
       <div class="swc-label">为什么这一段对你来说很重要</div>
       <p><span class="swc-pill ">直觉</span><span>Compaction 决定你如何理解 Pi 在此层的机制。</span></p>
@@ -6000,7 +7404,7 @@
       </div>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">.harness 与 compaction 分工</span><span class="lang-en-only">Harness vs compaction roles</span></h3>
+    <h3 class="sub"><span class="sec-num">C23.1</span> <span class="lang-zh-only">.harness 与 compaction 分工</span><span class="lang-en-only">Harness vs compaction roles</span></h3>
 
     <div class="lang-zh-only"><p>agent-loop 不管 token 数；AgentSession 在 turn_end 检查 shouldCompact；扩展可在 before_compact 注入结构化摘要。</p></div>
     <div class="lang-en-only"><p>agent-loop ignores token count; AgentSession checks shouldCompact at turn_end; extensions inject structured summary in before_compact.</p></div>
@@ -6037,14 +7441,16 @@
       <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 11</strong>: Context Compaction (<code>context.ts</code>) · production: <code>packages/coding-agent/src/core/compaction/</code></span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">交叉引用</span><span class="lang-en-only">Cross-ref</span></span> <span class="da-title lang-zh-only">pi-textbook checkpoint</span><span class="da-title lang-en-only">pi-textbook checkpoint</span></div>    <table class="cmp">
       <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
       <tbody>
       <tr><td>cp 11</td><td>Context Compaction</td><td><code>context.ts</code></td><td><code>packages/coding-agent/src/core/compaction/</code></td></tr>
       </tbody>
     </table>
 
-    <h3 class="sub"><span class="lang-zh-only">Compaction：主线 prompt 如何穿过此模块</span><span class="lang-en-only">Compaction: through-line crossing</span></h3>
+    <div class="depth-zone" data-chapter="C23"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C23.4+</span><span class="lang-en-only">Deep dive · C23.4+</span></div>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C23.4</span> <span class="lang-zh-only">主线 prompt 如何穿过此模块</span><span class="lang-en-only">through-line crossing</span></h4>
 
     <div class="lang-zh-only"><p>用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/coding-agent/src/core/compaction/index.ts</code> 定义了此阶段的类型契约与副作用边界。</p></div>
     <div class="lang-en-only"><p>After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/coding-agent/src/core/compaction/index.ts</code> defines type contracts and side-effect boundaries here.</p></div>
@@ -6058,7 +7464,7 @@
     <div class="lang-zh-only"><p>pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。</p></div>
     <div class="lang-en-only"><p>Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">Compaction：关键函数与数据流</span><span class="lang-en-only">Compaction: key functions and data flow</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C23.5</span> <span class="lang-zh-only">关键函数与数据流</span><span class="lang-en-only">key functions and data flow</span></h4>
 
     <div class="lang-zh-only"><p><code>index.ts</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。</p></div>
     <div class="lang-en-only"><p><code>async</code> functions in <code>index.ts</code> are usually IO boundaries: disk, network, or subprocess.</p></div>
@@ -6072,7 +7478,7 @@
     <div class="lang-zh-only"><p>对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。</p></div>
     <div class="lang-en-only"><p>Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">Compaction：与 agent-loop 的接口</span><span class="lang-en-only">Compaction: interface with agent-loop</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C23.6</span> <span class="lang-zh-only">与 agent-loop 的接口</span><span class="lang-en-only">interface with agent-loop</span></h4>
 
     <div class="lang-zh-only"><p><code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。</p></div>
     <div class="lang-en-only"><p><code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc.</p></div>
@@ -6086,7 +7492,7 @@
     <div class="lang-zh-only"><p>--verbose 模式下 stderr 事件类型可回溯到 <code>packages/coding-agent/src/core/compaction/index.ts</code> 的具体行。</p></div>
     <div class="lang-en-only"><p>Under --verbose, stderr event types trace to lines in <code>packages/coding-agent/src/core/compaction/index.ts</code>.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">Compaction：设计权衡与常见坑</span><span class="lang-en-only">Compaction: trade-offs and pitfalls</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C23.7</span> <span class="lang-zh-only">设计权衡与常见坑</span><span class="lang-en-only">trade-offs and pitfalls</span></h4>
 
     <div class="lang-zh-only"><p>显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。</p></div>
     <div class="lang-en-only"><p>Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union.</p></div>
@@ -6099,6 +7505,20 @@
 
     <div class="lang-zh-only"><p>对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。</p></div>
     <div class="lang-en-only"><p>vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable.</p></div>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C23.8</span> <span class="lang-zh-only">读完后应能回答的 5 个问题 · Compaction 与 Harness</span><span class="lang-en-only">Five questions you should answer after reading · Compaction 与 Harness</span></h4>
+
+    <div class="lang-zh-only"><p>① 主线 prompt 进入本章模块时，第一个被调用的 <code>export</code> 函数是什么？② 它 emit 的第一个 AgentEvent 类型是什么？③ 若在此层抛错，TUI 会卡在什么状态？④ 对应的 pi-textbook checkpoint 测试命令是什么？⑤ <code>packages/agent/src/agent-loop.ts</code> 中哪一行最值得打断点？</p></div>
+    <div class="lang-en-only"><p>① First <code>export</code> called when through-line enters this module? ② First AgentEvent type emitted? ③ If this layer throws, what TUI state stalls? ④ Matching pi-textbook checkpoint test command? ⑤ Best breakpoint line in <code>packages/agent/src/agent-loop.ts</code>?</p></div>
+
+    <div class="lang-zh-only"><p>不要一次读完整个文件。用「从测试入手」法：先 <code>npm test -- &lt;matching-test&gt;</code>，看失败断言指向哪行，再读那一行上下游 30 行。生产 pi-mono 的测试覆盖率在 agent-loop 与 session-manager 最高——优先读测试。</p></div>
+    <div class="lang-en-only"><p>Don't read whole files at once. «Test-first» method: run <code>npm test -- &lt;matching-test&gt;</code>, see which assertion fails, read ±30 lines around that line. Highest test coverage in agent-loop and session-manager — read tests first.</p></div>
+
+    <div class="lang-zh-only"><p>对照本文 TRACE 盒与 <code>--verbose</code> stderr：每个 event type 应在源码中有且仅有一处「决策点」——若找不到，说明事件在更上层（AgentSession）或更下层（pi-ai adapter）合并发出。</p></div>
+    <div class="lang-en-only"><p>Cross-check TRACE box with <code>--verbose</code> stderr: each event type should have exactly one «decision point» in source — if missing, event is merged upstream (AgentSession) or downstream (pi-ai adapter).</p></div>
+
+    <div class="lang-zh-only"><p>进阶：用 <code>git blame packages/agent/src/agent-loop.ts</code> 看最近改动——Pi 的 harness 接口仍在活跃演进，注释可能落后于 <code>AgentLoopConfig</code> 类型定义。类型即文档。</p></div>
+    <div class="lang-en-only"><p>Advanced: <code>git blame packages/agent/src/agent-loop.ts</code> for recent changes — Pi harness APIs still evolve; comments may lag <code>AgentLoopConfig</code> types. Types are the doc.</p></div>
 
     <div class="trace-box">
       <div class="tb-tag">TRACE · station 23</div>
@@ -6115,20 +7535,33 @@
       <span class="src-line"><span class="src-line"><span class="src-comment">// through-line: README.md</span></span></span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">交叉引用</span><span class="lang-en-only">Cross-ref</span></span> <span class="da-title lang-zh-only">pi-textbook checkpoint</span><span class="da-title lang-en-only">pi-textbook checkpoint</span></div>    <table class="cmp">
       <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
       <tbody>
       <tr><td>cp 11</td><td>Context Compaction</td><td><code>context.ts</code></td><td><code>packages/coding-agent/src/core/compaction/</code></td></tr>
       </tbody>
     </table>
 
-    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">附录</span><span class="lang-en-only">Appendix</span></span> <span class="da-title lang-zh-only">常见问题</span><span class="da-title lang-en-only">FAQ</span></div>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">Compaction最关键文件？</span><span class="lang-en-only">Key file?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p><code>packages/coding-agent/src/core/compaction/index.ts</code>。</p></div><div class="lang-en-only"><p><code>packages/coding-agent/src/core/compaction/index.ts</code>.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">如何单测？</span><span class="lang-en-only">Unit test?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>mock StreamFn 或 ScriptedModel。</p></div><div class="lang-en-only"><p>mock StreamFn or ScriptedModel.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">与 textbook 差异？</span><span class="lang-en-only">vs textbook?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>生产含 OAuth/TUI/40+ providers。</p></div><div class="lang-en-only"><p>Production adds OAuth/TUI/40+ providers.</p></div></div></details>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C23.9</span> <span class="lang-zh-only">打开源码：packages/coding-agent/src/core/compaction/</span><span class="lang-en-only">Open source: packages/coding-agent/src/core/compaction/</span></h4>
+
+    <div class="lang-zh-only"><p>本章主线 prompt 经过此模块时，请在 pi-mono 打开 <code>packages/coding-agent/src/core/compaction/</code>，搜索 <code>export</code> 与测试文件中的同名场景。对照 pi-textbook 对应 checkpoint 的 workshop 测试——先让测试绿，再读生产实现。</p></div>
+    <div class="lang-en-only"><p>When the through-line prompt crosses this module, open <code>packages/coding-agent/src/core/compaction/</code> in pi-mono, search <code>export</code> and matching test scenarios. Cross-read the pi-textbook checkpoint workshop test — green test first, then production.</p></div>
+
+    <div class="lang-zh-only"><p>建议命令：<code>cd packages/agent && npm test -- agent-loop</code>（路径因章而异）。测试文件是行为契约的executable spec，比注释更可靠。</p></div>
+    <div class="lang-en-only"><p>Suggested: <code>cd packages/agent && npm test -- agent-loop</code> (path varies). Tests are executable specs of behavior contracts — more reliable than comments.</p></div>
+
+    <div class="lang-zh-only"><p>用 <code>--verbose</code> 跑一轮主线 prompt，把 stderr event 类型与源码中的 <code>emit</code> 调用逐行对齐——这是本文 C26 推荐的 trace 方法。</p></div>
+    <div class="lang-en-only"><p>Run the through-line with <code>--verbose</code>, align stderr event types with <code>emit</code> calls in source — the trace method recommended in C26.</p></div>
+
+    </div>
   </section>
 
   <section class="chap" id="c24">
@@ -6137,6 +7570,26 @@
     <h2 class="chap-title lang-en-only">vs Claude Code / Cursor</h2>
     <p class="chap-en lang-zh-only">minimal harness 的设计取舍</p>
     <p class="chap-en lang-en-only">design trade-offs of a minimal harness</p>
+    <nav class="chap-compass" aria-label="Chapter 24 navigation">
+      <div class="cc-row cc-loc">
+        <span class="cc-phase"><span class="lang-zh-only">Phase VII · 全景</span><span class="lang-en-only">Phase VII · Landscape</span></span>
+        <span class="cc-sep">·</span>
+        <span class="cc-chap">C24 / 26</span>
+        <span class="cc-sep">·</span>
+        <span class="cc-station"><span class="lang-zh-only">—</span><span class="lang-en-only">—</span></span>
+      </div>
+      <div class="cc-row cc-forest">
+        <span class="cc-forest-label lang-zh-only">你在森林的这里</span>
+        <span class="cc-forest-label lang-en-only">You are here</span>
+        <span class="cc-forest-text lang-zh-only">对比 Claude Code / Cursor</span>
+        <span class="cc-forest-text lang-en-only">vs Claude Code / Cursor</span>
+      </div>
+      <div class="cc-row cc-links">
+        <a class="cc-nav cc-prev" href="#c23"><span class="cc-arrow">←</span> <span class="cc-nav-num">C23</span> <span class="lang-zh-only">Compaction 与 Harness</span><span class="lang-en-only">Compaction and harness</span></a>
+        <a class="cc-back-map" href="#forest-overview"><span class="lang-zh-only">↑ 回到总览</span><span class="lang-en-only">↑ Forest map</span></a>
+        <a class="cc-nav cc-next" href="#c25"><span class="cc-nav-num">C25</span> <span class="lang-zh-only">RPC 与 pi-server</span><span class="lang-en-only">RPC and pi-server</span> <span class="cc-arrow">→</span></a>
+      </div>
+    </nav>
     <aside class="stage-why-care lang-zh-only">
       <div class="swc-label">为什么这一段对你来说很重要</div>
       <p><span class="swc-pill ">直觉</span><span>生态对比 决定你如何理解 Pi 在此层的机制。</span></p>
@@ -6183,7 +7636,7 @@
       </tbody>
     </table>
 
-    <h3 class="sub"><span class="lang-zh-only">设计取舍表</span><span class="lang-en-only">Design trade-off table</span></h3>
+    <h3 class="sub"><span class="sec-num">C24.1</span> <span class="lang-zh-only">设计取舍表</span><span class="lang-en-only">Design trade-off table</span></h3>
 
     <div class="lang-zh-only"><p>Pi 牺牲：一键 MCP 市场、GUI 权限、IDE 集成。Pi 获得：fork 会话、RPC 嵌入、完整事件日志、教学友好的代码体积。</p></div>
     <div class="lang-en-only"><p>Pi sacrifices: one-click MCP, GUI permissions, IDE integration. Pi gains: fork sessions, RPC embed, full event log, teachable code size.</p></div>
@@ -6207,7 +7660,9 @@
       </tbody>
     </table>
 
-    <h3 class="sub"><span class="lang-zh-only">生态对比：主线 prompt 如何穿过此模块</span><span class="lang-en-only">生态对比: through-line crossing</span></h3>
+    <div class="depth-zone" data-chapter="C24"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C24.4+</span><span class="lang-en-only">Deep dive · C24.4+</span></div>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C24.4</span> <span class="lang-zh-only">主线 prompt 如何穿过此模块</span><span class="lang-en-only">through-line crossing</span></h4>
 
     <div class="lang-zh-only"><p>用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>—</code> 定义了此阶段的类型契约与副作用边界。</p></div>
     <div class="lang-en-only"><p>After «<code>read README.md and tell me what this project does in one sentence</code>», <code>—</code> defines type contracts and side-effect boundaries here.</p></div>
@@ -6221,7 +7676,7 @@
     <div class="lang-zh-only"><p>pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。</p></div>
     <div class="lang-en-only"><p>Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">生态对比：关键函数与数据流</span><span class="lang-en-only">生态对比: key functions and data flow</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C24.5</span> <span class="lang-zh-only">关键函数与数据流</span><span class="lang-en-only">key functions and data flow</span></h4>
 
     <div class="lang-zh-only"><p><code>—</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。</p></div>
     <div class="lang-en-only"><p><code>async</code> functions in <code>—</code> are usually IO boundaries: disk, network, or subprocess.</p></div>
@@ -6235,7 +7690,7 @@
     <div class="lang-zh-only"><p>对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。</p></div>
     <div class="lang-en-only"><p>Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">生态对比：与 agent-loop 的接口</span><span class="lang-en-only">生态对比: interface with agent-loop</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C24.6</span> <span class="lang-zh-only">与 agent-loop 的接口</span><span class="lang-en-only">interface with agent-loop</span></h4>
 
     <div class="lang-zh-only"><p><code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。</p></div>
     <div class="lang-en-only"><p><code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc.</p></div>
@@ -6249,7 +7704,7 @@
     <div class="lang-zh-only"><p>--verbose 模式下 stderr 事件类型可回溯到 <code>—</code> 的具体行。</p></div>
     <div class="lang-en-only"><p>Under --verbose, stderr event types trace to lines in <code>—</code>.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">生态对比：设计权衡与常见坑</span><span class="lang-en-only">生态对比: trade-offs and pitfalls</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C24.7</span> <span class="lang-zh-only">设计权衡与常见坑</span><span class="lang-en-only">trade-offs and pitfalls</span></h4>
 
     <div class="lang-zh-only"><p>显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。</p></div>
     <div class="lang-en-only"><p>Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union.</p></div>
@@ -6263,6 +7718,20 @@
     <div class="lang-zh-only"><p>对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。</p></div>
     <div class="lang-en-only"><p>vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable.</p></div>
 
+    <h4 class="sub2 depth-sec"><span class="sec-num">C24.8</span> <span class="lang-zh-only">读完后应能回答的 5 个问题 · 对比 Claude Code / Cursor</span><span class="lang-en-only">Five questions you should answer after reading · 对比 Claude Code / Cursor</span></h4>
+
+    <div class="lang-zh-only"><p>① 主线 prompt 进入本章模块时，第一个被调用的 <code>export</code> 函数是什么？② 它 emit 的第一个 AgentEvent 类型是什么？③ 若在此层抛错，TUI 会卡在什么状态？④ 对应的 pi-textbook checkpoint 测试命令是什么？⑤ <code>packages/agent/src/agent-loop.ts</code> 中哪一行最值得打断点？</p></div>
+    <div class="lang-en-only"><p>① First <code>export</code> called when through-line enters this module? ② First AgentEvent type emitted? ③ If this layer throws, what TUI state stalls? ④ Matching pi-textbook checkpoint test command? ⑤ Best breakpoint line in <code>packages/agent/src/agent-loop.ts</code>?</p></div>
+
+    <div class="lang-zh-only"><p>不要一次读完整个文件。用「从测试入手」法：先 <code>npm test -- &lt;matching-test&gt;</code>，看失败断言指向哪行，再读那一行上下游 30 行。生产 pi-mono 的测试覆盖率在 agent-loop 与 session-manager 最高——优先读测试。</p></div>
+    <div class="lang-en-only"><p>Don't read whole files at once. «Test-first» method: run <code>npm test -- &lt;matching-test&gt;</code>, see which assertion fails, read ±30 lines around that line. Highest test coverage in agent-loop and session-manager — read tests first.</p></div>
+
+    <div class="lang-zh-only"><p>对照本文 TRACE 盒与 <code>--verbose</code> stderr：每个 event type 应在源码中有且仅有一处「决策点」——若找不到，说明事件在更上层（AgentSession）或更下层（pi-ai adapter）合并发出。</p></div>
+    <div class="lang-en-only"><p>Cross-check TRACE box with <code>--verbose</code> stderr: each event type should have exactly one «decision point» in source — if missing, event is merged upstream (AgentSession) or downstream (pi-ai adapter).</p></div>
+
+    <div class="lang-zh-only"><p>进阶：用 <code>git blame packages/agent/src/agent-loop.ts</code> 看最近改动——Pi 的 harness 接口仍在活跃演进，注释可能落后于 <code>AgentLoopConfig</code> 类型定义。类型即文档。</p></div>
+    <div class="lang-en-only"><p>Advanced: <code>git blame packages/agent/src/agent-loop.ts</code> for recent changes — Pi harness APIs still evolve; comments may lag <code>AgentLoopConfig</code> types. Types are the doc.</p></div>
+
     <div class="src-stack">
       <div class="src-h">
         <span>SOURCE &nbsp;·&nbsp; —</span>
@@ -6272,13 +7741,26 @@
       <span class="src-line"><span class="src-line"><span class="src-comment">// through-line: README.md</span></span></span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">附录</span><span class="lang-en-only">Appendix</span></span> <span class="da-title lang-zh-only">常见问题</span><span class="da-title lang-en-only">FAQ</span></div>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">生态对比最关键文件？</span><span class="lang-en-only">Key file?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p><code>—</code>。</p></div><div class="lang-en-only"><p><code>—</code>.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">如何单测？</span><span class="lang-en-only">Unit test?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>mock StreamFn 或 ScriptedModel。</p></div><div class="lang-en-only"><p>mock StreamFn or ScriptedModel.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">与 textbook 差异？</span><span class="lang-en-only">vs textbook?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>生产含 OAuth/TUI/40+ providers。</p></div><div class="lang-en-only"><p>Production adds OAuth/TUI/40+ providers.</p></div></div></details>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C24.9</span> <span class="lang-zh-only">打开源码：packages/coding-agent/src/core/sdk.ts</span><span class="lang-en-only">Open source: packages/coding-agent/src/core/sdk.ts</span></h4>
+
+    <div class="lang-zh-only"><p>本章主线 prompt 经过此模块时，请在 pi-mono 打开 <code>packages/coding-agent/src/core/sdk.ts</code>，搜索 <code>export</code> 与测试文件中的同名场景。对照 pi-textbook 对应 checkpoint 的 workshop 测试——先让测试绿，再读生产实现。</p></div>
+    <div class="lang-en-only"><p>When the through-line prompt crosses this module, open <code>packages/coding-agent/src/core/sdk.ts</code> in pi-mono, search <code>export</code> and matching test scenarios. Cross-read the pi-textbook checkpoint workshop test — green test first, then production.</p></div>
+
+    <div class="lang-zh-only"><p>建议命令：<code>cd packages/agent && npm test -- agent-loop</code>（路径因章而异）。测试文件是行为契约的executable spec，比注释更可靠。</p></div>
+    <div class="lang-en-only"><p>Suggested: <code>cd packages/agent && npm test -- agent-loop</code> (path varies). Tests are executable specs of behavior contracts — more reliable than comments.</p></div>
+
+    <div class="lang-zh-only"><p>用 <code>--verbose</code> 跑一轮主线 prompt，把 stderr event 类型与源码中的 <code>emit</code> 调用逐行对齐——这是本文 C26 推荐的 trace 方法。</p></div>
+    <div class="lang-en-only"><p>Run the through-line with <code>--verbose</code>, align stderr event types with <code>emit</code> calls in source — the trace method recommended in C26.</p></div>
+
+    </div>
   </section>
 
   <section class="chap" id="c25">
@@ -6287,6 +7769,26 @@
     <h2 class="chap-title lang-en-only">RPC and pi-server</h2>
     <p class="chap-en lang-zh-only">JSONL 进程协议 · CBOR 远程会话</p>
     <p class="chap-en lang-en-only">JSONL process protocol · CBOR remote sessions</p>
+    <nav class="chap-compass" aria-label="Chapter 25 navigation">
+      <div class="cc-row cc-loc">
+        <span class="cc-phase"><span class="lang-zh-only">Phase VII · 全景</span><span class="lang-en-only">Phase VII · Landscape</span></span>
+        <span class="cc-sep">·</span>
+        <span class="cc-chap">C25 / 26</span>
+        <span class="cc-sep">·</span>
+        <span class="cc-station"><span class="lang-zh-only">—</span><span class="lang-en-only">—</span></span>
+      </div>
+      <div class="cc-row cc-forest">
+        <span class="cc-forest-label lang-zh-only">你在森林的这里</span>
+        <span class="cc-forest-label lang-en-only">You are here</span>
+        <span class="cc-forest-text lang-zh-only">RPC · pi-server</span>
+        <span class="cc-forest-text lang-en-only">RPC · pi-server</span>
+      </div>
+      <div class="cc-row cc-links">
+        <a class="cc-nav cc-prev" href="#c24"><span class="cc-arrow">←</span> <span class="cc-nav-num">C24</span> <span class="lang-zh-only">对比 Claude Code / Cursor</span><span class="lang-en-only">vs Claude Code / Cursor</span></a>
+        <a class="cc-back-map" href="#forest-overview"><span class="lang-zh-only">↑ 回到总览</span><span class="lang-en-only">↑ Forest map</span></a>
+        <a class="cc-nav cc-next" href="#c26"><span class="cc-nav-num">C26</span> <span class="lang-zh-only">怎么自己 trace 一轮</span><span class="lang-en-only">How to trace a turn yourself</span> <span class="cc-arrow">→</span></a>
+      </div>
+    </nav>
     <aside class="stage-why-care lang-zh-only">
       <div class="swc-label">为什么这一段对你来说很重要</div>
       <p><span class="swc-pill ">直觉</span><span>pi-protocol 定义 JSONL 帧 + TypeBox schema；pi-server 用 CBOR 跑远程会话。</span></p>
@@ -6340,7 +7842,9 @@
       </tbody>
     </table>
 
-    <h3 class="sub"><span class="lang-zh-only">protocol 包：TypeBox schema</span><span class="lang-en-only">protocol: TypeBox schema</span></h3>
+    <div class="depth-zone" data-chapter="C25"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C25.4+</span><span class="lang-en-only">Deep dive · C25.4+</span></div>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C25.4</span> <span class="lang-zh-only">TypeBox schema</span><span class="lang-en-only">TypeBox schema</span></h4>
 
     <div class="lang-zh-only"><p>packages/protocol/src/schemas.ts：PROTOCOL_VERSION = 1；SessionPhaseSchema 对齐 AgentHarnessPhase（idle/turn/compaction/branch_summary/retry）。</p></div>
     <div class="lang-en-only"><p>schemas.ts: PROTOCOL_VERSION = 1; SessionPhaseSchema aligns with AgentHarnessPhase.</p></div>
@@ -6351,7 +7855,7 @@
     <div class="lang-zh-only"><p>帧格式在 framing.ts + codec.ts：长度前缀 JSONL 或 CBOR 二进制。</p></div>
     <div class="lang-en-only"><p>Frame format in framing.ts + codec.ts: length-prefixed JSONL or CBOR binary.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">RPC 模式启动链</span><span class="lang-en-only">RPC boot chain</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C25.5</span> <span class="lang-zh-only">RPC 模式启动链</span><span class="lang-en-only">RPC boot chain</span></h4>
 
     <div class="lang-zh-only"><p>main.ts 解析 --mode rpc → rpc-entry.ts 读 stdin JSONL 命令 → 调用 AgentSession 方法 → 写 stdout 响应。</p></div>
     <div class="lang-en-only"><p>main.ts --mode rpc → rpc-entry.ts reads stdin JSONL commands → AgentSession methods → stdout responses.</p></div>
@@ -6362,7 +7866,7 @@
     <div class="lang-zh-only"><p>适合 CI、外部 IDE 插件、多 pi 实例编排。</p></div>
     <div class="lang-en-only"><p>Suits CI, external IDE plugins, multi-pi orchestration.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">pi-server 远程会话</span><span class="lang-en-only">pi-server remote sessions</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C25.6</span> <span class="lang-zh-only">pi-server 远程会话</span><span class="lang-en-only">pi-server remote sessions</span></h4>
 
     <div class="lang-zh-only"><p>packages/server CBOR over HTTP 暴露远程 AgentSession；client 包 acquireSession 获取 lease。</p></div>
     <div class="lang-en-only"><p>server package exposes remote AgentSession via CBOR HTTP; client acquireSession gets lease.</p></div>
@@ -6370,12 +7874,12 @@
     <div class="lang-zh-only"><p>exclusive vs shared lease 防止并发写（client README 30 行）。</p></div>
     <div class="lang-en-only"><p>exclusive vs shared lease prevents concurrent writes (client README line 30).</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">与 session fork 组合</span><span class="lang-en-only">With session fork</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C25.7</span> <span class="lang-zh-only">与 session fork 组合</span><span class="lang-en-only">With session fork</span></h4>
 
     <div class="lang-zh-only"><p>RPC + fork：父进程 rpc fork 命令创建 branch session，子 pi 实例处理子任务——替代 sub-agent 的官方路径之一。</p></div>
     <div class="lang-en-only"><p>RPC + fork: parent rpc fork creates branch session, child pi handles subtask — official sub-agent alternative.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">主线 prompt 的 RPC trace</span><span class="lang-en-only">RPC trace of through-line</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C25.8</span> <span class="lang-zh-only">主线 prompt 的 RPC trace</span><span class="lang-en-only">RPC trace of through-line</span></h4>
 
     <div class="lang-zh-only"><p>管道 stdin 发送 prompt 命令 + <code>pi --mode rpc --verbose</code> 可无 TUI 观察完整事件 JSONL。</p></div>
     <div class="lang-en-only"><p>Pipe stdin prompt command + <code>pi --mode rpc --verbose</code> observes full event JSONL without TUI.</p></div>
@@ -6383,13 +7887,27 @@
     <div class="lang-zh-only"><p>对比 interactive：同一 <code>AgentSession.prompt()</code> 路径，仅 I/O 层从 TUI 换为 stdin/stdout 帧。</p></div>
     <div class="lang-en-only"><p>vs interactive: same <code>AgentSession.prompt()</code> path, only I/O layer swaps TUI for stdin/stdout frames.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">rpc-entry.ts 命令面</span><span class="lang-en-only">rpc-entry.ts command surface</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C25.9</span> <span class="lang-zh-only">rpc-entry.ts 命令面</span><span class="lang-en-only">rpc-entry.ts command surface</span></h4>
 
     <div class="lang-zh-only"><p><code>packages/coding-agent/src/rpc-entry.ts</code> 解析每行 JSON 命令：prompt、abort、set_model、fork 等，映射到 AgentSession 公开方法。</p></div>
     <div class="lang-en-only"><p><code>rpc-entry.ts</code> parses each JSON line command: prompt, abort, set_model, fork, etc., mapping to AgentSession public methods.</p></div>
 
     <div class="lang-zh-only"><p>响应帧同样 JSONL 序列化 AgentEvent，外部编排器可重建与 --verbose 等价的日志。</p></div>
     <div class="lang-en-only"><p>Response frames serialize AgentEvent as JSONL; external orchestrator can rebuild --verbose-equivalent logs.</p></div>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C25.10</span> <span class="lang-zh-only">读完后应能回答的 5 个问题 · RPC 与 pi-server</span><span class="lang-en-only">Five questions you should answer after reading · RPC 与 pi-server</span></h4>
+
+    <div class="lang-zh-only"><p>① 主线 prompt 进入本章模块时，第一个被调用的 <code>export</code> 函数是什么？② 它 emit 的第一个 AgentEvent 类型是什么？③ 若在此层抛错，TUI 会卡在什么状态？④ 对应的 pi-textbook checkpoint 测试命令是什么？⑤ <code>packages/agent/src/agent-loop.ts</code> 中哪一行最值得打断点？</p></div>
+    <div class="lang-en-only"><p>① First <code>export</code> called when through-line enters this module? ② First AgentEvent type emitted? ③ If this layer throws, what TUI state stalls? ④ Matching pi-textbook checkpoint test command? ⑤ Best breakpoint line in <code>packages/agent/src/agent-loop.ts</code>?</p></div>
+
+    <div class="lang-zh-only"><p>不要一次读完整个文件。用「从测试入手」法：先 <code>npm test -- &lt;matching-test&gt;</code>，看失败断言指向哪行，再读那一行上下游 30 行。生产 pi-mono 的测试覆盖率在 agent-loop 与 session-manager 最高——优先读测试。</p></div>
+    <div class="lang-en-only"><p>Don't read whole files at once. «Test-first» method: run <code>npm test -- &lt;matching-test&gt;</code>, see which assertion fails, read ±30 lines around that line. Highest test coverage in agent-loop and session-manager — read tests first.</p></div>
+
+    <div class="lang-zh-only"><p>对照本文 TRACE 盒与 <code>--verbose</code> stderr：每个 event type 应在源码中有且仅有一处「决策点」——若找不到，说明事件在更上层（AgentSession）或更下层（pi-ai adapter）合并发出。</p></div>
+    <div class="lang-en-only"><p>Cross-check TRACE box with <code>--verbose</code> stderr: each event type should have exactly one «decision point» in source — if missing, event is merged upstream (AgentSession) or downstream (pi-ai adapter).</p></div>
+
+    <div class="lang-zh-only"><p>进阶：用 <code>git blame packages/agent/src/agent-loop.ts</code> 看最近改动——Pi 的 harness 接口仍在活跃演进，注释可能落后于 <code>AgentLoopConfig</code> 类型定义。类型即文档。</p></div>
+    <div class="lang-en-only"><p>Advanced: <code>git blame packages/agent/src/agent-loop.ts</code> for recent changes — Pi harness APIs still evolve; comments may lag <code>AgentLoopConfig</code> types. Types are the doc.</p></div>
 
     <div class="trace-box">
       <div class="tb-tag">TRACE · station 21</div>
@@ -6406,20 +7924,33 @@
       <span class="src-line"><span class="src-line"><span class="src-kw">export const</span> <span class="src-arg">SessionPhaseSchema</span> = Type.Union([...]);</span></span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">交叉引用</span><span class="lang-en-only">Cross-ref</span></span> <span class="da-title lang-zh-only">pi-textbook checkpoint</span><span class="da-title lang-en-only">pi-textbook checkpoint</span></div>    <table class="cmp">
       <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
       <tbody>
       <tr><td>cp 13</td><td>Composition Root</td><td><code>composition-root</code></td><td><code>packages/coding-agent/src/core/agent-session.ts · sdk.ts</code></td></tr>
       </tbody>
     </table>
 
-    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">附录</span><span class="lang-en-only">Appendix</span></span> <span class="da-title lang-zh-only">常见问题</span><span class="da-title lang-en-only">FAQ</span></div>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">RPC 与 interactive 共享 AgentSession 吗？</span><span class="lang-en-only">Share AgentSession?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>是，同一类不同 I/O 层。</p></div><div class="lang-en-only"><p>Yes, same class, different I/O layer.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">CBOR 何时用？</span><span class="lang-en-only">When CBOR?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>pi-server 远程；本地 RPC 用 JSONL。</p></div><div class="lang-en-only"><p>pi-server remote; local RPC uses JSONL.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">如何测 RPC？</span><span class="lang-en-only">Test RPC?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>管道 stdin/stdout + 断言响应帧序列。</p></div><div class="lang-en-only"><p>Pipe stdin/stdout + assert response frame sequence.</p></div></div></details>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C25.11</span> <span class="lang-zh-only">打开源码：packages/protocol/src/</span><span class="lang-en-only">Open source: packages/protocol/src/</span></h4>
+
+    <div class="lang-zh-only"><p>本章主线 prompt 经过此模块时，请在 pi-mono 打开 <code>packages/protocol/src/</code>，搜索 <code>export</code> 与测试文件中的同名场景。对照 pi-textbook 对应 checkpoint 的 workshop 测试——先让测试绿，再读生产实现。</p></div>
+    <div class="lang-en-only"><p>When the through-line prompt crosses this module, open <code>packages/protocol/src/</code> in pi-mono, search <code>export</code> and matching test scenarios. Cross-read the pi-textbook checkpoint workshop test — green test first, then production.</p></div>
+
+    <div class="lang-zh-only"><p>建议命令：<code>cd packages/agent && npm test -- agent-loop</code>（路径因章而异）。测试文件是行为契约的executable spec，比注释更可靠。</p></div>
+    <div class="lang-en-only"><p>Suggested: <code>cd packages/agent && npm test -- agent-loop</code> (path varies). Tests are executable specs of behavior contracts — more reliable than comments.</p></div>
+
+    <div class="lang-zh-only"><p>用 <code>--verbose</code> 跑一轮主线 prompt，把 stderr event 类型与源码中的 <code>emit</code> 调用逐行对齐——这是本文 C26 推荐的 trace 方法。</p></div>
+    <div class="lang-en-only"><p>Run the through-line with <code>--verbose</code>, align stderr event types with <code>emit</code> calls in source — the trace method recommended in C26.</p></div>
+
+    </div>
   </section>
 
   <section class="chap" id="c26">
@@ -6428,6 +7959,26 @@
     <h2 class="chap-title lang-en-only">How to trace a turn yourself</h2>
     <p class="chap-en lang-zh-only">--verbose · event log · session file</p>
     <p class="chap-en lang-en-only">--verbose · event log · session file</p>
+    <nav class="chap-compass" aria-label="Chapter 26 navigation">
+      <div class="cc-row cc-loc">
+        <span class="cc-phase"><span class="lang-zh-only">Coda</span><span class="lang-en-only">Coda</span></span>
+        <span class="cc-sep">·</span>
+        <span class="cc-chap">C26 / 26</span>
+        <span class="cc-sep">·</span>
+        <span class="cc-station"><span class="lang-zh-only">—</span><span class="lang-en-only">—</span></span>
+      </div>
+      <div class="cc-row cc-forest">
+        <span class="cc-forest-label lang-zh-only">你在森林的这里</span>
+        <span class="cc-forest-label lang-en-only">You are here</span>
+        <span class="cc-forest-text lang-zh-only">自己 trace 一轮</span>
+        <span class="cc-forest-text lang-en-only">Trace a turn yourself</span>
+      </div>
+      <div class="cc-row cc-links">
+        <a class="cc-nav cc-prev" href="#c25"><span class="cc-arrow">←</span> <span class="cc-nav-num">C25</span> <span class="lang-zh-only">RPC 与 pi-server</span><span class="lang-en-only">RPC and pi-server</span></a>
+        <a class="cc-back-map" href="#forest-overview"><span class="lang-zh-only">↑ 回到总览</span><span class="lang-en-only">↑ Forest map</span></a>
+        <span class="cc-nav cc-empty"></span>
+      </div>
+    </nav>
     <aside class="stage-why-care lang-zh-only">
       <div class="swc-label">为什么这一段对你来说很重要</div>
       <p><span class="swc-pill ">直觉</span><span>自己 trace 决定你如何理解 Pi 在此层的机制。</span></p>
@@ -6504,7 +8055,7 @@
       <span class="src-line"><span class="src-comment">// agent_start → turn_start → message_update → ...</span></span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">推荐阅读顺序</span><span class="lang-en-only">Suggested reading order</span></h3>
+    <h3 class="sub"><span class="sec-num">C26.1</span> <span class="lang-zh-only">推荐阅读顺序</span><span class="lang-en-only">Suggested reading order</span></h3>
 
     <div class="lang-zh-only"><p>1. pi-textbook checkpoint 00 七里程碑 → 2. pi-mono agent-loop.ts runLoop → 3. agent-session.ts prompt() → 4. 本文 C02 22 站地图。</p></div>
     <div class="lang-en-only"><p>1. pi-textbook cp 00 seven milestones → 2. pi-mono agent-loop.ts runLoop → 3. agent-session.ts prompt() → 4. this article C02 22-station map.</p></div>
@@ -6520,7 +8071,9 @@
       <span class="lang-en-only">Answer should cite: AgentSession.prompt → agentLoop → two streamSimple → read tool → JSONL append → TUI message_update.</span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">自己 trace：主线 prompt 如何穿过此模块</span><span class="lang-en-only">自己 trace: through-line crossing</span></h3>
+    <div class="depth-zone" data-chapter="C26"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C26.4+</span><span class="lang-en-only">Deep dive · C26.4+</span></div>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C26.4</span> <span class="lang-zh-only">主线 prompt 如何穿过此模块</span><span class="lang-en-only">through-line crossing</span></h4>
 
     <div class="lang-zh-only"><p>用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/coding-agent/src/main.ts</code> 定义了此阶段的类型契约与副作用边界。</p></div>
     <div class="lang-en-only"><p>After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/coding-agent/src/main.ts</code> defines type contracts and side-effect boundaries here.</p></div>
@@ -6534,7 +8087,7 @@
     <div class="lang-zh-only"><p>pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。</p></div>
     <div class="lang-en-only"><p>Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">自己 trace：关键函数与数据流</span><span class="lang-en-only">自己 trace: key functions and data flow</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C26.5</span> <span class="lang-zh-only">关键函数与数据流</span><span class="lang-en-only">key functions and data flow</span></h4>
 
     <div class="lang-zh-only"><p><code>main.ts</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。</p></div>
     <div class="lang-en-only"><p><code>async</code> functions in <code>main.ts</code> are usually IO boundaries: disk, network, or subprocess.</p></div>
@@ -6548,7 +8101,7 @@
     <div class="lang-zh-only"><p>对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。</p></div>
     <div class="lang-en-only"><p>Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">自己 trace：与 agent-loop 的接口</span><span class="lang-en-only">自己 trace: interface with agent-loop</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C26.6</span> <span class="lang-zh-only">与 agent-loop 的接口</span><span class="lang-en-only">interface with agent-loop</span></h4>
 
     <div class="lang-zh-only"><p><code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。</p></div>
     <div class="lang-en-only"><p><code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc.</p></div>
@@ -6562,7 +8115,7 @@
     <div class="lang-zh-only"><p>--verbose 模式下 stderr 事件类型可回溯到 <code>packages/coding-agent/src/main.ts</code> 的具体行。</p></div>
     <div class="lang-en-only"><p>Under --verbose, stderr event types trace to lines in <code>packages/coding-agent/src/main.ts</code>.</p></div>
 
-    <h3 class="sub"><span class="lang-zh-only">自己 trace：设计权衡与常见坑</span><span class="lang-en-only">自己 trace: trade-offs and pitfalls</span></h3>
+    <h4 class="sub2 depth-sec"><span class="sec-num">C26.7</span> <span class="lang-zh-only">设计权衡与常见坑</span><span class="lang-en-only">trade-offs and pitfalls</span></h4>
 
     <div class="lang-zh-only"><p>显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。</p></div>
     <div class="lang-en-only"><p>Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union.</p></div>
@@ -6575,6 +8128,20 @@
 
     <div class="lang-zh-only"><p>对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。</p></div>
     <div class="lang-en-only"><p>vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable.</p></div>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C26.8</span> <span class="lang-zh-only">读完后应能回答的 5 个问题 · 怎么自己 trace 一轮</span><span class="lang-en-only">Five questions you should answer after reading · 怎么自己 trace 一轮</span></h4>
+
+    <div class="lang-zh-only"><p>① 主线 prompt 进入本章模块时，第一个被调用的 <code>export</code> 函数是什么？② 它 emit 的第一个 AgentEvent 类型是什么？③ 若在此层抛错，TUI 会卡在什么状态？④ 对应的 pi-textbook checkpoint 测试命令是什么？⑤ <code>packages/agent/src/agent-loop.ts</code> 中哪一行最值得打断点？</p></div>
+    <div class="lang-en-only"><p>① First <code>export</code> called when through-line enters this module? ② First AgentEvent type emitted? ③ If this layer throws, what TUI state stalls? ④ Matching pi-textbook checkpoint test command? ⑤ Best breakpoint line in <code>packages/agent/src/agent-loop.ts</code>?</p></div>
+
+    <div class="lang-zh-only"><p>不要一次读完整个文件。用「从测试入手」法：先 <code>npm test -- &lt;matching-test&gt;</code>，看失败断言指向哪行，再读那一行上下游 30 行。生产 pi-mono 的测试覆盖率在 agent-loop 与 session-manager 最高——优先读测试。</p></div>
+    <div class="lang-en-only"><p>Don't read whole files at once. «Test-first» method: run <code>npm test -- &lt;matching-test&gt;</code>, see which assertion fails, read ±30 lines around that line. Highest test coverage in agent-loop and session-manager — read tests first.</p></div>
+
+    <div class="lang-zh-only"><p>对照本文 TRACE 盒与 <code>--verbose</code> stderr：每个 event type 应在源码中有且仅有一处「决策点」——若找不到，说明事件在更上层（AgentSession）或更下层（pi-ai adapter）合并发出。</p></div>
+    <div class="lang-en-only"><p>Cross-check TRACE box with <code>--verbose</code> stderr: each event type should have exactly one «decision point» in source — if missing, event is merged upstream (AgentSession) or downstream (pi-ai adapter).</p></div>
+
+    <div class="lang-zh-only"><p>进阶：用 <code>git blame packages/agent/src/agent-loop.ts</code> 看最近改动——Pi 的 harness 接口仍在活跃演进，注释可能落后于 <code>AgentLoopConfig</code> 类型定义。类型即文档。</p></div>
+    <div class="lang-en-only"><p>Advanced: <code>git blame packages/agent/src/agent-loop.ts</code> for recent changes — Pi harness APIs still evolve; comments may lag <code>AgentLoopConfig</code> types. Types are the doc.</p></div>
 
     <div class="trace-box">
       <div class="tb-tag">TRACE · station 26</div>
@@ -6591,7 +8158,7 @@
       <span class="src-line"><span class="src-line"><span class="src-comment">// through-line: README.md</span></span></span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">交叉引用</span><span class="lang-en-only">Cross-ref</span></span> <span class="da-title lang-zh-only">pi-textbook checkpoint</span><span class="da-title lang-en-only">pi-textbook checkpoint</span></div>    <table class="cmp">
       <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
       <tbody>
       <tr><td>cp 00</td><td>一次 README 读取的七个里程碑</td><td><code>prologue.ts</code></td><td><code>packages/coding-agent/src/main.ts · packages/agent/src/agent-loop.ts</code></td></tr>
@@ -6599,13 +8166,26 @@
       </tbody>
     </table>
 
-    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">附录</span><span class="lang-en-only">Appendix</span></span> <span class="da-title lang-zh-only">常见问题</span><span class="da-title lang-en-only">FAQ</span></div>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">自己 trace最关键文件？</span><span class="lang-en-only">Key file?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p><code>packages/coding-agent/src/main.ts</code>。</p></div><div class="lang-en-only"><p><code>packages/coding-agent/src/main.ts</code>.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">如何单测？</span><span class="lang-en-only">Unit test?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>mock StreamFn 或 ScriptedModel。</p></div><div class="lang-en-only"><p>mock StreamFn or ScriptedModel.</p></div></div></details>
 
     <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">与 textbook 差异？</span><span class="lang-en-only">vs textbook?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>生产含 OAuth/TUI/40+ providers。</p></div><div class="lang-en-only"><p>Production adds OAuth/TUI/40+ providers.</p></div></div></details>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C26.9</span> <span class="lang-zh-only">打开源码：packages/coding-agent/src/cli.ts</span><span class="lang-en-only">Open source: packages/coding-agent/src/cli.ts</span></h4>
+
+    <div class="lang-zh-only"><p>本章主线 prompt 经过此模块时，请在 pi-mono 打开 <code>packages/coding-agent/src/cli.ts</code>，搜索 <code>export</code> 与测试文件中的同名场景。对照 pi-textbook 对应 checkpoint 的 workshop 测试——先让测试绿，再读生产实现。</p></div>
+    <div class="lang-en-only"><p>When the through-line prompt crosses this module, open <code>packages/coding-agent/src/cli.ts</code> in pi-mono, search <code>export</code> and matching test scenarios. Cross-read the pi-textbook checkpoint workshop test — green test first, then production.</p></div>
+
+    <div class="lang-zh-only"><p>建议命令：<code>cd packages/agent && npm test -- agent-loop</code>（路径因章而异）。测试文件是行为契约的executable spec，比注释更可靠。</p></div>
+    <div class="lang-en-only"><p>Suggested: <code>cd packages/agent && npm test -- agent-loop</code> (path varies). Tests are executable specs of behavior contracts — more reliable than comments.</p></div>
+
+    <div class="lang-zh-only"><p>用 <code>--verbose</code> 跑一轮主线 prompt，把 stderr event 类型与源码中的 <code>emit</code> 调用逐行对齐——这是本文 C26 推荐的 trace 方法。</p></div>
+    <div class="lang-en-only"><p>Run the through-line with <code>--verbose</code>, align stderr event types with <code>emit</code> calls in source — the trace method recommended in C26.</p></div>
+
+    </div>
   </section>
 
   <footer class="footer">
@@ -6702,6 +8282,36 @@
   window.addEventListener('scroll', update, { passive: true });
   window.addEventListener('resize', update);
   update();
+})();
+
+(function() {
+  var filmstrip = document.getElementById('card-filmstrip');
+  var cfTrack = document.getElementById('cf-track');
+  var cfCurrent = document.getElementById('cf-current');
+  if (!filmstrip || !cfTrack) return;
+  document.body.classList.add('has-filmstrip');
+  var cells = Array.prototype.slice.call(cfTrack.querySelectorAll('.cf-cell'));
+  var sections = cells.map(function(c) {
+    return { cell: c, el: document.querySelector(c.getAttribute('href')) };
+  }).filter(function(o) { return o.el; });
+
+  function updateFilmstrip() {
+    var offset = window.innerHeight * 0.25;
+    var activeIdx = 0;
+    for (var i = 0; i < sections.length; i++) {
+      if (sections[i].el.getBoundingClientRect().top - offset < 0) activeIdx = i;
+    }
+    var active = sections[activeIdx];
+    cells.forEach(function(c) { c.classList.remove('active'); });
+    if (active) {
+      active.cell.classList.add('active');
+      if (cfCurrent) cfCurrent.textContent = 'C' + (active.cell.dataset.chap || '');
+      active.cell.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'center' });
+    }
+    filmstrip.classList.toggle('is-visible', window.scrollY > 400);
+  }
+  window.addEventListener('scroll', updateFilmstrip, { passive: true });
+  updateFilmstrip();
 })();
 </script>
 

--- a/public/immersive/pi-agent/index.html
+++ b/public/immersive/pi-agent/index.html
@@ -902,6 +902,57 @@
     font-family: var(--mono); font-size: 8px; letter-spacing: 0.1em;
     text-transform: uppercase; color: var(--ink-mute); margin-top: 4px;
   }
+  .stage-why-care {
+    background: linear-gradient(180deg, #fdfbf3, #faf6ed);
+    border: 1px solid var(--rule); border-top: 3px solid var(--accent);
+    border-radius: 4px; padding: 18px 22px 16px; margin: 18px 0 22px;
+  }
+  .stage-why-care .swc-label {
+    font-family: var(--mono); font-size: 9px; color: var(--accent);
+    letter-spacing: 0.12em; text-transform: uppercase; margin-bottom: 10px;
+  }
+  .stage-why-care p {
+    font-family: var(--serif); font-size: 14px; color: var(--ink-soft);
+    line-height: 1.65; margin: 6px 0; display: flex; align-items: baseline; gap: 10px;
+  }
+  body.lang-en .stage-why-care p { font-family: var(--serif-en); }
+  .stage-why-care .swc-pill {
+    flex: 0 0 auto; font-family: var(--mono); font-size: 8px; font-weight: 700;
+    letter-spacing: 0.1em; text-transform: uppercase; color: #fff;
+    background: var(--ink-mute); padding: 2px 7px; border-radius: 2px;
+  }
+  .stage-why-care .swc-pill.rev { background: var(--accent); }
+  .stage-why-care .swc-pill.act { background: var(--copper); }
+  .stage-why-care em { color: var(--ink); font-style: normal; font-weight: 600; }
+  .stage-banner {
+    display: grid; grid-template-columns: repeat(4, 1fr); gap: 0;
+    background: var(--paper); border: 1px solid var(--rule);
+    border-radius: 4px; overflow: hidden; margin: 28px 0 36px;
+  }
+  .stage-banner .sb-cell {
+    padding: 14px 18px; border-right: 1px solid var(--rule-soft);
+  }
+  .stage-banner .sb-cell:last-child { border-right: none; }
+  .stage-banner .sb-key {
+    font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.18em;
+    text-transform: uppercase; color: var(--ink-mute); margin-bottom: 4px;
+  }
+  .stage-banner .sb-val {
+    font-family: var(--sans); font-size: 13.5px; font-weight: 600; color: var(--ink);
+  }
+  .trace-box {
+    margin: 24px 0; padding: 16px 20px;
+    background: var(--paper-2); border: 1px dashed var(--accent);
+    border-radius: 4px;
+  }
+  .trace-box .tb-tag {
+    font-family: var(--mono); font-size: 9px; letter-spacing: 0.16em;
+    color: var(--accent); font-weight: 700; margin-bottom: 8px;
+  }
+  @media (max-width: 760px) {
+    .stage-banner { grid-template-columns: 1fr 1fr; }
+    .stage-why-care p { flex-direction: column; gap: 4px; }
+  }
   .event-flow {
     border: 1px solid var(--rule); border-radius: 4px;
     background: var(--paper-2); padding: 4px 0;
@@ -1351,6 +1402,38 @@
     <h2 class="chap-title lang-en-only">Harness is not a product</h2>
     <p class="chap-en lang-zh-only">agent 产品战争里的第三条路</p>
     <p class="chap-en lang-en-only">a third path in the agent product war</p>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>Pi 把 agent 编排写成可读的 TypeScript 环，而不是黑盒产品。</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>「harness」是交付物本身，只是不替你决定 MCP 市场与 IDE 策略。</span></p>
+      <p><span class="swc-pill act">优化</span><span>fork 后换 <code>streamFn</code> 或 <code>SessionManager</code> 比 fork IDE 插件现实。</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>Pi writes agent orchestration as readable TypeScript loops, not a black-box product.</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>The harness is the deliverable; it refuses MCP marketplace and IDE policy.</span></p>
+      <p><span class="swc-pill act">优化</span><span>Swapping <code>streamFn</code> or <code>SessionManager</code> beats forking an IDE plugin.</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">哲学层</span><span class="lang-en-only">Philosophy</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">pi-mono</span><span class="lang-en-only">pi-mono</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">主线未进入</span><span class="lang-en-only">Through-line not entered</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">心智模型</span><span class="lang-en-only">Mental model</span></div>
+      </div>
+    </div>
+
     <div class="lang-zh-only"><p>2025–2026 年的 coding agent 市场被两条路线撕成两半：<strong>密封产品</strong>（Claude Code、Cursor、Windsurf）和<strong>可组合 harness</strong>（Pi、OpenCode、aider 变体）。我们的主线 prompt——<code>读取 README.md，用一句话告诉我这个项目做什么</code>——在两种架构里走的路径完全不同：产品把中间层焊死在二进制里；harness 把每一站写成可测试的 TypeScript。</p></div>
     <div class="lang-en-only"><p>The 2025–2026 coding-agent market splits into sealed products (Claude Code, Cursor, Windsurf) and composable harnesses (Pi, OpenCode, aider variants). Our through-line prompt — <code>read README.md and tell me what this project does in one sentence</code> — takes completely different paths: products weld the middle layers into a binary; harnesses write every station as testable TypeScript.</p></div>
 
@@ -1488,21 +1571,6 @@
       </figcaption>
     </figure>
 
-    <h3 class="sub"><span class="lang-zh-only">设计哲学</span><span class="lang-en-only">Design philosophy</span></h3>
-
-    <div class="lang-zh-only"><p>Pi 把 agent 拆成可测试的纯函数环，而不是把所有策略塞进一个 God class。</p></div>
-    <div class="lang-en-only"><p>Pi splits the agent into testable pure-function loops instead of one God class.</p></div>
-
-    <h3 class="sub"><span class="lang-zh-only">可 fork 意味着什么</span><span class="lang-en-only">What forkable means</span></h3>
-
-    <div class="lang-zh-only"><p>你可以换 streamFn、换 tool registry、换 SessionManager 实现，而不改 TUI。</p></div>
-    <div class="lang-en-only"><p>Swap streamFn, tool registry, SessionManager without touching TUI.</p></div>
-
-    <div class="note">
-      <span class="lang-zh-only">本章 (01) 在主线 prompt「agent 产品战争里的第三条路」路径上负责：<strong>Harness 不是 Product</strong>。回到 C02 的 22 站地图定位这一章。</span>
-      <span class="lang-en-only">Chapter (01) on the through-line path handles: <strong>Harness is not a product</strong>. Return to C02's 22-station map to locate this chapter.</span>
-    </div>
-
     <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
       <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
       <tbody>
@@ -1517,6 +1585,86 @@
       <div class="lang-zh-only"><p>Claude Code 把编排藏在产品里；Pi 把编排写在 agent-loop.ts。迁移的第一步不是换 CLI，而是跑通 pi-textbook checkpoint 00 的七里程碑，建立事件心智模型。</p></div>
       <div class="lang-en-only"><p>Claude Code hides orchestration in the product; Pi writes it in agent-loop.ts. Migration starts not with a new CLI but checkpoint 00's seven milestones — building an event mental model.</p></div>
     </div>
+
+    <h3 class="sub"><span class="lang-zh-only">Harness 哲学：主线 prompt 如何穿过此模块</span><span class="lang-en-only">Harness 哲学: through-line crossing</span></h3>
+
+    <div class="lang-zh-only"><p>用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/agent/src/agent-loop.ts</code> 定义了此阶段的类型契约与副作用边界。</p></div>
+    <div class="lang-en-only"><p>After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/agent/src/agent-loop.ts</code> defines type contracts and side-effect boundaries here.</p></div>
+
+    <div class="lang-zh-only"><p>在 pi-mono 仓库打开该文件，搜索 <code>export</code> 与 <code>AgentEvent</code>——这是比读 README 更快的定位法。</p></div>
+    <div class="lang-en-only"><p>In pi-mono, search <code>export</code> and <code>AgentEvent</code> — faster than README alone.</p></div>
+
+    <div class="lang-zh-only"><p>设计原则：核心循环（agent-loop）不 import TUI；本模块通过事件与回调与上游通信。</p></div>
+    <div class="lang-en-only"><p>Principle: agent-loop never imports TUI; this module talks upstream via events/callbacks.</p></div>
+
+    <div class="lang-zh-only"><p>pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。</p></div>
+    <div class="lang-en-only"><p>Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">Harness 哲学：关键函数与数据流</span><span class="lang-en-only">Harness 哲学: key functions and data flow</span></h3>
+
+    <div class="lang-zh-only"><p><code>agent-loop.ts</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。</p></div>
+    <div class="lang-en-only"><p><code>async</code> functions in <code>agent-loop.ts</code> are usually IO boundaries: disk, network, or subprocess.</p></div>
+
+    <div class="lang-zh-only"><p>成功路径与错误路径都必须 emit 事件，否则 TUI 会卡在 streaming 状态、JSONL 会缺 entry。</p></div>
+    <div class="lang-en-only"><p>Success and error paths must emit events or TUI stalls streaming and JSONL misses entries.</p></div>
+
+    <div class="lang-zh-only"><p>length 截断时 <code>agent-loop.ts</code> 的 <code>failToolCallsFromTruncatedMessage</code> 批量失败 tool calls，防止执行损坏参数。</p></div>
+    <div class="lang-en-only"><p>On length truncation, <code>failToolCallsFromTruncatedMessage</code> fails all tool calls to avoid corrupted args.</p></div>
+
+    <div class="lang-zh-only"><p>对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。</p></div>
+    <div class="lang-en-only"><p>Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">Harness 哲学：与 agent-loop 的接口</span><span class="lang-en-only">Harness 哲学: interface with agent-loop</span></h3>
+
+    <div class="lang-zh-only"><p><code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。</p></div>
+    <div class="lang-en-only"><p><code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc.</p></div>
+
+    <div class="lang-zh-only"><p><code>AgentSession</code> 在构造 config 时绑定本模块实现；换模式（print/rpc/interactive）不换 agent-loop。</p></div>
+    <div class="lang-en-only"><p><code>AgentSession</code> binds this module when building config; modes change, agent-loop does not.</p></div>
+
+    <div class="lang-zh-only"><p>fork 项目时优先替换本模块而非复制 agent-loop——这是 Pi 社区的实际 fork 模式。</p></div>
+    <div class="lang-en-only"><p>When forking, replace this module first rather than copying agent-loop — the common community pattern.</p></div>
+
+    <div class="lang-zh-only"><p>--verbose 模式下 stderr 事件类型可回溯到 <code>packages/agent/src/agent-loop.ts</code> 的具体行。</p></div>
+    <div class="lang-en-only"><p>Under --verbose, stderr event types trace to lines in <code>packages/agent/src/agent-loop.ts</code>.</p></div>
+
+    <div class="trace-box">
+      <div class="tb-tag">TRACE · station 00</div>
+      <div class="lang-zh-only"><p>Station 00：harness 心智，尚未 read。</p></div>
+      <div class="lang-en-only"><p>Station 00: harness mindset; read not yet.</p></div>
+    </div>
+
+    <div class="case-study">
+      <div class="cs-tag">CASE STUDY</div>
+      <h4 class="sub2"><span class="lang-zh-only">迁移到 Pi</span><span class="lang-en-only">Migrate to Pi</span></h4>
+      <div class="lang-zh-only"><p>跑 checkpoint 00 再对照 AgentSession.prompt()。</p></div>
+      <div class="lang-en-only"><p>Run checkpoint 00 then compare AgentSession.prompt().</p></div>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
+        <span class="src-tag">loop</span>
+      </div>
+      <span class="src-line"><span class="src-line"><span class="src-comment">/** Transforms to Message[] only at the LLM call boundary. */</span></span></span>
+      <span class="src-line"><span class="src-line"><span class="src-kw">export function</span> <span class="src-fn">agentLoop</span>(...)</span></span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+      <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
+      <tbody>
+      <tr><td>cp 00</td><td>一次 README 读取的七个里程碑</td><td><code>prologue.ts</code></td><td><code>packages/coding-agent/src/main.ts · packages/agent/src/agent-loop.ts</code></td></tr>
+      <tr><td>cp 13</td><td>Composition Root</td><td><code>composition-root</code></td><td><code>packages/coding-agent/src/core/agent-session.ts · sdk.ts</code></td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">Pi 是产品还是库？</span><span class="lang-en-only">Product or library?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>CLI + 可嵌入库。</p></div><div class="lang-en-only"><p>CLI plus embeddable libs.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">为何不 fork Claude Code？</span><span class="lang-en-only">Why not fork Claude Code?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>闭源，无法审计 agentLoop。</p></div><div class="lang-en-only"><p>Closed source.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">读完 C01？</span><span class="lang-en-only">After C01?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>克隆 pi 与 pi-textbook。</p></div><div class="lang-en-only"><p>Clone pi and pi-textbook.</p></div></div></details>
   </section>
 
   <section class="chap" id="c2">
@@ -1525,6 +1673,38 @@
     <h2 class="chap-title lang-en-only">22 stations for one message</h2>
     <p class="chap-en lang-zh-only">从回车到 JSONL 的全景图</p>
     <p class="chap-en lang-en-only">from Enter to JSONL, the full map</p>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>22 站地图是整篇文章骨架。</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>七里程碑覆盖两次 model.stream()。</span></p>
+      <p><span class="swc-pill act">优化</span><span>JSONL 落盘与渲染并行，非最后才写盘。</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>22-station map is the article skeleton.</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>Seven milestones cover two model.stream() calls.</span></p>
+      <p><span class="swc-pill act">优化</span><span>JSONL writes parallel rendering.</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">全景</span><span class="lang-en-only">Panorama</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">跨包</span><span class="lang-en-only">Cross-package</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">user→tool</span><span class="lang-en-only">user→tool</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">七里程碑</span><span class="lang-en-only">Seven milestones</span></div>
+      </div>
+    </div>
+
     <div class="lang-zh-only"><p>按下回车之后，<code>读取 README.md，用一句话告诉我这个项目做什么</code> 不是直接发给 LLM——它要先变成 <code>AgentMessage</code>，穿过 <code>AgentSession.prompt()</code>，触发 <code>agentLoop()</code>，在 <code>runLoop</code> 的双环里转两圈 model stream，中间插一次 <code>read</code> 工具，最后才在 TUI 里滚动、在 JSONL 里落盘。</p></div>
     <div class="lang-en-only"><p>After Enter, <code>read README.md and tell me what this project does in one sentence</code> does not go straight to the LLM — it becomes an <code>AgentMessage</code>, passes through <code>AgentSession.prompt()</code>, triggers <code>agentLoop()</code>, spins two model streams in <code>runLoop</code>'s twin loops with a <code>read</code> tool in between, then scrolls in the TUI and lands on disk as JSONL.</p></div>
 
@@ -1876,10 +2056,85 @@
       <cite>Field Note · 10</cite>
     </blockquote>
 
-    <div class="note">
-      <span class="lang-zh-only">本章 (02) 在主线 prompt「从回车到 JSONL 的全景图」路径上负责：<strong>一条消息的 22 站</strong>。回到 C02 的 22 站地图定位这一章。</span>
-      <span class="lang-en-only">Chapter (02) on the through-line path handles: <strong>22 stations for one message</strong>. Return to C02's 22-station map to locate this chapter.</span>
+    <h3 class="sub"><span class="lang-zh-only">回车到第一次 stream</span><span class="lang-en-only">Enter to first stream</span></h3>
+
+    <div class="lang-zh-only"><p>站 01–06：shell 回车 → cli.ts → main.ts → createAgentSession() → prompt() 将「读取 README.md，用一句话告诉我这个项目做什么」变为 AgentMessage 并写 JSONL。</p></div>
+    <div class="lang-en-only"><p>Stations 01–06: Enter → cli.ts → main.ts → createAgentSession() → prompt() turns «read README.md and tell me what this project does in one sentence» into AgentMessage + JSONL.</p></div>
+
+    <div class="lang-zh-only"><p>agentLoop emit agent_start/turn_start 后 runLoop 内环调用 streamAssistantResponse——第一次 owner=model 边界。</p></div>
+    <div class="lang-en-only"><p>agentLoop emits agent_start/turn_start; inner runLoop calls streamAssistantResponse — first owner=model boundary.</p></div>
+
+    <div class="lang-zh-only"><p>典型第一次 stream：stopReason=toolUse，toolCall type=read path=README.md（agent-loop.ts 第203行 filter toolCall）。</p></div>
+    <div class="lang-en-only"><p>Typical first stream: stopReason=toolUse, read README.md (agent-loop.ts line 203 filters toolCall).</p></div>
+
+    <div class="lang-zh-only"><p>owner=loop 站 07–11：executeToolCalls → packages/coding-agent/src/core/tools/read.ts createReadTool。</p></div>
+    <div class="lang-en-only"><p>owner=loop 07–11: executeToolCalls → createReadTool in read.ts.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">工具结果到第二次 stream</span><span class="lang-en-only">To second stream</span></h3>
+
+    <div class="lang-zh-only"><p>toolResult push 后 convertToLlm(messages) 转 Message[]；第二次 streamAssistantResponse。</p></div>
+    <div class="lang-en-only"><p>After toolResult, convertToLlm to Message[]; second streamAssistantResponse.</p></div>
+
+    <div class="lang-zh-only"><p>stopReason=stop 产出最终回答；message_update 驱动 TUI；message_end 写 JSONL。</p></div>
+    <div class="lang-en-only"><p>stopReason=stop yields answer; message_update drives TUI; message_end writes JSONL.</p></div>
+
+    <div class="lang-zh-only"><p>turn_end 携带 toolResults；无 follow-up 时 agent_end。</p></div>
+    <div class="lang-en-only"><p>turn_end carries toolResults; agent_end without follow-up.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">七里程碑映射</span><span class="lang-en-only">Milestone map</span></h3>
+
+    <div class="lang-zh-only"><p>01 user_message↔01–04；03 assistant(toolUse)↔06；04–05 tool↔07–12；07 stop↔15–18。</p></div>
+    <div class="lang-en-only"><p>01 user↔01–04; 03 toolUse↔06; 04–05 tool↔07–12; 07 stop↔15–18.</p></div>
+
+    <div class="lang-zh-only"><p>站 19–22：扩展 hook、compaction 检查、TUI flush、leafId——短任务可能 noop。</p></div>
+    <div class="lang-en-only"><p>19–22: extension hooks, compaction, TUI flush, leafId — may noop on short task.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">如何读后续章</span><span class="lang-en-only">Read later chapters</span></h3>
+
+    <div class="lang-zh-only"><p>C06↔03–05；C07↔05–08；C10↔09–11；C14↔14–16。</p></div>
+    <div class="lang-en-only"><p>C06↔03–05; C07↔05–08; C10↔09–11; C14↔14–16.</p></div>
+
+    <div class="lang-zh-only"><p>验收：pi --verbose 事件序列应对齐 prologue.ts 类型顺序。</p></div>
+    <div class="lang-en-only"><p>Acceptance: pi --verbose event types mirror prologue.ts order.</p></div>
+
+    <div class="trace-box">
+      <div class="tb-tag">TRACE · station 01</div>
+      <div class="lang-zh-only"><p>站 01：「读取 README.md，用一句话告诉我这个项目做什么」进入 cli.ts。</p></div>
+      <div class="lang-en-only"><p>Station 01: «read README.md and tell me what this project does in one sentence» enters cli.ts.</p></div>
     </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; pi-textbook/workshop/src/demo/prologue.ts</span>
+        <span class="src-tag">prologue</span>
+      </div>
+      <span class="src-line"><span class="src-line"><span class="src-fn">appendTrace</span>(trace, { type: "user_message" });</span></span>
+      <span class="src-line"><span class="src-line"><span class="src-fn">appendTrace</span>(trace, { type: "tool_start" });</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
+        <span class="src-tag">loop</span>
+      </div>
+      <span class="src-line"><span class="src-line"><span class="src-kw">while</span> (true) { // outer: follow-up</span></span>
+      <span class="src-line"><span class="src-line">  <span class="src-kw">while</span> (hasMoreToolCalls || pendingMessages.length) {</span></span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+      <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
+      <tbody>
+      <tr><td>cp 00</td><td>一次 README 读取的七个里程碑</td><td><code>prologue.ts</code></td><td><code>packages/coding-agent/src/main.ts · packages/agent/src/agent-loop.ts</code></td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">22 vs 26？</span><span class="lang-en-only">22 vs 26?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>章含背景 C03–C05 与全景 C24–C25。</p></div><div class="lang-en-only"><p>Chapters include background and landscape.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">owner 从哪来？</span><span class="lang-en-only">owner?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>prologue.ts trace 约定。</p></div><div class="lang-en-only"><p>prologue.ts trace convention.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">如何验证？</span><span class="lang-en-only">Verify?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>对照 coding-agent package.json 版本。</p></div><div class="lang-en-only"><p>Match coding-agent version.</p></div></div></details>
   </section>
 
   <section class="chap" id="c3">
@@ -1888,6 +2143,38 @@
     <h2 class="chap-title lang-en-only">The pi-mono family tree</h2>
     <p class="chap-en lang-zh-only">Mario Zechner 与 earendil-works</p>
     <p class="chap-en lang-en-only">Mario Zechner and earendil-works</p>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>pi-mono 家谱 决定你如何理解 Pi 在此层的机制。</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>反直觉：<code>package.json</code> 的复杂度在事件契约而非算法。</span></p>
+      <p><span class="swc-pill act">优化</span><span>优化：--verbose + 源码对照，不猜测模型行为。</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>pi-mono 家谱 shapes how you understand Pi at this layer.</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>Counter-intuitive: complexity in <code>package.json</code> is event contracts.</span></p>
+      <p><span class="swc-pill act">优化</span><span>Optimize: --verbose plus source, don't guess.</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">package.json</span><span class="lang-en-only">package.json</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">背景</span><span class="lang-en-only">Background</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">package.json</span><span class="lang-en-only">package.json</span></div>
+      </div>
+    </div>
+
     <div class="lang-zh-only"><p>pi-mono 是 Mario Zechner（Badlogic Games，libGDX 作者）在 earendil-works 组织下的 monorepo。它不是「又一个 ChatGPT 套壳」——而是一套可 fork 的 agent harness，npm 发布六个包。</p></div>
     <div class="lang-en-only"><p>pi-mono is Mario Zechner's (Badlogic Games, libGDX author) monorepo under earendil-works. Not another ChatGPT wrapper — a forkable agent harness published as six npm packages.</p></div>
 
@@ -2022,10 +2309,85 @@
       </figcaption>
     </figure>
 
-    <div class="note">
-      <span class="lang-zh-only">本章 (03) 在主线 prompt「Mario Zechner 与 earendil-works」路径上负责：<strong>pi-mono 家谱</strong>。回到 C02 的 22 站地图定位这一章。</span>
-      <span class="lang-en-only">Chapter (03) on the through-line path handles: <strong>The pi-mono family tree</strong>. Return to C02's 22-station map to locate this chapter.</span>
+    <h3 class="sub"><span class="lang-zh-only">pi-mono 家谱：主线 prompt 如何穿过此模块</span><span class="lang-en-only">pi-mono 家谱: through-line crossing</span></h3>
+
+    <div class="lang-zh-only"><p>用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>pi-mono/package.json</code> 定义了此阶段的类型契约与副作用边界。</p></div>
+    <div class="lang-en-only"><p>After «<code>read README.md and tell me what this project does in one sentence</code>», <code>pi-mono/package.json</code> defines type contracts and side-effect boundaries here.</p></div>
+
+    <div class="lang-zh-only"><p>在 pi-mono 仓库打开该文件，搜索 <code>export</code> 与 <code>AgentEvent</code>——这是比读 README 更快的定位法。</p></div>
+    <div class="lang-en-only"><p>In pi-mono, search <code>export</code> and <code>AgentEvent</code> — faster than README alone.</p></div>
+
+    <div class="lang-zh-only"><p>设计原则：核心循环（agent-loop）不 import TUI；本模块通过事件与回调与上游通信。</p></div>
+    <div class="lang-en-only"><p>Principle: agent-loop never imports TUI; this module talks upstream via events/callbacks.</p></div>
+
+    <div class="lang-zh-only"><p>pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。</p></div>
+    <div class="lang-en-only"><p>Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">pi-mono 家谱：关键函数与数据流</span><span class="lang-en-only">pi-mono 家谱: key functions and data flow</span></h3>
+
+    <div class="lang-zh-only"><p><code>package.json</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。</p></div>
+    <div class="lang-en-only"><p><code>async</code> functions in <code>package.json</code> are usually IO boundaries: disk, network, or subprocess.</p></div>
+
+    <div class="lang-zh-only"><p>成功路径与错误路径都必须 emit 事件，否则 TUI 会卡在 streaming 状态、JSONL 会缺 entry。</p></div>
+    <div class="lang-en-only"><p>Success and error paths must emit events or TUI stalls streaming and JSONL misses entries.</p></div>
+
+    <div class="lang-zh-only"><p>length 截断时 <code>agent-loop.ts</code> 的 <code>failToolCallsFromTruncatedMessage</code> 批量失败 tool calls，防止执行损坏参数。</p></div>
+    <div class="lang-en-only"><p>On length truncation, <code>failToolCallsFromTruncatedMessage</code> fails all tool calls to avoid corrupted args.</p></div>
+
+    <div class="lang-zh-only"><p>对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。</p></div>
+    <div class="lang-en-only"><p>Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">pi-mono 家谱：与 agent-loop 的接口</span><span class="lang-en-only">pi-mono 家谱: interface with agent-loop</span></h3>
+
+    <div class="lang-zh-only"><p><code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。</p></div>
+    <div class="lang-en-only"><p><code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc.</p></div>
+
+    <div class="lang-zh-only"><p><code>AgentSession</code> 在构造 config 时绑定本模块实现；换模式（print/rpc/interactive）不换 agent-loop。</p></div>
+    <div class="lang-en-only"><p><code>AgentSession</code> binds this module when building config; modes change, agent-loop does not.</p></div>
+
+    <div class="lang-zh-only"><p>fork 项目时优先替换本模块而非复制 agent-loop——这是 Pi 社区的实际 fork 模式。</p></div>
+    <div class="lang-en-only"><p>When forking, replace this module first rather than copying agent-loop — the common community pattern.</p></div>
+
+    <div class="lang-zh-only"><p>--verbose 模式下 stderr 事件类型可回溯到 <code>pi-mono/package.json</code> 的具体行。</p></div>
+    <div class="lang-en-only"><p>Under --verbose, stderr event types trace to lines in <code>pi-mono/package.json</code>.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">pi-mono 家谱：设计权衡与常见坑</span><span class="lang-en-only">pi-mono 家谱: trade-offs and pitfalls</span></h3>
+
+    <div class="lang-zh-only"><p>显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。</p></div>
+    <div class="lang-en-only"><p>Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union.</p></div>
+
+    <div class="lang-zh-only"><p>扩展应 subscribe 事件而非 monkey-patch 私有方法——<code>ExtensionRunner</code> 提供正规 hook 面。</p></div>
+    <div class="lang-en-only"><p>Extensions should subscribe to events, not monkey-patch privates — <code>ExtensionRunner</code> provides hooks.</p></div>
+
+    <div class="lang-zh-only"><p>JSONL <code>CURRENT_SESSION_VERSION = 3</code>：改 entry schema 必须 bump version 并提供迁移。</p></div>
+    <div class="lang-en-only"><p>JSONL <code>CURRENT_SESSION_VERSION = 3</code>: schema changes need version bump and migration.</p></div>
+
+    <div class="lang-zh-only"><p>对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。</p></div>
+    <div class="lang-en-only"><p>vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable.</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; pi-mono/package.json</span>
+        <span class="src-tag">src</span>
+      </div>
+      <span class="src-line"><span class="src-line"><span class="src-comment">// pi-mono 家谱 · pi-mono/package.json</span></span></span>
+      <span class="src-line"><span class="src-line"><span class="src-comment">// through-line: README.md</span></span></span>
     </div>
+
+    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+      <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
+      <tbody>
+      <tr><td>cp 13</td><td>Composition Root</td><td><code>composition-root</code></td><td><code>packages/coding-agent/src/core/agent-session.ts · sdk.ts</code></td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">pi-mono 家谱最关键文件？</span><span class="lang-en-only">Key file?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p><code>pi-mono/package.json</code>。</p></div><div class="lang-en-only"><p><code>pi-mono/package.json</code>.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">如何单测？</span><span class="lang-en-only">Unit test?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>mock StreamFn 或 ScriptedModel。</p></div><div class="lang-en-only"><p>mock StreamFn or ScriptedModel.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">与 textbook 差异？</span><span class="lang-en-only">vs textbook?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>生产含 OAuth/TUI/40+ providers。</p></div><div class="lang-en-only"><p>Production adds OAuth/TUI/40+ providers.</p></div></div></details>
   </section>
 
   <section class="chap" id="c4">
@@ -2034,6 +2396,38 @@
     <h2 class="chap-title lang-en-only">The six-layer cake</h2>
     <p class="chap-en lang-zh-only">agent-core · ai · tui · coding-agent</p>
     <p class="chap-en lang-en-only">agent-core · ai · tui · coding-agent</p>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>六层蛋糕 决定你如何理解 Pi 在此层的机制。</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>反直觉：<code>package.json</code> 的复杂度在事件契约而非算法。</span></p>
+      <p><span class="swc-pill act">优化</span><span>优化：--verbose + 源码对照，不猜测模型行为。</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>六层蛋糕 shapes how you understand Pi at this layer.</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>Counter-intuitive: complexity in <code>package.json</code> is event contracts.</span></p>
+      <p><span class="swc-pill act">优化</span><span>Optimize: --verbose plus source, don't guess.</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">agent</span><span class="lang-en-only">agent</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">背景</span><span class="lang-en-only">Background</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">package.json</span><span class="lang-en-only">package.json</span></div>
+      </div>
+    </div>
+
     <div class="lang-zh-only"><p>主线 prompt <code>读取 README.md，用一句话告诉我这个项目做什么</code> 从 L6 进入，在 L5 循环，L4 调模型，L3 渲染，L2/L1 只在 RPC 模式参与。</p></div>
     <div class="lang-en-only"><p>Through-line prompt enters at L6, loops in L5, calls model at L4, renders at L3; L2/L1 only in RPC mode.</p></div>
 
@@ -2176,10 +2570,86 @@
       <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 13</strong>: Composition Root (<code>composition-root</code>) · production: <code>packages/coding-agent/src/core/agent-session.ts · sdk.ts</code></span>
     </div>
 
-    <div class="note">
-      <span class="lang-zh-only">本章 (04) 在主线 prompt「agent-core · ai · tui · coding-agent」路径上负责：<strong>六层蛋糕</strong>。回到 C02 的 22 站地图定位这一章。</span>
-      <span class="lang-en-only">Chapter (04) on the through-line path handles: <strong>The six-layer cake</strong>. Return to C02's 22-station map to locate this chapter.</span>
+    <h3 class="sub"><span class="lang-zh-only">六层蛋糕：主线 prompt 如何穿过此模块</span><span class="lang-en-only">六层蛋糕: through-line crossing</span></h3>
+
+    <div class="lang-zh-only"><p>用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/agent/package.json</code> 定义了此阶段的类型契约与副作用边界。</p></div>
+    <div class="lang-en-only"><p>After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/agent/package.json</code> defines type contracts and side-effect boundaries here.</p></div>
+
+    <div class="lang-zh-only"><p>在 pi-mono 仓库打开该文件，搜索 <code>export</code> 与 <code>AgentEvent</code>——这是比读 README 更快的定位法。</p></div>
+    <div class="lang-en-only"><p>In pi-mono, search <code>export</code> and <code>AgentEvent</code> — faster than README alone.</p></div>
+
+    <div class="lang-zh-only"><p>设计原则：核心循环（agent-loop）不 import TUI；本模块通过事件与回调与上游通信。</p></div>
+    <div class="lang-en-only"><p>Principle: agent-loop never imports TUI; this module talks upstream via events/callbacks.</p></div>
+
+    <div class="lang-zh-only"><p>pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。</p></div>
+    <div class="lang-en-only"><p>Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">六层蛋糕：关键函数与数据流</span><span class="lang-en-only">六层蛋糕: key functions and data flow</span></h3>
+
+    <div class="lang-zh-only"><p><code>package.json</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。</p></div>
+    <div class="lang-en-only"><p><code>async</code> functions in <code>package.json</code> are usually IO boundaries: disk, network, or subprocess.</p></div>
+
+    <div class="lang-zh-only"><p>成功路径与错误路径都必须 emit 事件，否则 TUI 会卡在 streaming 状态、JSONL 会缺 entry。</p></div>
+    <div class="lang-en-only"><p>Success and error paths must emit events or TUI stalls streaming and JSONL misses entries.</p></div>
+
+    <div class="lang-zh-only"><p>length 截断时 <code>agent-loop.ts</code> 的 <code>failToolCallsFromTruncatedMessage</code> 批量失败 tool calls，防止执行损坏参数。</p></div>
+    <div class="lang-en-only"><p>On length truncation, <code>failToolCallsFromTruncatedMessage</code> fails all tool calls to avoid corrupted args.</p></div>
+
+    <div class="lang-zh-only"><p>对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。</p></div>
+    <div class="lang-en-only"><p>Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">六层蛋糕：与 agent-loop 的接口</span><span class="lang-en-only">六层蛋糕: interface with agent-loop</span></h3>
+
+    <div class="lang-zh-only"><p><code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。</p></div>
+    <div class="lang-en-only"><p><code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc.</p></div>
+
+    <div class="lang-zh-only"><p><code>AgentSession</code> 在构造 config 时绑定本模块实现；换模式（print/rpc/interactive）不换 agent-loop。</p></div>
+    <div class="lang-en-only"><p><code>AgentSession</code> binds this module when building config; modes change, agent-loop does not.</p></div>
+
+    <div class="lang-zh-only"><p>fork 项目时优先替换本模块而非复制 agent-loop——这是 Pi 社区的实际 fork 模式。</p></div>
+    <div class="lang-en-only"><p>When forking, replace this module first rather than copying agent-loop — the common community pattern.</p></div>
+
+    <div class="lang-zh-only"><p>--verbose 模式下 stderr 事件类型可回溯到 <code>packages/agent/package.json</code> 的具体行。</p></div>
+    <div class="lang-en-only"><p>Under --verbose, stderr event types trace to lines in <code>packages/agent/package.json</code>.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">六层蛋糕：设计权衡与常见坑</span><span class="lang-en-only">六层蛋糕: trade-offs and pitfalls</span></h3>
+
+    <div class="lang-zh-only"><p>显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。</p></div>
+    <div class="lang-en-only"><p>Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union.</p></div>
+
+    <div class="lang-zh-only"><p>扩展应 subscribe 事件而非 monkey-patch 私有方法——<code>ExtensionRunner</code> 提供正规 hook 面。</p></div>
+    <div class="lang-en-only"><p>Extensions should subscribe to events, not monkey-patch privates — <code>ExtensionRunner</code> provides hooks.</p></div>
+
+    <div class="lang-zh-only"><p>JSONL <code>CURRENT_SESSION_VERSION = 3</code>：改 entry schema 必须 bump version 并提供迁移。</p></div>
+    <div class="lang-en-only"><p>JSONL <code>CURRENT_SESSION_VERSION = 3</code>: schema changes need version bump and migration.</p></div>
+
+    <div class="lang-zh-only"><p>对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。</p></div>
+    <div class="lang-en-only"><p>vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable.</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/agent/package.json</span>
+        <span class="src-tag">src</span>
+      </div>
+      <span class="src-line"><span class="src-line"><span class="src-comment">// 六层蛋糕 · packages/agent/package.json</span></span></span>
+      <span class="src-line"><span class="src-line"><span class="src-comment">// through-line: README.md</span></span></span>
     </div>
+
+    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+      <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
+      <tbody>
+      <tr><td>cp 03</td><td>Message IR</td><td><code>types.ts</code></td><td><code>packages/agent/src/types.ts · packages/coding-agent/src/core/messages.ts</code></td></tr>
+      <tr><td>cp 13</td><td>Composition Root</td><td><code>composition-root</code></td><td><code>packages/coding-agent/src/core/agent-session.ts · sdk.ts</code></td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">六层蛋糕最关键文件？</span><span class="lang-en-only">Key file?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p><code>packages/agent/package.json</code>。</p></div><div class="lang-en-only"><p><code>packages/agent/package.json</code>.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">如何单测？</span><span class="lang-en-only">Unit test?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>mock StreamFn 或 ScriptedModel。</p></div><div class="lang-en-only"><p>mock StreamFn or ScriptedModel.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">与 textbook 差异？</span><span class="lang-en-only">vs textbook?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>生产含 OAuth/TUI/40+ providers。</p></div><div class="lang-en-only"><p>Production adds OAuth/TUI/40+ providers.</p></div></div></details>
   </section>
 
   <section class="chap" id="c5">
@@ -2188,6 +2658,38 @@
     <h2 class="chap-title lang-en-only">Intentionally missing features</h2>
     <p class="chap-en lang-zh-only">No MCP · No sub-agents · No plan mode</p>
     <p class="chap-en lang-en-only">No MCP · No sub-agents · No plan mode</p>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>Pi README 明确列出 No MCP / No sub-agents / No plan mode——这是边界声明，不是遗漏。</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>反直觉：「故意不做」反而让主线 prompt 路径更短、更可 trace。</span></p>
+      <p><span class="swc-pill act">优化</span><span>优化：用 Extension API + session fork 组合替代子 agent，类型安全且可观测。</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>Pi README explicitly lists No MCP / No sub-agents / No plan mode — boundary statements, not omissions.</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>Counter-intuitive: intentionally omitted features make the through-line shorter and more traceable.</span></p>
+      <p><span class="swc-pill act">优化</span><span>Optimize: Extension API + session fork replaces sub-agents with type safety and observability.</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">哲学</span><span class="lang-en-only">Philosophy</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">coding-agent/README.md</span><span class="lang-en-only">coding-agent/README.md</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">背景</span><span class="lang-en-only">Background</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">边界声明</span><span class="lang-en-only">Boundary manifesto</span></div>
+      </div>
+    </div>
+
     <div class="lang-zh-only"><p>Pi 的 README 明确列出<strong>故意不做</strong>的功能：No MCP · No sub-agents · No plan mode。这不是遗漏——是 harness 哲学的边界声明。</p></div>
     <div class="lang-en-only"><p>Pi's README explicitly lists <strong>intentionally omitted</strong> features: No MCP · No sub-agents · No plan mode. Not oversights — boundary statements of harness philosophy.</p></div>
 
@@ -2223,10 +2725,86 @@
       <cite>Field Note · 10</cite>
     </blockquote>
 
-    <div class="note">
-      <span class="lang-zh-only">本章 (05) 在主线 prompt「No MCP · No sub-agents · No plan mode」路径上负责：<strong>故意不做的功能</strong>。回到 C02 的 22 站地图定位这一章。</span>
-      <span class="lang-en-only">Chapter (05) on the through-line path handles: <strong>Intentionally missing features</strong>. Return to C02's 22-station map to locate this chapter.</span>
+    <h3 class="sub"><span class="lang-zh-only">为什么 No MCP</span><span class="lang-en-only">Why no MCP</span></h3>
+
+    <div class="lang-zh-only"><p><code>packages/coding-agent/README.md</code> 第 498 行：<strong>No MCP</strong>。Mario 的博客解释：MCP 把工具发现协议化，但 Pi 选择 <code>registerTool</code> + Skills + npm/git 扩展包。</p></div>
+    <div class="lang-en-only"><p><code>packages/coding-agent/README.md</code> line 498: <strong>No MCP</strong>. Mario's blog: MCP protocolizes tool discovery; Pi chooses <code>registerTool</code> + Skills + npm/git extension packages.</p></div>
+
+    <div class="lang-zh-only"><p>对主线 prompt 的影响：模型调用 <code>read</code> 是 coding-agent 内置 tool，经 <code>createReadTool</code> 同进程执行——无需 MCP server 握手。</p></div>
+    <div class="lang-en-only"><p>Through-line impact: model calls built-in <code>read</code> via <code>createReadTool</code> in-process — no MCP handshake.</p></div>
+
+    <div class="lang-zh-only"><p>代价：无法直接接入 Claude Desktop MCP 市场。收益：tool schema 在 TypeScript 中定义，<code>validateToolArguments</code> 在 <code>agent-loop.ts</code> 执行前校验。</p></div>
+    <div class="lang-en-only"><p>Cost: no Claude Desktop MCP marketplace. Payoff: TypeScript tool schemas; <code>validateToolArguments</code> before execution.</p></div>
+
+    <div class="lang-zh-only"><p>扩展路径：<code>examples/extensions/</code> 可添加 MCP；<code>plan-mode/</code> 示例展示 extension 实现产品功能。</p></div>
+    <div class="lang-en-only"><p>Extension path: <code>examples/extensions/</code> can add MCP; <code>plan-mode/</code> shows product features via extensions.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">为什么 No sub-agents</span><span class="lang-en-only">Why no sub-agents</span></h3>
+
+    <div class="lang-zh-only"><p>README 第 500 行：可用 tmux spawn 多个 pi 实例，或用 extension 自建，或安装第三方 pi package。</p></div>
+    <div class="lang-en-only"><p>README line 500: spawn pi via tmux, build with extensions, or install third-party pi packages.</p></div>
+
+    <div class="lang-zh-only"><p>Pi 的替代是 <strong>session fork</strong>（<code>SessionManager.fork</code>，<code>parentSession</code>）+ <strong>RPC 模式</strong>（<code>--mode rpc</code>）。嵌套层不隐藏——JSONL 树可 diff。</p></div>
+    <div class="lang-en-only"><p>Pi's alternative: <strong>session fork</strong> + <strong>RPC mode</strong>. Nesting visible in diffable JSONL tree.</p></div>
+
+    <div class="lang-zh-only"><p>主线 README 任务不需要子 agent：一次 read + 一次总结，单 agentLoop 足够。</p></div>
+    <div class="lang-en-only"><p>README through-line needs no sub-agent: one read + one summary suffices.</p></div>
+
+    <div class="lang-zh-only"><p><code>packages/client</code> 的 <code>acquireSession</code> exclusive lease 防止并发写同一会话。</p></div>
+    <div class="lang-en-only"><p><code>packages/client</code> <code>acquireSession</code> exclusive lease prevents concurrent session writes.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">为什么 No plan mode</span><span class="lang-en-only">Why no plan mode</span></h3>
+
+    <div class="lang-zh-only"><p>README 第 504 行：把计划写进文件、用 extension 实现、或安装 package。<code>examples/extensions/plan-mode/</code> 提供 <code>/plan</code> 与 <code>Ctrl+Alt+P</code>。</p></div>
+    <div class="lang-en-only"><p>README line 504: write plans to files, use extensions, or install packages. <code>plan-mode/</code> provides <code>/plan</code> and <code>Ctrl+Alt+P</code>.</p></div>
+
+    <div class="lang-zh-only"><p>Pi 的 thinking level（<code>ThinkingLevelSchema</code> in <code>protocol/schemas.ts</code>）是模型侧推理，不是 UI plan 模式。</p></div>
+    <div class="lang-en-only"><p>Pi's thinking level in <code>protocol/schemas.ts</code> is model-side reasoning, not UI plan mode.</p></div>
+
+    <div class="lang-zh-only"><p>对主线 prompt：模型可直接 toolUse read，无需先进入 plan 只读阶段。</p></div>
+    <div class="lang-en-only"><p>Through-line: model can toolUse read directly — no plan-only phase.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">故意不做 = 可观测性预算</span><span class="lang-en-only">Omissions = observability budget</span></h3>
+
+    <div class="lang-zh-only"><p>每省略一个产品功能，就少一层黑盒。Pi 用 <code>--verbose</code> 事件 + 开源 <code>agent-loop.ts</code> 补偿 IDE 集成缺失。</p></div>
+    <div class="lang-en-only"><p>Each omitted feature removes a black box. Pi compensates with <code>--verbose</code> events and open <code>agent-loop.ts</code>.</p></div>
+
+    <div class="lang-zh-only"><p>对比 Claude Code Plan 模式：用户看不见 plan 状态机；Pi plan-mode extension 仍走 <code>ExtensionRunner</code> 事件。</p></div>
+    <div class="lang-en-only"><p>vs Claude Code Plan: users cannot see state machine; Pi plan-mode extension still emits via <code>ExtensionRunner</code>.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">主线 prompt 在「故意不做」语境下</span><span class="lang-en-only">Through-line under omissions</span></h3>
+
+    <div class="lang-zh-only"><p>主线只需 read + summarize——恰好是 Pi 默认 tool 集的最小闭环。</p></div>
+    <div class="lang-en-only"><p>Through-line needs only read + summarize — Pi default tool set minimal loop.</p></div>
+
+    <div class="lang-zh-only"><p>若 fork Pi 加 MCP：改动 <code>ExtensionRunner</code> + tool registry，不必 fork <code>agent-loop.ts</code>。</p></div>
+    <div class="lang-en-only"><p>Forking to add MCP: change <code>ExtensionRunner</code> + tool registry, not <code>agent-loop.ts</code>.</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/README.md</span>
+        <span class="src-tag">readme</span>
+      </div>
+      <span class="src-line"><span class="src-line"><span class="src-str">**No MCP.**</span> Build CLI tools with READMEs ...</span></span>
+      <span class="src-line"><span class="src-line"><span class="src-str">**No sub-agents.**</span> Spawn pi instances via tmux ...</span></span>
+      <span class="src-line"><span class="src-line"><span class="src-str">**No plan mode.**</span> Write plans to files ...</span></span>
     </div>
+
+    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+      <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
+      <tbody>
+      <tr><td>cp 12</td><td>Resources + Extensions</td><td><code>resources-extensions</code></td><td><code>packages/coding-agent/src/core/extensions/ · resource-loader.ts</code></td></tr>
+      <tr><td>cp 13</td><td>Composition Root</td><td><code>composition-root</code></td><td><code>packages/coding-agent/src/core/agent-session.ts · sdk.ts</code></td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">Pi 永远不会有 MCP 吗？</span><span class="lang-en-only">Will Pi never have MCP?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>核心不做一等协议；社区 extension 可加。</p></div><div class="lang-en-only"><p>Not first-class in core; community extensions can add it.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">session fork 和 sub-agent 有何不同？</span><span class="lang-en-only">fork vs sub-agent?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>fork 显式 JSONL 树 + parentSession。</p></div><div class="lang-en-only"><p>fork has explicit JSONL tree + parentSession.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">plan-mode 示例在哪？</span><span class="lang-en-only">plan-mode example?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p><code>examples/extensions/plan-mode/</code>。</p></div><div class="lang-en-only"><p><code>examples/extensions/plan-mode/</code>.</p></div></div></details>
   </section>
 
   <section class="chap" id="c6">
@@ -2235,6 +2813,38 @@
     <h2 class="chap-title lang-en-only">CLI boot chain</h2>
     <p class="chap-en lang-zh-only">cli.ts → main.ts → createAgentSession</p>
     <p class="chap-en lang-en-only">cli.ts → main.ts → createAgentSession</p>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>CLI 启动 决定你如何理解 Pi 在此层的机制。</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>反直觉：<code>cli.ts</code> 的复杂度在事件契约而非算法。</span></p>
+      <p><span class="swc-pill act">优化</span><span>优化：--verbose + 源码对照，不猜测模型行为。</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>CLI 启动 shapes how you understand Pi at this layer.</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>Counter-intuitive: complexity in <code>cli.ts</code> is event contracts.</span></p>
+      <p><span class="swc-pill act">优化</span><span>Optimize: --verbose plus source, don't guess.</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">coding-agent</span><span class="lang-en-only">coding-agent</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">站 06</span><span class="lang-en-only">St. 06</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">cli.ts</span><span class="lang-en-only">cli.ts</span></div>
+      </div>
+    </div>
+
     <div class="lang-zh-only"><p>你在 shell 里输入 <code>pi</code> 或 <code>npx @earendil-works/coding-agent</code>，启动链从 <code>cli.ts</code> 解析 argv，到 <code>main.ts</code> 选择 interactive/print/rpc 模式，最终调用 <code>createAgentSession()</code>。</p></div>
     <div class="lang-en-only"><p>You type <code>pi</code> or <code>npx @earendil-works/coding-agent</code>; boot chain parses argv in <code>cli.ts</code>, <code>main.ts</code> picks interactive/print/rpc mode, then <code>createAgentSession()</code>.</p></div>
 
@@ -2314,20 +2924,91 @@
       <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 13</strong>: Composition Root (<code>composition-root</code>) · production: <code>packages/coding-agent/src/core/agent-session.ts · sdk.ts</code></span>
     </div>
 
-    <div class="note">
-      <span class="lang-zh-only">本章 (06) 在主线 prompt「cli.ts → main.ts → createAgentSession」路径上负责：<strong>CLI 启动链</strong>。回到 C02 的 22 站地图定位这一章。</span>
-      <span class="lang-en-only">Chapter (06) on the through-line path handles: <strong>CLI boot chain</strong>. Return to C02's 22-station map to locate this chapter.</span>
+    <h3 class="sub"><span class="lang-zh-only">CLI 启动：主线 prompt 如何穿过此模块</span><span class="lang-en-only">CLI 启动: through-line crossing</span></h3>
+
+    <div class="lang-zh-only"><p>用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/coding-agent/src/cli.ts</code> 定义了此阶段的类型契约与副作用边界。</p></div>
+    <div class="lang-en-only"><p>After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/coding-agent/src/cli.ts</code> defines type contracts and side-effect boundaries here.</p></div>
+
+    <div class="lang-zh-only"><p>在 pi-mono 仓库打开该文件，搜索 <code>export</code> 与 <code>AgentEvent</code>——这是比读 README 更快的定位法。</p></div>
+    <div class="lang-en-only"><p>In pi-mono, search <code>export</code> and <code>AgentEvent</code> — faster than README alone.</p></div>
+
+    <div class="lang-zh-only"><p>设计原则：核心循环（agent-loop）不 import TUI；本模块通过事件与回调与上游通信。</p></div>
+    <div class="lang-en-only"><p>Principle: agent-loop never imports TUI; this module talks upstream via events/callbacks.</p></div>
+
+    <div class="lang-zh-only"><p>pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。</p></div>
+    <div class="lang-en-only"><p>Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">CLI 启动：关键函数与数据流</span><span class="lang-en-only">CLI 启动: key functions and data flow</span></h3>
+
+    <div class="lang-zh-only"><p><code>cli.ts</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。</p></div>
+    <div class="lang-en-only"><p><code>async</code> functions in <code>cli.ts</code> are usually IO boundaries: disk, network, or subprocess.</p></div>
+
+    <div class="lang-zh-only"><p>成功路径与错误路径都必须 emit 事件，否则 TUI 会卡在 streaming 状态、JSONL 会缺 entry。</p></div>
+    <div class="lang-en-only"><p>Success and error paths must emit events or TUI stalls streaming and JSONL misses entries.</p></div>
+
+    <div class="lang-zh-only"><p>length 截断时 <code>agent-loop.ts</code> 的 <code>failToolCallsFromTruncatedMessage</code> 批量失败 tool calls，防止执行损坏参数。</p></div>
+    <div class="lang-en-only"><p>On length truncation, <code>failToolCallsFromTruncatedMessage</code> fails all tool calls to avoid corrupted args.</p></div>
+
+    <div class="lang-zh-only"><p>对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。</p></div>
+    <div class="lang-en-only"><p>Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">CLI 启动：与 agent-loop 的接口</span><span class="lang-en-only">CLI 启动: interface with agent-loop</span></h3>
+
+    <div class="lang-zh-only"><p><code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。</p></div>
+    <div class="lang-en-only"><p><code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc.</p></div>
+
+    <div class="lang-zh-only"><p><code>AgentSession</code> 在构造 config 时绑定本模块实现；换模式（print/rpc/interactive）不换 agent-loop。</p></div>
+    <div class="lang-en-only"><p><code>AgentSession</code> binds this module when building config; modes change, agent-loop does not.</p></div>
+
+    <div class="lang-zh-only"><p>fork 项目时优先替换本模块而非复制 agent-loop——这是 Pi 社区的实际 fork 模式。</p></div>
+    <div class="lang-en-only"><p>When forking, replace this module first rather than copying agent-loop — the common community pattern.</p></div>
+
+    <div class="lang-zh-only"><p>--verbose 模式下 stderr 事件类型可回溯到 <code>packages/coding-agent/src/cli.ts</code> 的具体行。</p></div>
+    <div class="lang-en-only"><p>Under --verbose, stderr event types trace to lines in <code>packages/coding-agent/src/cli.ts</code>.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">CLI 启动：设计权衡与常见坑</span><span class="lang-en-only">CLI 启动: trade-offs and pitfalls</span></h3>
+
+    <div class="lang-zh-only"><p>显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。</p></div>
+    <div class="lang-en-only"><p>Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union.</p></div>
+
+    <div class="lang-zh-only"><p>扩展应 subscribe 事件而非 monkey-patch 私有方法——<code>ExtensionRunner</code> 提供正规 hook 面。</p></div>
+    <div class="lang-en-only"><p>Extensions should subscribe to events, not monkey-patch privates — <code>ExtensionRunner</code> provides hooks.</p></div>
+
+    <div class="lang-zh-only"><p>JSONL <code>CURRENT_SESSION_VERSION = 3</code>：改 entry schema 必须 bump version 并提供迁移。</p></div>
+    <div class="lang-en-only"><p>JSONL <code>CURRENT_SESSION_VERSION = 3</code>: schema changes need version bump and migration.</p></div>
+
+    <div class="lang-zh-only"><p>对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。</p></div>
+    <div class="lang-en-only"><p>vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable.</p></div>
+
+    <div class="trace-box">
+      <div class="tb-tag">TRACE · station 06</div>
+      <div class="lang-zh-only"><p>站 06：<code>packages/coding-agent/src/cli.ts</code> 处理主线。</p></div>
+      <div class="lang-en-only"><p>Station 06: <code>packages/coding-agent/src/cli.ts</code> on through-line.</p></div>
     </div>
 
     <div class="src-stack">
       <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent · chapter 06</span>
-        <span class="src-tag">trace</span>
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/cli.ts</span>
+        <span class="src-tag">src</span>
       </div>
-      <span class="src-line"><span class="src-comment">// Through-line: cli.ts → main.ts → createAgentSession</span></span>
-      <span class="src-line"><span class="src-comment">// Phase: 入口 / Intake</span></span>
-      <span class="src-line"><span class="src-kw">await</span> <span class="src-fn">traceTurn</span>({ <span class="src-arg">prompt</span>: <span class="src-str">"README.md"</span> });</span>
+      <span class="src-line"><span class="src-line"><span class="src-comment">// CLI 启动 · packages/coding-agent/src/cli.ts</span></span></span>
+      <span class="src-line"><span class="src-line"><span class="src-comment">// through-line: README.md</span></span></span>
     </div>
+
+    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+      <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
+      <tbody>
+      <tr><td>cp 13</td><td>Composition Root</td><td><code>composition-root</code></td><td><code>packages/coding-agent/src/core/agent-session.ts · sdk.ts</code></td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">CLI 启动最关键文件？</span><span class="lang-en-only">Key file?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p><code>packages/coding-agent/src/cli.ts</code>。</p></div><div class="lang-en-only"><p><code>packages/coding-agent/src/cli.ts</code>.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">如何单测？</span><span class="lang-en-only">Unit test?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>mock StreamFn 或 ScriptedModel。</p></div><div class="lang-en-only"><p>mock StreamFn or ScriptedModel.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">与 textbook 差异？</span><span class="lang-en-only">vs textbook?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>生产含 OAuth/TUI/40+ providers。</p></div><div class="lang-en-only"><p>Production adds OAuth/TUI/40+ providers.</p></div></div></details>
   </section>
 
   <section class="chap" id="c7">
@@ -2336,6 +3017,38 @@
     <h2 class="chap-title lang-en-only">AgentSession orchestration</h2>
     <p class="chap-en lang-zh-only">唯一的中枢调度器</p>
     <p class="chap-en lang-en-only">the single orchestration hub</p>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>AgentSession 决定你如何理解 Pi 在此层的机制。</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>反直觉：<code>agent-session.ts</code> 的复杂度在事件契约而非算法。</span></p>
+      <p><span class="swc-pill act">优化</span><span>优化：--verbose + 源码对照，不猜测模型行为。</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>AgentSession shapes how you understand Pi at this layer.</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>Counter-intuitive: complexity in <code>agent-session.ts</code> is event contracts.</span></p>
+      <p><span class="swc-pill act">优化</span><span>Optimize: --verbose plus source, don't guess.</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">coding-agent</span><span class="lang-en-only">coding-agent</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">站 07</span><span class="lang-en-only">St. 07</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">agent-session.ts</span><span class="lang-en-only">agent-session.ts</span></div>
+      </div>
+    </div>
+
     <div class="lang-zh-only"><p><code>AgentSession</code> 是 Pi 的<strong>唯一中枢调度器</strong>——所有模式（interactive、print、rpc）共享它。主线 prompt 通过 <code>prompt()</code> 进入，内部调用 <code>agentLoop()</code> 并订阅事件写 JSONL。</p></div>
     <div class="lang-en-only"><p><code>AgentSession</code> is Pi's <strong>single orchestration hub</strong> — all modes share it. Through-line prompt enters via <code>prompt()</code>, internally calls <code>agentLoop()</code> and subscribes to events for JSONL persistence.</p></div>
 
@@ -2395,31 +3108,6 @@
       <span class="lang-en-only">Textbook checkpoint 09 covers steer/follow-up/abort — production code in AgentSession + agent-loop getSteeringMessages / queueFollowUp.</span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">prompt() 内部</span><span class="lang-en-only">Inside prompt()</span></h3>
-
-    <div class="lang-zh-only"><p>创建 UserMessage → 调用 agentLoop → for-await 事件 → SessionManager.append → ExtensionRunner 广播。</p></div>
-    <div class="lang-en-only"><p>Create UserMessage → call agentLoop → for-await events → SessionManager.append → ExtensionRunner broadcast.</p></div>
-
-    <h3 class="sub"><span class="lang-zh-only">错误恢复</span><span class="lang-en-only">Error recovery</span></h3>
-
-    <div class="lang-zh-only"><p>isRetryableAssistantError 触发重试；isContextOverflow 触发 compact 或分支摘要。</p></div>
-    <div class="lang-en-only"><p>isRetryableAssistantError triggers retry; isContextOverflow triggers compact or branch summary.</p></div>
-
-    <div class="note">
-      <span class="lang-zh-only">本章 (07) 在主线 prompt「唯一的中枢调度器」路径上负责：<strong>AgentSession 编排</strong>。回到 C02 的 22 站地图定位这一章。</span>
-      <span class="lang-en-only">Chapter (07) on the through-line path handles: <strong>AgentSession orchestration</strong>. Return to C02's 22-station map to locate this chapter.</span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent · chapter 07</span>
-        <span class="src-tag">trace</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// Through-line: 唯一的中枢调度器</span></span>
-      <span class="src-line"><span class="src-comment">// Phase: 入口 / Intake</span></span>
-      <span class="src-line"><span class="src-kw">await</span> <span class="src-fn">traceTurn</span>({ <span class="src-arg">prompt</span>: <span class="src-str">"README.md"</span> });</span>
-    </div>
-
     <div class="src-stack">
       <div class="src-h">
         <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/agent-session.ts</span>
@@ -2442,6 +3130,93 @@
       <tr><td>cp 13</td><td>Composition Root</td><td><code>composition-root</code></td><td><code>packages/coding-agent/src/core/agent-session.ts · sdk.ts</code></td></tr>
       </tbody>
     </table>
+
+    <h3 class="sub"><span class="lang-zh-only">AgentSession：主线 prompt 如何穿过此模块</span><span class="lang-en-only">AgentSession: through-line crossing</span></h3>
+
+    <div class="lang-zh-only"><p>用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/coding-agent/src/core/agent-session.ts</code> 定义了此阶段的类型契约与副作用边界。</p></div>
+    <div class="lang-en-only"><p>After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/coding-agent/src/core/agent-session.ts</code> defines type contracts and side-effect boundaries here.</p></div>
+
+    <div class="lang-zh-only"><p>在 pi-mono 仓库打开该文件，搜索 <code>export</code> 与 <code>AgentEvent</code>——这是比读 README 更快的定位法。</p></div>
+    <div class="lang-en-only"><p>In pi-mono, search <code>export</code> and <code>AgentEvent</code> — faster than README alone.</p></div>
+
+    <div class="lang-zh-only"><p>设计原则：核心循环（agent-loop）不 import TUI；本模块通过事件与回调与上游通信。</p></div>
+    <div class="lang-en-only"><p>Principle: agent-loop never imports TUI; this module talks upstream via events/callbacks.</p></div>
+
+    <div class="lang-zh-only"><p>pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。</p></div>
+    <div class="lang-en-only"><p>Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">AgentSession：关键函数与数据流</span><span class="lang-en-only">AgentSession: key functions and data flow</span></h3>
+
+    <div class="lang-zh-only"><p><code>agent-session.ts</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。</p></div>
+    <div class="lang-en-only"><p><code>async</code> functions in <code>agent-session.ts</code> are usually IO boundaries: disk, network, or subprocess.</p></div>
+
+    <div class="lang-zh-only"><p>成功路径与错误路径都必须 emit 事件，否则 TUI 会卡在 streaming 状态、JSONL 会缺 entry。</p></div>
+    <div class="lang-en-only"><p>Success and error paths must emit events or TUI stalls streaming and JSONL misses entries.</p></div>
+
+    <div class="lang-zh-only"><p>length 截断时 <code>agent-loop.ts</code> 的 <code>failToolCallsFromTruncatedMessage</code> 批量失败 tool calls，防止执行损坏参数。</p></div>
+    <div class="lang-en-only"><p>On length truncation, <code>failToolCallsFromTruncatedMessage</code> fails all tool calls to avoid corrupted args.</p></div>
+
+    <div class="lang-zh-only"><p>对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。</p></div>
+    <div class="lang-en-only"><p>Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">AgentSession：与 agent-loop 的接口</span><span class="lang-en-only">AgentSession: interface with agent-loop</span></h3>
+
+    <div class="lang-zh-only"><p><code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。</p></div>
+    <div class="lang-en-only"><p><code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc.</p></div>
+
+    <div class="lang-zh-only"><p><code>AgentSession</code> 在构造 config 时绑定本模块实现；换模式（print/rpc/interactive）不换 agent-loop。</p></div>
+    <div class="lang-en-only"><p><code>AgentSession</code> binds this module when building config; modes change, agent-loop does not.</p></div>
+
+    <div class="lang-zh-only"><p>fork 项目时优先替换本模块而非复制 agent-loop——这是 Pi 社区的实际 fork 模式。</p></div>
+    <div class="lang-en-only"><p>When forking, replace this module first rather than copying agent-loop — the common community pattern.</p></div>
+
+    <div class="lang-zh-only"><p>--verbose 模式下 stderr 事件类型可回溯到 <code>packages/coding-agent/src/core/agent-session.ts</code> 的具体行。</p></div>
+    <div class="lang-en-only"><p>Under --verbose, stderr event types trace to lines in <code>packages/coding-agent/src/core/agent-session.ts</code>.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">AgentSession：设计权衡与常见坑</span><span class="lang-en-only">AgentSession: trade-offs and pitfalls</span></h3>
+
+    <div class="lang-zh-only"><p>显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。</p></div>
+    <div class="lang-en-only"><p>Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union.</p></div>
+
+    <div class="lang-zh-only"><p>扩展应 subscribe 事件而非 monkey-patch 私有方法——<code>ExtensionRunner</code> 提供正规 hook 面。</p></div>
+    <div class="lang-en-only"><p>Extensions should subscribe to events, not monkey-patch privates — <code>ExtensionRunner</code> provides hooks.</p></div>
+
+    <div class="lang-zh-only"><p>JSONL <code>CURRENT_SESSION_VERSION = 3</code>：改 entry schema 必须 bump version 并提供迁移。</p></div>
+    <div class="lang-en-only"><p>JSONL <code>CURRENT_SESSION_VERSION = 3</code>: schema changes need version bump and migration.</p></div>
+
+    <div class="lang-zh-only"><p>对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。</p></div>
+    <div class="lang-en-only"><p>vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable.</p></div>
+
+    <div class="trace-box">
+      <div class="tb-tag">TRACE · station 07</div>
+      <div class="lang-zh-only"><p>站 07：<code>packages/coding-agent/src/core/agent-session.ts</code> 处理主线。</p></div>
+      <div class="lang-en-only"><p>Station 07: <code>packages/coding-agent/src/core/agent-session.ts</code> on through-line.</p></div>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/agent-session.ts</span>
+        <span class="src-tag">src</span>
+      </div>
+      <span class="src-line"><span class="src-line"><span class="src-comment">// AgentSession · packages/coding-agent/src/core/agent-session.ts</span></span></span>
+      <span class="src-line"><span class="src-line"><span class="src-comment">// through-line: README.md</span></span></span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+      <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
+      <tbody>
+      <tr><td>cp 09</td><td>Stateful Agent</td><td><code>stateful-agent</code></td><td><code>packages/agent/src/agent.ts</code></td></tr>
+      <tr><td>cp 13</td><td>Composition Root</td><td><code>composition-root</code></td><td><code>packages/coding-agent/src/core/agent-session.ts · sdk.ts</code></td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">AgentSession最关键文件？</span><span class="lang-en-only">Key file?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p><code>packages/coding-agent/src/core/agent-session.ts</code>。</p></div><div class="lang-en-only"><p><code>packages/coding-agent/src/core/agent-session.ts</code>.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">如何单测？</span><span class="lang-en-only">Unit test?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>mock StreamFn 或 ScriptedModel。</p></div><div class="lang-en-only"><p>mock StreamFn or ScriptedModel.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">与 textbook 差异？</span><span class="lang-en-only">vs textbook?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>生产含 OAuth/TUI/40+ providers。</p></div><div class="lang-en-only"><p>Production adds OAuth/TUI/40+ providers.</p></div></div></details>
   </section>
 
   <section class="chap" id="c8">
@@ -2450,6 +3225,38 @@
     <h2 class="chap-title lang-en-only">The AGENTS.md context stack</h2>
     <p class="chap-en lang-zh-only">从 ~/.pi 到项目根的指令叠加</p>
     <p class="chap-en lang-en-only">instructions stacked from ~/.pi to project root</p>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>AGENTS.md 栈 决定你如何理解 Pi 在此层的机制。</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>反直觉：<code>resource-loader.ts</code> 的复杂度在事件契约而非算法。</span></p>
+      <p><span class="swc-pill act">优化</span><span>优化：--verbose + 源码对照，不猜测模型行为。</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>AGENTS.md 栈 shapes how you understand Pi at this layer.</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>Counter-intuitive: complexity in <code>resource-loader.ts</code> is event contracts.</span></p>
+      <p><span class="swc-pill act">优化</span><span>Optimize: --verbose plus source, don't guess.</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">coding-agent</span><span class="lang-en-only">coding-agent</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">站 08</span><span class="lang-en-only">St. 08</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">resource-loader.ts</span><span class="lang-en-only">resource-loader.ts</span></div>
+      </div>
+    </div>
+
     <div class="lang-zh-only"><p>在主线 prompt 到达模型之前，<code>ResourceLoader</code> 把从 <code>~/.pi/AGENTS.md</code> 到项目根目录的指令文件<strong>叠加</strong>进 system context。每一层目录的 AGENTS.md 追加规则。</p></div>
     <div class="lang-en-only"><p>Before the through-line prompt reaches the model, <code>ResourceLoader</code> <strong>stacks</strong> instruction files from <code>~/.pi/AGENTS.md</code> to project root into system context.</p></div>
 
@@ -2520,10 +3327,91 @@
       <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 12</strong>: Resources + Extensions (<code>resources-extensions</code>) · production: <code>packages/coding-agent/src/core/extensions/ · resource-loader.ts</code></span>
     </div>
 
-    <div class="note">
-      <span class="lang-zh-only">本章 (08) 在主线 prompt「从 ~/.pi 到项目根的指令叠加」路径上负责：<strong>AGENTS.md 上下文栈</strong>。回到 C02 的 22 站地图定位这一章。</span>
-      <span class="lang-en-only">Chapter (08) on the through-line path handles: <strong>The AGENTS.md context stack</strong>. Return to C02's 22-station map to locate this chapter.</span>
+    <h3 class="sub"><span class="lang-zh-only">AGENTS.md 栈：主线 prompt 如何穿过此模块</span><span class="lang-en-only">AGENTS.md 栈: through-line crossing</span></h3>
+
+    <div class="lang-zh-only"><p>用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/coding-agent/src/core/resource-loader.ts</code> 定义了此阶段的类型契约与副作用边界。</p></div>
+    <div class="lang-en-only"><p>After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/coding-agent/src/core/resource-loader.ts</code> defines type contracts and side-effect boundaries here.</p></div>
+
+    <div class="lang-zh-only"><p>在 pi-mono 仓库打开该文件，搜索 <code>export</code> 与 <code>AgentEvent</code>——这是比读 README 更快的定位法。</p></div>
+    <div class="lang-en-only"><p>In pi-mono, search <code>export</code> and <code>AgentEvent</code> — faster than README alone.</p></div>
+
+    <div class="lang-zh-only"><p>设计原则：核心循环（agent-loop）不 import TUI；本模块通过事件与回调与上游通信。</p></div>
+    <div class="lang-en-only"><p>Principle: agent-loop never imports TUI; this module talks upstream via events/callbacks.</p></div>
+
+    <div class="lang-zh-only"><p>pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。</p></div>
+    <div class="lang-en-only"><p>Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">AGENTS.md 栈：关键函数与数据流</span><span class="lang-en-only">AGENTS.md 栈: key functions and data flow</span></h3>
+
+    <div class="lang-zh-only"><p><code>resource-loader.ts</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。</p></div>
+    <div class="lang-en-only"><p><code>async</code> functions in <code>resource-loader.ts</code> are usually IO boundaries: disk, network, or subprocess.</p></div>
+
+    <div class="lang-zh-only"><p>成功路径与错误路径都必须 emit 事件，否则 TUI 会卡在 streaming 状态、JSONL 会缺 entry。</p></div>
+    <div class="lang-en-only"><p>Success and error paths must emit events or TUI stalls streaming and JSONL misses entries.</p></div>
+
+    <div class="lang-zh-only"><p>length 截断时 <code>agent-loop.ts</code> 的 <code>failToolCallsFromTruncatedMessage</code> 批量失败 tool calls，防止执行损坏参数。</p></div>
+    <div class="lang-en-only"><p>On length truncation, <code>failToolCallsFromTruncatedMessage</code> fails all tool calls to avoid corrupted args.</p></div>
+
+    <div class="lang-zh-only"><p>对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。</p></div>
+    <div class="lang-en-only"><p>Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">AGENTS.md 栈：与 agent-loop 的接口</span><span class="lang-en-only">AGENTS.md 栈: interface with agent-loop</span></h3>
+
+    <div class="lang-zh-only"><p><code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。</p></div>
+    <div class="lang-en-only"><p><code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc.</p></div>
+
+    <div class="lang-zh-only"><p><code>AgentSession</code> 在构造 config 时绑定本模块实现；换模式（print/rpc/interactive）不换 agent-loop。</p></div>
+    <div class="lang-en-only"><p><code>AgentSession</code> binds this module when building config; modes change, agent-loop does not.</p></div>
+
+    <div class="lang-zh-only"><p>fork 项目时优先替换本模块而非复制 agent-loop——这是 Pi 社区的实际 fork 模式。</p></div>
+    <div class="lang-en-only"><p>When forking, replace this module first rather than copying agent-loop — the common community pattern.</p></div>
+
+    <div class="lang-zh-only"><p>--verbose 模式下 stderr 事件类型可回溯到 <code>packages/coding-agent/src/core/resource-loader.ts</code> 的具体行。</p></div>
+    <div class="lang-en-only"><p>Under --verbose, stderr event types trace to lines in <code>packages/coding-agent/src/core/resource-loader.ts</code>.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">AGENTS.md 栈：设计权衡与常见坑</span><span class="lang-en-only">AGENTS.md 栈: trade-offs and pitfalls</span></h3>
+
+    <div class="lang-zh-only"><p>显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。</p></div>
+    <div class="lang-en-only"><p>Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union.</p></div>
+
+    <div class="lang-zh-only"><p>扩展应 subscribe 事件而非 monkey-patch 私有方法——<code>ExtensionRunner</code> 提供正规 hook 面。</p></div>
+    <div class="lang-en-only"><p>Extensions should subscribe to events, not monkey-patch privates — <code>ExtensionRunner</code> provides hooks.</p></div>
+
+    <div class="lang-zh-only"><p>JSONL <code>CURRENT_SESSION_VERSION = 3</code>：改 entry schema 必须 bump version 并提供迁移。</p></div>
+    <div class="lang-en-only"><p>JSONL <code>CURRENT_SESSION_VERSION = 3</code>: schema changes need version bump and migration.</p></div>
+
+    <div class="lang-zh-only"><p>对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。</p></div>
+    <div class="lang-en-only"><p>vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable.</p></div>
+
+    <div class="trace-box">
+      <div class="tb-tag">TRACE · station 08</div>
+      <div class="lang-zh-only"><p>站 08：<code>packages/coding-agent/src/core/resource-loader.ts</code> 处理主线。</p></div>
+      <div class="lang-en-only"><p>Station 08: <code>packages/coding-agent/src/core/resource-loader.ts</code> on through-line.</p></div>
     </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/resource-loader.ts</span>
+        <span class="src-tag">src</span>
+      </div>
+      <span class="src-line"><span class="src-line"><span class="src-comment">// AGENTS.md 栈 · packages/coding-agent/src/core/resource-loader.ts</span></span></span>
+      <span class="src-line"><span class="src-line"><span class="src-comment">// through-line: README.md</span></span></span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+      <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
+      <tbody>
+      <tr><td>cp 12</td><td>Resources + Extensions</td><td><code>resources-extensions</code></td><td><code>packages/coding-agent/src/core/extensions/ · resource-loader.ts</code></td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">AGENTS.md 栈最关键文件？</span><span class="lang-en-only">Key file?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p><code>packages/coding-agent/src/core/resource-loader.ts</code>。</p></div><div class="lang-en-only"><p><code>packages/coding-agent/src/core/resource-loader.ts</code>.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">如何单测？</span><span class="lang-en-only">Unit test?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>mock StreamFn 或 ScriptedModel。</p></div><div class="lang-en-only"><p>mock StreamFn or ScriptedModel.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">与 textbook 差异？</span><span class="lang-en-only">vs textbook?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>生产含 OAuth/TUI/40+ providers。</p></div><div class="lang-en-only"><p>Production adds OAuth/TUI/40+ providers.</p></div></div></details>
   </section>
 
   <section class="chap" id="c9">
@@ -2532,6 +3420,38 @@
     <h2 class="chap-title lang-en-only">Two-layer message model</h2>
     <p class="chap-en lang-zh-only">AgentMessage ≠ Message</p>
     <p class="chap-en lang-en-only">AgentMessage ≠ Message</p>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>消息模型 决定你如何理解 Pi 在此层的机制。</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>反直觉：<code>types.ts</code> 的复杂度在事件契约而非算法。</span></p>
+      <p><span class="swc-pill act">优化</span><span>优化：--verbose + 源码对照，不猜测模型行为。</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>消息模型 shapes how you understand Pi at this layer.</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>Counter-intuitive: complexity in <code>types.ts</code> is event contracts.</span></p>
+      <p><span class="swc-pill act">优化</span><span>Optimize: --verbose plus source, don't guess.</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">agent</span><span class="lang-en-only">agent</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">站 09</span><span class="lang-en-only">St. 09</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">types.ts</span><span class="lang-en-only">types.ts</span></div>
+      </div>
+    </div>
+
     <div class="lang-zh-only"><p>Pi 维护<strong>两层消息模型</strong>：<code>AgentMessage</code>（agent-core 内部，可含自定义 role）和 <code>Message</code>（pi-ai LLM API，严格 user/assistant/tool）。<code>convertToLlm</code> 是唯一转换点。</p></div>
     <div class="lang-en-only"><p>Pi maintains <strong>two message layers</strong>: <code>AgentMessage</code> (agent-core, custom roles) and <code>Message</code> (pi-ai LLM API, strict user/assistant/tool). <code>convertToLlm</code> is the sole conversion point.</p></div>
 
@@ -2614,10 +3534,91 @@
       <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 03</strong>: Message IR (<code>types.ts</code>) · production: <code>packages/agent/src/types.ts · packages/coding-agent/src/core/messages.ts</code></span>
     </div>
 
-    <div class="note">
-      <span class="lang-zh-only">本章 (09) 在主线 prompt「AgentMessage ≠ Message」路径上负责：<strong>两层消息模型</strong>。回到 C02 的 22 站地图定位这一章。</span>
-      <span class="lang-en-only">Chapter (09) on the through-line path handles: <strong>Two-layer message model</strong>. Return to C02's 22-station map to locate this chapter.</span>
+    <h3 class="sub"><span class="lang-zh-only">消息模型：主线 prompt 如何穿过此模块</span><span class="lang-en-only">消息模型: through-line crossing</span></h3>
+
+    <div class="lang-zh-only"><p>用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/agent/src/types.ts</code> 定义了此阶段的类型契约与副作用边界。</p></div>
+    <div class="lang-en-only"><p>After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/agent/src/types.ts</code> defines type contracts and side-effect boundaries here.</p></div>
+
+    <div class="lang-zh-only"><p>在 pi-mono 仓库打开该文件，搜索 <code>export</code> 与 <code>AgentEvent</code>——这是比读 README 更快的定位法。</p></div>
+    <div class="lang-en-only"><p>In pi-mono, search <code>export</code> and <code>AgentEvent</code> — faster than README alone.</p></div>
+
+    <div class="lang-zh-only"><p>设计原则：核心循环（agent-loop）不 import TUI；本模块通过事件与回调与上游通信。</p></div>
+    <div class="lang-en-only"><p>Principle: agent-loop never imports TUI; this module talks upstream via events/callbacks.</p></div>
+
+    <div class="lang-zh-only"><p>pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。</p></div>
+    <div class="lang-en-only"><p>Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">消息模型：关键函数与数据流</span><span class="lang-en-only">消息模型: key functions and data flow</span></h3>
+
+    <div class="lang-zh-only"><p><code>types.ts</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。</p></div>
+    <div class="lang-en-only"><p><code>async</code> functions in <code>types.ts</code> are usually IO boundaries: disk, network, or subprocess.</p></div>
+
+    <div class="lang-zh-only"><p>成功路径与错误路径都必须 emit 事件，否则 TUI 会卡在 streaming 状态、JSONL 会缺 entry。</p></div>
+    <div class="lang-en-only"><p>Success and error paths must emit events or TUI stalls streaming and JSONL misses entries.</p></div>
+
+    <div class="lang-zh-only"><p>length 截断时 <code>agent-loop.ts</code> 的 <code>failToolCallsFromTruncatedMessage</code> 批量失败 tool calls，防止执行损坏参数。</p></div>
+    <div class="lang-en-only"><p>On length truncation, <code>failToolCallsFromTruncatedMessage</code> fails all tool calls to avoid corrupted args.</p></div>
+
+    <div class="lang-zh-only"><p>对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。</p></div>
+    <div class="lang-en-only"><p>Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">消息模型：与 agent-loop 的接口</span><span class="lang-en-only">消息模型: interface with agent-loop</span></h3>
+
+    <div class="lang-zh-only"><p><code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。</p></div>
+    <div class="lang-en-only"><p><code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc.</p></div>
+
+    <div class="lang-zh-only"><p><code>AgentSession</code> 在构造 config 时绑定本模块实现；换模式（print/rpc/interactive）不换 agent-loop。</p></div>
+    <div class="lang-en-only"><p><code>AgentSession</code> binds this module when building config; modes change, agent-loop does not.</p></div>
+
+    <div class="lang-zh-only"><p>fork 项目时优先替换本模块而非复制 agent-loop——这是 Pi 社区的实际 fork 模式。</p></div>
+    <div class="lang-en-only"><p>When forking, replace this module first rather than copying agent-loop — the common community pattern.</p></div>
+
+    <div class="lang-zh-only"><p>--verbose 模式下 stderr 事件类型可回溯到 <code>packages/agent/src/types.ts</code> 的具体行。</p></div>
+    <div class="lang-en-only"><p>Under --verbose, stderr event types trace to lines in <code>packages/agent/src/types.ts</code>.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">消息模型：设计权衡与常见坑</span><span class="lang-en-only">消息模型: trade-offs and pitfalls</span></h3>
+
+    <div class="lang-zh-only"><p>显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。</p></div>
+    <div class="lang-en-only"><p>Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union.</p></div>
+
+    <div class="lang-zh-only"><p>扩展应 subscribe 事件而非 monkey-patch 私有方法——<code>ExtensionRunner</code> 提供正规 hook 面。</p></div>
+    <div class="lang-en-only"><p>Extensions should subscribe to events, not monkey-patch privates — <code>ExtensionRunner</code> provides hooks.</p></div>
+
+    <div class="lang-zh-only"><p>JSONL <code>CURRENT_SESSION_VERSION = 3</code>：改 entry schema 必须 bump version 并提供迁移。</p></div>
+    <div class="lang-en-only"><p>JSONL <code>CURRENT_SESSION_VERSION = 3</code>: schema changes need version bump and migration.</p></div>
+
+    <div class="lang-zh-only"><p>对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。</p></div>
+    <div class="lang-en-only"><p>vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable.</p></div>
+
+    <div class="trace-box">
+      <div class="tb-tag">TRACE · station 09</div>
+      <div class="lang-zh-only"><p>站 09：<code>packages/agent/src/types.ts</code> 处理主线。</p></div>
+      <div class="lang-en-only"><p>Station 09: <code>packages/agent/src/types.ts</code> on through-line.</p></div>
     </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/types.ts</span>
+        <span class="src-tag">src</span>
+      </div>
+      <span class="src-line"><span class="src-line"><span class="src-comment">// 消息模型 · packages/agent/src/types.ts</span></span></span>
+      <span class="src-line"><span class="src-line"><span class="src-comment">// through-line: README.md</span></span></span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+      <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
+      <tbody>
+      <tr><td>cp 03</td><td>Message IR</td><td><code>types.ts</code></td><td><code>packages/agent/src/types.ts · packages/coding-agent/src/core/messages.ts</code></td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">消息模型最关键文件？</span><span class="lang-en-only">Key file?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p><code>packages/agent/src/types.ts</code>。</p></div><div class="lang-en-only"><p><code>packages/agent/src/types.ts</code>.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">如何单测？</span><span class="lang-en-only">Unit test?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>mock StreamFn 或 ScriptedModel。</p></div><div class="lang-en-only"><p>mock StreamFn or ScriptedModel.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">与 textbook 差异？</span><span class="lang-en-only">vs textbook?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>生产含 OAuth/TUI/40+ providers。</p></div><div class="lang-en-only"><p>Production adds OAuth/TUI/40+ providers.</p></div></div></details>
   </section>
 
   <section class="chap" id="c10">
@@ -2626,6 +3627,38 @@
     <h2 class="chap-title lang-en-only">The runLoop twin loops</h2>
     <p class="chap-en lang-zh-only">outer follow-up · inner tool batch</p>
     <p class="chap-en lang-en-only">outer follow-up · inner tool batch</p>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>runLoop 双环 决定你如何理解 Pi 在此层的机制。</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>反直觉：<code>agent-loop.ts</code> 的复杂度在事件契约而非算法。</span></p>
+      <p><span class="swc-pill act">优化</span><span>优化：--verbose + 源码对照，不猜测模型行为。</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>runLoop 双环 shapes how you understand Pi at this layer.</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>Counter-intuitive: complexity in <code>agent-loop.ts</code> is event contracts.</span></p>
+      <p><span class="swc-pill act">优化</span><span>Optimize: --verbose plus source, don't guess.</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">agent</span><span class="lang-en-only">agent</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">站 10</span><span class="lang-en-only">St. 10</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">agent-loop.ts</span><span class="lang-en-only">agent-loop.ts</span></div>
+      </div>
+    </div>
+
     <div class="lang-zh-only"><p><code>runLoop</code> 是 agent 的心脏：<strong>外环</strong>处理 follow-up 队列（用户在你以为结束时又发了一条），<strong>内环</strong>处理 tool batch 和 steering 注入。</p></div>
     <div class="lang-en-only"><p><code>runLoop</code> is the agent heart: <strong>outer loop</strong> handles follow-up queue; <strong>inner loop</strong> handles tool batch and steering injection.</p></div>
 
@@ -2737,31 +3770,6 @@
       <cite>Field Note · 10</cite>
     </blockquote>
 
-    <h3 class="sub"><span class="lang-zh-only">streamAssistantResponse</span><span class="lang-en-only">streamAssistantResponse</span></h3>
-
-    <div class="lang-zh-only"><p>convertToLlm → streamFn → 累积 delta → 组装 AssistantMessage → emit message_end。</p></div>
-    <div class="lang-en-only"><p>convertToLlm → streamFn → accumulate deltas → assemble AssistantMessage → emit message_end.</p></div>
-
-    <h3 class="sub"><span class="lang-zh-only">stopReason 分支</span><span class="lang-en-only">stopReason branches</span></h3>
-
-    <div class="lang-zh-only"><p>toolUse 进内环；stop 可能退出；error/aborted 立即 agent_end。</p></div>
-    <div class="lang-en-only"><p>toolUse enters inner loop; stop may exit; error/aborted immediate agent_end.</p></div>
-
-    <div class="note">
-      <span class="lang-zh-only">本章 (10) 在主线 prompt「outer follow-up · inner tool batch」路径上负责：<strong>runLoop 双环</strong>。回到 C02 的 22 站地图定位这一章。</span>
-      <span class="lang-en-only">Chapter (10) on the through-line path handles: <strong>The runLoop twin loops</strong>. Return to C02's 22-station map to locate this chapter.</span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent · chapter 10</span>
-        <span class="src-tag">trace</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// Through-line: outer follow-up · inner tool batch</span></span>
-      <span class="src-line"><span class="src-comment">// Phase: 心脏 / Heart</span></span>
-      <span class="src-line"><span class="src-kw">await</span> <span class="src-fn">traceTurn</span>({ <span class="src-arg">prompt</span>: <span class="src-str">"README.md"</span> });</span>
-    </div>
-
     <div class="src-stack">
       <div class="src-h">
         <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
@@ -2783,6 +3791,92 @@
       <tr><td>cp 07</td><td>Agent Loop</td><td><code>agent-loop.ts</code></td><td><code>packages/agent/src/agent-loop.ts</code></td></tr>
       </tbody>
     </table>
+
+    <h3 class="sub"><span class="lang-zh-only">runLoop 双环：主线 prompt 如何穿过此模块</span><span class="lang-en-only">runLoop 双环: through-line crossing</span></h3>
+
+    <div class="lang-zh-only"><p>用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/agent/src/agent-loop.ts</code> 定义了此阶段的类型契约与副作用边界。</p></div>
+    <div class="lang-en-only"><p>After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/agent/src/agent-loop.ts</code> defines type contracts and side-effect boundaries here.</p></div>
+
+    <div class="lang-zh-only"><p>在 pi-mono 仓库打开该文件，搜索 <code>export</code> 与 <code>AgentEvent</code>——这是比读 README 更快的定位法。</p></div>
+    <div class="lang-en-only"><p>In pi-mono, search <code>export</code> and <code>AgentEvent</code> — faster than README alone.</p></div>
+
+    <div class="lang-zh-only"><p>设计原则：核心循环（agent-loop）不 import TUI；本模块通过事件与回调与上游通信。</p></div>
+    <div class="lang-en-only"><p>Principle: agent-loop never imports TUI; this module talks upstream via events/callbacks.</p></div>
+
+    <div class="lang-zh-only"><p>pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。</p></div>
+    <div class="lang-en-only"><p>Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">runLoop 双环：关键函数与数据流</span><span class="lang-en-only">runLoop 双环: key functions and data flow</span></h3>
+
+    <div class="lang-zh-only"><p><code>agent-loop.ts</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。</p></div>
+    <div class="lang-en-only"><p><code>async</code> functions in <code>agent-loop.ts</code> are usually IO boundaries: disk, network, or subprocess.</p></div>
+
+    <div class="lang-zh-only"><p>成功路径与错误路径都必须 emit 事件，否则 TUI 会卡在 streaming 状态、JSONL 会缺 entry。</p></div>
+    <div class="lang-en-only"><p>Success and error paths must emit events or TUI stalls streaming and JSONL misses entries.</p></div>
+
+    <div class="lang-zh-only"><p>length 截断时 <code>agent-loop.ts</code> 的 <code>failToolCallsFromTruncatedMessage</code> 批量失败 tool calls，防止执行损坏参数。</p></div>
+    <div class="lang-en-only"><p>On length truncation, <code>failToolCallsFromTruncatedMessage</code> fails all tool calls to avoid corrupted args.</p></div>
+
+    <div class="lang-zh-only"><p>对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。</p></div>
+    <div class="lang-en-only"><p>Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">runLoop 双环：与 agent-loop 的接口</span><span class="lang-en-only">runLoop 双环: interface with agent-loop</span></h3>
+
+    <div class="lang-zh-only"><p><code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。</p></div>
+    <div class="lang-en-only"><p><code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc.</p></div>
+
+    <div class="lang-zh-only"><p><code>AgentSession</code> 在构造 config 时绑定本模块实现；换模式（print/rpc/interactive）不换 agent-loop。</p></div>
+    <div class="lang-en-only"><p><code>AgentSession</code> binds this module when building config; modes change, agent-loop does not.</p></div>
+
+    <div class="lang-zh-only"><p>fork 项目时优先替换本模块而非复制 agent-loop——这是 Pi 社区的实际 fork 模式。</p></div>
+    <div class="lang-en-only"><p>When forking, replace this module first rather than copying agent-loop — the common community pattern.</p></div>
+
+    <div class="lang-zh-only"><p>--verbose 模式下 stderr 事件类型可回溯到 <code>packages/agent/src/agent-loop.ts</code> 的具体行。</p></div>
+    <div class="lang-en-only"><p>Under --verbose, stderr event types trace to lines in <code>packages/agent/src/agent-loop.ts</code>.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">runLoop 双环：设计权衡与常见坑</span><span class="lang-en-only">runLoop 双环: trade-offs and pitfalls</span></h3>
+
+    <div class="lang-zh-only"><p>显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。</p></div>
+    <div class="lang-en-only"><p>Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union.</p></div>
+
+    <div class="lang-zh-only"><p>扩展应 subscribe 事件而非 monkey-patch 私有方法——<code>ExtensionRunner</code> 提供正规 hook 面。</p></div>
+    <div class="lang-en-only"><p>Extensions should subscribe to events, not monkey-patch privates — <code>ExtensionRunner</code> provides hooks.</p></div>
+
+    <div class="lang-zh-only"><p>JSONL <code>CURRENT_SESSION_VERSION = 3</code>：改 entry schema 必须 bump version 并提供迁移。</p></div>
+    <div class="lang-en-only"><p>JSONL <code>CURRENT_SESSION_VERSION = 3</code>: schema changes need version bump and migration.</p></div>
+
+    <div class="lang-zh-only"><p>对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。</p></div>
+    <div class="lang-en-only"><p>vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable.</p></div>
+
+    <div class="trace-box">
+      <div class="tb-tag">TRACE · station 10</div>
+      <div class="lang-zh-only"><p>站 10：<code>packages/agent/src/agent-loop.ts</code> 处理主线。</p></div>
+      <div class="lang-en-only"><p>Station 10: <code>packages/agent/src/agent-loop.ts</code> on through-line.</p></div>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
+        <span class="src-tag">src</span>
+      </div>
+      <span class="src-line"><span class="src-line"><span class="src-kw">while</span> (true) { // outer follow-up</span></span>
+      <span class="src-line"><span class="src-line">  <span class="src-kw">while</span> (hasMoreToolCalls || pendingMessages.length) {</span></span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+      <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
+      <tbody>
+      <tr><td>cp 07</td><td>Agent Loop</td><td><code>agent-loop.ts</code></td><td><code>packages/agent/src/agent-loop.ts</code></td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">runLoop 双环最关键文件？</span><span class="lang-en-only">Key file?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p><code>packages/agent/src/agent-loop.ts</code>。</p></div><div class="lang-en-only"><p><code>packages/agent/src/agent-loop.ts</code>.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">如何单测？</span><span class="lang-en-only">Unit test?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>mock StreamFn 或 ScriptedModel。</p></div><div class="lang-en-only"><p>mock StreamFn or ScriptedModel.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">与 textbook 差异？</span><span class="lang-en-only">vs textbook?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>生产含 OAuth/TUI/40+ providers。</p></div><div class="lang-en-only"><p>Production adds OAuth/TUI/40+ providers.</p></div></div></details>
   </section>
 
   <section class="chap" id="c11">
@@ -2791,6 +3885,38 @@
     <h2 class="chap-title lang-en-only">Steering and follow-up</h2>
     <p class="chap-en lang-zh-only">运行中插队与结束后续</p>
     <p class="chap-en lang-en-only">mid-run injection and post-stop follow-up</p>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>Steering 在 tool 执行期间插队；Follow-up 在 agent 将停时续聊。</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>反直觉：两队列在 Agent 与 AgentSession 各有一份，由 config 桥接。</span></p>
+      <p><span class="swc-pill act">优化</span><span>优化：读 agent-loop.ts 259 行 getSteeringMessages 与 263 行 getFollowUpMessages。</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>Steering injects mid-run; follow-up continues after agent would stop.</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>Counter-intuitive: two queues in Agent and AgentSession, bridged via config.</span></p>
+      <p><span class="swc-pill act">优化</span><span>Optimize: read agent-loop.ts lines 259 and 263.</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">agent-core</span><span class="lang-en-only">agent-core</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">agent.ts + agent-loop.ts</span><span class="lang-en-only">agent.ts + agent-loop.ts</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">站 10–11</span><span class="lang-en-only">Stations 10–11</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">steeringQueue / followUpQueue</span><span class="lang-en-only">steeringQueue / followUpQueue</span></div>
+      </div>
+    </div>
+
     <div class="lang-zh-only"><p><strong>Steering</strong>：运行中用户插入新消息（内环下一轮前注入）。<strong>Follow-up</strong>：agent 即将停止时队列里的后续消息（外环重启）。</p></div>
     <div class="lang-en-only"><p><strong>Steering</strong>: user inserts mid-run (injected before next inner round). <strong>Follow-up</strong>: queued messages when agent would stop (outer loop restarts).</p></div>
 
@@ -2824,10 +3950,96 @@
       <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 09</strong>: Stateful Agent (<code>stateful-agent</code>) · production: <code>packages/agent/src/agent.ts</code></span>
     </div>
 
-    <div class="note">
-      <span class="lang-zh-only">本章 (11) 在主线 prompt「运行中插队与结束后续」路径上负责：<strong>Steering 与 Follow-up</strong>。回到 C02 的 22 站地图定位这一章。</span>
-      <span class="lang-en-only">Chapter (11) on the through-line path handles: <strong>Steering and follow-up</strong>. Return to C02's 22-station map to locate this chapter.</span>
+    <h3 class="sub"><span class="lang-zh-only">Steering：内环插队语义</span><span class="lang-en-only">Steering: inner-loop injection</span></h3>
+
+    <div class="lang-zh-only"><p>runLoop 内环每次迭代末尾调用 getSteeringMessages（agent-loop.ts 259 行）。返回的 AgentMessage[] 在下一次 streamAssistantResponse 之前 push 进 context。</p></div>
+    <div class="lang-en-only"><p>Inner loop calls getSteeringMessages (line 259). AgentMessage[] pushed before next streamAssistantResponse.</p></div>
+
+    <div class="lang-zh-only"><p>agent.ts 475–480 行：steeringQueue.drain()；skipInitialSteeringPoll 避免首轮重复 drain。</p></div>
+    <div class="lang-en-only"><p>agent.ts 475–480: steeringQueue.drain(); skipInitialSteeringPoll avoids double drain.</p></div>
+
+    <div class="lang-zh-only"><p>AgentSession 1545 行 getSteeringMessages() 暴露只读副本给 TUI。</p></div>
+    <div class="lang-en-only"><p>AgentSession line 1545 exposes read-only copy for TUI.</p></div>
+
+    <div class="lang-zh-only"><p>场景：read 执行中用户输入「先 ls」——steering 在 tool batch 完成后、下次 LLM 前注入。</p></div>
+    <div class="lang-en-only"><p>Scenario: while read runs, user types «ls first» — steering injects after tool batch.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">Follow-up：外环续聊语义</span><span class="lang-en-only">Follow-up: outer-loop continuation</span></h3>
+
+    <div class="lang-zh-only"><p>内环结束后外环检查 getFollowUpMessages（263 行）。非空则 pendingMessages 并 continue 外环。</p></div>
+    <div class="lang-en-only"><p>Outer loop checks getFollowUpMessages (line 263). Non-empty continues outer loop.</p></div>
+
+    <div class="lang-zh-only"><p>agent.ts 482 行 followUpQueue.drain()。AgentSession._queueFollowUp（1407 行）路由后续用户输入。</p></div>
+    <div class="lang-en-only"><p>agent.ts 482 followUpQueue.drain(); AgentSession._queueFollowUp routes post-turn input.</p></div>
+
+    <div class="lang-zh-only"><p>与 steering 区别：follow-up 在 agent would stop 时；steering 在 still running 时。</p></div>
+    <div class="lang-en-only"><p>vs steering: follow-up when would stop; steering while still running.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">AgentSession 与 Agent 的分工</span><span class="lang-en-only">AgentSession vs Agent</span></h3>
+
+    <div class="lang-zh-only"><p>AgentSession 维护 _steeringMessages / _followUpMessages；构造 AgentLoopConfig 时绑定 drain。</p></div>
+    <div class="lang-en-only"><p>AgentSession maintains queues; binds drain when building AgentLoopConfig.</p></div>
+
+    <div class="lang-zh-only"><p>Agent 类封装有状态队列，供 SDK 与测试使用。</p></div>
+    <div class="lang-en-only"><p>Agent class wraps stateful queues for SDK and tests.</p></div>
+
+    <div class="lang-zh-only"><p>interactive-mode.ts 4303 行合并队列状态渲染 footer。</p></div>
+    <div class="lang-en-only"><p>interactive-mode.ts line 4303 merges queue state in footer.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">QueueMode 与并发</span><span class="lang-en-only">QueueMode and concurrency</span></h3>
+
+    <div class="lang-zh-only"><p>types.ts 导出 QueueMode 控制排队策略。</p></div>
+    <div class="lang-en-only"><p>types.ts exports QueueMode for queue policy.</p></div>
+
+    <div class="lang-zh-only"><p>agent-session-concurrent.test.ts 验证 extension steer。</p></div>
+    <div class="lang-en-only"><p>concurrent test verifies extension steering.</p></div>
+
+    <div class="lang-zh-only"><p>abort：AgentSession.abort() 1561 行调用 agent.abort()。</p></div>
+    <div class="lang-en-only"><p>Abort: AgentSession.abort() line 1561 calls agent.abort().</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">主线 prompt 下的 steering/follow-up</span><span class="lang-en-only">On through-line</span></h3>
+
+    <div class="lang-zh-only"><p>默认 README 任务不触发 steering；测试 mock getSteeringMessages 观察内环注入。</p></div>
+    <div class="lang-en-only"><p>Default README task does not steer; mock getSteeringMessages to test injection.</p></div>
+
+    <div class="trace-box">
+      <div class="tb-tag">TRACE · station 10</div>
+      <div class="lang-zh-only"><p>站 10–11：getSteeringMessages / getFollowUpMessages 桥接 AgentSession 与 runLoop。</p></div>
+      <div class="lang-en-only"><p>Stations 10–11: steering/follow-up bridge AgentSession and runLoop.</p></div>
     </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
+        <span class="src-tag">loop</span>
+      </div>
+      <span class="src-line"><span class="src-line"><span class="src-arg">pendingMessages</span> = (<span class="src-kw">await</span> config.<span class="src-fn">getSteeringMessages</span>?.()) || [];</span></span>
+      <span class="src-line"><span class="src-line"><span class="src-kw">const</span> followUpMessages = (<span class="src-kw">await</span> config.<span class="src-fn">getFollowUpMessages</span>?.()) || [];</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent.ts</span>
+        <span class="src-tag">agent</span>
+      </div>
+      <span class="src-line"><span class="src-line"><span class="src-fn">getSteeringMessages</span>: <span class="src-kw">async</span> () => <span class="src-kw">this</span>.steeringQueue.<span class="src-fn">drain</span>(),</span></span>
+      <span class="src-line"><span class="src-line"><span class="src-fn">getFollowUpMessages</span>: <span class="src-kw">async</span> () => <span class="src-kw">this</span>.followUpQueue.<span class="src-fn">drain</span>(),</span></span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+      <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
+      <tbody>
+      <tr><td>cp 09</td><td>Stateful Agent</td><td><code>stateful-agent</code></td><td><code>packages/agent/src/agent.ts</code></td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">steering 和 follow-up 能否同时排队？</span><span class="lang-en-only">Both queue?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>可以；pendingMessageCount 1540 行返回两者之和。</p></div><div class="lang-en-only"><p>Yes; pendingMessageCount sums both.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">steering 会打断 bash 吗？</span><span class="lang-en-only">Interrupt bash?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>不立即；在当前 tool batch 完成后注入。</p></div><div class="lang-en-only"><p>Not immediately; after tool batch.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">extension 如何注入 steering？</span><span class="lang-en-only">Extension steer?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>通过 ExtensionActions queue 方法。</p></div><div class="lang-en-only"><p>Via ExtensionActions queue methods.</p></div></div></details>
   </section>
 
   <section class="chap" id="c12">
@@ -2836,6 +4048,38 @@
     <h2 class="chap-title lang-en-only">Tool execution pipeline</h2>
     <p class="chap-en lang-zh-only">parallel vs sequential · length 截断</p>
     <p class="chap-en lang-en-only">parallel vs sequential · length truncation</p>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>Tool 管线 决定你如何理解 Pi 在此层的机制。</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>反直觉：<code>read.ts</code> 的复杂度在事件契约而非算法。</span></p>
+      <p><span class="swc-pill act">优化</span><span>优化：--verbose + 源码对照，不猜测模型行为。</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>Tool 管线 shapes how you understand Pi at this layer.</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>Counter-intuitive: complexity in <code>read.ts</code> is event contracts.</span></p>
+      <p><span class="swc-pill act">优化</span><span>Optimize: --verbose plus source, don't guess.</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">coding-agent</span><span class="lang-en-only">coding-agent</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">站 12</span><span class="lang-en-only">St. 12</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">read.ts</span><span class="lang-en-only">read.ts</span></div>
+      </div>
+    </div>
+
     <div class="lang-zh-only"><p>模型返回 toolUse 后，<code>executeTools</code> 按 <code>parallel</code> 或 <code>sequential</code> 策略调度。read/write/edit/bash 各有 executor；结果超长时 <code>truncateToolResult</code> 截断。</p></div>
     <div class="lang-en-only"><p>After model returns toolUse, <code>executeTools</code> dispatches per <code>parallel</code> or <code>sequential</code> policy. read/write/edit/bash have executors; oversized results hit <code>truncateToolResult</code>.</p></div>
 
@@ -2915,20 +4159,92 @@
       <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 08</strong>: Coding Tools (<code>coding-tools</code>) · production: <code>packages/coding-agent/src/core/tools/index.ts</code></span>
     </div>
 
-    <div class="note">
-      <span class="lang-zh-only">本章 (12) 在主线 prompt「parallel vs sequential · length 截断」路径上负责：<strong>Tool 执行管线</strong>。回到 C02 的 22 站地图定位这一章。</span>
-      <span class="lang-en-only">Chapter (12) on the through-line path handles: <strong>Tool execution pipeline</strong>. Return to C02's 22-station map to locate this chapter.</span>
+    <h3 class="sub"><span class="lang-zh-only">Tool 管线：主线 prompt 如何穿过此模块</span><span class="lang-en-only">Tool 管线: through-line crossing</span></h3>
+
+    <div class="lang-zh-only"><p>用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/coding-agent/src/core/tools/read.ts</code> 定义了此阶段的类型契约与副作用边界。</p></div>
+    <div class="lang-en-only"><p>After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/coding-agent/src/core/tools/read.ts</code> defines type contracts and side-effect boundaries here.</p></div>
+
+    <div class="lang-zh-only"><p>在 pi-mono 仓库打开该文件，搜索 <code>export</code> 与 <code>AgentEvent</code>——这是比读 README 更快的定位法。</p></div>
+    <div class="lang-en-only"><p>In pi-mono, search <code>export</code> and <code>AgentEvent</code> — faster than README alone.</p></div>
+
+    <div class="lang-zh-only"><p>设计原则：核心循环（agent-loop）不 import TUI；本模块通过事件与回调与上游通信。</p></div>
+    <div class="lang-en-only"><p>Principle: agent-loop never imports TUI; this module talks upstream via events/callbacks.</p></div>
+
+    <div class="lang-zh-only"><p>pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。</p></div>
+    <div class="lang-en-only"><p>Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">Tool 管线：关键函数与数据流</span><span class="lang-en-only">Tool 管线: key functions and data flow</span></h3>
+
+    <div class="lang-zh-only"><p><code>read.ts</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。</p></div>
+    <div class="lang-en-only"><p><code>async</code> functions in <code>read.ts</code> are usually IO boundaries: disk, network, or subprocess.</p></div>
+
+    <div class="lang-zh-only"><p>成功路径与错误路径都必须 emit 事件，否则 TUI 会卡在 streaming 状态、JSONL 会缺 entry。</p></div>
+    <div class="lang-en-only"><p>Success and error paths must emit events or TUI stalls streaming and JSONL misses entries.</p></div>
+
+    <div class="lang-zh-only"><p>length 截断时 <code>agent-loop.ts</code> 的 <code>failToolCallsFromTruncatedMessage</code> 批量失败 tool calls，防止执行损坏参数。</p></div>
+    <div class="lang-en-only"><p>On length truncation, <code>failToolCallsFromTruncatedMessage</code> fails all tool calls to avoid corrupted args.</p></div>
+
+    <div class="lang-zh-only"><p>对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。</p></div>
+    <div class="lang-en-only"><p>Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">Tool 管线：与 agent-loop 的接口</span><span class="lang-en-only">Tool 管线: interface with agent-loop</span></h3>
+
+    <div class="lang-zh-only"><p><code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。</p></div>
+    <div class="lang-en-only"><p><code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc.</p></div>
+
+    <div class="lang-zh-only"><p><code>AgentSession</code> 在构造 config 时绑定本模块实现；换模式（print/rpc/interactive）不换 agent-loop。</p></div>
+    <div class="lang-en-only"><p><code>AgentSession</code> binds this module when building config; modes change, agent-loop does not.</p></div>
+
+    <div class="lang-zh-only"><p>fork 项目时优先替换本模块而非复制 agent-loop——这是 Pi 社区的实际 fork 模式。</p></div>
+    <div class="lang-en-only"><p>When forking, replace this module first rather than copying agent-loop — the common community pattern.</p></div>
+
+    <div class="lang-zh-only"><p>--verbose 模式下 stderr 事件类型可回溯到 <code>packages/coding-agent/src/core/tools/read.ts</code> 的具体行。</p></div>
+    <div class="lang-en-only"><p>Under --verbose, stderr event types trace to lines in <code>packages/coding-agent/src/core/tools/read.ts</code>.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">Tool 管线：设计权衡与常见坑</span><span class="lang-en-only">Tool 管线: trade-offs and pitfalls</span></h3>
+
+    <div class="lang-zh-only"><p>显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。</p></div>
+    <div class="lang-en-only"><p>Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union.</p></div>
+
+    <div class="lang-zh-only"><p>扩展应 subscribe 事件而非 monkey-patch 私有方法——<code>ExtensionRunner</code> 提供正规 hook 面。</p></div>
+    <div class="lang-en-only"><p>Extensions should subscribe to events, not monkey-patch privates — <code>ExtensionRunner</code> provides hooks.</p></div>
+
+    <div class="lang-zh-only"><p>JSONL <code>CURRENT_SESSION_VERSION = 3</code>：改 entry schema 必须 bump version 并提供迁移。</p></div>
+    <div class="lang-en-only"><p>JSONL <code>CURRENT_SESSION_VERSION = 3</code>: schema changes need version bump and migration.</p></div>
+
+    <div class="lang-zh-only"><p>对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。</p></div>
+    <div class="lang-en-only"><p>vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable.</p></div>
+
+    <div class="trace-box">
+      <div class="tb-tag">TRACE · station 12</div>
+      <div class="lang-zh-only"><p>站 12：<code>packages/coding-agent/src/core/tools/read.ts</code> 处理主线。</p></div>
+      <div class="lang-en-only"><p>Station 12: <code>packages/coding-agent/src/core/tools/read.ts</code> on through-line.</p></div>
     </div>
 
     <div class="src-stack">
       <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent · chapter 12</span>
-        <span class="src-tag">trace</span>
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/tools/read.ts</span>
+        <span class="src-tag">src</span>
       </div>
-      <span class="src-line"><span class="src-comment">// Through-line: parallel vs sequential · length 截断</span></span>
-      <span class="src-line"><span class="src-comment">// Phase: 心脏 / Heart</span></span>
-      <span class="src-line"><span class="src-kw">await</span> <span class="src-fn">traceTurn</span>({ <span class="src-arg">prompt</span>: <span class="src-str">"README.md"</span> });</span>
+      <span class="src-line"><span class="src-line"><span class="src-comment">// Tool 管线 · packages/coding-agent/src/core/tools/read.ts</span></span></span>
+      <span class="src-line"><span class="src-line"><span class="src-comment">// through-line: README.md</span></span></span>
     </div>
+
+    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+      <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
+      <tbody>
+      <tr><td>cp 06</td><td>Tool Contract</td><td><code>tool-contract</code></td><td><code>packages/agent/src/agent-loop.ts · packages/coding-agent/src/core/tools/</code></td></tr>
+      <tr><td>cp 08</td><td>Coding Tools</td><td><code>coding-tools</code></td><td><code>packages/coding-agent/src/core/tools/index.ts</code></td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">Tool 管线最关键文件？</span><span class="lang-en-only">Key file?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p><code>packages/coding-agent/src/core/tools/read.ts</code>。</p></div><div class="lang-en-only"><p><code>packages/coding-agent/src/core/tools/read.ts</code>.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">如何单测？</span><span class="lang-en-only">Unit test?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>mock StreamFn 或 ScriptedModel。</p></div><div class="lang-en-only"><p>mock StreamFn or ScriptedModel.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">与 textbook 差异？</span><span class="lang-en-only">vs textbook?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>生产含 OAuth/TUI/40+ providers。</p></div><div class="lang-en-only"><p>Production adds OAuth/TUI/40+ providers.</p></div></div></details>
   </section>
 
   <section class="chap" id="c13">
@@ -2937,6 +4253,38 @@
     <h2 class="chap-title lang-en-only">The event bus</h2>
     <p class="chap-en lang-zh-only">message_update 如何驱动 TUI</p>
     <p class="chap-en lang-en-only">how message_update drives the TUI</p>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>事件总线 决定你如何理解 Pi 在此层的机制。</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>反直觉：<code>agent-session.ts</code> 的复杂度在事件契约而非算法。</span></p>
+      <p><span class="swc-pill act">优化</span><span>优化：--verbose + 源码对照，不猜测模型行为。</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>事件总线 shapes how you understand Pi at this layer.</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>Counter-intuitive: complexity in <code>agent-session.ts</code> is event contracts.</span></p>
+      <p><span class="swc-pill act">优化</span><span>Optimize: --verbose plus source, don't guess.</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">coding-agent</span><span class="lang-en-only">coding-agent</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">站 13</span><span class="lang-en-only">St. 13</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">agent-session.ts</span><span class="lang-en-only">agent-session.ts</span></div>
+      </div>
+    </div>
+
     <div class="lang-zh-only"><p>agent-core 通过 <code>AgentEvent</code> tagged union 广播状态变化。<code>message_update</code> 携带 <code>text_delta</code> 或 <code>toolcall_delta</code>——TUI 差分渲染的唯一输入。</p></div>
     <div class="lang-en-only"><p>agent-core broadcasts state via <code>AgentEvent</code> tagged union. <code>message_update</code> carries <code>text_delta</code> or <code>toolcall_delta</code> — sole input for TUI differential render.</p></div>
 
@@ -2995,10 +4343,91 @@
       <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 02</strong>: EventStream (<code>event-stream.ts</code>) · production: <code>packages/ai/src/utils/event-stream.ts</code></span>
     </div>
 
-    <div class="note">
-      <span class="lang-zh-only">本章 (13) 在主线 prompt「message_update 如何驱动 TUI」路径上负责：<strong>事件总线</strong>。回到 C02 的 22 站地图定位这一章。</span>
-      <span class="lang-en-only">Chapter (13) on the through-line path handles: <strong>The event bus</strong>. Return to C02's 22-station map to locate this chapter.</span>
+    <h3 class="sub"><span class="lang-zh-only">事件总线：主线 prompt 如何穿过此模块</span><span class="lang-en-only">事件总线: through-line crossing</span></h3>
+
+    <div class="lang-zh-only"><p>用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/coding-agent/src/core/agent-session.ts</code> 定义了此阶段的类型契约与副作用边界。</p></div>
+    <div class="lang-en-only"><p>After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/coding-agent/src/core/agent-session.ts</code> defines type contracts and side-effect boundaries here.</p></div>
+
+    <div class="lang-zh-only"><p>在 pi-mono 仓库打开该文件，搜索 <code>export</code> 与 <code>AgentEvent</code>——这是比读 README 更快的定位法。</p></div>
+    <div class="lang-en-only"><p>In pi-mono, search <code>export</code> and <code>AgentEvent</code> — faster than README alone.</p></div>
+
+    <div class="lang-zh-only"><p>设计原则：核心循环（agent-loop）不 import TUI；本模块通过事件与回调与上游通信。</p></div>
+    <div class="lang-en-only"><p>Principle: agent-loop never imports TUI; this module talks upstream via events/callbacks.</p></div>
+
+    <div class="lang-zh-only"><p>pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。</p></div>
+    <div class="lang-en-only"><p>Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">事件总线：关键函数与数据流</span><span class="lang-en-only">事件总线: key functions and data flow</span></h3>
+
+    <div class="lang-zh-only"><p><code>agent-session.ts</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。</p></div>
+    <div class="lang-en-only"><p><code>async</code> functions in <code>agent-session.ts</code> are usually IO boundaries: disk, network, or subprocess.</p></div>
+
+    <div class="lang-zh-only"><p>成功路径与错误路径都必须 emit 事件，否则 TUI 会卡在 streaming 状态、JSONL 会缺 entry。</p></div>
+    <div class="lang-en-only"><p>Success and error paths must emit events or TUI stalls streaming and JSONL misses entries.</p></div>
+
+    <div class="lang-zh-only"><p>length 截断时 <code>agent-loop.ts</code> 的 <code>failToolCallsFromTruncatedMessage</code> 批量失败 tool calls，防止执行损坏参数。</p></div>
+    <div class="lang-en-only"><p>On length truncation, <code>failToolCallsFromTruncatedMessage</code> fails all tool calls to avoid corrupted args.</p></div>
+
+    <div class="lang-zh-only"><p>对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。</p></div>
+    <div class="lang-en-only"><p>Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">事件总线：与 agent-loop 的接口</span><span class="lang-en-only">事件总线: interface with agent-loop</span></h3>
+
+    <div class="lang-zh-only"><p><code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。</p></div>
+    <div class="lang-en-only"><p><code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc.</p></div>
+
+    <div class="lang-zh-only"><p><code>AgentSession</code> 在构造 config 时绑定本模块实现；换模式（print/rpc/interactive）不换 agent-loop。</p></div>
+    <div class="lang-en-only"><p><code>AgentSession</code> binds this module when building config; modes change, agent-loop does not.</p></div>
+
+    <div class="lang-zh-only"><p>fork 项目时优先替换本模块而非复制 agent-loop——这是 Pi 社区的实际 fork 模式。</p></div>
+    <div class="lang-en-only"><p>When forking, replace this module first rather than copying agent-loop — the common community pattern.</p></div>
+
+    <div class="lang-zh-only"><p>--verbose 模式下 stderr 事件类型可回溯到 <code>packages/coding-agent/src/core/agent-session.ts</code> 的具体行。</p></div>
+    <div class="lang-en-only"><p>Under --verbose, stderr event types trace to lines in <code>packages/coding-agent/src/core/agent-session.ts</code>.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">事件总线：设计权衡与常见坑</span><span class="lang-en-only">事件总线: trade-offs and pitfalls</span></h3>
+
+    <div class="lang-zh-only"><p>显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。</p></div>
+    <div class="lang-en-only"><p>Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union.</p></div>
+
+    <div class="lang-zh-only"><p>扩展应 subscribe 事件而非 monkey-patch 私有方法——<code>ExtensionRunner</code> 提供正规 hook 面。</p></div>
+    <div class="lang-en-only"><p>Extensions should subscribe to events, not monkey-patch privates — <code>ExtensionRunner</code> provides hooks.</p></div>
+
+    <div class="lang-zh-only"><p>JSONL <code>CURRENT_SESSION_VERSION = 3</code>：改 entry schema 必须 bump version 并提供迁移。</p></div>
+    <div class="lang-en-only"><p>JSONL <code>CURRENT_SESSION_VERSION = 3</code>: schema changes need version bump and migration.</p></div>
+
+    <div class="lang-zh-only"><p>对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。</p></div>
+    <div class="lang-en-only"><p>vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable.</p></div>
+
+    <div class="trace-box">
+      <div class="tb-tag">TRACE · station 13</div>
+      <div class="lang-zh-only"><p>站 13：<code>packages/coding-agent/src/core/agent-session.ts</code> 处理主线。</p></div>
+      <div class="lang-en-only"><p>Station 13: <code>packages/coding-agent/src/core/agent-session.ts</code> on through-line.</p></div>
     </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/agent-session.ts</span>
+        <span class="src-tag">src</span>
+      </div>
+      <span class="src-line"><span class="src-line"><span class="src-comment">// 事件总线 · packages/coding-agent/src/core/agent-session.ts</span></span></span>
+      <span class="src-line"><span class="src-line"><span class="src-comment">// through-line: README.md</span></span></span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+      <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
+      <tbody>
+      <tr><td>cp 09</td><td>Stateful Agent</td><td><code>stateful-agent</code></td><td><code>packages/agent/src/agent.ts</code></td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">事件总线最关键文件？</span><span class="lang-en-only">Key file?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p><code>packages/coding-agent/src/core/agent-session.ts</code>。</p></div><div class="lang-en-only"><p><code>packages/coding-agent/src/core/agent-session.ts</code>.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">如何单测？</span><span class="lang-en-only">Unit test?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>mock StreamFn 或 ScriptedModel。</p></div><div class="lang-en-only"><p>mock StreamFn or ScriptedModel.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">与 textbook 差异？</span><span class="lang-en-only">vs textbook?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>生产含 OAuth/TUI/40+ providers。</p></div><div class="lang-en-only"><p>Production adds OAuth/TUI/40+ providers.</p></div></div></details>
   </section>
 
   <section class="chap" id="c14">
@@ -3007,6 +4436,38 @@
     <h2 class="chap-title lang-en-only">pi-ai provider abstraction</h2>
     <p class="chap-en lang-zh-only">Models · createProvider · streamSimple</p>
     <p class="chap-en lang-en-only">Models · createProvider · streamSimple</p>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>pi-ai 提供商 决定你如何理解 Pi 在此层的机制。</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>反直觉：<code>models.ts</code> 的复杂度在事件契约而非算法。</span></p>
+      <p><span class="swc-pill act">优化</span><span>优化：--verbose + 源码对照，不猜测模型行为。</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>pi-ai 提供商 shapes how you understand Pi at this layer.</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>Counter-intuitive: complexity in <code>models.ts</code> is event contracts.</span></p>
+      <p><span class="swc-pill act">优化</span><span>Optimize: --verbose plus source, don't guess.</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">ai</span><span class="lang-en-only">ai</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">站 14</span><span class="lang-en-only">St. 14</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">models.ts</span><span class="lang-en-only">models.ts</span></div>
+      </div>
+    </div>
+
     <div class="lang-zh-only"><p><code>pi-ai</code> 抽象 40+ provider：<code>Models</code> 目录 · <code>createProvider</code> 工厂 · <code>streamSimple</code> 统一流式入口。agent-loop 只依赖 <code>StreamFn</code> 签名。</p></div>
     <div class="lang-en-only"><p><code>pi-ai</code> abstracts 40+ providers: <code>Models</code> catalog · <code>createProvider</code> factory · <code>streamSimple</code> unified streaming entry. agent-loop depends only on <code>StreamFn</code> signature.</p></div>
 
@@ -3040,20 +4501,91 @@
       <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 05</strong>: Provider Adapter (<code>provider-adapter.ts</code>) · production: <code>packages/ai/src/api/*.ts · packages/ai/src/models.ts</code></span>
     </div>
 
-    <div class="note">
-      <span class="lang-zh-only">本章 (14) 在主线 prompt「Models · createProvider · streamSimple」路径上负责：<strong>pi-ai 提供商抽象</strong>。回到 C02 的 22 站地图定位这一章。</span>
-      <span class="lang-en-only">Chapter (14) on the through-line path handles: <strong>pi-ai provider abstraction</strong>. Return to C02's 22-station map to locate this chapter.</span>
+    <h3 class="sub"><span class="lang-zh-only">pi-ai 提供商：主线 prompt 如何穿过此模块</span><span class="lang-en-only">pi-ai 提供商: through-line crossing</span></h3>
+
+    <div class="lang-zh-only"><p>用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/ai/src/models.ts</code> 定义了此阶段的类型契约与副作用边界。</p></div>
+    <div class="lang-en-only"><p>After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/ai/src/models.ts</code> defines type contracts and side-effect boundaries here.</p></div>
+
+    <div class="lang-zh-only"><p>在 pi-mono 仓库打开该文件，搜索 <code>export</code> 与 <code>AgentEvent</code>——这是比读 README 更快的定位法。</p></div>
+    <div class="lang-en-only"><p>In pi-mono, search <code>export</code> and <code>AgentEvent</code> — faster than README alone.</p></div>
+
+    <div class="lang-zh-only"><p>设计原则：核心循环（agent-loop）不 import TUI；本模块通过事件与回调与上游通信。</p></div>
+    <div class="lang-en-only"><p>Principle: agent-loop never imports TUI; this module talks upstream via events/callbacks.</p></div>
+
+    <div class="lang-zh-only"><p>pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。</p></div>
+    <div class="lang-en-only"><p>Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">pi-ai 提供商：关键函数与数据流</span><span class="lang-en-only">pi-ai 提供商: key functions and data flow</span></h3>
+
+    <div class="lang-zh-only"><p><code>models.ts</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。</p></div>
+    <div class="lang-en-only"><p><code>async</code> functions in <code>models.ts</code> are usually IO boundaries: disk, network, or subprocess.</p></div>
+
+    <div class="lang-zh-only"><p>成功路径与错误路径都必须 emit 事件，否则 TUI 会卡在 streaming 状态、JSONL 会缺 entry。</p></div>
+    <div class="lang-en-only"><p>Success and error paths must emit events or TUI stalls streaming and JSONL misses entries.</p></div>
+
+    <div class="lang-zh-only"><p>length 截断时 <code>agent-loop.ts</code> 的 <code>failToolCallsFromTruncatedMessage</code> 批量失败 tool calls，防止执行损坏参数。</p></div>
+    <div class="lang-en-only"><p>On length truncation, <code>failToolCallsFromTruncatedMessage</code> fails all tool calls to avoid corrupted args.</p></div>
+
+    <div class="lang-zh-only"><p>对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。</p></div>
+    <div class="lang-en-only"><p>Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">pi-ai 提供商：与 agent-loop 的接口</span><span class="lang-en-only">pi-ai 提供商: interface with agent-loop</span></h3>
+
+    <div class="lang-zh-only"><p><code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。</p></div>
+    <div class="lang-en-only"><p><code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc.</p></div>
+
+    <div class="lang-zh-only"><p><code>AgentSession</code> 在构造 config 时绑定本模块实现；换模式（print/rpc/interactive）不换 agent-loop。</p></div>
+    <div class="lang-en-only"><p><code>AgentSession</code> binds this module when building config; modes change, agent-loop does not.</p></div>
+
+    <div class="lang-zh-only"><p>fork 项目时优先替换本模块而非复制 agent-loop——这是 Pi 社区的实际 fork 模式。</p></div>
+    <div class="lang-en-only"><p>When forking, replace this module first rather than copying agent-loop — the common community pattern.</p></div>
+
+    <div class="lang-zh-only"><p>--verbose 模式下 stderr 事件类型可回溯到 <code>packages/ai/src/models.ts</code> 的具体行。</p></div>
+    <div class="lang-en-only"><p>Under --verbose, stderr event types trace to lines in <code>packages/ai/src/models.ts</code>.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">pi-ai 提供商：设计权衡与常见坑</span><span class="lang-en-only">pi-ai 提供商: trade-offs and pitfalls</span></h3>
+
+    <div class="lang-zh-only"><p>显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。</p></div>
+    <div class="lang-en-only"><p>Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union.</p></div>
+
+    <div class="lang-zh-only"><p>扩展应 subscribe 事件而非 monkey-patch 私有方法——<code>ExtensionRunner</code> 提供正规 hook 面。</p></div>
+    <div class="lang-en-only"><p>Extensions should subscribe to events, not monkey-patch privates — <code>ExtensionRunner</code> provides hooks.</p></div>
+
+    <div class="lang-zh-only"><p>JSONL <code>CURRENT_SESSION_VERSION = 3</code>：改 entry schema 必须 bump version 并提供迁移。</p></div>
+    <div class="lang-en-only"><p>JSONL <code>CURRENT_SESSION_VERSION = 3</code>: schema changes need version bump and migration.</p></div>
+
+    <div class="lang-zh-only"><p>对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。</p></div>
+    <div class="lang-en-only"><p>vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable.</p></div>
+
+    <div class="trace-box">
+      <div class="tb-tag">TRACE · station 14</div>
+      <div class="lang-zh-only"><p>站 14：<code>packages/ai/src/models.ts</code> 处理主线。</p></div>
+      <div class="lang-en-only"><p>Station 14: <code>packages/ai/src/models.ts</code> on through-line.</p></div>
     </div>
 
     <div class="src-stack">
       <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent · chapter 14</span>
-        <span class="src-tag">trace</span>
+        <span>SOURCE &nbsp;·&nbsp; packages/ai/src/models.ts</span>
+        <span class="src-tag">src</span>
       </div>
-      <span class="src-line"><span class="src-comment">// Through-line: Models · createProvider · streamSimple</span></span>
-      <span class="src-line"><span class="src-comment">// Phase: LLM / LLM</span></span>
-      <span class="src-line"><span class="src-kw">await</span> <span class="src-fn">traceTurn</span>({ <span class="src-arg">prompt</span>: <span class="src-str">"README.md"</span> });</span>
+      <span class="src-line"><span class="src-line"><span class="src-comment">// pi-ai 提供商 · packages/ai/src/models.ts</span></span></span>
+      <span class="src-line"><span class="src-line"><span class="src-comment">// through-line: README.md</span></span></span>
     </div>
+
+    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+      <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
+      <tbody>
+      <tr><td>cp 05</td><td>Provider Adapter</td><td><code>provider-adapter.ts</code></td><td><code>packages/ai/src/api/*.ts · packages/ai/src/models.ts</code></td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">pi-ai 提供商最关键文件？</span><span class="lang-en-only">Key file?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p><code>packages/ai/src/models.ts</code>。</p></div><div class="lang-en-only"><p><code>packages/ai/src/models.ts</code>.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">如何单测？</span><span class="lang-en-only">Unit test?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>mock StreamFn 或 ScriptedModel。</p></div><div class="lang-en-only"><p>mock StreamFn or ScriptedModel.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">与 textbook 差异？</span><span class="lang-en-only">vs textbook?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>生产含 OAuth/TUI/40+ providers。</p></div><div class="lang-en-only"><p>Production adds OAuth/TUI/40+ providers.</p></div></div></details>
   </section>
 
   <section class="chap" id="c15">
@@ -3062,6 +4594,38 @@
     <h2 class="chap-title lang-en-only">Streaming EventStream</h2>
     <p class="chap-en lang-zh-only">text_delta · toolcall_delta · done</p>
     <p class="chap-en lang-en-only">text_delta · toolcall_delta · done</p>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>EventStream 是 pi-ai 与 agent-loop 之间的异步泵——token 与终态同流交付。</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>反直觉：Agent 层 EventStream 与 LLM 层 AssistantMessageEventStream 是两套 isComplete 谓词。</span></p>
+      <p><span class="swc-pill act">优化</span><span>优化：读 event-stream.ts push/end 与 agent-loop createAgentStream 的对称设计。</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>EventStream is the async pump between pi-ai and agent-loop — tokens and terminal state in one stream.</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>Counter-intuitive: Agent EventStream vs LLM AssistantMessageEventStream use different isComplete predicates.</span></p>
+      <p><span class="swc-pill act">优化</span><span>Optimize: read symmetric design of event-stream.ts push/end and createAgentStream.</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">pi-ai</span><span class="lang-en-only">pi-ai</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">event-stream.ts</span><span class="lang-en-only">event-stream.ts</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">站 15</span><span class="lang-en-only">St. 15</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">text_delta → done</span><span class="lang-en-only">text_delta → done</span></div>
+      </div>
+    </div>
+
     <div class="lang-zh-only"><p><code>EventStream&lt;T&gt;</code> 同时交付<strong>过程项</strong>（delta）和<strong>终态</strong>（done）。TUI 订阅过程项；agent-loop 等待终态 AssistantMessage。</p></div>
     <div class="lang-en-only"><p><code>EventStream&lt;T&gt;</code> delivers both <strong>progress items</strong> (deltas) and <strong>terminal state</strong> (done). TUI subscribes to progress; agent-loop awaits terminal AssistantMessage.</p></div>
 
@@ -3090,10 +4654,88 @@
       <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 02</strong>: EventStream (<code>event-stream.ts</code>) · production: <code>packages/ai/src/utils/event-stream.ts</code></span>
     </div>
 
-    <div class="note">
-      <span class="lang-zh-only">本章 (15) 在主线 prompt「text_delta · toolcall_delta · done」路径上负责：<strong>流式 EventStream</strong>。回到 C02 的 22 站地图定位这一章。</span>
-      <span class="lang-en-only">Chapter (15) on the through-line path handles: <strong>Streaming EventStream</strong>. Return to C02's 22-station map to locate this chapter.</span>
+    <h3 class="sub"><span class="lang-zh-only">EventStream 核心语义</span><span class="lang-en-only">EventStream core semantics</span></h3>
+
+    <div class="lang-zh-only"><p>packages/ai/src/utils/event-stream.ts：泛型 EventStream<T,R>，构造时传入 isComplete 与 extractResult。</p></div>
+    <div class="lang-en-only"><p>packages/ai/src/utils/event-stream.ts: generic EventStream<T,R> with isComplete and extractResult at construction.</p></div>
+
+    <div class="lang-zh-only"><p>push(event)：若 isComplete(event) 为真，设 done=true 并 resolveFinalResult；否则入队或交给 waiting consumer。</p></div>
+    <div class="lang-en-only"><p>push(event): if isComplete, set done and resolveFinalResult; else queue or deliver to waiting consumer.</p></div>
+
+    <div class="lang-zh-only"><p>AsyncIterable 协议：消费者 for-await 时，队列空且未 done 则挂起在 waiting 数组。</p></div>
+    <div class="lang-en-only"><p>AsyncIterable: for-await suspends on waiting array when queue empty and not done.</p></div>
+
+    <div class="lang-zh-only"><p>AssistantMessageEventStream 子类：isComplete 当 type===done 或 error；extractResult 返回 message 或抛错。</p></div>
+    <div class="lang-en-only"><p>AssistantMessageEventStream: isComplete on done/error; extractResult returns message or throws.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">主线 prompt 上的流事件类型</span><span class="lang-en-only">Stream events on through-line</span></h3>
+
+    <div class="lang-zh-only"><p>第一次 stream（toolUse）：text_delta 可能为空或极短；toolcall_delta 累积 read 参数；done 时 stopReason=toolUse。</p></div>
+    <div class="lang-en-only"><p>First stream (toolUse): short text_delta; toolcall_delta accumulates read args; done with stopReason=toolUse.</p></div>
+
+    <div class="lang-zh-only"><p>第二次 stream（stop）：text_delta 逐 chunk 推送最终总结；done 时 stopReason=stop。</p></div>
+    <div class="lang-en-only"><p>Second stream (stop): text_delta chunks for summary; done with stopReason=stop.</p></div>
+
+    <div class="lang-zh-only"><p>streamAssistantResponse 把 LLM EventStream 事件映射为 AgentEvent message_update。</p></div>
+    <div class="lang-en-only"><p>streamAssistantResponse maps LLM EventStream events to AgentEvent message_update.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">agent-loop 侧的 EventStream</span><span class="lang-en-only">Agent-side EventStream</span></h3>
+
+    <div class="lang-zh-only"><p>createAgentStream（agent-loop.ts 145 行）：isComplete 当 type===agent_end；extractResult 返回 messages 数组。</p></div>
+    <div class="lang-en-only"><p>createAgentStream (line 145): isComplete on agent_end; extractResult returns messages array.</p></div>
+
+    <div class="lang-zh-only"><p>agentLoop 返回 EventStream<AgentEvent, AgentMessage[]>；AgentSession for-await 消费并写 JSONL。</p></div>
+    <div class="lang-en-only"><p>agentLoop returns EventStream<AgentEvent, AgentMessage[]>; AgentSession for-await consumes and writes JSONL.</p></div>
+
+    <div class="lang-zh-only"><p>end(result) 手动 resolve——用于 abort 或错误路径提前结束。</p></div>
+    <div class="lang-en-only"><p>end(result) manually resolves — for abort or error early termination.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">背压与 TUI 消费</span><span class="lang-en-only">Backpressure and TUI consumption</span></h3>
+
+    <div class="lang-zh-only"><p>EventStream 无界队列：高速 token 时 TUI diff 渲染可能落后；TuiMainScreen firstChanged/lastChanged 优化重绘区间。</p></div>
+    <div class="lang-en-only"><p>Unbounded queue: TUI diff may lag on fast tokens; TuiMainScreen firstChanged/lastChanged optimizes redraw.</p></div>
+
+    <div class="lang-zh-only"><p>message_update 携带 partial content；message_end 携带完整 AssistantMessage。</p></div>
+    <div class="lang-en-only"><p>message_update carries partial content; message_end carries full AssistantMessage.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">与 textbook checkpoint 02 对照</span><span class="lang-en-only">vs textbook checkpoint 02</span></h3>
+
+    <div class="lang-zh-only"><p>textbook event-stream.ts 教学「过程项与终态同时交付」——生产代码在 streamSimple 与 agentLoop 两层复用同一模式。</p></div>
+    <div class="lang-en-only"><p>Textbook checkpoint 02 teaches simultaneous partial and terminal delivery — production reuses pattern in streamSimple and agentLoop.</p></div>
+
+    <div class="lang-zh-only"><p>测试：用 ScriptedModel 注入固定 delta 序列，断言 message_update 次数与顺序。</p></div>
+    <div class="lang-en-only"><p>Test: ScriptedModel injects fixed delta sequence; assert message_update count and order.</p></div>
+
+    <div class="trace-box">
+      <div class="tb-tag">TRACE · station 15</div>
+      <div class="lang-zh-only"><p>站 15：EventStream push text_delta/toolcall_delta；done 触发 stopReason 分支。</p></div>
+      <div class="lang-en-only"><p>Station 15: EventStream pushes deltas; done triggers stopReason branch.</p></div>
     </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/ai/src/utils/event-stream.ts</span>
+        <span class="src-tag">es</span>
+      </div>
+      <span class="src-line"><span class="src-line"><span class="src-kw">export class</span> <span class="src-cls">EventStream</span>&lt;T, R = T&gt;</span></span>
+      <span class="src-line"><span class="src-line"><span class="src-fn">push</span>(event: T): <span class="src-cls">void</span> {</span></span>
+      <span class="src-line"><span class="src-line">  <span class="src-kw">if</span> (<span class="src-kw">this</span>.isComplete(event)) { <span class="src-kw">this</span>.done = <span class="src-num">true</span>; ... }</span></span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+      <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
+      <tbody>
+      <tr><td>cp 02</td><td>EventStream</td><td><code>event-stream.ts</code></td><td><code>packages/ai/src/utils/event-stream.ts</code></td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">EventStream 会丢事件吗？</span><span class="lang-en-only">Drop events?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>push 在 done 后忽略；正常路径不丢。</p></div><div class="lang-en-only"><p>push ignores after done; normal path does not drop.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">agent_end 与 done 区别？</span><span class="lang-en-only">agent_end vs done?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>agent_end 是 AgentEvent；done 是 LLM AssistantMessageEvent。</p></div><div class="lang-en-only"><p>agent_end is AgentEvent; done is LLM AssistantMessageEvent.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">如何 mock 流？</span><span class="lang-en-only">Mock stream?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>ScriptedModel 或自定义 StreamFn 返回预置 EventStream。</p></div><div class="lang-en-only"><p>ScriptedModel or custom StreamFn returning preset EventStream.</p></div></div></details>
   </section>
 
   <section class="chap" id="c16">
@@ -3102,6 +4744,38 @@
     <h2 class="chap-title lang-en-only">Auth and model catalog</h2>
     <p class="chap-en lang-zh-only">40+ providers · OAuth · models.generated.ts</p>
     <p class="chap-en lang-en-only">40+ providers · OAuth · models.generated.ts</p>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>models.generated.ts 聚合 40+ provider 的模型目录——OAuth 与 API key 分流。</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>反直觉：模型列表是构建时生成，不是运行时爬取。</span></p>
+      <p><span class="swc-pill act">优化</span><span>优化：ModelRegistry + auth-guidance.ts 处理「无 key」时的用户引导。</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>models.generated.ts aggregates 40+ provider catalogs — OAuth vs API key paths.</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>Counter-intuitive: model list is build-time generated, not runtime scraped.</span></p>
+      <p><span class="swc-pill act">优化</span><span>Optimize: ModelRegistry + auth-guidance.ts for no-key user guidance.</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">pi-ai</span><span class="lang-en-only">pi-ai</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">models.generated.ts</span><span class="lang-en-only">models.generated.ts</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">站 16</span><span class="lang-en-only">St. 16</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">Model + AuthResult</span><span class="lang-en-only">Model + AuthResult</span></div>
+      </div>
+    </div>
+
     <div class="lang-zh-only"><p><code>models.generated.ts</code> 由脚本从模型目录生成；OAuth 流程把 token 存 agent dir。无 key 时 <code>formatNoApiKeyFoundMessage</code> 给可操作的引导。</p></div>
     <div class="lang-en-only"><p><code>models.generated.ts</code> is script-generated from model catalog; OAuth stores tokens in agent dir. Without keys, <code>formatNoApiKeyFoundMessage</code> gives actionable guidance.</p></div>
 
@@ -3128,10 +4802,81 @@
       </div>
     </div>
 
-    <div class="note">
-      <span class="lang-zh-only">本章 (16) 在主线 prompt「40+ providers · OAuth · models.generated.ts」路径上负责：<strong>认证与模型目录</strong>。回到 C02 的 22 站地图定位这一章。</span>
-      <span class="lang-en-only">Chapter (16) on the through-line path handles: <strong>Auth and model catalog</strong>. Return to C02's 22-station map to locate this chapter.</span>
+    <h3 class="sub"><span class="lang-zh-only">模型目录生成管线</span><span class="lang-en-only">Model catalog pipeline</span></h3>
+
+    <div class="lang-zh-only"><p>packages/ai/src/models.generated.ts 头部注释：auto-generated by scripts/generate-models.ts，勿手改。</p></div>
+    <div class="lang-en-only"><p>models.generated.ts header: auto-generated by generate-models.ts, do not edit manually.</p></div>
+
+    <div class="lang-zh-only"><p>导入 AMAZON_BEDROCK_MODELS、ANTHROPIC_MODELS、OPENAI_MODELS 等 40+ provider 常量，汇总为 MODELS 对象。</p></div>
+    <div class="lang-en-only"><p>Imports 40+ provider constants into MODELS object.</p></div>
+
+    <div class="lang-zh-only"><p>每个 Model 含 id、provider、contextWindow、maxTokens、cost、reasoning 支持等字段。</p></div>
+    <div class="lang-en-only"><p>Each Model has id, provider, contextWindow, maxTokens, cost, reasoning support.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">认证路径</span><span class="lang-en-only">Auth paths</span></h3>
+
+    <div class="lang-zh-only"><p>packages/ai/src/oauth.ts 与 bun-oauth.ts 处理交互式 OAuth（GitHub Copilot、OpenAI Codex 等）。</p></div>
+    <div class="lang-en-only"><p>oauth.ts and bun-oauth.ts handle interactive OAuth for Copilot, Codex, etc.</p></div>
+
+    <div class="lang-zh-only"><p>env-api-keys.ts 从环境变量读取 ANTHROPIC_API_KEY 等；getApiKey 注入 agentLoop config。</p></div>
+    <div class="lang-en-only"><p>env-api-keys.ts reads env vars; getApiKey injected into agentLoop config.</p></div>
+
+    <div class="lang-zh-only"><p>agent-session.ts formatNoApiKeyFoundMessage 在冷启动无 key 时给出 auth-guidance。</p></div>
+    <div class="lang-en-only"><p>formatNoApiKeyFoundMessage gives auth-guidance on cold start without key.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">主线 prompt 的模型选择</span><span class="lang-en-only">Model selection for through-line</span></h3>
+
+    <div class="lang-zh-only"><p>CLI --model provider/id 或交互式 /model 选择；model_change entry 写入 JSONL。</p></div>
+    <div class="lang-en-only"><p>CLI --model provider/id or /model picker; model_change entry in JSONL.</p></div>
+
+    <div class="lang-zh-only"><p>第一次 stream 用选定 Model 调 streamSimple；thinkingLevel 映射到 reasoning 参数。</p></div>
+    <div class="lang-en-only"><p>First stream uses selected Model via streamSimple; thinkingLevel maps to reasoning.</p></div>
+
+    <div class="lang-zh-only"><p>换模型不丢会话：SessionManager 保留历史，新 model_change entry 标记切换点。</p></div>
+    <div class="lang-en-only"><p>Model switch preserves session: model_change entry marks switch point.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">ModelRegistry 运行时</span><span class="lang-en-only">ModelRegistry runtime</span></h3>
+
+    <div class="lang-zh-only"><p>coding-agent ModelRegistry 读取 generated  catalog，合并用户 settings 与 extension 贡献的 provider config。</p></div>
+    <div class="lang-en-only"><p>ModelRegistry reads generated catalog, merges user settings and extension provider configs.</p></div>
+
+    <div class="lang-zh-only"><p>modelsAreEqual 用于避免重复 emit model_select 事件。</p></div>
+    <div class="lang-en-only"><p>modelsAreEqual avoids duplicate model_select events.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">与 textbook checkpoint 05 对照</span><span class="lang-en-only">vs textbook checkpoint 05</span></h3>
+
+    <div class="lang-zh-only"><p>textbook Provider Adapter 教 SSE→统一事件；生产 pi-ai api/*.ts 实现各厂商 adapter。</p></div>
+    <div class="lang-en-only"><p>Textbook checkpoint 05 teaches SSE→unified events; production api/*.ts implements per-vendor adapters.</p></div>
+
+    <div class="trace-box">
+      <div class="tb-tag">TRACE · station 16</div>
+      <div class="lang-zh-only"><p>站 16：streamSimple 用 Model + Auth 调 provider adapter。</p></div>
+      <div class="lang-en-only"><p>Station 16: streamSimple calls provider adapter with Model + Auth.</p></div>
     </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/ai/src/models.generated.ts</span>
+        <span class="src-tag">models</span>
+      </div>
+      <span class="src-line"><span class="src-line"><span class="src-comment">// auto-generated by scripts/generate-models.ts</span></span></span>
+      <span class="src-line"><span class="src-line"><span class="src-kw">export const</span> <span class="src-arg">MODELS</span> = { ... <span class="src-num">40</span>+ providers ... };</span></span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+      <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
+      <tbody>
+      <tr><td>cp 05</td><td>Provider Adapter</td><td><code>provider-adapter.ts</code></td><td><code>packages/ai/src/api/*.ts · packages/ai/src/models.ts</code></td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">如何添加新 provider？</span><span class="lang-en-only">Add provider?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>在 pi-ai providers/ 加 models 文件并跑 generate-models。</p></div><div class="lang-en-only"><p>Add models file under providers/ and run generate-models.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">OAuth 失败怎么办？</span><span class="lang-en-only">OAuth fails?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>检查 bun-oauth 回调与 ~/.pi 凭据存储。</p></div><div class="lang-en-only"><p>Check bun-oauth callback and ~/.pi credential storage.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">默认模型在哪设？</span><span class="lang-en-only">Default model?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>settings.json 与 CLI --model。</p></div><div class="lang-en-only"><p>settings.json and CLI --model.</p></div></div></details>
   </section>
 
   <section class="chap" id="c17">
@@ -3140,6 +4885,38 @@
     <h2 class="chap-title lang-en-only">Differential-render TUI</h2>
     <p class="chap-en lang-zh-only">CSI 2026 · firstChanged → lastChanged</p>
     <p class="chap-en lang-en-only">CSI 2026 · firstChanged → lastChanged</p>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>差分 TUI 决定你如何理解 Pi 在此层的机制。</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>反直觉：<code>tui-main-screen.ts</code> 的复杂度在事件契约而非算法。</span></p>
+      <p><span class="swc-pill act">优化</span><span>优化：--verbose + 源码对照，不猜测模型行为。</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>差分 TUI shapes how you understand Pi at this layer.</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>Counter-intuitive: complexity in <code>tui-main-screen.ts</code> is event contracts.</span></p>
+      <p><span class="swc-pill act">优化</span><span>Optimize: --verbose plus source, don't guess.</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">tui</span><span class="lang-en-only">tui</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">站 17</span><span class="lang-en-only">St. 17</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">tui-main-screen.ts</span><span class="lang-en-only">tui-main-screen.ts</span></div>
+      </div>
+    </div>
+
     <div class="lang-zh-only"><p>Pi TUI 用 <strong>CSI 2026</strong> 差分更新：<code>firstChanged</code> 到 <code>lastChanged</code> 行重绘，而非全屏刷新。流式 token 因此不闪烁。</p></div>
     <div class="lang-en-only"><p>Pi TUI uses <strong>CSI 2026</strong> differential updates: redraw <code>firstChanged</code> to <code>lastChanged</code> lines, not full screen. Streaming tokens don't flicker.</p></div>
 
@@ -3198,10 +4975,84 @@
       </figcaption>
     </figure>
 
-    <div class="note">
-      <span class="lang-zh-only">本章 (17) 在主线 prompt「CSI 2026 · firstChanged → lastChanged」路径上负责：<strong>差分渲染 TUI</strong>。回到 C02 的 22 站地图定位这一章。</span>
-      <span class="lang-en-only">Chapter (17) on the through-line path handles: <strong>Differential-render TUI</strong>. Return to C02's 22-station map to locate this chapter.</span>
+    <h3 class="sub"><span class="lang-zh-only">差分 TUI：主线 prompt 如何穿过此模块</span><span class="lang-en-only">差分 TUI: through-line crossing</span></h3>
+
+    <div class="lang-zh-only"><p>用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/tui/src/tui-main-screen.ts</code> 定义了此阶段的类型契约与副作用边界。</p></div>
+    <div class="lang-en-only"><p>After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/tui/src/tui-main-screen.ts</code> defines type contracts and side-effect boundaries here.</p></div>
+
+    <div class="lang-zh-only"><p>在 pi-mono 仓库打开该文件，搜索 <code>export</code> 与 <code>AgentEvent</code>——这是比读 README 更快的定位法。</p></div>
+    <div class="lang-en-only"><p>In pi-mono, search <code>export</code> and <code>AgentEvent</code> — faster than README alone.</p></div>
+
+    <div class="lang-zh-only"><p>设计原则：核心循环（agent-loop）不 import TUI；本模块通过事件与回调与上游通信。</p></div>
+    <div class="lang-en-only"><p>Principle: agent-loop never imports TUI; this module talks upstream via events/callbacks.</p></div>
+
+    <div class="lang-zh-only"><p>pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。</p></div>
+    <div class="lang-en-only"><p>Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">差分 TUI：关键函数与数据流</span><span class="lang-en-only">差分 TUI: key functions and data flow</span></h3>
+
+    <div class="lang-zh-only"><p><code>tui-main-screen.ts</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。</p></div>
+    <div class="lang-en-only"><p><code>async</code> functions in <code>tui-main-screen.ts</code> are usually IO boundaries: disk, network, or subprocess.</p></div>
+
+    <div class="lang-zh-only"><p>成功路径与错误路径都必须 emit 事件，否则 TUI 会卡在 streaming 状态、JSONL 会缺 entry。</p></div>
+    <div class="lang-en-only"><p>Success and error paths must emit events or TUI stalls streaming and JSONL misses entries.</p></div>
+
+    <div class="lang-zh-only"><p>length 截断时 <code>agent-loop.ts</code> 的 <code>failToolCallsFromTruncatedMessage</code> 批量失败 tool calls，防止执行损坏参数。</p></div>
+    <div class="lang-en-only"><p>On length truncation, <code>failToolCallsFromTruncatedMessage</code> fails all tool calls to avoid corrupted args.</p></div>
+
+    <div class="lang-zh-only"><p>对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。</p></div>
+    <div class="lang-en-only"><p>Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">差分 TUI：与 agent-loop 的接口</span><span class="lang-en-only">差分 TUI: interface with agent-loop</span></h3>
+
+    <div class="lang-zh-only"><p><code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。</p></div>
+    <div class="lang-en-only"><p><code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc.</p></div>
+
+    <div class="lang-zh-only"><p><code>AgentSession</code> 在构造 config 时绑定本模块实现；换模式（print/rpc/interactive）不换 agent-loop。</p></div>
+    <div class="lang-en-only"><p><code>AgentSession</code> binds this module when building config; modes change, agent-loop does not.</p></div>
+
+    <div class="lang-zh-only"><p>fork 项目时优先替换本模块而非复制 agent-loop——这是 Pi 社区的实际 fork 模式。</p></div>
+    <div class="lang-en-only"><p>When forking, replace this module first rather than copying agent-loop — the common community pattern.</p></div>
+
+    <div class="lang-zh-only"><p>--verbose 模式下 stderr 事件类型可回溯到 <code>packages/tui/src/tui-main-screen.ts</code> 的具体行。</p></div>
+    <div class="lang-en-only"><p>Under --verbose, stderr event types trace to lines in <code>packages/tui/src/tui-main-screen.ts</code>.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">差分 TUI：设计权衡与常见坑</span><span class="lang-en-only">差分 TUI: trade-offs and pitfalls</span></h3>
+
+    <div class="lang-zh-only"><p>显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。</p></div>
+    <div class="lang-en-only"><p>Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union.</p></div>
+
+    <div class="lang-zh-only"><p>扩展应 subscribe 事件而非 monkey-patch 私有方法——<code>ExtensionRunner</code> 提供正规 hook 面。</p></div>
+    <div class="lang-en-only"><p>Extensions should subscribe to events, not monkey-patch privates — <code>ExtensionRunner</code> provides hooks.</p></div>
+
+    <div class="lang-zh-only"><p>JSONL <code>CURRENT_SESSION_VERSION = 3</code>：改 entry schema 必须 bump version 并提供迁移。</p></div>
+    <div class="lang-en-only"><p>JSONL <code>CURRENT_SESSION_VERSION = 3</code>: schema changes need version bump and migration.</p></div>
+
+    <div class="lang-zh-only"><p>对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。</p></div>
+    <div class="lang-en-only"><p>vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable.</p></div>
+
+    <div class="trace-box">
+      <div class="tb-tag">TRACE · station 17</div>
+      <div class="lang-zh-only"><p>站 17：<code>packages/tui/src/tui-main-screen.ts</code> 处理主线。</p></div>
+      <div class="lang-en-only"><p>Station 17: <code>packages/tui/src/tui-main-screen.ts</code> on through-line.</p></div>
     </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/tui/src/tui-main-screen.ts</span>
+        <span class="src-tag">src</span>
+      </div>
+      <span class="src-line"><span class="src-line"><span class="src-kw">let</span> <span class="src-arg">firstChanged</span> = -<span class="src-num">1</span>;</span></span>
+      <span class="src-line"><span class="src-line"><span class="src-kw">let</span> <span class="src-arg">lastChanged</span> = -<span class="src-num">1</span>;</span></span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">差分 TUI最关键文件？</span><span class="lang-en-only">Key file?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p><code>packages/tui/src/tui-main-screen.ts</code>。</p></div><div class="lang-en-only"><p><code>packages/tui/src/tui-main-screen.ts</code>.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">如何单测？</span><span class="lang-en-only">Unit test?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>mock StreamFn 或 ScriptedModel。</p></div><div class="lang-en-only"><p>mock StreamFn or ScriptedModel.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">与 textbook 差异？</span><span class="lang-en-only">vs textbook?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>生产含 OAuth/TUI/40+ providers。</p></div><div class="lang-en-only"><p>Production adds OAuth/TUI/40+ providers.</p></div></div></details>
   </section>
 
   <section class="chap" id="c18">
@@ -3210,6 +5061,38 @@
     <h2 class="chap-title lang-en-only">Interactive mode</h2>
     <p class="chap-en lang-zh-only">Editor · Markdown · tool renderers</p>
     <p class="chap-en lang-en-only">Editor · Markdown · tool renderers</p>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>Interactive Mode 决定你如何理解 Pi 在此层的机制。</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>反直觉：<code>interactive-mode.ts</code> 的复杂度在事件契约而非算法。</span></p>
+      <p><span class="swc-pill act">优化</span><span>优化：--verbose + 源码对照，不猜测模型行为。</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>Interactive Mode shapes how you understand Pi at this layer.</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>Counter-intuitive: complexity in <code>interactive-mode.ts</code> is event contracts.</span></p>
+      <p><span class="swc-pill act">优化</span><span>Optimize: --verbose plus source, don't guess.</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">coding-agent</span><span class="lang-en-only">coding-agent</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">站 18</span><span class="lang-en-only">St. 18</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">interactive-mode.ts</span><span class="lang-en-only">interactive-mode.ts</span></div>
+      </div>
+    </div>
+
     <div class="lang-zh-only"><p>Interactive mode 组合 <code>Editor</code>（输入）、<code>Markdown</code>（输出）、<code>tool renderers</code>（read 结果预览）。主线 prompt 在 Editor 提交，最终结果在 Markdown 区滚动。</p></div>
     <div class="lang-en-only"><p>Interactive mode composes <code>Editor</code> (input), <code>Markdown</code> (output), <code>tool renderers</code> (read preview). Through-line prompt submits from Editor; final answer scrolls in Markdown area.</p></div>
 
@@ -3236,10 +5119,98 @@
       </div>
     </div>
 
-    <div class="note">
-      <span class="lang-zh-only">本章 (18) 在主线 prompt「Editor · Markdown · tool renderers」路径上负责：<strong>Interactive Mode</strong>。回到 C02 的 22 站地图定位这一章。</span>
-      <span class="lang-en-only">Chapter (18) on the through-line path handles: <strong>Interactive mode</strong>. Return to C02's 22-station map to locate this chapter.</span>
+    <h3 class="sub"><span class="lang-zh-only">Interactive Mode：主线 prompt 如何穿过此模块</span><span class="lang-en-only">Interactive Mode: through-line crossing</span></h3>
+
+    <div class="lang-zh-only"><p>用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/coding-agent/src/modes/interactive/interactive-mode.ts</code> 定义了此阶段的类型契约与副作用边界。</p></div>
+    <div class="lang-en-only"><p>After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/coding-agent/src/modes/interactive/interactive-mode.ts</code> defines type contracts and side-effect boundaries here.</p></div>
+
+    <div class="lang-zh-only"><p>在 pi-mono 仓库打开该文件，搜索 <code>export</code> 与 <code>AgentEvent</code>——这是比读 README 更快的定位法。</p></div>
+    <div class="lang-en-only"><p>In pi-mono, search <code>export</code> and <code>AgentEvent</code> — faster than README alone.</p></div>
+
+    <div class="lang-zh-only"><p>设计原则：核心循环（agent-loop）不 import TUI；本模块通过事件与回调与上游通信。</p></div>
+    <div class="lang-en-only"><p>Principle: agent-loop never imports TUI; this module talks upstream via events/callbacks.</p></div>
+
+    <div class="lang-zh-only"><p>pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。</p></div>
+    <div class="lang-en-only"><p>Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">Interactive Mode：关键函数与数据流</span><span class="lang-en-only">Interactive Mode: key functions and data flow</span></h3>
+
+    <div class="lang-zh-only"><p><code>interactive-mode.ts</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。</p></div>
+    <div class="lang-en-only"><p><code>async</code> functions in <code>interactive-mode.ts</code> are usually IO boundaries: disk, network, or subprocess.</p></div>
+
+    <div class="lang-zh-only"><p>成功路径与错误路径都必须 emit 事件，否则 TUI 会卡在 streaming 状态、JSONL 会缺 entry。</p></div>
+    <div class="lang-en-only"><p>Success and error paths must emit events or TUI stalls streaming and JSONL misses entries.</p></div>
+
+    <div class="lang-zh-only"><p>length 截断时 <code>agent-loop.ts</code> 的 <code>failToolCallsFromTruncatedMessage</code> 批量失败 tool calls，防止执行损坏参数。</p></div>
+    <div class="lang-en-only"><p>On length truncation, <code>failToolCallsFromTruncatedMessage</code> fails all tool calls to avoid corrupted args.</p></div>
+
+    <div class="lang-zh-only"><p>对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。</p></div>
+    <div class="lang-en-only"><p>Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">Interactive Mode：与 agent-loop 的接口</span><span class="lang-en-only">Interactive Mode: interface with agent-loop</span></h3>
+
+    <div class="lang-zh-only"><p><code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。</p></div>
+    <div class="lang-en-only"><p><code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc.</p></div>
+
+    <div class="lang-zh-only"><p><code>AgentSession</code> 在构造 config 时绑定本模块实现；换模式（print/rpc/interactive）不换 agent-loop。</p></div>
+    <div class="lang-en-only"><p><code>AgentSession</code> binds this module when building config; modes change, agent-loop does not.</p></div>
+
+    <div class="lang-zh-only"><p>fork 项目时优先替换本模块而非复制 agent-loop——这是 Pi 社区的实际 fork 模式。</p></div>
+    <div class="lang-en-only"><p>When forking, replace this module first rather than copying agent-loop — the common community pattern.</p></div>
+
+    <div class="lang-zh-only"><p>--verbose 模式下 stderr 事件类型可回溯到 <code>packages/coding-agent/src/modes/interactive/interactive-mode.ts</code> 的具体行。</p></div>
+    <div class="lang-en-only"><p>Under --verbose, stderr event types trace to lines in <code>packages/coding-agent/src/modes/interactive/interactive-mode.ts</code>.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">Interactive Mode：设计权衡与常见坑</span><span class="lang-en-only">Interactive Mode: trade-offs and pitfalls</span></h3>
+
+    <div class="lang-zh-only"><p>显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。</p></div>
+    <div class="lang-en-only"><p>Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union.</p></div>
+
+    <div class="lang-zh-only"><p>扩展应 subscribe 事件而非 monkey-patch 私有方法——<code>ExtensionRunner</code> 提供正规 hook 面。</p></div>
+    <div class="lang-en-only"><p>Extensions should subscribe to events, not monkey-patch privates — <code>ExtensionRunner</code> provides hooks.</p></div>
+
+    <div class="lang-zh-only"><p>JSONL <code>CURRENT_SESSION_VERSION = 3</code>：改 entry schema 必须 bump version 并提供迁移。</p></div>
+    <div class="lang-en-only"><p>JSONL <code>CURRENT_SESSION_VERSION = 3</code>: schema changes need version bump and migration.</p></div>
+
+    <div class="lang-zh-only"><p>对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。</p></div>
+    <div class="lang-en-only"><p>vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">Interactive Mode：深度走读清单</span><span class="lang-en-only">Interactive Mode: deep walk checklist</span></h3>
+
+    <div class="lang-zh-only"><p>① 打开 <code>packages/coding-agent/src/modes/interactive/interactive-mode.ts</code>；② 从 export 符号跟踪 README 路径调用链；③ 标注每个 await 的 IO 类型。</p></div>
+    <div class="lang-en-only"><p>① Open <code>packages/coding-agent/src/modes/interactive/interactive-mode.ts</code>; ② trace README call chain from exports; ③ label each await's IO type.</p></div>
+
+    <div class="lang-zh-only"><p>④ 在 <code>agent-loop.test.ts</code> 或 coding-agent 测试中找覆盖此站的用例；⑤ 用 <code>pi --verbose</code> 验证事件顺序。</p></div>
+    <div class="lang-en-only"><p>④ Find tests covering this station; ⑤ verify event order with <code>pi --verbose</code>.</p></div>
+
+    <div class="lang-zh-only"><p>记录三个不变量：若修改会破坏主线 prompt 的行为假设。</p></div>
+    <div class="lang-en-only"><p>Record three invariants: assumptions whose change would break the through-line.</p></div>
+
+    <div class="lang-zh-only"><p>将观察结果与 pi-textbook workshop 的 checkpoint 测试输出 diff。</p></div>
+    <div class="lang-en-only"><p>Diff observations against pi-textbook workshop checkpoint test output.</p></div>
+
+    <div class="trace-box">
+      <div class="tb-tag">TRACE · station 18</div>
+      <div class="lang-zh-only"><p>站 18：<code>packages/coding-agent/src/modes/interactive/interactive-mode.ts</code> 处理主线。</p></div>
+      <div class="lang-en-only"><p>Station 18: <code>packages/coding-agent/src/modes/interactive/interactive-mode.ts</code> on through-line.</p></div>
     </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/modes/interactive/interactive-mode.ts</span>
+        <span class="src-tag">src</span>
+      </div>
+      <span class="src-line"><span class="src-line"><span class="src-comment">// Interactive Mode · packages/coding-agent/src/modes/interactive/interactive-mode.ts</span></span></span>
+      <span class="src-line"><span class="src-line"><span class="src-comment">// through-line: README.md</span></span></span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">Interactive Mode最关键文件？</span><span class="lang-en-only">Key file?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p><code>packages/coding-agent/src/modes/interactive/interactive-mode.ts</code>。</p></div><div class="lang-en-only"><p><code>packages/coding-agent/src/modes/interactive/interactive-mode.ts</code>.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">如何单测？</span><span class="lang-en-only">Unit test?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>mock StreamFn 或 ScriptedModel。</p></div><div class="lang-en-only"><p>mock StreamFn or ScriptedModel.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">与 textbook 差异？</span><span class="lang-en-only">vs textbook?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>生产含 OAuth/TUI/40+ providers。</p></div><div class="lang-en-only"><p>Production adds OAuth/TUI/40+ providers.</p></div></div></details>
   </section>
 
   <section class="chap" id="c19">
@@ -3248,6 +5219,38 @@
     <h2 class="chap-title lang-en-only">Extension API surface</h2>
     <p class="chap-en lang-zh-only">registerTool · registerCommand · events</p>
     <p class="chap-en lang-en-only">registerTool · registerCommand · events</p>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>Extension API 决定你如何理解 Pi 在此层的机制。</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>反直觉：<code>types.ts</code> 的复杂度在事件契约而非算法。</span></p>
+      <p><span class="swc-pill act">优化</span><span>优化：--verbose + 源码对照，不猜测模型行为。</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>Extension API shapes how you understand Pi at this layer.</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>Counter-intuitive: complexity in <code>types.ts</code> is event contracts.</span></p>
+      <p><span class="swc-pill act">优化</span><span>Optimize: --verbose plus source, don't guess.</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">coding-agent</span><span class="lang-en-only">coding-agent</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">站 19</span><span class="lang-en-only">St. 19</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">types.ts</span><span class="lang-en-only">types.ts</span></div>
+      </div>
+    </div>
+
     <div class="lang-zh-only"><p>扩展通过 <code>registerTool</code> · <code>registerCommand</code> · 事件 hook 注入能力——无需 MCP，同进程 TypeScript。</p></div>
     <div class="lang-en-only"><p>Extensions inject via <code>registerTool</code> · <code>registerCommand</code> · event hooks — no MCP, same-process TypeScript.</p></div>
 
@@ -3307,10 +5310,91 @@
       <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 12</strong>: Resources + Extensions (<code>resources-extensions</code>) · production: <code>packages/coding-agent/src/core/extensions/ · resource-loader.ts</code></span>
     </div>
 
-    <div class="note">
-      <span class="lang-zh-only">本章 (19) 在主线 prompt「registerTool · registerCommand · events」路径上负责：<strong>Extension API 面</strong>。回到 C02 的 22 站地图定位这一章。</span>
-      <span class="lang-en-only">Chapter (19) on the through-line path handles: <strong>Extension API surface</strong>. Return to C02's 22-station map to locate this chapter.</span>
+    <h3 class="sub"><span class="lang-zh-only">Extension API：主线 prompt 如何穿过此模块</span><span class="lang-en-only">Extension API: through-line crossing</span></h3>
+
+    <div class="lang-zh-only"><p>用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/coding-agent/src/core/extensions/types.ts</code> 定义了此阶段的类型契约与副作用边界。</p></div>
+    <div class="lang-en-only"><p>After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/coding-agent/src/core/extensions/types.ts</code> defines type contracts and side-effect boundaries here.</p></div>
+
+    <div class="lang-zh-only"><p>在 pi-mono 仓库打开该文件，搜索 <code>export</code> 与 <code>AgentEvent</code>——这是比读 README 更快的定位法。</p></div>
+    <div class="lang-en-only"><p>In pi-mono, search <code>export</code> and <code>AgentEvent</code> — faster than README alone.</p></div>
+
+    <div class="lang-zh-only"><p>设计原则：核心循环（agent-loop）不 import TUI；本模块通过事件与回调与上游通信。</p></div>
+    <div class="lang-en-only"><p>Principle: agent-loop never imports TUI; this module talks upstream via events/callbacks.</p></div>
+
+    <div class="lang-zh-only"><p>pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。</p></div>
+    <div class="lang-en-only"><p>Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">Extension API：关键函数与数据流</span><span class="lang-en-only">Extension API: key functions and data flow</span></h3>
+
+    <div class="lang-zh-only"><p><code>types.ts</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。</p></div>
+    <div class="lang-en-only"><p><code>async</code> functions in <code>types.ts</code> are usually IO boundaries: disk, network, or subprocess.</p></div>
+
+    <div class="lang-zh-only"><p>成功路径与错误路径都必须 emit 事件，否则 TUI 会卡在 streaming 状态、JSONL 会缺 entry。</p></div>
+    <div class="lang-en-only"><p>Success and error paths must emit events or TUI stalls streaming and JSONL misses entries.</p></div>
+
+    <div class="lang-zh-only"><p>length 截断时 <code>agent-loop.ts</code> 的 <code>failToolCallsFromTruncatedMessage</code> 批量失败 tool calls，防止执行损坏参数。</p></div>
+    <div class="lang-en-only"><p>On length truncation, <code>failToolCallsFromTruncatedMessage</code> fails all tool calls to avoid corrupted args.</p></div>
+
+    <div class="lang-zh-only"><p>对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。</p></div>
+    <div class="lang-en-only"><p>Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">Extension API：与 agent-loop 的接口</span><span class="lang-en-only">Extension API: interface with agent-loop</span></h3>
+
+    <div class="lang-zh-only"><p><code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。</p></div>
+    <div class="lang-en-only"><p><code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc.</p></div>
+
+    <div class="lang-zh-only"><p><code>AgentSession</code> 在构造 config 时绑定本模块实现；换模式（print/rpc/interactive）不换 agent-loop。</p></div>
+    <div class="lang-en-only"><p><code>AgentSession</code> binds this module when building config; modes change, agent-loop does not.</p></div>
+
+    <div class="lang-zh-only"><p>fork 项目时优先替换本模块而非复制 agent-loop——这是 Pi 社区的实际 fork 模式。</p></div>
+    <div class="lang-en-only"><p>When forking, replace this module first rather than copying agent-loop — the common community pattern.</p></div>
+
+    <div class="lang-zh-only"><p>--verbose 模式下 stderr 事件类型可回溯到 <code>packages/coding-agent/src/core/extensions/types.ts</code> 的具体行。</p></div>
+    <div class="lang-en-only"><p>Under --verbose, stderr event types trace to lines in <code>packages/coding-agent/src/core/extensions/types.ts</code>.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">Extension API：设计权衡与常见坑</span><span class="lang-en-only">Extension API: trade-offs and pitfalls</span></h3>
+
+    <div class="lang-zh-only"><p>显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。</p></div>
+    <div class="lang-en-only"><p>Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union.</p></div>
+
+    <div class="lang-zh-only"><p>扩展应 subscribe 事件而非 monkey-patch 私有方法——<code>ExtensionRunner</code> 提供正规 hook 面。</p></div>
+    <div class="lang-en-only"><p>Extensions should subscribe to events, not monkey-patch privates — <code>ExtensionRunner</code> provides hooks.</p></div>
+
+    <div class="lang-zh-only"><p>JSONL <code>CURRENT_SESSION_VERSION = 3</code>：改 entry schema 必须 bump version 并提供迁移。</p></div>
+    <div class="lang-en-only"><p>JSONL <code>CURRENT_SESSION_VERSION = 3</code>: schema changes need version bump and migration.</p></div>
+
+    <div class="lang-zh-only"><p>对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。</p></div>
+    <div class="lang-en-only"><p>vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable.</p></div>
+
+    <div class="trace-box">
+      <div class="tb-tag">TRACE · station 19</div>
+      <div class="lang-zh-only"><p>站 19：<code>packages/coding-agent/src/core/extensions/types.ts</code> 处理主线。</p></div>
+      <div class="lang-en-only"><p>Station 19: <code>packages/coding-agent/src/core/extensions/types.ts</code> on through-line.</p></div>
     </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/extensions/types.ts</span>
+        <span class="src-tag">src</span>
+      </div>
+      <span class="src-line"><span class="src-line"><span class="src-comment">// Extension API · packages/coding-agent/src/core/extensions/types.ts</span></span></span>
+      <span class="src-line"><span class="src-line"><span class="src-comment">// through-line: README.md</span></span></span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+      <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
+      <tbody>
+      <tr><td>cp 12</td><td>Resources + Extensions</td><td><code>resources-extensions</code></td><td><code>packages/coding-agent/src/core/extensions/ · resource-loader.ts</code></td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">Extension API最关键文件？</span><span class="lang-en-only">Key file?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p><code>packages/coding-agent/src/core/extensions/types.ts</code>。</p></div><div class="lang-en-only"><p><code>packages/coding-agent/src/core/extensions/types.ts</code>.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">如何单测？</span><span class="lang-en-only">Unit test?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>mock StreamFn 或 ScriptedModel。</p></div><div class="lang-en-only"><p>mock StreamFn or ScriptedModel.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">与 textbook 差异？</span><span class="lang-en-only">vs textbook?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>生产含 OAuth/TUI/40+ providers。</p></div><div class="lang-en-only"><p>Production adds OAuth/TUI/40+ providers.</p></div></div></details>
   </section>
 
   <section class="chap" id="c20">
@@ -3319,6 +5403,38 @@
     <h2 class="chap-title lang-en-only">ExtensionRunner</h2>
     <p class="chap-en lang-zh-only">jiti 加载 · 事件合并 · hook 注入</p>
     <p class="chap-en lang-en-only">jiti load · event merge · hook injection</p>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>ExtensionRunner 决定你如何理解 Pi 在此层的机制。</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>反直觉：<code>runner.ts</code> 的复杂度在事件契约而非算法。</span></p>
+      <p><span class="swc-pill act">优化</span><span>优化：--verbose + 源码对照，不猜测模型行为。</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>ExtensionRunner shapes how you understand Pi at this layer.</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>Counter-intuitive: complexity in <code>runner.ts</code> is event contracts.</span></p>
+      <p><span class="swc-pill act">优化</span><span>Optimize: --verbose plus source, don't guess.</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">coding-agent</span><span class="lang-en-only">coding-agent</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">站 20</span><span class="lang-en-only">St. 20</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">runner.ts</span><span class="lang-en-only">runner.ts</span></div>
+      </div>
+    </div>
+
     <div class="lang-zh-only"><p><code>ExtensionRunner</code> 用 <code>jiti</code> 动态加载扩展 TS，合并事件处理器，在 agent 生命周期关键点注入 hook。</p></div>
     <div class="lang-en-only"><p><code>ExtensionRunner</code> uses <code>jiti</code> to load extension TS, merges event handlers, injects hooks at agent lifecycle points.</p></div>
 
@@ -3342,10 +5458,106 @@
       <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 13</strong>: Composition Root (<code>composition-root</code>) · production: <code>packages/coding-agent/src/core/agent-session.ts · sdk.ts</code></span>
     </div>
 
-    <div class="note">
-      <span class="lang-zh-only">本章 (20) 在主线 prompt「jiti 加载 · 事件合并 · hook 注入」路径上负责：<strong>ExtensionRunner</strong>。回到 C02 的 22 站地图定位这一章。</span>
-      <span class="lang-en-only">Chapter (20) on the through-line path handles: <strong>ExtensionRunner</strong>. Return to C02's 22-station map to locate this chapter.</span>
+    <h3 class="sub"><span class="lang-zh-only">ExtensionRunner：主线 prompt 如何穿过此模块</span><span class="lang-en-only">ExtensionRunner: through-line crossing</span></h3>
+
+    <div class="lang-zh-only"><p>用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/coding-agent/src/core/extensions/runner.ts</code> 定义了此阶段的类型契约与副作用边界。</p></div>
+    <div class="lang-en-only"><p>After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/coding-agent/src/core/extensions/runner.ts</code> defines type contracts and side-effect boundaries here.</p></div>
+
+    <div class="lang-zh-only"><p>在 pi-mono 仓库打开该文件，搜索 <code>export</code> 与 <code>AgentEvent</code>——这是比读 README 更快的定位法。</p></div>
+    <div class="lang-en-only"><p>In pi-mono, search <code>export</code> and <code>AgentEvent</code> — faster than README alone.</p></div>
+
+    <div class="lang-zh-only"><p>设计原则：核心循环（agent-loop）不 import TUI；本模块通过事件与回调与上游通信。</p></div>
+    <div class="lang-en-only"><p>Principle: agent-loop never imports TUI; this module talks upstream via events/callbacks.</p></div>
+
+    <div class="lang-zh-only"><p>pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。</p></div>
+    <div class="lang-en-only"><p>Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">ExtensionRunner：关键函数与数据流</span><span class="lang-en-only">ExtensionRunner: key functions and data flow</span></h3>
+
+    <div class="lang-zh-only"><p><code>runner.ts</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。</p></div>
+    <div class="lang-en-only"><p><code>async</code> functions in <code>runner.ts</code> are usually IO boundaries: disk, network, or subprocess.</p></div>
+
+    <div class="lang-zh-only"><p>成功路径与错误路径都必须 emit 事件，否则 TUI 会卡在 streaming 状态、JSONL 会缺 entry。</p></div>
+    <div class="lang-en-only"><p>Success and error paths must emit events or TUI stalls streaming and JSONL misses entries.</p></div>
+
+    <div class="lang-zh-only"><p>length 截断时 <code>agent-loop.ts</code> 的 <code>failToolCallsFromTruncatedMessage</code> 批量失败 tool calls，防止执行损坏参数。</p></div>
+    <div class="lang-en-only"><p>On length truncation, <code>failToolCallsFromTruncatedMessage</code> fails all tool calls to avoid corrupted args.</p></div>
+
+    <div class="lang-zh-only"><p>对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。</p></div>
+    <div class="lang-en-only"><p>Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">ExtensionRunner：与 agent-loop 的接口</span><span class="lang-en-only">ExtensionRunner: interface with agent-loop</span></h3>
+
+    <div class="lang-zh-only"><p><code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。</p></div>
+    <div class="lang-en-only"><p><code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc.</p></div>
+
+    <div class="lang-zh-only"><p><code>AgentSession</code> 在构造 config 时绑定本模块实现；换模式（print/rpc/interactive）不换 agent-loop。</p></div>
+    <div class="lang-en-only"><p><code>AgentSession</code> binds this module when building config; modes change, agent-loop does not.</p></div>
+
+    <div class="lang-zh-only"><p>fork 项目时优先替换本模块而非复制 agent-loop——这是 Pi 社区的实际 fork 模式。</p></div>
+    <div class="lang-en-only"><p>When forking, replace this module first rather than copying agent-loop — the common community pattern.</p></div>
+
+    <div class="lang-zh-only"><p>--verbose 模式下 stderr 事件类型可回溯到 <code>packages/coding-agent/src/core/extensions/runner.ts</code> 的具体行。</p></div>
+    <div class="lang-en-only"><p>Under --verbose, stderr event types trace to lines in <code>packages/coding-agent/src/core/extensions/runner.ts</code>.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">ExtensionRunner：设计权衡与常见坑</span><span class="lang-en-only">ExtensionRunner: trade-offs and pitfalls</span></h3>
+
+    <div class="lang-zh-only"><p>显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。</p></div>
+    <div class="lang-en-only"><p>Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union.</p></div>
+
+    <div class="lang-zh-only"><p>扩展应 subscribe 事件而非 monkey-patch 私有方法——<code>ExtensionRunner</code> 提供正规 hook 面。</p></div>
+    <div class="lang-en-only"><p>Extensions should subscribe to events, not monkey-patch privates — <code>ExtensionRunner</code> provides hooks.</p></div>
+
+    <div class="lang-zh-only"><p>JSONL <code>CURRENT_SESSION_VERSION = 3</code>：改 entry schema 必须 bump version 并提供迁移。</p></div>
+    <div class="lang-en-only"><p>JSONL <code>CURRENT_SESSION_VERSION = 3</code>: schema changes need version bump and migration.</p></div>
+
+    <div class="lang-zh-only"><p>对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。</p></div>
+    <div class="lang-en-only"><p>vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">ExtensionRunner：深度走读清单</span><span class="lang-en-only">ExtensionRunner: deep walk checklist</span></h3>
+
+    <div class="lang-zh-only"><p>① 打开 <code>packages/coding-agent/src/core/extensions/runner.ts</code>；② 从 export 符号跟踪 README 路径调用链；③ 标注每个 await 的 IO 类型。</p></div>
+    <div class="lang-en-only"><p>① Open <code>packages/coding-agent/src/core/extensions/runner.ts</code>; ② trace README call chain from exports; ③ label each await's IO type.</p></div>
+
+    <div class="lang-zh-only"><p>④ 在 <code>agent-loop.test.ts</code> 或 coding-agent 测试中找覆盖此站的用例；⑤ 用 <code>pi --verbose</code> 验证事件顺序。</p></div>
+    <div class="lang-en-only"><p>④ Find tests covering this station; ⑤ verify event order with <code>pi --verbose</code>.</p></div>
+
+    <div class="lang-zh-only"><p>记录三个不变量：若修改会破坏主线 prompt 的行为假设。</p></div>
+    <div class="lang-en-only"><p>Record three invariants: assumptions whose change would break the through-line.</p></div>
+
+    <div class="lang-zh-only"><p>将观察结果与 pi-textbook workshop 的 checkpoint 测试输出 diff。</p></div>
+    <div class="lang-en-only"><p>Diff observations against pi-textbook workshop checkpoint test output.</p></div>
+
+    <div class="trace-box">
+      <div class="tb-tag">TRACE · station 20</div>
+      <div class="lang-zh-only"><p>站 20：<code>packages/coding-agent/src/core/extensions/runner.ts</code> 处理主线。</p></div>
+      <div class="lang-en-only"><p>Station 20: <code>packages/coding-agent/src/core/extensions/runner.ts</code> on through-line.</p></div>
     </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/extensions/runner.ts</span>
+        <span class="src-tag">src</span>
+      </div>
+      <span class="src-line"><span class="src-line"><span class="src-kw">export class</span> <span class="src-cls">ExtensionRunner</span></span></span>
+      <span class="src-line"><span class="src-line"><span class="src-comment">/** executes extensions and manages lifecycle */</span></span></span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+      <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
+      <tbody>
+      <tr><td>cp 12</td><td>Resources + Extensions</td><td><code>resources-extensions</code></td><td><code>packages/coding-agent/src/core/extensions/ · resource-loader.ts</code></td></tr>
+      <tr><td>cp 13</td><td>Composition Root</td><td><code>composition-root</code></td><td><code>packages/coding-agent/src/core/agent-session.ts · sdk.ts</code></td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">ExtensionRunner最关键文件？</span><span class="lang-en-only">Key file?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p><code>packages/coding-agent/src/core/extensions/runner.ts</code>。</p></div><div class="lang-en-only"><p><code>packages/coding-agent/src/core/extensions/runner.ts</code>.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">如何单测？</span><span class="lang-en-only">Unit test?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>mock StreamFn 或 ScriptedModel。</p></div><div class="lang-en-only"><p>mock StreamFn or ScriptedModel.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">与 textbook 差异？</span><span class="lang-en-only">vs textbook?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>生产含 OAuth/TUI/40+ providers。</p></div><div class="lang-en-only"><p>Production adds OAuth/TUI/40+ providers.</p></div></div></details>
   </section>
 
   <section class="chap" id="c21">
@@ -3354,6 +5566,38 @@
     <h2 class="chap-title lang-en-only">Pi packages</h2>
     <p class="chap-en lang-zh-only">npm · git · 可分享的 harness 能力</p>
     <p class="chap-en lang-en-only">npm · git · shareable harness capabilities</p>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>Pi Packages 决定你如何理解 Pi 在此层的机制。</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>反直觉：<code>package-manager.ts</code> 的复杂度在事件契约而非算法。</span></p>
+      <p><span class="swc-pill act">优化</span><span>优化：--verbose + 源码对照，不猜测模型行为。</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>Pi Packages shapes how you understand Pi at this layer.</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>Counter-intuitive: complexity in <code>package-manager.ts</code> is event contracts.</span></p>
+      <p><span class="swc-pill act">优化</span><span>Optimize: --verbose plus source, don't guess.</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">coding-agent</span><span class="lang-en-only">coding-agent</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">站 21</span><span class="lang-en-only">St. 21</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">package-manager.ts</span><span class="lang-en-only">package-manager.ts</span></div>
+      </div>
+    </div>
+
     <div class="lang-zh-only"><p><code>pi package</code> 命令管理可分享的 harness 能力包——npm 或 git 依赖，把工具+扩展+资源打包分发。</p></div>
     <div class="lang-en-only"><p><code>pi package</code> manages shareable harness capability bundles — npm or git deps packaging tools+extensions+resources.</p></div>
 
@@ -3371,10 +5615,105 @@
       <span class="lang-en-only">Extension ecosystem replaces MCP marketplace — type-safe, but requires writing TypeScript.</span>
     </div>
 
-    <div class="note">
-      <span class="lang-zh-only">本章 (21) 在主线 prompt「npm · git · 可分享的 harness 能力」路径上负责：<strong>Pi Packages</strong>。回到 C02 的 22 站地图定位这一章。</span>
-      <span class="lang-en-only">Chapter (21) on the through-line path handles: <strong>Pi packages</strong>. Return to C02's 22-station map to locate this chapter.</span>
+    <h3 class="sub"><span class="lang-zh-only">Pi Packages：主线 prompt 如何穿过此模块</span><span class="lang-en-only">Pi Packages: through-line crossing</span></h3>
+
+    <div class="lang-zh-only"><p>用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/coding-agent/src/core/package-manager.ts</code> 定义了此阶段的类型契约与副作用边界。</p></div>
+    <div class="lang-en-only"><p>After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/coding-agent/src/core/package-manager.ts</code> defines type contracts and side-effect boundaries here.</p></div>
+
+    <div class="lang-zh-only"><p>在 pi-mono 仓库打开该文件，搜索 <code>export</code> 与 <code>AgentEvent</code>——这是比读 README 更快的定位法。</p></div>
+    <div class="lang-en-only"><p>In pi-mono, search <code>export</code> and <code>AgentEvent</code> — faster than README alone.</p></div>
+
+    <div class="lang-zh-only"><p>设计原则：核心循环（agent-loop）不 import TUI；本模块通过事件与回调与上游通信。</p></div>
+    <div class="lang-en-only"><p>Principle: agent-loop never imports TUI; this module talks upstream via events/callbacks.</p></div>
+
+    <div class="lang-zh-only"><p>pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。</p></div>
+    <div class="lang-en-only"><p>Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">Pi Packages：关键函数与数据流</span><span class="lang-en-only">Pi Packages: key functions and data flow</span></h3>
+
+    <div class="lang-zh-only"><p><code>package-manager.ts</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。</p></div>
+    <div class="lang-en-only"><p><code>async</code> functions in <code>package-manager.ts</code> are usually IO boundaries: disk, network, or subprocess.</p></div>
+
+    <div class="lang-zh-only"><p>成功路径与错误路径都必须 emit 事件，否则 TUI 会卡在 streaming 状态、JSONL 会缺 entry。</p></div>
+    <div class="lang-en-only"><p>Success and error paths must emit events or TUI stalls streaming and JSONL misses entries.</p></div>
+
+    <div class="lang-zh-only"><p>length 截断时 <code>agent-loop.ts</code> 的 <code>failToolCallsFromTruncatedMessage</code> 批量失败 tool calls，防止执行损坏参数。</p></div>
+    <div class="lang-en-only"><p>On length truncation, <code>failToolCallsFromTruncatedMessage</code> fails all tool calls to avoid corrupted args.</p></div>
+
+    <div class="lang-zh-only"><p>对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。</p></div>
+    <div class="lang-en-only"><p>Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">Pi Packages：与 agent-loop 的接口</span><span class="lang-en-only">Pi Packages: interface with agent-loop</span></h3>
+
+    <div class="lang-zh-only"><p><code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。</p></div>
+    <div class="lang-en-only"><p><code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc.</p></div>
+
+    <div class="lang-zh-only"><p><code>AgentSession</code> 在构造 config 时绑定本模块实现；换模式（print/rpc/interactive）不换 agent-loop。</p></div>
+    <div class="lang-en-only"><p><code>AgentSession</code> binds this module when building config; modes change, agent-loop does not.</p></div>
+
+    <div class="lang-zh-only"><p>fork 项目时优先替换本模块而非复制 agent-loop——这是 Pi 社区的实际 fork 模式。</p></div>
+    <div class="lang-en-only"><p>When forking, replace this module first rather than copying agent-loop — the common community pattern.</p></div>
+
+    <div class="lang-zh-only"><p>--verbose 模式下 stderr 事件类型可回溯到 <code>packages/coding-agent/src/core/package-manager.ts</code> 的具体行。</p></div>
+    <div class="lang-en-only"><p>Under --verbose, stderr event types trace to lines in <code>packages/coding-agent/src/core/package-manager.ts</code>.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">Pi Packages：设计权衡与常见坑</span><span class="lang-en-only">Pi Packages: trade-offs and pitfalls</span></h3>
+
+    <div class="lang-zh-only"><p>显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。</p></div>
+    <div class="lang-en-only"><p>Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union.</p></div>
+
+    <div class="lang-zh-only"><p>扩展应 subscribe 事件而非 monkey-patch 私有方法——<code>ExtensionRunner</code> 提供正规 hook 面。</p></div>
+    <div class="lang-en-only"><p>Extensions should subscribe to events, not monkey-patch privates — <code>ExtensionRunner</code> provides hooks.</p></div>
+
+    <div class="lang-zh-only"><p>JSONL <code>CURRENT_SESSION_VERSION = 3</code>：改 entry schema 必须 bump version 并提供迁移。</p></div>
+    <div class="lang-en-only"><p>JSONL <code>CURRENT_SESSION_VERSION = 3</code>: schema changes need version bump and migration.</p></div>
+
+    <div class="lang-zh-only"><p>对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。</p></div>
+    <div class="lang-en-only"><p>vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">Pi Packages：深度走读清单</span><span class="lang-en-only">Pi Packages: deep walk checklist</span></h3>
+
+    <div class="lang-zh-only"><p>① 打开 <code>packages/coding-agent/src/core/package-manager.ts</code>；② 从 export 符号跟踪 README 路径调用链；③ 标注每个 await 的 IO 类型。</p></div>
+    <div class="lang-en-only"><p>① Open <code>packages/coding-agent/src/core/package-manager.ts</code>; ② trace README call chain from exports; ③ label each await's IO type.</p></div>
+
+    <div class="lang-zh-only"><p>④ 在 <code>agent-loop.test.ts</code> 或 coding-agent 测试中找覆盖此站的用例；⑤ 用 <code>pi --verbose</code> 验证事件顺序。</p></div>
+    <div class="lang-en-only"><p>④ Find tests covering this station; ⑤ verify event order with <code>pi --verbose</code>.</p></div>
+
+    <div class="lang-zh-only"><p>记录三个不变量：若修改会破坏主线 prompt 的行为假设。</p></div>
+    <div class="lang-en-only"><p>Record three invariants: assumptions whose change would break the through-line.</p></div>
+
+    <div class="lang-zh-only"><p>将观察结果与 pi-textbook workshop 的 checkpoint 测试输出 diff。</p></div>
+    <div class="lang-en-only"><p>Diff observations against pi-textbook workshop checkpoint test output.</p></div>
+
+    <div class="trace-box">
+      <div class="tb-tag">TRACE · station 21</div>
+      <div class="lang-zh-only"><p>站 21：<code>packages/coding-agent/src/core/package-manager.ts</code> 处理主线。</p></div>
+      <div class="lang-en-only"><p>Station 21: <code>packages/coding-agent/src/core/package-manager.ts</code> on through-line.</p></div>
     </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/package-manager.ts</span>
+        <span class="src-tag">src</span>
+      </div>
+      <span class="src-line"><span class="src-line"><span class="src-comment">// Pi Packages · packages/coding-agent/src/core/package-manager.ts</span></span></span>
+      <span class="src-line"><span class="src-line"><span class="src-comment">// through-line: README.md</span></span></span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+      <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
+      <tbody>
+      <tr><td>cp 12</td><td>Resources + Extensions</td><td><code>resources-extensions</code></td><td><code>packages/coding-agent/src/core/extensions/ · resource-loader.ts</code></td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">Pi Packages最关键文件？</span><span class="lang-en-only">Key file?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p><code>packages/coding-agent/src/core/package-manager.ts</code>。</p></div><div class="lang-en-only"><p><code>packages/coding-agent/src/core/package-manager.ts</code>.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">如何单测？</span><span class="lang-en-only">Unit test?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>mock StreamFn 或 ScriptedModel。</p></div><div class="lang-en-only"><p>mock StreamFn or ScriptedModel.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">与 textbook 差异？</span><span class="lang-en-only">vs textbook?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>生产含 OAuth/TUI/40+ providers。</p></div><div class="lang-en-only"><p>Production adds OAuth/TUI/40+ providers.</p></div></div></details>
   </section>
 
   <section class="chap" id="c22">
@@ -3383,6 +5722,38 @@
     <h2 class="chap-title lang-en-only">JSONL session tree</h2>
     <p class="chap-en lang-zh-only">parentId · leafId · fork</p>
     <p class="chap-en lang-en-only">parentId · leafId · fork</p>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>JSONL 会话树 决定你如何理解 Pi 在此层的机制。</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>反直觉：<code>session-manager.ts</code> 的复杂度在事件契约而非算法。</span></p>
+      <p><span class="swc-pill act">优化</span><span>优化：--verbose + 源码对照，不猜测模型行为。</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>JSONL 会话树 shapes how you understand Pi at this layer.</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>Counter-intuitive: complexity in <code>session-manager.ts</code> is event contracts.</span></p>
+      <p><span class="swc-pill act">优化</span><span>Optimize: --verbose plus source, don't guess.</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">coding-agent</span><span class="lang-en-only">coding-agent</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">站 22</span><span class="lang-en-only">St. 22</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">session-manager.ts</span><span class="lang-en-only">session-manager.ts</span></div>
+      </div>
+    </div>
+
     <div class="lang-zh-only"><p>每个会话是 JSONL 文件：<code>parentId</code> 链构成树，<code>leafId</code> 指向当前叶节点，<code>fork</code> 创建 <code>parentSession</code> 子会话。</p></div>
     <div class="lang-en-only"><p>Each session is a JSONL file: <code>parentId</code> chain forms tree, <code>leafId</code> points to current leaf, <code>fork</code> creates child with <code>parentSession</code>.</p></div>
 
@@ -3455,31 +5826,6 @@
       <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 10</strong>: Session Tree (<code>session.ts</code>) · production: <code>packages/coding-agent/src/core/session-manager.ts</code></span>
     </div>
 
-    <h3 class="sub"><span class="lang-zh-only">fork 工作流</span><span class="lang-en-only">Fork workflow</span></h3>
-
-    <div class="lang-zh-only"><p>从任意 message entry 创建 branch_summary + 新 session 文件，parentSession 指向原会话。</p></div>
-    <div class="lang-en-only"><p>From any message entry create branch_summary + new session file with parentSession pointer.</p></div>
-
-    <h3 class="sub"><span class="lang-zh-only">leafId 语义</span><span class="lang-en-only">leafId semantics</span></h3>
-
-    <div class="lang-zh-only"><p>继续会话时从 leaf 重放 parentId 链到根，重建 AgentMessage[]。</p></div>
-    <div class="lang-en-only"><p>Continue session replays parentId chain from leaf to root, rebuilding AgentMessage[].</p></div>
-
-    <div class="note">
-      <span class="lang-zh-only">本章 (22) 在主线 prompt「parentId · leafId · fork」路径上负责：<strong>JSONL 会话树</strong>。回到 C02 的 22 站地图定位这一章。</span>
-      <span class="lang-en-only">Chapter (22) on the through-line path handles: <strong>JSONL session tree</strong>. Return to C02's 22-station map to locate this chapter.</span>
-    </div>
-
-    <div class="src-stack">
-      <div class="src-h">
-        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent · chapter 22</span>
-        <span class="src-tag">trace</span>
-      </div>
-      <span class="src-line"><span class="src-comment">// Through-line: parentId · leafId · fork</span></span>
-      <span class="src-line"><span class="src-comment">// Phase: 持久化 / Persistence</span></span>
-      <span class="src-line"><span class="src-kw">await</span> <span class="src-fn">traceTurn</span>({ <span class="src-arg">prompt</span>: <span class="src-str">"README.md"</span> });</span>
-    </div>
-
     <div class="src-stack">
       <div class="src-h">
         <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/session-manager.ts</span>
@@ -3501,6 +5847,92 @@
       <tr><td>cp 10</td><td>Session Tree</td><td><code>session.ts</code></td><td><code>packages/coding-agent/src/core/session-manager.ts</code></td></tr>
       </tbody>
     </table>
+
+    <h3 class="sub"><span class="lang-zh-only">JSONL 会话树：主线 prompt 如何穿过此模块</span><span class="lang-en-only">JSONL 会话树: through-line crossing</span></h3>
+
+    <div class="lang-zh-only"><p>用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/coding-agent/src/core/session-manager.ts</code> 定义了此阶段的类型契约与副作用边界。</p></div>
+    <div class="lang-en-only"><p>After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/coding-agent/src/core/session-manager.ts</code> defines type contracts and side-effect boundaries here.</p></div>
+
+    <div class="lang-zh-only"><p>在 pi-mono 仓库打开该文件，搜索 <code>export</code> 与 <code>AgentEvent</code>——这是比读 README 更快的定位法。</p></div>
+    <div class="lang-en-only"><p>In pi-mono, search <code>export</code> and <code>AgentEvent</code> — faster than README alone.</p></div>
+
+    <div class="lang-zh-only"><p>设计原则：核心循环（agent-loop）不 import TUI；本模块通过事件与回调与上游通信。</p></div>
+    <div class="lang-en-only"><p>Principle: agent-loop never imports TUI; this module talks upstream via events/callbacks.</p></div>
+
+    <div class="lang-zh-only"><p>pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。</p></div>
+    <div class="lang-en-only"><p>Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">JSONL 会话树：关键函数与数据流</span><span class="lang-en-only">JSONL 会话树: key functions and data flow</span></h3>
+
+    <div class="lang-zh-only"><p><code>session-manager.ts</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。</p></div>
+    <div class="lang-en-only"><p><code>async</code> functions in <code>session-manager.ts</code> are usually IO boundaries: disk, network, or subprocess.</p></div>
+
+    <div class="lang-zh-only"><p>成功路径与错误路径都必须 emit 事件，否则 TUI 会卡在 streaming 状态、JSONL 会缺 entry。</p></div>
+    <div class="lang-en-only"><p>Success and error paths must emit events or TUI stalls streaming and JSONL misses entries.</p></div>
+
+    <div class="lang-zh-only"><p>length 截断时 <code>agent-loop.ts</code> 的 <code>failToolCallsFromTruncatedMessage</code> 批量失败 tool calls，防止执行损坏参数。</p></div>
+    <div class="lang-en-only"><p>On length truncation, <code>failToolCallsFromTruncatedMessage</code> fails all tool calls to avoid corrupted args.</p></div>
+
+    <div class="lang-zh-only"><p>对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。</p></div>
+    <div class="lang-en-only"><p>Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">JSONL 会话树：与 agent-loop 的接口</span><span class="lang-en-only">JSONL 会话树: interface with agent-loop</span></h3>
+
+    <div class="lang-zh-only"><p><code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。</p></div>
+    <div class="lang-en-only"><p><code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc.</p></div>
+
+    <div class="lang-zh-only"><p><code>AgentSession</code> 在构造 config 时绑定本模块实现；换模式（print/rpc/interactive）不换 agent-loop。</p></div>
+    <div class="lang-en-only"><p><code>AgentSession</code> binds this module when building config; modes change, agent-loop does not.</p></div>
+
+    <div class="lang-zh-only"><p>fork 项目时优先替换本模块而非复制 agent-loop——这是 Pi 社区的实际 fork 模式。</p></div>
+    <div class="lang-en-only"><p>When forking, replace this module first rather than copying agent-loop — the common community pattern.</p></div>
+
+    <div class="lang-zh-only"><p>--verbose 模式下 stderr 事件类型可回溯到 <code>packages/coding-agent/src/core/session-manager.ts</code> 的具体行。</p></div>
+    <div class="lang-en-only"><p>Under --verbose, stderr event types trace to lines in <code>packages/coding-agent/src/core/session-manager.ts</code>.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">JSONL 会话树：设计权衡与常见坑</span><span class="lang-en-only">JSONL 会话树: trade-offs and pitfalls</span></h3>
+
+    <div class="lang-zh-only"><p>显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。</p></div>
+    <div class="lang-en-only"><p>Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union.</p></div>
+
+    <div class="lang-zh-only"><p>扩展应 subscribe 事件而非 monkey-patch 私有方法——<code>ExtensionRunner</code> 提供正规 hook 面。</p></div>
+    <div class="lang-en-only"><p>Extensions should subscribe to events, not monkey-patch privates — <code>ExtensionRunner</code> provides hooks.</p></div>
+
+    <div class="lang-zh-only"><p>JSONL <code>CURRENT_SESSION_VERSION = 3</code>：改 entry schema 必须 bump version 并提供迁移。</p></div>
+    <div class="lang-en-only"><p>JSONL <code>CURRENT_SESSION_VERSION = 3</code>: schema changes need version bump and migration.</p></div>
+
+    <div class="lang-zh-only"><p>对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。</p></div>
+    <div class="lang-en-only"><p>vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable.</p></div>
+
+    <div class="trace-box">
+      <div class="tb-tag">TRACE · station 22</div>
+      <div class="lang-zh-only"><p>站 22：<code>packages/coding-agent/src/core/session-manager.ts</code> 处理主线。</p></div>
+      <div class="lang-en-only"><p>Station 22: <code>packages/coding-agent/src/core/session-manager.ts</code> on through-line.</p></div>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/session-manager.ts</span>
+        <span class="src-tag">src</span>
+      </div>
+      <span class="src-line"><span class="src-line"><span class="src-kw">export const</span> <span class="src-arg">CURRENT_SESSION_VERSION</span> = <span class="src-num">3</span>;</span></span>
+      <span class="src-line"><span class="src-line"><span class="src-arg">parentId</span>: <span class="src-cls">string</span> | <span class="src-cls">null</span>;</span></span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+      <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
+      <tbody>
+      <tr><td>cp 10</td><td>Session Tree</td><td><code>session.ts</code></td><td><code>packages/coding-agent/src/core/session-manager.ts</code></td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">JSONL 会话树最关键文件？</span><span class="lang-en-only">Key file?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p><code>packages/coding-agent/src/core/session-manager.ts</code>。</p></div><div class="lang-en-only"><p><code>packages/coding-agent/src/core/session-manager.ts</code>.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">如何单测？</span><span class="lang-en-only">Unit test?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>mock StreamFn 或 ScriptedModel。</p></div><div class="lang-en-only"><p>mock StreamFn or ScriptedModel.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">与 textbook 差异？</span><span class="lang-en-only">vs textbook?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>生产含 OAuth/TUI/40+ providers。</p></div><div class="lang-en-only"><p>Production adds OAuth/TUI/40+ providers.</p></div></div></details>
   </section>
 
   <section class="chap" id="c23">
@@ -3509,6 +5941,38 @@
     <h2 class="chap-title lang-en-only">Compaction and harness</h2>
     <p class="chap-en lang-zh-only">上下文压缩 · SQLite lanes</p>
     <p class="chap-en lang-en-only">context compression · SQLite lanes</p>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>Compaction 决定你如何理解 Pi 在此层的机制。</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>反直觉：<code>index.ts</code> 的复杂度在事件契约而非算法。</span></p>
+      <p><span class="swc-pill act">优化</span><span>优化：--verbose + 源码对照，不猜测模型行为。</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>Compaction shapes how you understand Pi at this layer.</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>Counter-intuitive: complexity in <code>index.ts</code> is event contracts.</span></p>
+      <p><span class="swc-pill act">优化</span><span>Optimize: --verbose plus source, don't guess.</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">coding-agent</span><span class="lang-en-only">coding-agent</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">站 23</span><span class="lang-en-only">St. 23</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">index.ts</span><span class="lang-en-only">index.ts</span></div>
+      </div>
+    </div>
+
     <div class="lang-zh-only"><p><strong>Compaction</strong>：上下文超阈值时，历史消息<strong>不动</strong>（JSONL 完整保留），但<strong>重建</strong>发给模型的 context——用 LLM 生成摘要替换早期消息。</p></div>
     <div class="lang-en-only"><p><strong>Compaction</strong>: when context exceeds threshold, history <strong>stays</strong> in JSONL but <strong>rebuilt</strong> context for model — LLM summary replaces early messages.</p></div>
 
@@ -3573,9 +6037,82 @@
       <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 11</strong>: Context Compaction (<code>context.ts</code>) · production: <code>packages/coding-agent/src/core/compaction/</code></span>
     </div>
 
-    <div class="note">
-      <span class="lang-zh-only">本章 (23) 在主线 prompt「上下文压缩 · SQLite lanes」路径上负责：<strong>Compaction 与 Harness</strong>。回到 C02 的 22 站地图定位这一章。</span>
-      <span class="lang-en-only">Chapter (23) on the through-line path handles: <strong>Compaction and harness</strong>. Return to C02's 22-station map to locate this chapter.</span>
+    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+      <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
+      <tbody>
+      <tr><td>cp 11</td><td>Context Compaction</td><td><code>context.ts</code></td><td><code>packages/coding-agent/src/core/compaction/</code></td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">Compaction：主线 prompt 如何穿过此模块</span><span class="lang-en-only">Compaction: through-line crossing</span></h3>
+
+    <div class="lang-zh-only"><p>用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/coding-agent/src/core/compaction/index.ts</code> 定义了此阶段的类型契约与副作用边界。</p></div>
+    <div class="lang-en-only"><p>After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/coding-agent/src/core/compaction/index.ts</code> defines type contracts and side-effect boundaries here.</p></div>
+
+    <div class="lang-zh-only"><p>在 pi-mono 仓库打开该文件，搜索 <code>export</code> 与 <code>AgentEvent</code>——这是比读 README 更快的定位法。</p></div>
+    <div class="lang-en-only"><p>In pi-mono, search <code>export</code> and <code>AgentEvent</code> — faster than README alone.</p></div>
+
+    <div class="lang-zh-only"><p>设计原则：核心循环（agent-loop）不 import TUI；本模块通过事件与回调与上游通信。</p></div>
+    <div class="lang-en-only"><p>Principle: agent-loop never imports TUI; this module talks upstream via events/callbacks.</p></div>
+
+    <div class="lang-zh-only"><p>pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。</p></div>
+    <div class="lang-en-only"><p>Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">Compaction：关键函数与数据流</span><span class="lang-en-only">Compaction: key functions and data flow</span></h3>
+
+    <div class="lang-zh-only"><p><code>index.ts</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。</p></div>
+    <div class="lang-en-only"><p><code>async</code> functions in <code>index.ts</code> are usually IO boundaries: disk, network, or subprocess.</p></div>
+
+    <div class="lang-zh-only"><p>成功路径与错误路径都必须 emit 事件，否则 TUI 会卡在 streaming 状态、JSONL 会缺 entry。</p></div>
+    <div class="lang-en-only"><p>Success and error paths must emit events or TUI stalls streaming and JSONL misses entries.</p></div>
+
+    <div class="lang-zh-only"><p>length 截断时 <code>agent-loop.ts</code> 的 <code>failToolCallsFromTruncatedMessage</code> 批量失败 tool calls，防止执行损坏参数。</p></div>
+    <div class="lang-en-only"><p>On length truncation, <code>failToolCallsFromTruncatedMessage</code> fails all tool calls to avoid corrupted args.</p></div>
+
+    <div class="lang-zh-only"><p>对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。</p></div>
+    <div class="lang-en-only"><p>Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">Compaction：与 agent-loop 的接口</span><span class="lang-en-only">Compaction: interface with agent-loop</span></h3>
+
+    <div class="lang-zh-only"><p><code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。</p></div>
+    <div class="lang-en-only"><p><code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc.</p></div>
+
+    <div class="lang-zh-only"><p><code>AgentSession</code> 在构造 config 时绑定本模块实现；换模式（print/rpc/interactive）不换 agent-loop。</p></div>
+    <div class="lang-en-only"><p><code>AgentSession</code> binds this module when building config; modes change, agent-loop does not.</p></div>
+
+    <div class="lang-zh-only"><p>fork 项目时优先替换本模块而非复制 agent-loop——这是 Pi 社区的实际 fork 模式。</p></div>
+    <div class="lang-en-only"><p>When forking, replace this module first rather than copying agent-loop — the common community pattern.</p></div>
+
+    <div class="lang-zh-only"><p>--verbose 模式下 stderr 事件类型可回溯到 <code>packages/coding-agent/src/core/compaction/index.ts</code> 的具体行。</p></div>
+    <div class="lang-en-only"><p>Under --verbose, stderr event types trace to lines in <code>packages/coding-agent/src/core/compaction/index.ts</code>.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">Compaction：设计权衡与常见坑</span><span class="lang-en-only">Compaction: trade-offs and pitfalls</span></h3>
+
+    <div class="lang-zh-only"><p>显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。</p></div>
+    <div class="lang-en-only"><p>Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union.</p></div>
+
+    <div class="lang-zh-only"><p>扩展应 subscribe 事件而非 monkey-patch 私有方法——<code>ExtensionRunner</code> 提供正规 hook 面。</p></div>
+    <div class="lang-en-only"><p>Extensions should subscribe to events, not monkey-patch privates — <code>ExtensionRunner</code> provides hooks.</p></div>
+
+    <div class="lang-zh-only"><p>JSONL <code>CURRENT_SESSION_VERSION = 3</code>：改 entry schema 必须 bump version 并提供迁移。</p></div>
+    <div class="lang-en-only"><p>JSONL <code>CURRENT_SESSION_VERSION = 3</code>: schema changes need version bump and migration.</p></div>
+
+    <div class="lang-zh-only"><p>对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。</p></div>
+    <div class="lang-en-only"><p>vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable.</p></div>
+
+    <div class="trace-box">
+      <div class="tb-tag">TRACE · station 23</div>
+      <div class="lang-zh-only"><p>站 23：<code>packages/coding-agent/src/core/compaction/index.ts</code> 处理主线。</p></div>
+      <div class="lang-en-only"><p>Station 23: <code>packages/coding-agent/src/core/compaction/index.ts</code> on through-line.</p></div>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/compaction/index.ts</span>
+        <span class="src-tag">src</span>
+      </div>
+      <span class="src-line"><span class="src-line"><span class="src-comment">// Compaction · packages/coding-agent/src/core/compaction/index.ts</span></span></span>
+      <span class="src-line"><span class="src-line"><span class="src-comment">// through-line: README.md</span></span></span>
     </div>
 
     <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
@@ -3584,6 +6121,14 @@
       <tr><td>cp 11</td><td>Context Compaction</td><td><code>context.ts</code></td><td><code>packages/coding-agent/src/core/compaction/</code></td></tr>
       </tbody>
     </table>
+
+    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">Compaction最关键文件？</span><span class="lang-en-only">Key file?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p><code>packages/coding-agent/src/core/compaction/index.ts</code>。</p></div><div class="lang-en-only"><p><code>packages/coding-agent/src/core/compaction/index.ts</code>.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">如何单测？</span><span class="lang-en-only">Unit test?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>mock StreamFn 或 ScriptedModel。</p></div><div class="lang-en-only"><p>mock StreamFn or ScriptedModel.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">与 textbook 差异？</span><span class="lang-en-only">vs textbook?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>生产含 OAuth/TUI/40+ providers。</p></div><div class="lang-en-only"><p>Production adds OAuth/TUI/40+ providers.</p></div></div></details>
   </section>
 
   <section class="chap" id="c24">
@@ -3592,6 +6137,38 @@
     <h2 class="chap-title lang-en-only">vs Claude Code / Cursor</h2>
     <p class="chap-en lang-zh-only">minimal harness 的设计取舍</p>
     <p class="chap-en lang-en-only">design trade-offs of a minimal harness</p>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>生态对比 决定你如何理解 Pi 在此层的机制。</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>反直觉：<code>—</code> 的复杂度在事件契约而非算法。</span></p>
+      <p><span class="swc-pill act">优化</span><span>优化：--verbose + 源码对照，不猜测模型行为。</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>生态对比 shapes how you understand Pi at this layer.</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>Counter-intuitive: complexity in <code>—</code> is event contracts.</span></p>
+      <p><span class="swc-pill act">优化</span><span>Optimize: --verbose plus source, don't guess.</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">pi-mono</span><span class="lang-en-only">pi-mono</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">背景</span><span class="lang-en-only">Background</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">—</span><span class="lang-en-only">—</span></div>
+      </div>
+    </div>
+
     <div class="lang-zh-only"><p>对比三条路线：Claude Code（密封 CLI + MCP）、Cursor（密封 IDE + 全生态）、Pi（开源 harness + 终端 + JSONL）。</p></div>
     <div class="lang-en-only"><p>Three routes: Claude Code (sealed CLI + MCP), Cursor (sealed IDE + ecosystem), Pi (open harness + terminal + JSONL).</p></div>
 
@@ -3616,11 +6193,6 @@
       <span class="lang-en-only">Not «which is better» — «do you want closed-loop UX or open-book exam».</span>
     </div>
 
-    <div class="note">
-      <span class="lang-zh-only">本章 (24) 在主线 prompt「minimal harness 的设计取舍」路径上负责：<strong>对比 Claude Code / Cursor</strong>。回到 C02 的 22 站地图定位这一章。</span>
-      <span class="lang-en-only">Chapter (24) on the through-line path handles: <strong>vs Claude Code / Cursor</strong>. Return to C02's 22-station map to locate this chapter.</span>
-    </div>
-
     <table class="cmp">
       <thead><tr><th>特性</th><th>Claude Code</th><th>Cursor</th><th>Pi</th></tr></thead>
       <tbody>
@@ -3634,6 +6206,79 @@
       <tr><td>OAuth 40+ 模型</td><td>△</td><td>△</td><td>✓</td></tr>
       </tbody>
     </table>
+
+    <h3 class="sub"><span class="lang-zh-only">生态对比：主线 prompt 如何穿过此模块</span><span class="lang-en-only">生态对比: through-line crossing</span></h3>
+
+    <div class="lang-zh-only"><p>用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>—</code> 定义了此阶段的类型契约与副作用边界。</p></div>
+    <div class="lang-en-only"><p>After «<code>read README.md and tell me what this project does in one sentence</code>», <code>—</code> defines type contracts and side-effect boundaries here.</p></div>
+
+    <div class="lang-zh-only"><p>在 pi-mono 仓库打开该文件，搜索 <code>export</code> 与 <code>AgentEvent</code>——这是比读 README 更快的定位法。</p></div>
+    <div class="lang-en-only"><p>In pi-mono, search <code>export</code> and <code>AgentEvent</code> — faster than README alone.</p></div>
+
+    <div class="lang-zh-only"><p>设计原则：核心循环（agent-loop）不 import TUI；本模块通过事件与回调与上游通信。</p></div>
+    <div class="lang-en-only"><p>Principle: agent-loop never imports TUI; this module talks upstream via events/callbacks.</p></div>
+
+    <div class="lang-zh-only"><p>pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。</p></div>
+    <div class="lang-en-only"><p>Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">生态对比：关键函数与数据流</span><span class="lang-en-only">生态对比: key functions and data flow</span></h3>
+
+    <div class="lang-zh-only"><p><code>—</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。</p></div>
+    <div class="lang-en-only"><p><code>async</code> functions in <code>—</code> are usually IO boundaries: disk, network, or subprocess.</p></div>
+
+    <div class="lang-zh-only"><p>成功路径与错误路径都必须 emit 事件，否则 TUI 会卡在 streaming 状态、JSONL 会缺 entry。</p></div>
+    <div class="lang-en-only"><p>Success and error paths must emit events or TUI stalls streaming and JSONL misses entries.</p></div>
+
+    <div class="lang-zh-only"><p>length 截断时 <code>agent-loop.ts</code> 的 <code>failToolCallsFromTruncatedMessage</code> 批量失败 tool calls，防止执行损坏参数。</p></div>
+    <div class="lang-en-only"><p>On length truncation, <code>failToolCallsFromTruncatedMessage</code> fails all tool calls to avoid corrupted args.</p></div>
+
+    <div class="lang-zh-only"><p>对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。</p></div>
+    <div class="lang-en-only"><p>Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">生态对比：与 agent-loop 的接口</span><span class="lang-en-only">生态对比: interface with agent-loop</span></h3>
+
+    <div class="lang-zh-only"><p><code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。</p></div>
+    <div class="lang-en-only"><p><code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc.</p></div>
+
+    <div class="lang-zh-only"><p><code>AgentSession</code> 在构造 config 时绑定本模块实现；换模式（print/rpc/interactive）不换 agent-loop。</p></div>
+    <div class="lang-en-only"><p><code>AgentSession</code> binds this module when building config; modes change, agent-loop does not.</p></div>
+
+    <div class="lang-zh-only"><p>fork 项目时优先替换本模块而非复制 agent-loop——这是 Pi 社区的实际 fork 模式。</p></div>
+    <div class="lang-en-only"><p>When forking, replace this module first rather than copying agent-loop — the common community pattern.</p></div>
+
+    <div class="lang-zh-only"><p>--verbose 模式下 stderr 事件类型可回溯到 <code>—</code> 的具体行。</p></div>
+    <div class="lang-en-only"><p>Under --verbose, stderr event types trace to lines in <code>—</code>.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">生态对比：设计权衡与常见坑</span><span class="lang-en-only">生态对比: trade-offs and pitfalls</span></h3>
+
+    <div class="lang-zh-only"><p>显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。</p></div>
+    <div class="lang-en-only"><p>Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union.</p></div>
+
+    <div class="lang-zh-only"><p>扩展应 subscribe 事件而非 monkey-patch 私有方法——<code>ExtensionRunner</code> 提供正规 hook 面。</p></div>
+    <div class="lang-en-only"><p>Extensions should subscribe to events, not monkey-patch privates — <code>ExtensionRunner</code> provides hooks.</p></div>
+
+    <div class="lang-zh-only"><p>JSONL <code>CURRENT_SESSION_VERSION = 3</code>：改 entry schema 必须 bump version 并提供迁移。</p></div>
+    <div class="lang-en-only"><p>JSONL <code>CURRENT_SESSION_VERSION = 3</code>: schema changes need version bump and migration.</p></div>
+
+    <div class="lang-zh-only"><p>对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。</p></div>
+    <div class="lang-en-only"><p>vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable.</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; —</span>
+        <span class="src-tag">src</span>
+      </div>
+      <span class="src-line"><span class="src-line"><span class="src-comment">// 生态对比 · —</span></span></span>
+      <span class="src-line"><span class="src-line"><span class="src-comment">// through-line: README.md</span></span></span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">生态对比最关键文件？</span><span class="lang-en-only">Key file?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p><code>—</code>。</p></div><div class="lang-en-only"><p><code>—</code>.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">如何单测？</span><span class="lang-en-only">Unit test?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>mock StreamFn 或 ScriptedModel。</p></div><div class="lang-en-only"><p>mock StreamFn or ScriptedModel.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">与 textbook 差异？</span><span class="lang-en-only">vs textbook?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>生产含 OAuth/TUI/40+ providers。</p></div><div class="lang-en-only"><p>Production adds OAuth/TUI/40+ providers.</p></div></div></details>
   </section>
 
   <section class="chap" id="c25">
@@ -3642,6 +6287,38 @@
     <h2 class="chap-title lang-en-only">RPC and pi-server</h2>
     <p class="chap-en lang-zh-only">JSONL 进程协议 · CBOR 远程会话</p>
     <p class="chap-en lang-en-only">JSONL process protocol · CBOR remote sessions</p>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>pi-protocol 定义 JSONL 帧 + TypeBox schema；pi-server 用 CBOR 跑远程会话。</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>反直觉：RPC 模式不是 HTTP REST，而是 stdin/stdout JSONL 进程协议。</span></p>
+      <p><span class="swc-pill act">优化</span><span>优化：--mode rpc 让外部编排器驱动 AgentSession 而不启动 TUI。</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>pi-protocol defines JSONL frames + TypeBox schema; pi-server runs remote sessions over CBOR.</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>Counter-intuitive: RPC mode is stdin/stdout JSONL process protocol, not HTTP REST.</span></p>
+      <p><span class="swc-pill act">优化</span><span>Optimize: --mode rpc lets external orchestrator drive AgentSession without TUI.</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">protocol + server</span><span class="lang-en-only">protocol + server</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">schemas.ts + rpc-entry.ts</span><span class="lang-en-only">schemas.ts + rpc-entry.ts</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">站 21</span><span class="lang-en-only">St. 21</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">JSONL / CBOR</span><span class="lang-en-only">JSONL / CBOR</span></div>
+      </div>
+    </div>
+
     <div class="lang-zh-only"><p><code>--mode rpc</code> 把 AgentSession 变成 JSONL 帧协议：stdin 收命令，stdout 吐事件。远程场景用 pi-server + CBOR。</p></div>
     <div class="lang-en-only"><p><code>--mode rpc</code> turns AgentSession into JSONL frame protocol: stdin commands, stdout events. Remote uses pi-server + CBOR.</p></div>
 
@@ -3663,10 +6340,86 @@
       </tbody>
     </table>
 
-    <div class="note">
-      <span class="lang-zh-only">本章 (25) 在主线 prompt「JSONL 进程协议 · CBOR 远程会话」路径上负责：<strong>RPC 与 pi-server</strong>。回到 C02 的 22 站地图定位这一章。</span>
-      <span class="lang-en-only">Chapter (25) on the through-line path handles: <strong>RPC and pi-server</strong>. Return to C02's 22-station map to locate this chapter.</span>
+    <h3 class="sub"><span class="lang-zh-only">protocol 包：TypeBox schema</span><span class="lang-en-only">protocol: TypeBox schema</span></h3>
+
+    <div class="lang-zh-only"><p>packages/protocol/src/schemas.ts：PROTOCOL_VERSION = 1；SessionPhaseSchema 对齐 AgentHarnessPhase（idle/turn/compaction/branch_summary/retry）。</p></div>
+    <div class="lang-en-only"><p>schemas.ts: PROTOCOL_VERSION = 1; SessionPhaseSchema aligns with AgentHarnessPhase.</p></div>
+
+    <div class="lang-zh-only"><p>ModelRefSchema、ThinkingLevelSchema、JsonValueSchema 用 Type.Strict 禁止 additionalProperties。</p></div>
+    <div class="lang-en-only"><p>ModelRefSchema, ThinkingLevelSchema, JsonValueSchema use strict objects.</p></div>
+
+    <div class="lang-zh-only"><p>帧格式在 framing.ts + codec.ts：长度前缀 JSONL 或 CBOR 二进制。</p></div>
+    <div class="lang-en-only"><p>Frame format in framing.ts + codec.ts: length-prefixed JSONL or CBOR binary.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">RPC 模式启动链</span><span class="lang-en-only">RPC boot chain</span></h3>
+
+    <div class="lang-zh-only"><p>main.ts 解析 --mode rpc → rpc-entry.ts 读 stdin JSONL 命令 → 调用 AgentSession 方法 → 写 stdout 响应。</p></div>
+    <div class="lang-en-only"><p>main.ts --mode rpc → rpc-entry.ts reads stdin JSONL commands → AgentSession methods → stdout responses.</p></div>
+
+    <div class="lang-zh-only"><p>主线 prompt 可作为 rpc prompt 命令注入，无需 TUI。</p></div>
+    <div class="lang-en-only"><p>Through-line injectable as rpc prompt command without TUI.</p></div>
+
+    <div class="lang-zh-only"><p>适合 CI、外部 IDE 插件、多 pi 实例编排。</p></div>
+    <div class="lang-en-only"><p>Suits CI, external IDE plugins, multi-pi orchestration.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">pi-server 远程会话</span><span class="lang-en-only">pi-server remote sessions</span></h3>
+
+    <div class="lang-zh-only"><p>packages/server CBOR over HTTP 暴露远程 AgentSession；client 包 acquireSession 获取 lease。</p></div>
+    <div class="lang-en-only"><p>server package exposes remote AgentSession via CBOR HTTP; client acquireSession gets lease.</p></div>
+
+    <div class="lang-zh-only"><p>exclusive vs shared lease 防止并发写（client README 30 行）。</p></div>
+    <div class="lang-en-only"><p>exclusive vs shared lease prevents concurrent writes (client README line 30).</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">与 session fork 组合</span><span class="lang-en-only">With session fork</span></h3>
+
+    <div class="lang-zh-only"><p>RPC + fork：父进程 rpc fork 命令创建 branch session，子 pi 实例处理子任务——替代 sub-agent 的官方路径之一。</p></div>
+    <div class="lang-en-only"><p>RPC + fork: parent rpc fork creates branch session, child pi handles subtask — official sub-agent alternative.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">主线 prompt 的 RPC trace</span><span class="lang-en-only">RPC trace of through-line</span></h3>
+
+    <div class="lang-zh-only"><p>管道 stdin 发送 prompt 命令 + <code>pi --mode rpc --verbose</code> 可无 TUI 观察完整事件 JSONL。</p></div>
+    <div class="lang-en-only"><p>Pipe stdin prompt command + <code>pi --mode rpc --verbose</code> observes full event JSONL without TUI.</p></div>
+
+    <div class="lang-zh-only"><p>对比 interactive：同一 <code>AgentSession.prompt()</code> 路径，仅 I/O 层从 TUI 换为 stdin/stdout 帧。</p></div>
+    <div class="lang-en-only"><p>vs interactive: same <code>AgentSession.prompt()</code> path, only I/O layer swaps TUI for stdin/stdout frames.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">rpc-entry.ts 命令面</span><span class="lang-en-only">rpc-entry.ts command surface</span></h3>
+
+    <div class="lang-zh-only"><p><code>packages/coding-agent/src/rpc-entry.ts</code> 解析每行 JSON 命令：prompt、abort、set_model、fork 等，映射到 AgentSession 公开方法。</p></div>
+    <div class="lang-en-only"><p><code>rpc-entry.ts</code> parses each JSON line command: prompt, abort, set_model, fork, etc., mapping to AgentSession public methods.</p></div>
+
+    <div class="lang-zh-only"><p>响应帧同样 JSONL 序列化 AgentEvent，外部编排器可重建与 --verbose 等价的日志。</p></div>
+    <div class="lang-en-only"><p>Response frames serialize AgentEvent as JSONL; external orchestrator can rebuild --verbose-equivalent logs.</p></div>
+
+    <div class="trace-box">
+      <div class="tb-tag">TRACE · station 21</div>
+      <div class="lang-zh-only"><p>站 21：RPC JSONL 帧或 CBOR 远程驱动 AgentSession。</p></div>
+      <div class="lang-en-only"><p>Station 21: RPC JSONL frames or CBOR remote drives AgentSession.</p></div>
     </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/protocol/src/schemas.ts</span>
+        <span class="src-tag">proto</span>
+      </div>
+      <span class="src-line"><span class="src-line"><span class="src-kw">export const</span> <span class="src-arg">PROTOCOL_VERSION</span> = <span class="src-num">1</span>;</span></span>
+      <span class="src-line"><span class="src-line"><span class="src-kw">export const</span> <span class="src-arg">SessionPhaseSchema</span> = Type.Union([...]);</span></span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+      <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
+      <tbody>
+      <tr><td>cp 13</td><td>Composition Root</td><td><code>composition-root</code></td><td><code>packages/coding-agent/src/core/agent-session.ts · sdk.ts</code></td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">RPC 与 interactive 共享 AgentSession 吗？</span><span class="lang-en-only">Share AgentSession?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>是，同一类不同 I/O 层。</p></div><div class="lang-en-only"><p>Yes, same class, different I/O layer.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">CBOR 何时用？</span><span class="lang-en-only">When CBOR?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>pi-server 远程；本地 RPC 用 JSONL。</p></div><div class="lang-en-only"><p>pi-server remote; local RPC uses JSONL.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">如何测 RPC？</span><span class="lang-en-only">Test RPC?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>管道 stdin/stdout + 断言响应帧序列。</p></div><div class="lang-en-only"><p>Pipe stdin/stdout + assert response frame sequence.</p></div></div></details>
   </section>
 
   <section class="chap" id="c26">
@@ -3675,6 +6428,38 @@
     <h2 class="chap-title lang-en-only">How to trace a turn yourself</h2>
     <p class="chap-en lang-zh-only">--verbose · event log · session file</p>
     <p class="chap-en lang-en-only">--verbose · event log · session file</p>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>自己 trace 决定你如何理解 Pi 在此层的机制。</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>反直觉：<code>main.ts</code> 的复杂度在事件契约而非算法。</span></p>
+      <p><span class="swc-pill act">优化</span><span>优化：--verbose + 源码对照，不猜测模型行为。</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>自己 trace shapes how you understand Pi at this layer.</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>Counter-intuitive: complexity in <code>main.ts</code> is event contracts.</span></p>
+      <p><span class="swc-pill act">优化</span><span>Optimize: --verbose plus source, don't guess.</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">coding-agent</span><span class="lang-en-only">coding-agent</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">站 26</span><span class="lang-en-only">St. 26</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">main.ts</span><span class="lang-en-only">main.ts</span></div>
+      </div>
+    </div>
+
     <div class="lang-zh-only"><p>自己 trace 主线 prompt 的三件套：<code>pi --verbose</code> 看 AgentEvent、打开 JSONL 会话文件、对照 pi-textbook workshop 测试。</p></div>
     <div class="lang-en-only"><p>Trace the through-line yourself: <code>pi --verbose</code> for AgentEvents, open JSONL session file, compare pi-textbook workshop tests.</p></div>
 
@@ -3735,10 +6520,92 @@
       <span class="lang-en-only">Answer should cite: AgentSession.prompt → agentLoop → two streamSimple → read tool → JSONL append → TUI message_update.</span>
     </div>
 
-    <div class="note">
-      <span class="lang-zh-only">本章 (26) 在主线 prompt「--verbose · event log · session file」路径上负责：<strong>怎么自己 trace 一轮</strong>。回到 C02 的 22 站地图定位这一章。</span>
-      <span class="lang-en-only">Chapter (26) on the through-line path handles: <strong>How to trace a turn yourself</strong>. Return to C02's 22-station map to locate this chapter.</span>
+    <h3 class="sub"><span class="lang-zh-only">自己 trace：主线 prompt 如何穿过此模块</span><span class="lang-en-only">自己 trace: through-line crossing</span></h3>
+
+    <div class="lang-zh-only"><p>用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/coding-agent/src/main.ts</code> 定义了此阶段的类型契约与副作用边界。</p></div>
+    <div class="lang-en-only"><p>After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/coding-agent/src/main.ts</code> defines type contracts and side-effect boundaries here.</p></div>
+
+    <div class="lang-zh-only"><p>在 pi-mono 仓库打开该文件，搜索 <code>export</code> 与 <code>AgentEvent</code>——这是比读 README 更快的定位法。</p></div>
+    <div class="lang-en-only"><p>In pi-mono, search <code>export</code> and <code>AgentEvent</code> — faster than README alone.</p></div>
+
+    <div class="lang-zh-only"><p>设计原则：核心循环（agent-loop）不 import TUI；本模块通过事件与回调与上游通信。</p></div>
+    <div class="lang-en-only"><p>Principle: agent-loop never imports TUI; this module talks upstream via events/callbacks.</p></div>
+
+    <div class="lang-zh-only"><p>pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。</p></div>
+    <div class="lang-en-only"><p>Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">自己 trace：关键函数与数据流</span><span class="lang-en-only">自己 trace: key functions and data flow</span></h3>
+
+    <div class="lang-zh-only"><p><code>main.ts</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。</p></div>
+    <div class="lang-en-only"><p><code>async</code> functions in <code>main.ts</code> are usually IO boundaries: disk, network, or subprocess.</p></div>
+
+    <div class="lang-zh-only"><p>成功路径与错误路径都必须 emit 事件，否则 TUI 会卡在 streaming 状态、JSONL 会缺 entry。</p></div>
+    <div class="lang-en-only"><p>Success and error paths must emit events or TUI stalls streaming and JSONL misses entries.</p></div>
+
+    <div class="lang-zh-only"><p>length 截断时 <code>agent-loop.ts</code> 的 <code>failToolCallsFromTruncatedMessage</code> 批量失败 tool calls，防止执行损坏参数。</p></div>
+    <div class="lang-en-only"><p>On length truncation, <code>failToolCallsFromTruncatedMessage</code> fails all tool calls to avoid corrupted args.</p></div>
+
+    <div class="lang-zh-only"><p>对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。</p></div>
+    <div class="lang-en-only"><p>Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">自己 trace：与 agent-loop 的接口</span><span class="lang-en-only">自己 trace: interface with agent-loop</span></h3>
+
+    <div class="lang-zh-only"><p><code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。</p></div>
+    <div class="lang-en-only"><p><code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc.</p></div>
+
+    <div class="lang-zh-only"><p><code>AgentSession</code> 在构造 config 时绑定本模块实现；换模式（print/rpc/interactive）不换 agent-loop。</p></div>
+    <div class="lang-en-only"><p><code>AgentSession</code> binds this module when building config; modes change, agent-loop does not.</p></div>
+
+    <div class="lang-zh-only"><p>fork 项目时优先替换本模块而非复制 agent-loop——这是 Pi 社区的实际 fork 模式。</p></div>
+    <div class="lang-en-only"><p>When forking, replace this module first rather than copying agent-loop — the common community pattern.</p></div>
+
+    <div class="lang-zh-only"><p>--verbose 模式下 stderr 事件类型可回溯到 <code>packages/coding-agent/src/main.ts</code> 的具体行。</p></div>
+    <div class="lang-en-only"><p>Under --verbose, stderr event types trace to lines in <code>packages/coding-agent/src/main.ts</code>.</p></div>
+
+    <h3 class="sub"><span class="lang-zh-only">自己 trace：设计权衡与常见坑</span><span class="lang-en-only">自己 trace: trade-offs and pitfalls</span></h3>
+
+    <div class="lang-zh-only"><p>显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。</p></div>
+    <div class="lang-en-only"><p>Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union.</p></div>
+
+    <div class="lang-zh-only"><p>扩展应 subscribe 事件而非 monkey-patch 私有方法——<code>ExtensionRunner</code> 提供正规 hook 面。</p></div>
+    <div class="lang-en-only"><p>Extensions should subscribe to events, not monkey-patch privates — <code>ExtensionRunner</code> provides hooks.</p></div>
+
+    <div class="lang-zh-only"><p>JSONL <code>CURRENT_SESSION_VERSION = 3</code>：改 entry schema 必须 bump version 并提供迁移。</p></div>
+    <div class="lang-en-only"><p>JSONL <code>CURRENT_SESSION_VERSION = 3</code>: schema changes need version bump and migration.</p></div>
+
+    <div class="lang-zh-only"><p>对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。</p></div>
+    <div class="lang-en-only"><p>vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable.</p></div>
+
+    <div class="trace-box">
+      <div class="tb-tag">TRACE · station 26</div>
+      <div class="lang-zh-only"><p>站 26：<code>packages/coding-agent/src/main.ts</code> 处理主线。</p></div>
+      <div class="lang-en-only"><p>Station 26: <code>packages/coding-agent/src/main.ts</code> on through-line.</p></div>
     </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/main.ts</span>
+        <span class="src-tag">src</span>
+      </div>
+      <span class="src-line"><span class="src-line"><span class="src-comment">// 自己 trace · packages/coding-agent/src/main.ts</span></span></span>
+      <span class="src-line"><span class="src-line"><span class="src-comment">// through-line: README.md</span></span></span>
+    </div>
+
+    <h3 class="sub"><span class="lang-zh-only">pi-textbook 交叉引用</span><span class="lang-en-only">pi-textbook cross-reference</span></h3>    <table class="cmp">
+      <thead><tr><th>CP</th><th>主题</th><th>教学 artifact</th><th>生产映射</th></tr></thead>
+      <tbody>
+      <tr><td>cp 00</td><td>一次 README 读取的七个里程碑</td><td><code>prologue.ts</code></td><td><code>packages/coding-agent/src/main.ts · packages/agent/src/agent-loop.ts</code></td></tr>
+      <tr><td>cp 14</td><td>Eval Capstone</td><td><code>eval-capstone</code></td><td><code>packages/evals/</code></td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="lang-zh-only">常见问题</span><span class="lang-en-only">FAQ</span></h3>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">自己 trace最关键文件？</span><span class="lang-en-only">Key file?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p><code>packages/coding-agent/src/main.ts</code>。</p></div><div class="lang-en-only"><p><code>packages/coding-agent/src/main.ts</code>.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">如何单测？</span><span class="lang-en-only">Unit test?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>mock StreamFn 或 ScriptedModel。</p></div><div class="lang-en-only"><p>mock StreamFn or ScriptedModel.</p></div></div></details>
+
+    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">与 textbook 差异？</span><span class="lang-en-only">vs textbook?</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>生产含 OAuth/TUI/40+ providers。</p></div><div class="lang-en-only"><p>Production adds OAuth/TUI/40+ providers.</p></div></div></details>
   </section>
 
   <footer class="footer">

--- a/public/immersive/pi-agent/index.html
+++ b/public/immersive/pi-agent/index.html
@@ -5060,6 +5060,210 @@
       <span class="src-line">      <span class="src-ln"> 405</span> <span class="src-hl">	<span class="src-kw">return</span> { messages, terminate: <span class="src-kw">false</span> };</span></span>
     </div>
 
+    <div class="lang-zh-only"><p>C10 心脏止于 <code>streamFunction</code> 调用点——再往下就是 C14 的 pi-ai 层。下面这条桥接 trace 把<strong>同一次 turn-1 model stream</strong>从 agent-loop 追到 Anthropic SSE，是理解「双环」与「provider 抽象」接缝的关键。</p></div>
+    <div class="lang-en-only"><p>C10 heart ends at <code>streamFunction</code> — below that is C14 pi-ai. This bridge trace follows <strong>the same turn-1 model stream</strong> from agent-loop to Anthropic SSE; the seam between twin loops and provider abstraction.</p></div>
+
+    <div class="trace-steps"><div class="ts-label"><span class="lang-zh-only">C10 → C14 跨层调用链（主线 turn-1）</span><span class="lang-en-only">C10 → C14 cross-layer call chain (through-line turn-1)</span></div>    <table class="cmp">
+      <thead><tr><th>#</th><th>location</th><th>主线时刻 / through-line moment</th></tr></thead>
+      <tbody>
+      <tr><td>1</td><td>agent-loop.ts:308</td><td>streamFunction(model, llmContext, options)</td></tr>
+      <tr><td>2</td><td>agent.ts:222</td><td>Agent.streamFunction ← sdk streamFn</td></tr>
+      <tr><td>3</td><td>sdk.ts:322</td><td>modelRuntime.streamSimple(model, context, …)</td></tr>
+      <tr><td>4</td><td>model-runtime.ts:638</td><td>prepareRequest → provider.streamSimple</td></tr>
+      <tr><td>5</td><td>models.ts:693</td><td>applyAuth → apiKey/headers/baseUrl</td></tr>
+      <tr><td>6</td><td>compat.ts:275</td><td>streamSimple → builtinProvider / resolveApiProvider</td></tr>
+      <tr><td>7</td><td>anthropic-messages.ts:584</td><td>SSE → stream.push(start|toolcall_delta|done)</td></tr>
+      <tr><td>8</td><td>agent-loop.ts:317</td><td>for await event → message_update → emit</td></tr>
+      </tbody>
+    </table></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
+        <span class="src-tag">bridge-call</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 297</span> <span class="src-hl">	<span class="src-comment">// Build LLM context</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 298</span> <span class="src-hl">	<span class="src-kw">const</span> llmContext: Context = {</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">llmContext：systemPrompt + messages + tools</span><span class="lang-en-only">llmContext: systemPrompt + messages + tools</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 299</span> <span class="src-hl">		systemPrompt: context.systemPrompt,</span></span>
+      <span class="src-line">      <span class="src-ln"> 300</span> <span class="src-hl">		messages: llmMessages,</span></span>
+      <span class="src-line">      <span class="src-ln"> 301</span> <span class="src-hl">		tools: context.tools,</span></span>
+      <span class="src-line">      <span class="src-ln"> 302</span> <span class="src-hl">	};</span></span>
+      <span class="src-line">      <span class="src-ln"> 303</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 304</span> <span class="src-hl">	<span class="src-comment">// Resolve API key (important for expiring tokens)</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 305</span> <span class="src-hl">	<span class="src-kw">const</span> resolvedApiKey =</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">getApiKey：OAuth token 可能在此刷新</span><span class="lang-en-only">getApiKey: OAuth token may refresh here</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 306</span> <span class="src-hl">		(config.getApiKey ? <span class="src-kw">await</span> config.getApiKey(config.model.provider) : <span class="src-kw">undefined</span>) || config.apiKey;</span></span>
+      <span class="src-line">      <span class="src-ln"> 307</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 308</span> <span class="src-hl">	<span class="src-kw">const</span> response = <span class="src-kw">await</span> streamFunction(config.model, llmContext, {</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">★ 跨层边界：agent-core 不再感知 provider</span><span class="lang-en-only">★ cross-layer boundary: agent-core unaware of provider</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 309</span> <span class="src-hl">		...config,</span></span>
+      <span class="src-line">      <span class="src-ln"> 310</span> <span class="src-hl">		apiKey: resolvedApiKey,</span></span>
+      <span class="src-line">      <span class="src-ln"> 311</span> <span class="src-hl">		signal,</span></span>
+      <span class="src-line">      <span class="src-ln"> 312</span> <span class="src-hl">	});</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/sdk.ts</span>
+        <span class="src-tag">default-stream</span>
+      </div>
+      <span class="src-line">      <span class="src-ln">  33</span> <span class="src-hl"><span class="src-comment">// Preserve the pre-0.81 fallback for extensions that construct Agent instances</span></span></span>
+      <span class="src-line">      <span class="src-ln">  34</span> <span class="src-hl"><span class="src-comment">// or invoke low-level agent loops without supplying streamFn. Agent core remains</span></span></span>
+      <span class="src-line">      <span class="src-ln">  35</span> <span class="src-hl"><span class="src-comment">// provider-agnostic and does not import pi-ai/compat itself.</span></span></span>
+      <span class="src-line">      <span class="src-ln">  36</span> <span class="src-hl">setDefaultStreamFn(streamSimple);</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">模块加载时注入默认 streamFn=streamSimple</span><span class="lang-en-only">module load injects default streamFn=streamSimple</span></span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/stream-fn.ts</span>
+        <span class="src-tag">stream-fn</span>
+      </div>
+      <span class="src-line">      <span class="src-ln">   5</span> <span class="src-hl">/**</span></span>
+      <span class="src-line">      <span class="src-ln">   6</span> <span class="src-hl"> * Configure the fallback used by Agent and low-level loops when callers omit streamFn.</span></span>
+      <span class="src-line">      <span class="src-ln">   7</span> <span class="src-hl"> *</span></span>
+      <span class="src-line">      <span class="src-ln">   8</span> <span class="src-hl"> * Hosts that provide a default model runtime can install its stream <span class="src-kw">function</span> here</span></span>
+      <span class="src-line">      <span class="src-ln">   9</span> <span class="src-hl"> * without making pi-agent-core depend on a provider catalog or compatibility layer.</span></span>
+      <span class="src-line">      <span class="src-ln">  10</span> <span class="src-hl"> */</span></span>
+      <span class="src-line">      <span class="src-ln">  11</span> <span class="src-hl"><span class="src-kw">export</span> <span class="src-kw">function</span> setDefaultStreamFn(streamFn: StreamFn | <span class="src-kw">undefined</span>): void {</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">setDefaultStreamFn：agent-core 与 pi-ai 解耦点</span><span class="lang-en-only">setDefaultStreamFn: agent-core / pi-ai decoupling</span></span></span>
+      <span class="src-line">      <span class="src-ln">  12</span> <span class="src-hl">	defaultStreamFn = streamFn;</span></span>
+      <span class="src-line">      <span class="src-ln">  13</span> <span class="src-hl">}</span></span>
+      <span class="src-line">      <span class="src-ln">  14</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln">  15</span> <span class="src-hl"><span class="src-kw">export</span> <span class="src-kw">function</span> getDefaultStreamFn(): StreamFn {</span></span>
+      <span class="src-line">      <span class="src-ln">  16</span> <span class="src-hl">	<span class="src-kw">if</span> (!defaultStreamFn) {</span></span>
+      <span class="src-line">      <span class="src-ln">  17</span> <span class="src-hl">		<span class="src-kw">throw</span> <span class="src-kw">new</span> Error(&quot;No default stream <span class="src-kw">function</span> configured. Pass streamFn explicitly or call setDefaultStreamFn().&quot;);</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">未配置时抛错——extensions 必须显式传 streamFn</span><span class="lang-en-only">throws if unset — extensions must pass streamFn</span></span></span>
+      <span class="src-line">      <span class="src-ln">  18</span> <span class="src-hl">	}</span></span>
+      <span class="src-line">      <span class="src-ln">  19</span> <span class="src-hl">	<span class="src-kw">return</span> defaultStreamFn;</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/sdk.ts</span>
+        <span class="src-tag">sdk-streamfn</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 304</span> <span class="src-hl">	agent = <span class="src-kw">new</span> Agent({</span></span>
+      <span class="src-line">      <span class="src-ln"> 305</span> <span class="src-hl">		initialState: {</span></span>
+      <span class="src-line">      <span class="src-ln"> 306</span> <span class="src-hl">			systemPrompt: &quot;&quot;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 307</span> <span class="src-hl">			model,</span></span>
+      <span class="src-line">      <span class="src-ln"> 308</span> <span class="src-hl">			thinkingLevel,</span></span>
+      <span class="src-line">      <span class="src-ln"> 309</span> <span class="src-hl">			tools: [],</span></span>
+      <span class="src-line">      <span class="src-ln"> 310</span> <span class="src-hl">		},</span></span>
+      <span class="src-line">      <span class="src-ln"> 311</span> <span class="src-hl">		convertToLlm: convertToLlmWithBlockImages,</span></span>
+      <span class="src-line">      <span class="src-ln"> 312</span> <span class="src-hl">		streamFn: <span class="src-kw">async</span> (model, context, options) =&gt; {</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">Agent 构造时覆盖默认 streamFn</span><span class="lang-en-only">Agent ctor overrides default streamFn</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 313</span> <span class="src-hl">			<span class="src-kw">const</span> providerRetrySettings = settingsManager.getProviderRetrySettings();</span></span>
+      <span class="src-line">      <span class="src-ln"> 314</span> <span class="src-hl">			<span class="src-kw">const</span> httpIdleTimeoutMs = settingsManager.getHttpIdleTimeoutMs();</span></span>
+      <span class="src-line">      <span class="src-ln"> 315</span> <span class="src-hl">			<span class="src-comment">// SDKs treat timeout=0 as 0ms (immediate timeout), not &amp;quot;no timeout&amp;quot;.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 316</span> <span class="src-hl">			<span class="src-comment">// Use max int32 to effectively disable the timeout.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 317</span> <span class="src-hl">			<span class="src-kw">const</span> effectiveTimeoutMs = httpIdleTimeoutMs === 0 ? 2147483647 : httpIdleTimeoutMs;</span></span>
+      <span class="src-line">      <span class="src-ln"> 318</span> <span class="src-hl">			<span class="src-kw">const</span> timeoutMs = options?.timeoutMs ?? providerRetrySettings.timeoutMs ?? effectiveTimeoutMs;</span></span>
+      <span class="src-line">      <span class="src-ln"> 319</span> <span class="src-hl">			<span class="src-kw">const</span> websocketConnectTimeoutMs =</span></span>
+      <span class="src-line">      <span class="src-ln"> 320</span> <span class="src-hl">				options?.websocketConnectTimeoutMs ?? settingsManager.getWebSocketConnectTimeoutMs();</span></span>
+      <span class="src-line">      <span class="src-ln"> 321</span> <span class="src-hl">			<span class="src-kw">const</span> headerRunner = extensionRunnerRef.current;</span></span>
+      <span class="src-line">      <span class="src-ln"> 322</span> <span class="src-hl">			<span class="src-kw">return</span> modelRuntime.streamSimple(model, context, {</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">★ modelRuntime.streamSimple：重试/timeout/header 在此</span><span class="lang-en-only">★ modelRuntime.streamSimple: retry/timeout/headers here</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 323</span> <span class="src-hl">				...options,</span></span>
+      <span class="src-line">      <span class="src-ln"> 324</span> <span class="src-hl">				timeoutMs,</span></span>
+      <span class="src-line">      <span class="src-ln"> 325</span> <span class="src-hl">				websocketConnectTimeoutMs,</span></span>
+      <span class="src-line">      <span class="src-ln"> 326</span> <span class="src-hl">				maxRetries: options?.maxRetries ?? providerRetrySettings.maxRetries,</span></span>
+      <span class="src-line">      <span class="src-ln"> 327</span> <span class="src-hl">				maxRetryDelayMs: options?.maxRetryDelayMs ?? providerRetrySettings.maxRetryDelayMs,</span></span>
+      <span class="src-line">      <span class="src-ln"> 328</span> <span class="src-hl">				transformHeaders: <span class="src-kw">async</span> (requestHeaders) =&gt; {</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">transformHeaders：扩展 before_provider_headers</span><span class="lang-en-only">transformHeaders: extension before_provider_headers</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 329</span> <span class="src-hl">					<span class="src-kw">const</span> headers = mergeProviderAttributionHeaders(</span></span>
+      <span class="src-line">      <span class="src-ln"> 330</span> <span class="src-hl">						model,</span></span>
+      <span class="src-line">      <span class="src-ln"> 331</span> <span class="src-hl">						settingsManager,</span></span>
+      <span class="src-line">      <span class="src-ln"> 332</span> <span class="src-hl">						options?.sessionId,</span></span>
+      <span class="src-line">      <span class="src-ln"> 333</span> <span class="src-hl">						requestHeaders,</span></span>
+      <span class="src-line">      <span class="src-ln"> 334</span> <span class="src-hl">					);</span></span>
+      <span class="src-line">      <span class="src-ln"> 335</span> <span class="src-hl">					<span class="src-kw">return</span> headerRunner?.hasHandlers(&quot;before_provider_headers&quot;)</span></span>
+      <span class="src-line">      <span class="src-ln"> 336</span> <span class="src-hl">						? headerRunner.emitBeforeProviderHeaders(headers ?? {})</span></span>
+      <span class="src-line">      <span class="src-ln"> 337</span> <span class="src-hl">						: (headers ?? {});</span></span>
+      <span class="src-line">      <span class="src-ln"> 338</span> <span class="src-hl">				},</span></span>
+      <span class="src-line">      <span class="src-ln"> 339</span> <span class="src-hl">			});</span></span>
+      <span class="src-line">      <span class="src-ln"> 340</span> <span class="src-hl">		},</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/model-runtime.ts</span>
+        <span class="src-tag">runtime-simple</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 573</span> <span class="src-hl">	private <span class="src-kw">async</span> prepareRequest&lt;TOptions extends ProviderRequestOptions &amp; ModelsRequestTransforms&gt;(</span></span>
+      <span class="src-line">      <span class="src-ln"> 574</span> <span class="src-hl">		model: Model&lt;Api&gt;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 575</span> <span class="src-hl">		options: TOptions | <span class="src-kw">undefined</span>,</span></span>
+      <span class="src-line">      <span class="src-ln"> 576</span> <span class="src-hl">	): Promise&lt;{</span></span>
+      <span class="src-line">      <span class="src-ln"> 577</span> <span class="src-hl">		provider: Provider;</span></span>
+      <span class="src-line">      <span class="src-ln"> 578</span> <span class="src-hl">		model: Model&lt;Api&gt;;</span></span>
+      <span class="src-line">      <span class="src-ln"> 579</span> <span class="src-hl">		options: Omit&lt;TOptions, &quot;transformHeaders&quot;&gt; &amp; ProviderRequestOptions;</span></span>
+      <span class="src-line">      <span class="src-ln"> 580</span> <span class="src-hl">	}&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln"> 581</span> <span class="src-hl">		<span class="src-kw">const</span> provider = this.models.getProvider(model.provider);</span></span>
+      <span class="src-line">      <span class="src-ln"> 582</span> <span class="src-hl">		<span class="src-kw">if</span> (!provider) <span class="src-kw">throw</span> <span class="src-kw">new</span> ModelsError(&quot;provider&quot;, <span class=<span class="src-str">"src-str"</span>>`Unknown provider: ${model.provider}`</span>);</span></span>
+      <span class="src-line">      <span class="src-ln"> 583</span> <span class="src-hl">		<span class="src-kw">const</span> resolution = <span class="src-kw">await</span> this.getAuth(model, {</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">prepareRequest：getAuth + merge headers</span><span class="lang-en-only">prepareRequest: getAuth + merge headers</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 584</span> <span class="src-hl">			apiKey: options?.apiKey,</span></span>
+      <span class="src-line">      <span class="src-ln"> 585</span> <span class="src-hl">			env: options?.env,</span></span>
+      <span class="src-line">      <span class="src-ln"> 586</span> <span class="src-hl">			signal: options?.signal,</span></span>
+      <span class="src-line">      <span class="src-ln"> 587</span> <span class="src-hl">		});</span></span>
+      <span class="src-line">      <span class="src-ln"> 588</span> <span class="src-hl">		<span class="src-kw">if</span> (!resolution) <span class="src-kw">throw</span> <span class="src-kw">new</span> ModelsError(&quot;auth&quot;, <span class=<span class="src-str">"src-str"</span>>`Provider is not configured: ${model.provider}`</span>);</span></span>
+      <span class="src-line">      <span class="src-ln"> 589</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 590</span> <span class="src-hl">		<span class="src-kw">const</span> { transformHeaders, ...rawProviderOptions } = options ?? {};</span></span>
+      <span class="src-line">      <span class="src-ln"> 591</span> <span class="src-hl">		<span class="src-kw">const</span> providerOptions = rawProviderOptions as Omit&lt;TOptions, &quot;transformHeaders&quot;&gt; &amp; ProviderRequestOptions;</span></span>
+      <span class="src-line">      <span class="src-ln"> 592</span> <span class="src-hl">		<span class="src-kw">let</span> headers = mergeHeaders(resolution.auth.headers, providerOptions.headers);</span></span>
+      <span class="src-line">      <span class="src-ln"> 593</span> <span class="src-hl">		<span class="src-kw">if</span> (transformHeaders) headers = <span class="src-kw">await</span> transformHeaders(headers ?? {});</span></span>
+      <span class="src-line">      <span class="src-ln"> 594</span> <span class="src-hl">		<span class="src-kw">const</span> env =</span></span>
+      <span class="src-line">      <span class="src-ln"> 595</span> <span class="src-hl">			resolution.env || providerOptions.env</span></span>
+      <span class="src-line">      <span class="src-ln"> 596</span> <span class="src-hl">				? { ...(resolution.env ?? {}), ...(providerOptions.env ?? {}) }</span></span>
+      <span class="src-line">      <span class="src-ln"> 597</span> <span class="src-hl">				: <span class="src-kw">undefined</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 598</span> <span class="src-hl">		<span class="src-kw">return</span> {</span></span>
+      <span class="src-line">      <span class="src-ln"> 599</span> <span class="src-hl">			provider,</span></span>
+      <span class="src-line">      <span class="src-ln"> 600</span> <span class="src-hl">			model: resolution.auth.baseUrl ? { ...model, baseUrl: resolution.auth.baseUrl } : model,</span></span>
+      <span class="src-line">      <span class="src-ln"> 601</span> <span class="src-hl">			options: {</span></span>
+      <span class="src-line">      <span class="src-ln"> 602</span> <span class="src-hl">				...providerOptions,</span></span>
+      <span class="src-line">      <span class="src-ln"> 603</span> <span class="src-hl">				apiKey: providerOptions.apiKey ?? resolution.auth.apiKey,</span></span>
+      <span class="src-line">      <span class="src-ln"> 604</span> <span class="src-hl">				headers,</span></span>
+      <span class="src-line">      <span class="src-ln"> 605</span> <span class="src-hl">				env,</span></span>
+      <span class="src-line">      <span class="src-ln"> 606</span> <span class="src-hl">			} as Omit&lt;TOptions, &quot;transformHeaders&quot;&gt; &amp; ProviderRequestOptions,</span></span>
+      <span class="src-line">      <span class="src-ln"> 607</span> <span class="src-hl">		};</span></span>
+      <span class="src-line">      <span class="src-ln"> 608</span> <span class="src-hl">	}</span></span>
+      <span class="src-line">      <span class="src-ln"> 609</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 610</span> <span class="src-hl">	stream&lt;TApi extends Api&gt;(</span></span>
+      <span class="src-line">      <span class="src-ln"> 611</span> <span class="src-hl">		model: Model&lt;TApi&gt;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 612</span> <span class="src-hl">		context: Context,</span></span>
+      <span class="src-line">      <span class="src-ln"> 613</span> <span class="src-hl">		options?: ModelsApiStreamOptions&lt;TApi&gt;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 614</span> <span class="src-hl">	): AssistantMessageEventStream {</span></span>
+      <span class="src-line">      <span class="src-ln"> 615</span> <span class="src-hl">		<span class="src-kw">return</span> lazyStream(model, <span class="src-kw">async</span> () =&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln"> 616</span> <span class="src-hl">			<span class="src-kw">const</span> prepared = <span class="src-kw">await</span> this.prepareRequest(</span></span>
+      <span class="src-line">      <span class="src-ln"> 617</span> <span class="src-hl">				model,</span></span>
+      <span class="src-line">      <span class="src-ln"> 618</span> <span class="src-hl">				options as (StreamOptions &amp; ModelsRequestTransforms) | <span class="src-kw">undefined</span>,</span></span>
+      <span class="src-line">      <span class="src-ln"> 619</span> <span class="src-hl">			);</span></span>
+      <span class="src-line">      <span class="src-ln"> 620</span> <span class="src-hl">			<span class="src-kw">return</span> prepared.provider.stream(</span></span>
+      <span class="src-line">      <span class="src-ln"> 621</span> <span class="src-hl">				prepared.model as Model&lt;TApi&gt;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 622</span> <span class="src-hl">				context,</span></span>
+      <span class="src-line">      <span class="src-ln"> 623</span> <span class="src-hl">				prepared.options as ApiStreamOptions&lt;TApi&gt;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 624</span> <span class="src-hl">			);</span></span>
+      <span class="src-line">      <span class="src-ln"> 625</span> <span class="src-hl">		});</span></span>
+      <span class="src-line">      <span class="src-ln"> 626</span> <span class="src-hl">	}</span></span>
+      <span class="src-line">      <span class="src-ln"> 627</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 628</span> <span class="src-hl">	complete&lt;TApi extends Api&gt;(</span></span>
+      <span class="src-line">      <span class="src-ln"> 629</span> <span class="src-hl">		model: Model&lt;TApi&gt;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 630</span> <span class="src-hl">		context: Context,</span></span>
+      <span class="src-line">      <span class="src-ln"> 631</span> <span class="src-hl">		options?: ModelsApiStreamOptions&lt;TApi&gt;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 632</span> <span class="src-hl">	): Promise&lt;AssistantMessage&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln"> 633</span> <span class="src-hl">		<span class="src-kw">return</span> this.stream(model, context, options).result();</span></span>
+      <span class="src-line">      <span class="src-ln"> 634</span> <span class="src-hl">	}</span></span>
+      <span class="src-line">      <span class="src-ln"> 635</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 636</span> <span class="src-hl">	streamSimple(model: Model&lt;Api&gt;, context: Context, options?: ModelsSimpleStreamOptions): AssistantMessageEventStream {</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">ModelRuntime.streamSimple 入口</span><span class="lang-en-only">ModelRuntime.streamSimple entry</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 637</span> <span class="src-hl">		<span class="src-kw">return</span> lazyStream(model, <span class="src-kw">async</span> () =&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln"> 638</span> <span class="src-hl">			<span class="src-kw">const</span> prepared = <span class="src-kw">await</span> this.prepareRequest(model, options);</span></span>
+      <span class="src-line">      <span class="src-ln"> 639</span> <span class="src-hl">			<span class="src-kw">return</span> prepared.provider.streamSimple(prepared.model, context, prepared.options as SimpleStreamOptions);</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">委托 provider.streamSimple</span><span class="lang-en-only">delegate to provider.streamSimple</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 640</span> <span class="src-hl">		});</span></span>
+    </div>
+
     <div class="note copper">
       <span class="lang-zh-only">对照 pi-textbook cp07 <code>agent-loop.test.ts</code>：搜索 <code>two turn</code> 或 <code>toolUse</code>，测试里的 event 序列应与 --verbose stderr 同构。</span>
       <span class="lang-en-only">Cross-read textbook cp07 <code>agent-loop.test.ts</code>: search <code>two turn</code> or <code>toolUse</code>; test event sequence should match --verbose stderr.</span>
@@ -6665,6 +6869,351 @@
       <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 05</strong>: Provider Adapter (<code>provider-adapter.ts</code>) · production: <code>packages/ai/src/api/*.ts · packages/ai/src/models.ts</code></span>
     </div>
 
+    <div class="trace-walk">
+      <div class="tw-head">
+        <span class="tw-tag">SOURCE TRACE · C14</span>
+        <span class="lang-zh-only">pi-ai 提供商抽象：streamSimple 如何接到 agent-loop</span>
+        <span class="lang-en-only">pi-ai provider abstraction: how streamSimple connects to agent-loop</span>
+      </div>
+
+    <div class="lang-zh-only"><p>pi-ai（<code>packages/ai</code>）是 Pi 的 LLM 适配层。<code>streamSimple</code> 是 agent-core 与 40+ provider 之间的<strong>唯一窄接口</strong>：输入 <code>Model + Context + options</code>，输出 <code>AssistantMessageEventStream</code>。主线 prompt turn-1 的 <code>toolcall_delta</code> 组装 <code>read({"path":"README.md"})</code> 就发生在此层。</p></div>
+    <div class="lang-en-only"><p>pi-ai (<code>packages/ai</code>) is Pi's LLM adapter layer. <code>streamSimple</code> is the <strong>sole narrow interface</strong> between agent-core and 40+ providers: <code>Model + Context + options</code> in, <code>AssistantMessageEventStream</code> out. Through-line turn-1 <code>toolcall_delta</code> assembling <code>read({"path":"README.md"})</code> happens here.</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/ai/src/compat.ts</span>
+        <span class="src-tag">stream-simple</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 275</span> <span class="src-hl"><span class="src-kw">export</span> <span class="src-kw">function</span> streamSimple&lt;TApi extends Api&gt;(</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">compat 层 streamSimple 入口</span><span class="lang-en-only">compat layer streamSimple entry</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 276</span> <span class="src-hl">	model: Model&lt;TApi&gt;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 277</span> <span class="src-hl">	context: Context,</span></span>
+      <span class="src-line">      <span class="src-ln"> 278</span> <span class="src-hl">	options?: SimpleStreamOptions,</span></span>
+      <span class="src-line">      <span class="src-ln"> 279</span> <span class="src-hl">): AssistantMessageEventStream {</span></span>
+      <span class="src-line">      <span class="src-ln"> 280</span> <span class="src-hl">	<span class="src-kw">const</span> builtinProvider = getBuiltinProviderForModel(model);</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">builtin provider 优先（anthropic/openai/…）</span><span class="lang-en-only">builtin provider first (anthropic/openai/…)</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 281</span> <span class="src-hl">	<span class="src-kw">if</span> (builtinProvider) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 282</span> <span class="src-hl">		<span class="src-kw">if</span> (model.provider.startsWith(&quot;cloudflare-&quot;) &amp;&amp; !hasResolvedCloudflareAuth(options)) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 283</span> <span class="src-hl">			<span class="src-kw">return</span> compatModels.streamSimple(model, context, options);</span></span>
+      <span class="src-line">      <span class="src-ln"> 284</span> <span class="src-hl">		}</span></span>
+      <span class="src-line">      <span class="src-ln"> 285</span> <span class="src-hl">		<span class="src-kw">return</span> builtinProvider.streamSimple(model, context, withEnvApiKey(model, options));</span></span>
+      <span class="src-line">      <span class="src-ln"> 286</span> <span class="src-hl">	}</span></span>
+      <span class="src-line">      <span class="src-ln"> 287</span> <span class="src-hl">	<span class="src-kw">const</span> provider = resolveApiProvider(model.api);</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">自定义 provider 走 resolveApiProvider</span><span class="lang-en-only">custom providers via resolveApiProvider</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 288</span> <span class="src-hl">	<span class="src-kw">return</span> provider.streamSimple(model, context, withEnvApiKey(model, options));</span></span>
+      <span class="src-line">      <span class="src-ln"> 289</span> <span class="src-hl">}</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/ai/src/models.ts</span>
+        <span class="src-tag">provider-if</span>
+      </div>
+      <span class="src-line">      <span class="src-ln">  97</span> <span class="src-hl"><span class="src-kw">export</span> <span class="src-kw">interface</span> Provider&lt;TApi extends Api = Api&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln">  98</span> <span class="src-hl">	readonly id: string;</span></span>
+      <span class="src-line">      <span class="src-ln">  99</span> <span class="src-hl">	readonly name: string;</span></span>
+      <span class="src-line">      <span class="src-ln"> 100</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 101</span> <span class="src-hl">	readonly baseUrl?: string;</span></span>
+      <span class="src-line">      <span class="src-ln"> 102</span> <span class="src-hl">	readonly headers?: ProviderHeaders;</span></span>
+      <span class="src-line">      <span class="src-ln"> 103</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 104</span> <span class="src-hl">	/**</span></span>
+      <span class="src-line">      <span class="src-ln"> 105</span> <span class="src-hl">	 * Required: at least one of <span class=<span class="src-str">"src-str"</span>>`apiKey`</span>/<span class=<span class="src-str">"src-str"</span>>`oauth`</span>. Every provider has auth</span></span>
+      <span class="src-line">      <span class="src-ln"> 106</span> <span class="src-hl">	 * semantics — even providers with only ambient credentials (env vars, AWS</span></span>
+      <span class="src-line">      <span class="src-ln"> 107</span> <span class="src-hl">	 * profiles, ADC files) and keyless local servers provide <span class=<span class="src-str">"src-str"</span>>`apiKey`</span> auth</span></span>
+      <span class="src-line">      <span class="src-ln"> 108</span> <span class="src-hl">	 * whose <span class=<span class="src-str">"src-str"</span>>`resolve()`</span> reports whether the provider is configured.</span></span>
+      <span class="src-line">      <span class="src-ln"> 109</span> <span class="src-hl">	 * <span class=<span class="src-str">"src-str"</span>>`Models.getAuth()`</span> returns <span class="src-kw">undefined</span> when the provider is unconfigured.</span></span>
+      <span class="src-line">      <span class="src-ln"> 110</span> <span class="src-hl">	 */</span></span>
+      <span class="src-line">      <span class="src-ln"> 111</span> <span class="src-hl">	readonly auth: ProviderAuth;</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">Provider.auth：每个 provider 必有认证语义</span><span class="lang-en-only">Provider.auth: every provider has auth semantics</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 112</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 113</span> <span class="src-hl">	/**</span></span>
+      <span class="src-line">      <span class="src-ln"> 114</span> <span class="src-hl">	 * Current known models, sync. Static providers <span class="src-kw">return</span> their catalog;</span></span>
+      <span class="src-line">      <span class="src-ln"> 115</span> <span class="src-hl">	 * dynamic providers <span class="src-kw">return</span> the list as of the last <span class=<span class="src-str">"src-str"</span>>`refreshModels()`</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 116</span> <span class="src-hl">	 * (empty before the first). Must not <span class="src-kw">throw</span>; <span class=<span class="src-str">"src-str"</span>>`Models`</span> treats a throwing</span></span>
+      <span class="src-line">      <span class="src-ln"> 117</span> <span class="src-hl">	 * implementation as having no models.</span></span>
+      <span class="src-line">      <span class="src-ln"> 118</span> <span class="src-hl">	 */</span></span>
+      <span class="src-line">      <span class="src-ln"> 119</span> <span class="src-hl">	getModels(): readonly Model&lt;TApi&gt;[];</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">getModels()：静态目录或 refresh 后动态列表</span><span class="lang-en-only">getModels(): static catalog or post-refresh dynamic list</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 120</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 121</span> <span class="src-hl">	/**</span></span>
+      <span class="src-line">      <span class="src-ln"> 122</span> <span class="src-hl">	 * Dynamic providers only: restore <span class=<span class="src-str">"src-str"</span>>`context.stored`</span> and optionally fetch a newer list using</span></span>
+      <span class="src-line">      <span class="src-ln"> 123</span> <span class="src-hl">	 * the effective credential. Implementations retain their previous list on failure, publish</span></span>
+      <span class="src-line">      <span class="src-ln"> 124</span> <span class="src-hl">	 * persistence and synchronous state changes through <span class=<span class="src-str">"src-str"</span>>`context.publish()`</span>, and honor the</span></span>
+      <span class="src-line">      <span class="src-ln"> 125</span> <span class="src-hl">	 * shared abort signal <span class="src-kw">for</span> blocking work.</span></span>
+      <span class="src-line">      <span class="src-ln"> 126</span> <span class="src-hl">	 */</span></span>
+      <span class="src-line">      <span class="src-ln"> 127</span> <span class="src-hl">	refreshModels?(context: RefreshModelsContext): Promise&lt;void&gt;;</span></span>
+      <span class="src-line">      <span class="src-ln"> 128</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 129</span> <span class="src-hl">	/**</span></span>
+      <span class="src-line">      <span class="src-ln"> 130</span> <span class="src-hl">	 * Optional provider policy <span class="src-kw">for</span> credential-specific model availability.</span></span>
+      <span class="src-line">      <span class="src-ln"> 131</span> <span class="src-hl">	 * <span class=<span class="src-str">"src-str"</span>>`getModels()`</span> remains the complete synchronous catalog; <span class=<span class="src-str">"src-str"</span>>`Models.getAvailable()`</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 132</span> <span class="src-hl">	 * applies this filter after confirming that provider auth is configured.</span></span>
+      <span class="src-line">      <span class="src-ln"> 133</span> <span class="src-hl">	 */</span></span>
+      <span class="src-line">      <span class="src-ln"> 134</span> <span class="src-hl">	filterModels?(models: readonly Model&lt;TApi&gt;[], credential: Credential | <span class="src-kw">undefined</span>): readonly Model&lt;TApi&gt;[];</span></span>
+      <span class="src-line">      <span class="src-ln"> 135</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 136</span> <span class="src-hl">	stream&lt;T extends TApi&gt;(</span></span>
+      <span class="src-line">      <span class="src-ln"> 137</span> <span class="src-hl">		model: Model&lt;T&gt;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 138</span> <span class="src-hl">		context: Context,</span></span>
+      <span class="src-line">      <span class="src-ln"> 139</span> <span class="src-hl">		options?: ApiStreamOptions&lt;T&gt;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 140</span> <span class="src-hl">	): AssistantMessageEventStream;</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/ai/src/models.ts</span>
+        <span class="src-tag">apply-auth</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 636</span> <span class="src-hl">	private <span class="src-kw">async</span> applyAuth&lt;TOptions extends ProviderRequestOptions &amp; ModelsRequestTransforms&gt;(</span></span>
+      <span class="src-line">      <span class="src-ln"> 637</span> <span class="src-hl">		model: Model&lt;Api&gt;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 638</span> <span class="src-hl">		options: TOptions | <span class="src-kw">undefined</span>,</span></span>
+      <span class="src-line">      <span class="src-ln"> 639</span> <span class="src-hl">	): Promise&lt;{</span></span>
+      <span class="src-line">      <span class="src-ln"> 640</span> <span class="src-hl">		requestModel: Model&lt;Api&gt;;</span></span>
+      <span class="src-line">      <span class="src-ln"> 641</span> <span class="src-hl">		requestOptions: Omit&lt;TOptions, &quot;transformHeaders&quot;&gt; &amp; ProviderRequestOptions;</span></span>
+      <span class="src-line">      <span class="src-ln"> 642</span> <span class="src-hl">	}&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln"> 643</span> <span class="src-hl">		this.requireProvider(model);</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">requireProvider：model.provider → Provider 实例</span><span class="lang-en-only">requireProvider: model.provider → Provider instance</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 644</span> <span class="src-hl">		<span class="src-kw">const</span> resolution = <span class="src-kw">await</span> this.getAuth(model, {</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">getAuth：credential / env / OAuth 解析</span><span class="lang-en-only">getAuth: credential / env / OAuth resolution</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 645</span> <span class="src-hl">			apiKey: options?.apiKey,</span></span>
+      <span class="src-line">      <span class="src-ln"> 646</span> <span class="src-hl">			env: options?.env,</span></span>
+      <span class="src-line">      <span class="src-ln"> 647</span> <span class="src-hl">			signal: options?.signal,</span></span>
+      <span class="src-line">      <span class="src-ln"> 648</span> <span class="src-hl">		});</span></span>
+      <span class="src-line">      <span class="src-ln"> 649</span> <span class="src-hl">		<span class="src-kw">if</span> (!resolution) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 650</span> <span class="src-hl">			<span class="src-kw">throw</span> <span class="src-kw">new</span> ModelsError(&quot;auth&quot;, <span class=<span class="src-str">"src-str"</span>>`Provider is not configured: ${model.provider}`</span>);</span></span>
+      <span class="src-line">      <span class="src-ln"> 651</span> <span class="src-hl">		}</span></span>
+      <span class="src-line">      <span class="src-ln"> 652</span> <span class="src-hl">		<span class="src-kw">const</span> auth = resolution.auth;</span></span>
+      <span class="src-line">      <span class="src-ln"> 653</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 654</span> <span class="src-hl">		<span class="src-comment">// Explicit request options win per-field; the Models-only transform runs last.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 655</span> <span class="src-hl">		<span class="src-kw">const</span> apiKey = options?.apiKey ?? auth.apiKey;</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">apiKey = options.apiKey ?? auth.apiKey</span><span class="lang-en-only">apiKey = options.apiKey ?? auth.apiKey</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 656</span> <span class="src-hl">		<span class="src-kw">let</span> headers = mergeHeaders(auth.headers, options?.headers);</span></span>
+      <span class="src-line">      <span class="src-ln"> 657</span> <span class="src-hl">		<span class="src-kw">if</span> (options?.transformHeaders) headers = <span class="src-kw">await</span> options.transformHeaders(headers ?? {});</span></span>
+      <span class="src-line">      <span class="src-ln"> 658</span> <span class="src-hl">		<span class="src-kw">const</span> env = resolution.env || options?.env ? { ...(resolution.env ?? {}), ...(options?.env ?? {}) } : <span class="src-kw">undefined</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 659</span> <span class="src-hl">		<span class="src-kw">const</span> requestModel = auth.baseUrl ? { ...model, baseUrl: auth.baseUrl } : model;</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">baseUrl overlay：代理/自定义 endpoint</span><span class="lang-en-only">baseUrl overlay: proxy/custom endpoint</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 660</span> <span class="src-hl">		<span class="src-kw">const</span> { transformHeaders: _transformHeaders, ...providerOptions } = options ?? {};</span></span>
+      <span class="src-line">      <span class="src-ln"> 661</span> <span class="src-hl">		<span class="src-kw">const</span> requestOptions = { ...providerOptions, apiKey, headers, env } as Omit&lt;TOptions, &quot;transformHeaders&quot;&gt; &amp;</span></span>
+      <span class="src-line">      <span class="src-ln"> 662</span> <span class="src-hl">			ProviderRequestOptions;</span></span>
+      <span class="src-line">      <span class="src-ln"> 663</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 664</span> <span class="src-hl">		<span class="src-kw">return</span> { requestModel, requestOptions };</span></span>
+      <span class="src-line">      <span class="src-ln"> 665</span> <span class="src-hl">	}</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/ai/src/models.ts</span>
+        <span class="src-tag">models-stream</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 690</span> <span class="src-hl">	streamSimple(model: Model&lt;Api&gt;, context: Context, options?: ModelsSimpleStreamOptions): AssistantMessageEventStream {</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">Models.streamSimple：lazyStream + applyAuth</span><span class="lang-en-only">Models.streamSimple: lazyStream + applyAuth</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 691</span> <span class="src-hl">		<span class="src-kw">return</span> lazyStream(model, <span class="src-kw">async</span> () =&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln"> 692</span> <span class="src-hl">			<span class="src-kw">const</span> provider = this.requireProvider(model);</span></span>
+      <span class="src-line">      <span class="src-ln"> 693</span> <span class="src-hl">			<span class="src-kw">const</span> { requestModel, requestOptions } = <span class="src-kw">await</span> this.applyAuth(model, options);</span></span>
+      <span class="src-line">      <span class="src-ln"> 694</span> <span class="src-hl">			<span class="src-kw">return</span> provider.streamSimple(requestModel, context, requestOptions as SimpleStreamOptions);</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">provider.streamSimple 真正发 HTTP</span><span class="lang-en-only">provider.streamSimple actually sends HTTP</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 695</span> <span class="src-hl">		});</span></span>
+      <span class="src-line">      <span class="src-ln"> 696</span> <span class="src-hl">	}</span></span>
+      <span class="src-line">      <span class="src-ln"> 697</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 698</span> <span class="src-hl">	<span class="src-kw">async</span> completeSimple(</span></span>
+      <span class="src-line">      <span class="src-ln"> 699</span> <span class="src-hl">		model: Model&lt;Api&gt;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 700</span> <span class="src-hl">		context: Context,</span></span>
+      <span class="src-line">      <span class="src-ln"> 701</span> <span class="src-hl">		options?: ModelsSimpleStreamOptions,</span></span>
+      <span class="src-line">      <span class="src-ln"> 702</span> <span class="src-hl">	): Promise&lt;AssistantMessage&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln"> 703</span> <span class="src-hl">		<span class="src-kw">return</span> this.streamSimple(model, context, options).result();</span></span>
+      <span class="src-line">      <span class="src-ln"> 704</span> <span class="src-hl">	}</span></span>
+    </div>
+
+    <div class="trace-steps"><div class="ts-label"><span class="lang-zh-only">主线 turn-1 · streamSimple 数据流</span><span class="lang-en-only">Through-line turn-1 · streamSimple data flow</span></div>    <table class="cmp">
+      <thead><tr><th>#</th><th>location</th><th>主线时刻 / through-line moment</th></tr></thead>
+      <tbody>
+      <tr><td>in</td><td>Context.messages</td><td>user + system + tools schema</td></tr>
+      <tr><td>auth</td><td>applyAuth</td><td>ANTHROPIC_API_KEY / OAuth bearer</td></tr>
+      <tr><td>http</td><td>anthropic-messages</td><td>POST /v1/messages stream:true</td></tr>
+      <tr><td>out</td><td>EventStream</td><td>start → toolcall_delta×N → done(toolUse)</td></tr>
+      <tr><td>up</td><td>agent-loop:317</td><td>message_update → TUI tool 卡片</td></tr>
+      </tbody>
+    </table></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/ai/src/models.ts</span>
+        <span class="src-tag">create-provider</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 739</span> <span class="src-hl"><span class="src-kw">export</span> <span class="src-kw">interface</span> CreateProviderOptions&lt;TApi extends Api = Api&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln"> 740</span> <span class="src-hl">	id: string;</span></span>
+      <span class="src-line">      <span class="src-ln"> 741</span> <span class="src-hl">	/** Display name. Default: <span class=<span class="src-str">"src-str"</span>>`id`</span>. */</span></span>
+      <span class="src-line">      <span class="src-ln"> 742</span> <span class="src-hl">	name?: string;</span></span>
+      <span class="src-line">      <span class="src-ln"> 743</span> <span class="src-hl">	baseUrl?: string;</span></span>
+      <span class="src-line">      <span class="src-ln"> 744</span> <span class="src-hl">	headers?: ProviderHeaders;</span></span>
+      <span class="src-line">      <span class="src-ln"> 745</span> <span class="src-hl">	/** Required — every provider has auth semantics, even ambient/keyless ones. */</span></span>
+      <span class="src-line">      <span class="src-ln"> 746</span> <span class="src-hl">	auth: ProviderAuth;</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">auth 必填——即使 ambient/keyless provider</span><span class="lang-en-only">auth required — even ambient/keyless providers</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 747</span> <span class="src-hl">	/** Static baseline model list (empty <span class="src-kw">for</span> purely dynamic providers). */</span></span>
+      <span class="src-line">      <span class="src-ln"> 748</span> <span class="src-hl">	models: readonly Model&lt;TApi&gt;[];</span></span>
+      <span class="src-line">      <span class="src-ln"> 749</span> <span class="src-hl">	/** Fetch a dynamic model overlay. createProvider restores and publishes it transactionally. */</span></span>
+      <span class="src-line">      <span class="src-ln"> 750</span> <span class="src-hl">	fetchModels?: (context: RefreshModelsContext) =&gt; Promise&lt;readonly Model&lt;TApi&gt;[]&gt;;</span></span>
+      <span class="src-line">      <span class="src-ln"> 751</span> <span class="src-hl">	filterModels?: (models: readonly Model&lt;TApi&gt;[], credential: Credential | <span class="src-kw">undefined</span>) =&gt; readonly Model&lt;TApi&gt;[];</span></span>
+      <span class="src-line">      <span class="src-ln"> 752</span> <span class="src-hl">	/** Single implementation, or map keyed by <span class=<span class="src-str">"src-str"</span>>`model.api`</span> <span class="src-kw">for</span> mixed-API providers. */</span></span>
+      <span class="src-line">      <span class="src-ln"> 753</span> <span class="src-hl">	api: ProviderStreams | Partial&lt;Record&lt;TApi, ProviderStreams&gt;&gt;;</span></span>
+      <span class="src-line">      <span class="src-ln"> 754</span> <span class="src-hl">}</span></span>
+      <span class="src-line">      <span class="src-ln"> 755</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 756</span> <span class="src-hl">/**</span></span>
+      <span class="src-line">      <span class="src-ln"> 757</span> <span class="src-hl"> * Builds a provider <span class="src-kw">from</span> parts. Built-in provider factories and models.json</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">api 字段：单实现或按 model.api 分派</span><span class="lang-en-only">api field: single impl or dispatch by model.api</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 758</span> <span class="src-hl"> * custom providers both go through this. A single <span class=<span class="src-str">"src-str"</span>>`api`</span> streams all models;</span></span>
+      <span class="src-line">      <span class="src-ln"> 759</span> <span class="src-hl"> * an <span class=<span class="src-str">"src-str"</span>>`api`</span> map dispatches on <span class=<span class="src-str">"src-str"</span>>`model.api`</span>, and a model whose api has no entry</span></span>
+      <span class="src-line">      <span class="src-ln"> 760</span> <span class="src-hl"> * produces a stream error.</span></span>
+      <span class="src-line">      <span class="src-ln"> 761</span> <span class="src-hl"> */</span></span>
+      <span class="src-line">      <span class="src-ln"> 762</span> <span class="src-hl"><span class="src-kw">export</span> <span class="src-kw">function</span> createProvider&lt;TApi extends Api = Api&gt;(input: CreateProviderOptions&lt;TApi&gt;): Provider&lt;TApi&gt; {</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">createProvider：内置与 models.json 自定义共用</span><span class="lang-en-only">createProvider: built-in and models.json custom share this</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 763</span> <span class="src-hl">	<span class="src-kw">const</span> baselineModels = input.models;</span></span>
+      <span class="src-line">      <span class="src-ln"> 764</span> <span class="src-hl">	<span class="src-kw">let</span> dynamicModels: readonly Model&lt;TApi&gt;[] = [];</span></span>
+      <span class="src-line">      <span class="src-ln"> 765</span> <span class="src-hl">	<span class="src-kw">const</span> fetchModels = input.fetchModels;</span></span>
+      <span class="src-line">      <span class="src-ln"> 766</span> <span class="src-hl">	<span class="src-kw">const</span> currentModels = (): readonly Model&lt;TApi&gt;[] =&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln"> 767</span> <span class="src-hl">		<span class="src-kw">const</span> merged = [...baselineModels];</span></span>
+      <span class="src-line">      <span class="src-ln"> 768</span> <span class="src-hl">		<span class="src-kw">for</span> (<span class="src-kw">const</span> model of dynamicModels) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 769</span> <span class="src-hl">			<span class="src-kw">const</span> index = merged.findIndex((entry) =&gt; entry.id === model.id);</span></span>
+      <span class="src-line">      <span class="src-ln"> 770</span> <span class="src-hl">			<span class="src-kw">if</span> (index &gt;= 0) merged[index] = model;</span></span>
+      <span class="src-line">      <span class="src-ln"> 771</span> <span class="src-hl">			<span class="src-kw">else</span> merged.push(model);</span></span>
+      <span class="src-line">      <span class="src-ln"> 772</span> <span class="src-hl">		}</span></span>
+      <span class="src-line">      <span class="src-ln"> 773</span> <span class="src-hl">		<span class="src-kw">return</span> merged;</span></span>
+      <span class="src-line">      <span class="src-ln"> 774</span> <span class="src-hl">	};</span></span>
+      <span class="src-line">      <span class="src-ln"> 775</span> <span class="src-hl">	<span class="src-kw">const</span> single =</span></span>
+      <span class="src-line">      <span class="src-ln"> 776</span> <span class="src-hl">		<span class="src-kw">typeof</span> (input.api as ProviderStreams).stream === &quot;<span class="src-kw">function</span>&quot; ? (input.api as ProviderStreams) : <span class="src-kw">undefined</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 777</span> <span class="src-hl">	<span class="src-kw">const</span> byApi = single ? <span class="src-kw">undefined</span> : (input.api as Partial&lt;Record&lt;string, ProviderStreams&gt;&gt;);</span></span>
+      <span class="src-line">      <span class="src-ln"> 778</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 779</span> <span class="src-hl">	<span class="src-kw">const</span> apiFor = (model: Model&lt;Api&gt;): ProviderStreams | <span class="src-kw">undefined</span> =&gt; single ?? byApi?.[model.api];</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">apiFor(model)：按 model.api 选 stream 实现</span><span class="lang-en-only">apiFor(model): pick stream impl by model.api</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 780</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 781</span> <span class="src-hl">	<span class="src-kw">const</span> dispatch = (</span></span>
+      <span class="src-line">      <span class="src-ln"> 782</span> <span class="src-hl">		model: Model&lt;Api&gt;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 783</span> <span class="src-hl">		run: (streams: ProviderStreams) =&gt; AssistantMessageEventStream,</span></span>
+      <span class="src-line">      <span class="src-ln"> 784</span> <span class="src-hl">	): AssistantMessageEventStream =&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln"> 785</span> <span class="src-hl">		<span class="src-kw">const</span> streams = apiFor(model);</span></span>
+      <span class="src-line">      <span class="src-ln"> 786</span> <span class="src-hl">		<span class="src-kw">if</span> (!streams) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 787</span> <span class="src-hl">			<span class="src-kw">return</span> lazyStream(model, <span class="src-kw">async</span> () =&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln"> 788</span> <span class="src-hl">				<span class="src-kw">throw</span> <span class="src-kw">new</span> ModelsError(&quot;stream&quot;, <span class=<span class="src-str">"src-str"</span>>`Provider ${input.id} has no API implementation <span class="src-kw">for</span> &quot;${model.api}&quot;`</span>);</span></span>
+      <span class="src-line">      <span class="src-ln"> 789</span> <span class="src-hl">			});</span></span>
+      <span class="src-line">      <span class="src-ln"> 790</span> <span class="src-hl">		}</span></span>
+      <span class="src-line">      <span class="src-ln"> 791</span> <span class="src-hl">		<span class="src-kw">return</span> run(streams);</span></span>
+      <span class="src-line">      <span class="src-ln"> 792</span> <span class="src-hl">	};</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/ai/src/providers/anthropic.ts</span>
+        <span class="src-tag">anthropic-prov</span>
+      </div>
+      <span class="src-line">      <span class="src-ln">   9</span> <span class="src-hl"><span class="src-kw">function</span> anthropicApiKeyAuth(): ApiKeyAuth {</span></span>
+      <span class="src-line">      <span class="src-ln">  10</span> <span class="src-hl">	<span class="src-kw">return</span> {</span></span>
+      <span class="src-line">      <span class="src-ln">  11</span> <span class="src-hl">		name: &quot;Anthropic API key&quot;,</span></span>
+      <span class="src-line">      <span class="src-ln">  12</span> <span class="src-hl">		login: <span class="src-kw">async</span> (interaction) =&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln">  13</span> <span class="src-hl">			interaction.signal.throwIfAborted();</span></span>
+      <span class="src-line">      <span class="src-ln">  14</span> <span class="src-hl">			<span class="src-kw">const</span> key = <span class="src-kw">await</span> interaction.prompt({ <span class="src-kw">type</span>: &quot;secret&quot;, message: &quot;Enter Anthropic API key&quot; });</span></span>
+      <span class="src-line">      <span class="src-ln">  15</span> <span class="src-hl">			interaction.signal.throwIfAborted();</span></span>
+      <span class="src-line">      <span class="src-ln">  16</span> <span class="src-hl">			<span class="src-kw">return</span> { <span class="src-kw">type</span>: &quot;api_key&quot;, key };</span></span>
+      <span class="src-line">      <span class="src-ln">  17</span> <span class="src-hl">		},</span></span>
+      <span class="src-line">      <span class="src-ln">  18</span> <span class="src-hl">		resolve: <span class="src-kw">async</span> ({ ctx, credential, signal }) =&gt; {</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">resolve：credential → env ANTHROPIC_* 回退</span><span class="lang-en-only">resolve: credential → env ANTHROPIC_* fallback</span></span></span>
+      <span class="src-line">      <span class="src-ln">  19</span> <span class="src-hl">			signal.throwIfAborted();</span></span>
+      <span class="src-line">      <span class="src-ln">  20</span> <span class="src-hl">			<span class="src-kw">if</span> (credential?.key) {</span></span>
+      <span class="src-line">      <span class="src-ln">  21</span> <span class="src-hl">				<span class="src-kw">return</span> { auth: { apiKey: credential.key }, env: credential.env, source: &quot;stored credential&quot; };</span></span>
+      <span class="src-line">      <span class="src-ln">  22</span> <span class="src-hl">			}</span></span>
+      <span class="src-line">      <span class="src-ln">  23</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln">  24</span> <span class="src-hl">			<span class="src-kw">const</span> authToken = <span class="src-kw">await</span> ctx.env(ANTHROPIC_AUTH_TOKEN_ENV);</span></span>
+      <span class="src-line">      <span class="src-ln">  25</span> <span class="src-hl">			signal.throwIfAborted();</span></span>
+      <span class="src-line">      <span class="src-ln">  26</span> <span class="src-hl">			<span class="src-kw">if</span> (authToken) {</span></span>
+      <span class="src-line">      <span class="src-ln">  27</span> <span class="src-hl">				<span class="src-kw">return</span> {</span></span>
+      <span class="src-line">      <span class="src-ln">  28</span> <span class="src-hl">					auth: { headers: { Authorization: <span class=<span class="src-str">"src-str"</span>>`Bearer ${authToken}`</span> } },</span></span>
+      <span class="src-line">      <span class="src-ln">  29</span> <span class="src-hl">					source: ANTHROPIC_AUTH_TOKEN_ENV,</span></span>
+      <span class="src-line">      <span class="src-ln">  30</span> <span class="src-hl">				};</span></span>
+      <span class="src-line">      <span class="src-ln">  31</span> <span class="src-hl">			}</span></span>
+      <span class="src-line">      <span class="src-ln">  32</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln">  33</span> <span class="src-hl">			<span class="src-kw">for</span> (<span class="src-kw">const</span> envVar of [ANTHROPIC_OAUTH_TOKEN_ENV, ANTHROPIC_API_KEY_ENV]) {</span></span>
+      <span class="src-line">      <span class="src-ln">  34</span> <span class="src-hl">				<span class="src-kw">const</span> apiKey = <span class="src-kw">await</span> ctx.env(envVar);</span></span>
+      <span class="src-line">      <span class="src-ln">  35</span> <span class="src-hl">				signal.throwIfAborted();</span></span>
+      <span class="src-line">      <span class="src-ln">  36</span> <span class="src-hl">				<span class="src-kw">if</span> (apiKey) <span class="src-kw">return</span> { auth: { apiKey }, source: envVar };</span></span>
+      <span class="src-line">      <span class="src-ln">  37</span> <span class="src-hl">			}</span></span>
+      <span class="src-line">      <span class="src-ln">  38</span> <span class="src-hl">			<span class="src-kw">return</span> <span class="src-kw">undefined</span>;</span></span>
+      <span class="src-line">      <span class="src-ln">  39</span> <span class="src-hl">		},</span></span>
+      <span class="src-line">      <span class="src-ln">  40</span> <span class="src-hl">	};</span></span>
+      <span class="src-line">      <span class="src-ln">  41</span> <span class="src-hl">}</span></span>
+      <span class="src-line">      <span class="src-ln">  42</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln">  43</span> <span class="src-hl"><span class="src-kw">export</span> <span class="src-kw">function</span> anthropicProvider(): Provider&lt;&quot;anthropic-messages&quot;&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln">  44</span> <span class="src-hl">	<span class="src-kw">return</span> createProvider({</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">anthropicProvider() 工厂</span><span class="lang-en-only">anthropicProvider() factory</span></span></span>
+      <span class="src-line">      <span class="src-ln">  45</span> <span class="src-hl">		id: &quot;anthropic&quot;,</span></span>
+      <span class="src-line">      <span class="src-ln">  46</span> <span class="src-hl">		name: &quot;Anthropic&quot;,</span></span>
+      <span class="src-line">      <span class="src-ln">  47</span> <span class="src-hl">		baseUrl: &quot;https:<span class="src-comment">//api.anthropic.com&amp;quot;,</span></span></span>
+      <span class="src-line">      <span class="src-ln">  48</span> <span class="src-hl">		auth: {</span></span>
+      <span class="src-line">      <span class="src-ln">  49</span> <span class="src-hl">			apiKey: anthropicApiKeyAuth(),</span></span>
+      <span class="src-line">      <span class="src-ln">  50</span> <span class="src-hl">			oauth: lazyOAuth({</span></span>
+      <span class="src-line">      <span class="src-ln">  51</span> <span class="src-hl">				name: &quot;Anthropic (Claude Pro/Max)&quot;,</span></span>
+      <span class="src-line">      <span class="src-ln">  52</span> <span class="src-hl">				isSubscription: <span class="src-kw">true</span>,</span></span>
+      <span class="src-line">      <span class="src-ln">  53</span> <span class="src-hl">				load: loadAnthropicOAuth,</span></span>
+      <span class="src-line">      <span class="src-ln">  54</span> <span class="src-hl">			}),</span></span>
+      <span class="src-line">      <span class="src-ln">  55</span> <span class="src-hl">		},</span></span>
+      <span class="src-line">      <span class="src-ln">  56</span> <span class="src-hl">		models: Object.values(ANTHROPIC_MODELS),</span></span>
+      <span class="src-line">      <span class="src-ln">  57</span> <span class="src-hl">		api: anthropicMessagesApi(),</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">api: anthropicMessagesApi()</span><span class="lang-en-only">api: anthropicMessagesApi()</span></span></span>
+      <span class="src-line">      <span class="src-ln">  58</span> <span class="src-hl">	});</span></span>
+    </div>
+
+    <div class="lang-zh-only"><p><code>createProvider</code> 把 auth、models、api 三块粘成不可再分的 Provider 对象。<code>Models</code> 类持有 provider map，<code>ModelRuntime</code>（coding-agent）在其上叠加 credential store、extension provider、availability snapshot——但<strong>HTTP/SSE 协议细节永远不下沉到 agent-loop</strong>。</p></div>
+    <div class="lang-en-only"><p><code>createProvider</code> glues auth, models, api into one Provider. <code>Models</code> holds the provider map; <code>ModelRuntime</code> adds credential store, extension providers, availability — but <strong>HTTP/SSE protocol never sinks into agent-loop</strong>.</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/ai/src/models.ts</span>
+        <span class="src-tag">provider-dispatch</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 794</span> <span class="src-hl">	<span class="src-kw">const</span> provider: Provider&lt;TApi&gt; = {</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">Provider 对象：stream/streamSimple 分派</span><span class="lang-en-only">Provider object: stream/streamSimple dispatch</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 795</span> <span class="src-hl">		id: input.id,</span></span>
+      <span class="src-line">      <span class="src-ln"> 796</span> <span class="src-hl">		name: input.name ?? input.id,</span></span>
+      <span class="src-line">      <span class="src-ln"> 797</span> <span class="src-hl">		baseUrl: input.baseUrl,</span></span>
+      <span class="src-line">      <span class="src-ln"> 798</span> <span class="src-hl">		headers: input.headers,</span></span>
+      <span class="src-line">      <span class="src-ln"> 799</span> <span class="src-hl">		auth: input.auth,</span></span>
+      <span class="src-line">      <span class="src-ln"> 800</span> <span class="src-hl">		getModels: currentModels,</span></span>
+      <span class="src-line">      <span class="src-ln"> 801</span> <span class="src-hl">		refreshModels: fetchModels</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">refreshModels：动态 provider 拉取模型列表</span><span class="lang-en-only">refreshModels: dynamic provider fetches model list</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 802</span> <span class="src-hl">			? <span class="src-kw">async</span> (context) =&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln"> 803</span> <span class="src-hl">					<span class="src-kw">if</span> (context.stored) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 804</span> <span class="src-hl">						<span class="src-kw">const</span> restored = context.stored.models</span></span>
+      <span class="src-line">      <span class="src-ln"> 805</span> <span class="src-hl">							.filter((model) =&gt; model.provider === input.id)</span></span>
+      <span class="src-line">      <span class="src-ln"> 806</span> <span class="src-hl">							.map((model) =&gt; model as Model&lt;TApi&gt;);</span></span>
+      <span class="src-line">      <span class="src-ln"> 807</span> <span class="src-hl">						<span class="src-kw">if</span> (</span></span>
+      <span class="src-line">      <span class="src-ln"> 808</span> <span class="src-hl">							!(<span class="src-kw">await</span> context.publish({</span></span>
+      <span class="src-line">      <span class="src-ln"> 809</span> <span class="src-hl">								update: () =&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln"> 810</span> <span class="src-hl">									dynamicModels = restored;</span></span>
+      <span class="src-line">      <span class="src-ln"> 811</span> <span class="src-hl">								},</span></span>
+      <span class="src-line">      <span class="src-ln"> 812</span> <span class="src-hl">							}))</span></span>
+      <span class="src-line">      <span class="src-ln"> 813</span> <span class="src-hl">						) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 814</span> <span class="src-hl">							<span class="src-kw">return</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 815</span> <span class="src-hl">						}</span></span>
+      <span class="src-line">      <span class="src-ln"> 816</span> <span class="src-hl">					}</span></span>
+      <span class="src-line">      <span class="src-ln"> 817</span> <span class="src-hl">					<span class="src-kw">if</span> (!context.allowNetwork || context.signal.aborted) <span class="src-kw">return</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 818</span> <span class="src-hl">					<span class="src-kw">const</span> refreshed = <span class="src-kw">await</span> fetchModels(context);</span></span>
+      <span class="src-line">      <span class="src-ln"> 819</span> <span class="src-hl">					<span class="src-kw">if</span> (context.signal.aborted) <span class="src-kw">return</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 820</span> <span class="src-hl">					<span class="src-kw">await</span> context.publish({</span></span>
+      <span class="src-line">      <span class="src-ln"> 821</span> <span class="src-hl">						persist: { models: refreshed, checkedAt: Date.now() },</span></span>
+      <span class="src-line">      <span class="src-ln"> 822</span> <span class="src-hl">						update: () =&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln"> 823</span> <span class="src-hl">							dynamicModels = refreshed;</span></span>
+      <span class="src-line">      <span class="src-ln"> 824</span> <span class="src-hl">						},</span></span>
+      <span class="src-line">      <span class="src-ln"> 825</span> <span class="src-hl">					});</span></span>
+      <span class="src-line">      <span class="src-ln"> 826</span> <span class="src-hl">				}</span></span>
+      <span class="src-line">      <span class="src-ln"> 827</span> <span class="src-hl">			: <span class="src-kw">undefined</span>,</span></span>
+      <span class="src-line">      <span class="src-ln"> 828</span> <span class="src-hl">		filterModels: input.filterModels,</span></span>
+      <span class="src-line">      <span class="src-ln"> 829</span> <span class="src-hl">		stream: (model, context, options) =&gt; dispatch(model, (streams) =&gt; streams.stream(model, context, options)),</span></span>
+      <span class="src-line">      <span class="src-ln"> 830</span> <span class="src-hl">		streamSimple: (model, context, options) =&gt;</span></span>
+    </div>
+
+    <div class="note copper">
+      <span class="lang-zh-only">练习：在 pi-textbook 用 <code>registerFauxProvider</code> 替换 streamSimple，观察 agent-loop 是否仍收到相同形状的 toolcall_delta。</span>
+      <span class="lang-en-only">Exercise: in pi-textbook replace streamSimple with <code>registerFauxProvider</code>; observe agent-loop still gets same-shaped toolcall_delta.</span>
+    </div>
+
+    </div>
+
     <div class="depth-zone" data-chapter="C14"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C14.4+</span><span class="lang-en-only">Deep dive · C14.4+</span></div>
 
     <h4 class="sub2 depth-sec"><span class="sec-num">C14.4</span> <span class="lang-zh-only">主线 prompt 如何穿过此模块</span><span class="lang-en-only">through-line crossing</span></h4>
@@ -6864,6 +7413,502 @@
       <span class="lang-en-only">📘 <strong>pi-textbook checkpoint 02</strong>: EventStream (<code>event-stream.ts</code>) · production: <code>packages/ai/src/utils/event-stream.ts</code></span>
     </div>
 
+    <div class="trace-walk">
+      <div class="tw-head">
+        <span class="tw-tag">SOURCE TRACE · C15</span>
+        <span class="lang-zh-only">流式 EventStream：text_delta / toolcall_delta 协议全 trace</span>
+        <span class="lang-en-only">Streaming EventStream: full text_delta / toolcall_delta protocol trace</span>
+      </div>
+
+    <div class="lang-zh-only"><p>pi-ai 与 agent-core 之间的流式契约是 <code>AssistantMessageEvent</code> 联合类型 + <code>AssistantMessageEventStream</code> 队列。<code>agent-loop</code> 的 <code>for await (event of response)</code> 消费的正是这个协议——<strong>不是</strong> provider 原始 SSE。主线 turn-1 的 read toolUse 由一串 <code>toolcall_start → toolcall_delta×N → toolcall_end</code> 组装。</p></div>
+    <div class="lang-en-only"><p>The streaming contract between pi-ai and agent-core is <code>AssistantMessageEvent</code> union + <code>AssistantMessageEventStream</code> queue. <code>agent-loop</code>'s <code>for await (event of response)</code> consumes this protocol — <strong>not</strong> raw provider SSE. Through-line turn-1 read toolUse is assembled from <code>toolcall_start → toolcall_delta×N → toolcall_end</code>.</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/ai/src/types.ts</span>
+        <span class="src-tag">event-protocol</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 527</span> <span class="src-hl">/**</span></span>
+      <span class="src-line">      <span class="src-ln"> 528</span> <span class="src-hl"> * Event protocol <span class="src-kw">for</span> AssistantMessageEventStream.</span></span>
+      <span class="src-line">      <span class="src-ln"> 529</span> <span class="src-hl"> *</span></span>
+      <span class="src-line">      <span class="src-ln"> 530</span> <span class="src-hl"> * Streams should emit <span class=<span class="src-str">"src-str"</span>>`start`</span> before partial updates, then terminate with either:</span></span>
+      <span class="src-line">      <span class="src-ln"> 531</span> <span class="src-hl"> * - <span class=<span class="src-str">"src-str"</span>>`done`</span> carrying the final successful AssistantMessage, or</span></span>
+      <span class="src-line">      <span class="src-ln"> 532</span> <span class="src-hl"> * - <span class=<span class="src-str">"src-str"</span>>`error`</span> carrying the final AssistantMessage with stopReason &quot;error&quot; or &quot;aborted&quot;</span></span>
+      <span class="src-line">      <span class="src-ln"> 533</span> <span class="src-hl"> *   and errorMessage.</span></span>
+      <span class="src-line">      <span class="src-ln"> 534</span> <span class="src-hl"> */</span></span>
+      <span class="src-line">      <span class="src-ln"> 535</span> <span class="src-hl"><span class="src-kw">export</span> <span class="src-kw">type</span> AssistantMessageEvent =</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">AssistantMessageEvent 联合类型定义</span><span class="lang-en-only">AssistantMessageEvent union definition</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 536</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;start&quot;; partial: AssistantMessage }</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">start：携带 partial AssistantMessage</span><span class="lang-en-only">start: carries partial AssistantMessage</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 537</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;text_start&quot;; contentIndex: number; partial: AssistantMessage }</span></span>
+      <span class="src-line">      <span class="src-ln"> 538</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;text_delta&quot;; contentIndex: number; delta: string; partial: AssistantMessage }</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">text_delta：turn-2 最终回答的增量</span><span class="lang-en-only">text_delta: turn-2 final answer increments</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 539</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;text_end&quot;; contentIndex: number; content: string; partial: AssistantMessage }</span></span>
+      <span class="src-line">      <span class="src-ln"> 540</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;thinking_start&quot;; contentIndex: number; partial: AssistantMessage }</span></span>
+      <span class="src-line">      <span class="src-ln"> 541</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;thinking_delta&quot;; contentIndex: number; delta: string; partial: AssistantMessage }</span></span>
+      <span class="src-line">      <span class="src-ln"> 542</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;thinking_end&quot;; contentIndex: number; content: string; partial: AssistantMessage }</span></span>
+      <span class="src-line">      <span class="src-ln"> 543</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;toolcall_start&quot;; contentIndex: number; partial: AssistantMessage }</span></span>
+      <span class="src-line">      <span class="src-ln"> 544</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;toolcall_delta&quot;; contentIndex: number; delta: string; partial: AssistantMessage }</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">★ toolcall_delta：turn-1 read args 增量 JSON</span><span class="lang-en-only">★ toolcall_delta: turn-1 read args incremental JSON</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 545</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;toolcall_end&quot;; contentIndex: number; toolCall: ToolCall; partial: AssistantMessage }</span></span>
+      <span class="src-line">      <span class="src-ln"> 546</span> <span class="src-hl">	| {</span></span>
+      <span class="src-line">      <span class="src-ln"> 547</span> <span class="src-hl">			<span class="src-kw">type</span>: &quot;done&quot;;</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">done：stopReason=stop|toolUse|length|deferred</span><span class="lang-en-only">done: stopReason=stop|toolUse|length|deferred</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 548</span> <span class="src-hl">			reason: Extract&lt;StopReason, &quot;stop&quot; | &quot;length&quot; | &quot;toolUse&quot; | &quot;deferred&quot;&gt;;</span></span>
+      <span class="src-line">      <span class="src-ln"> 549</span> <span class="src-hl">			message: AssistantMessage;</span></span>
+      <span class="src-line">      <span class="src-ln"> 550</span> <span class="src-hl">	  }</span></span>
+      <span class="src-line">      <span class="src-ln"> 551</span> <span class="src-hl">	| { <span class="src-kw">type</span>: &quot;error&quot;; reason: Extract&lt;StopReason, &quot;aborted&quot; | &quot;error&quot;&gt;; error: AssistantMessage };</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">error：aborted|error + errorMessage</span><span class="lang-en-only">error: aborted|error + errorMessage</span></span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/ai/src/utils/event-stream.ts</span>
+        <span class="src-tag">event-stream</span>
+      </div>
+      <span class="src-line">      <span class="src-ln">   1</span> <span class="src-hl"><span class="src-kw">import</span> <span class="src-kw">type</span> { AssistantMessage, AssistantMessageEvent } <span class="src-kw">from</span> &quot;../types.ts&quot;;</span></span>
+      <span class="src-line">      <span class="src-ln">   2</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln">   3</span> <span class="src-hl"><span class="src-comment">// Generic event stream class for async iteration</span></span></span>
+      <span class="src-line">      <span class="src-ln">   4</span> <span class="src-hl"><span class="src-kw">export</span> class EventStream&lt;T, R = T&gt; implements AsyncIterable&lt;T&gt; {</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">EventStream 泛型：AsyncIterable + result()</span><span class="lang-en-only">EventStream generic: AsyncIterable + result()</span></span></span>
+      <span class="src-line">      <span class="src-ln">   5</span> <span class="src-hl">	private queue: T[] = [];</span></span>
+      <span class="src-line">      <span class="src-ln">   6</span> <span class="src-hl">	private waiting: ((value: IteratorResult&lt;T&gt;) =&gt; void)[] = [];</span></span>
+      <span class="src-line">      <span class="src-ln">   7</span> <span class="src-hl">	private done = <span class="src-kw">false</span>;</span></span>
+      <span class="src-line">      <span class="src-ln">   8</span> <span class="src-hl">	private finalResultPromise: Promise&lt;R&gt;;</span></span>
+      <span class="src-line">      <span class="src-ln">   9</span> <span class="src-hl">	private resolveFinalResult!: (result: R) =&gt; void;</span></span>
+      <span class="src-line">      <span class="src-ln">  10</span> <span class="src-hl">	private isComplete: (event: T) =&gt; boolean;</span></span>
+      <span class="src-line">      <span class="src-ln">  11</span> <span class="src-hl">	private extractResult: (event: T) =&gt; R;</span></span>
+      <span class="src-line">      <span class="src-ln">  12</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln">  13</span> <span class="src-hl">	constructor(isComplete: (event: T) =&gt; boolean, extractResult: (event: T) =&gt; R) {</span></span>
+      <span class="src-line">      <span class="src-ln">  14</span> <span class="src-hl">		this.isComplete = isComplete;</span></span>
+      <span class="src-line">      <span class="src-ln">  15</span> <span class="src-hl">		this.extractResult = extractResult;</span></span>
+      <span class="src-line">      <span class="src-ln">  16</span> <span class="src-hl">		this.finalResultPromise = <span class="src-kw">new</span> Promise((resolve) =&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln">  17</span> <span class="src-hl">			this.resolveFinalResult = resolve;</span></span>
+      <span class="src-line">      <span class="src-ln">  18</span> <span class="src-hl">		});</span></span>
+      <span class="src-line">      <span class="src-ln">  19</span> <span class="src-hl">	}</span></span>
+      <span class="src-line">      <span class="src-ln">  20</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln">  21</span> <span class="src-hl">	push(event: T): void {</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">push：完成事件 resolve finalResult</span><span class="lang-en-only">push: complete event resolves finalResult</span></span></span>
+      <span class="src-line">      <span class="src-ln">  22</span> <span class="src-hl">		<span class="src-kw">if</span> (this.done) <span class="src-kw">return</span>;</span></span>
+      <span class="src-line">      <span class="src-ln">  23</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln">  24</span> <span class="src-hl">		<span class="src-kw">if</span> (this.isComplete(event)) {</span></span>
+      <span class="src-line">      <span class="src-ln">  25</span> <span class="src-hl">			this.done = <span class="src-kw">true</span>;</span></span>
+      <span class="src-line">      <span class="src-ln">  26</span> <span class="src-hl">			this.resolveFinalResult(this.extractResult(event));</span></span>
+      <span class="src-line">      <span class="src-ln">  27</span> <span class="src-hl">		}</span></span>
+      <span class="src-line">      <span class="src-ln">  28</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln">  29</span> <span class="src-hl">		<span class="src-comment">// Deliver to waiting consumer or queue it</span></span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">等待消费者或入队</span><span class="lang-en-only">wait for consumer or enqueue</span></span></span>
+      <span class="src-line">      <span class="src-ln">  30</span> <span class="src-hl">		<span class="src-kw">const</span> waiter = this.waiting.shift();</span></span>
+      <span class="src-line">      <span class="src-ln">  31</span> <span class="src-hl">		<span class="src-kw">if</span> (waiter) {</span></span>
+      <span class="src-line">      <span class="src-ln">  32</span> <span class="src-hl">			waiter({ value: event, done: <span class="src-kw">false</span> });</span></span>
+      <span class="src-line">      <span class="src-ln">  33</span> <span class="src-hl">		} <span class="src-kw">else</span> {</span></span>
+      <span class="src-line">      <span class="src-ln">  34</span> <span class="src-hl">			this.queue.push(event);</span></span>
+      <span class="src-line">      <span class="src-ln">  35</span> <span class="src-hl">		}</span></span>
+      <span class="src-line">      <span class="src-ln">  36</span> <span class="src-hl">	}</span></span>
+      <span class="src-line">      <span class="src-ln">  37</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln">  38</span> <span class="src-hl">	end(result?: R): void {</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">end()：强制结束迭代器</span><span class="lang-en-only">end(): force iterator completion</span></span></span>
+      <span class="src-line">      <span class="src-ln">  39</span> <span class="src-hl">		this.done = <span class="src-kw">true</span>;</span></span>
+      <span class="src-line">      <span class="src-ln">  40</span> <span class="src-hl">		<span class="src-kw">if</span> (result !== <span class="src-kw">undefined</span>) {</span></span>
+      <span class="src-line">      <span class="src-ln">  41</span> <span class="src-hl">			this.resolveFinalResult(result);</span></span>
+      <span class="src-line">      <span class="src-ln">  42</span> <span class="src-hl">		}</span></span>
+      <span class="src-line">      <span class="src-ln">  43</span> <span class="src-hl">		<span class="src-comment">// Notify all waiting consumers that we&amp;#x27;re done</span></span></span>
+      <span class="src-line">      <span class="src-ln">  44</span> <span class="src-hl">		<span class="src-kw">while</span> (this.waiting.length &gt; 0) {</span></span>
+      <span class="src-line">      <span class="src-ln">  45</span> <span class="src-hl">			<span class="src-kw">const</span> waiter = this.waiting.shift()!;</span></span>
+      <span class="src-line">      <span class="src-ln">  46</span> <span class="src-hl">			waiter({ value: <span class="src-kw">undefined</span> as any, done: <span class="src-kw">true</span> });</span></span>
+      <span class="src-line">      <span class="src-ln">  47</span> <span class="src-hl">		}</span></span>
+      <span class="src-line">      <span class="src-ln">  48</span> <span class="src-hl">	}</span></span>
+      <span class="src-line">      <span class="src-ln">  49</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln">  50</span> <span class="src-hl">	<span class="src-kw">async</span> *[Symbol.asyncIterator](): AsyncIterator&lt;T&gt; {</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">async iterator：背压友好</span><span class="lang-en-only">async iterator: backpressure-friendly</span></span></span>
+      <span class="src-line">      <span class="src-ln">  51</span> <span class="src-hl">		<span class="src-kw">while</span> (<span class="src-kw">true</span>) {</span></span>
+      <span class="src-line">      <span class="src-ln">  52</span> <span class="src-hl">			<span class="src-kw">if</span> (this.queue.length &gt; 0) {</span></span>
+      <span class="src-line">      <span class="src-ln">  53</span> <span class="src-hl">				yield this.queue.shift()!;</span></span>
+      <span class="src-line">      <span class="src-ln">  54</span> <span class="src-hl">			} <span class="src-kw">else</span> <span class="src-kw">if</span> (this.done) {</span></span>
+      <span class="src-line">      <span class="src-ln">  55</span> <span class="src-hl">				<span class="src-kw">return</span>;</span></span>
+      <span class="src-line">      <span class="src-ln">  56</span> <span class="src-hl">			} <span class="src-kw">else</span> {</span></span>
+      <span class="src-line">      <span class="src-ln">  57</span> <span class="src-hl">				<span class="src-kw">const</span> result = <span class="src-kw">await</span> <span class="src-kw">new</span> Promise&lt;IteratorResult&lt;T&gt;&gt;((resolve) =&gt; this.waiting.push(resolve));</span></span>
+      <span class="src-line">      <span class="src-ln">  58</span> <span class="src-hl">				<span class="src-kw">if</span> (result.done) <span class="src-kw">return</span>;</span></span>
+      <span class="src-line">      <span class="src-ln">  59</span> <span class="src-hl">				yield result.value;</span></span>
+      <span class="src-line">      <span class="src-ln">  60</span> <span class="src-hl">			}</span></span>
+      <span class="src-line">      <span class="src-ln">  61</span> <span class="src-hl">		}</span></span>
+      <span class="src-line">      <span class="src-ln">  62</span> <span class="src-hl">	}</span></span>
+      <span class="src-line">      <span class="src-ln">  63</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln">  64</span> <span class="src-hl">	result(): Promise&lt;R&gt; {</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">result()：await 最终 AssistantMessage</span><span class="lang-en-only">result(): await final AssistantMessage</span></span></span>
+      <span class="src-line">      <span class="src-ln">  65</span> <span class="src-hl">		<span class="src-kw">return</span> this.finalResultPromise;</span></span>
+      <span class="src-line">      <span class="src-ln">  66</span> <span class="src-hl">	}</span></span>
+      <span class="src-line">      <span class="src-ln">  67</span> <span class="src-hl">}</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/ai/src/utils/event-stream.ts</span>
+        <span class="src-tag">assistant-stream</span>
+      </div>
+      <span class="src-line">      <span class="src-ln">  69</span> <span class="src-hl"><span class="src-kw">export</span> class AssistantMessageEventStream extends EventStream&lt;AssistantMessageEvent, AssistantMessage&gt; {</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">AssistantMessageEventStream 子类</span><span class="lang-en-only">AssistantMessageEventStream subclass</span></span></span>
+      <span class="src-line">      <span class="src-ln">  70</span> <span class="src-hl">	constructor() {</span></span>
+      <span class="src-line">      <span class="src-ln">  71</span> <span class="src-hl">		super(</span></span>
+      <span class="src-line">      <span class="src-ln">  72</span> <span class="src-hl">			(event) =&gt; event.<span class="src-kw">type</span> === &quot;done&quot; || event.<span class="src-kw">type</span> === &quot;error&quot;,</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">isComplete：done 或 error</span><span class="lang-en-only">isComplete: done or error</span></span></span>
+      <span class="src-line">      <span class="src-ln">  73</span> <span class="src-hl">			(event) =&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln">  74</span> <span class="src-hl">				<span class="src-kw">if</span> (event.<span class="src-kw">type</span> === &quot;done&quot;) {</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">extractResult：done→message, error→error</span><span class="lang-en-only">extractResult: done→message, error→error</span></span></span>
+      <span class="src-line">      <span class="src-ln">  75</span> <span class="src-hl">					<span class="src-kw">return</span> event.message;</span></span>
+      <span class="src-line">      <span class="src-ln">  76</span> <span class="src-hl">				} <span class="src-kw">else</span> <span class="src-kw">if</span> (event.<span class="src-kw">type</span> === &quot;error&quot;) {</span></span>
+      <span class="src-line">      <span class="src-ln">  77</span> <span class="src-hl">					<span class="src-kw">return</span> event.error;</span></span>
+      <span class="src-line">      <span class="src-ln">  78</span> <span class="src-hl">				}</span></span>
+      <span class="src-line">      <span class="src-ln">  79</span> <span class="src-hl">				<span class="src-kw">throw</span> <span class="src-kw">new</span> Error(&quot;Unexpected event <span class="src-kw">type</span> <span class="src-kw">for</span> final result&quot;);</span></span>
+      <span class="src-line">      <span class="src-ln">  80</span> <span class="src-hl">			},</span></span>
+      <span class="src-line">      <span class="src-ln">  81</span> <span class="src-hl">		);</span></span>
+      <span class="src-line">      <span class="src-ln">  82</span> <span class="src-hl">	}</span></span>
+      <span class="src-line">      <span class="src-ln">  83</span> <span class="src-hl">}</span></span>
+      <span class="src-line">      <span class="src-ln">  84</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln">  85</span> <span class="src-hl">/** Factory <span class="src-kw">function</span> <span class="src-kw">for</span> AssistantMessageEventStream (<span class="src-kw">for</span> use in extensions) */</span></span>
+      <span class="src-line">      <span class="src-ln">  86</span> <span class="src-hl"><span class="src-kw">export</span> <span class="src-kw">function</span> createAssistantMessageEventStream(): AssistantMessageEventStream {</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">工厂：extensions 可构造假流</span><span class="lang-en-only">factory: extensions can build fake streams</span></span></span>
+      <span class="src-line">      <span class="src-ln">  87</span> <span class="src-hl">	<span class="src-kw">return</span> <span class="src-kw">new</span> AssistantMessageEventStream();</span></span>
+      <span class="src-line">      <span class="src-ln">  88</span> <span class="src-hl">}</span></span>
+    </div>
+
+    <div class="trace-steps"><div class="ts-label"><span class="lang-zh-only">主线 turn-1 · toolcall_delta 时间线</span><span class="lang-en-only">Through-line turn-1 · toolcall_delta timeline</span></div>    <table class="cmp">
+      <thead><tr><th>#</th><th>location</th><th>主线时刻 / through-line moment</th></tr></thead>
+      <tbody>
+      <tr><td>1</td><td>toolcall_start</td><td>content block tool_use 开始</td></tr>
+      <tr><td>2</td><td>toolcall_delta</td><td>{"path"</td></tr>
+      <tr><td>3</td><td>toolcall_delta</td><td>:"README.md"}</td></tr>
+      <tr><td>4</td><td>toolcall_delta</td><td>} 片段…</td></tr>
+      <tr><td>5</td><td>toolcall_end</td><td>arguments 解析完成 · id=toolu_…</td></tr>
+      <tr><td>6</td><td>done</td><td>stopReason=toolUse</td></tr>
+      <tr><td>7</td><td>agent-loop</td><td>message_update×N → executeToolCalls</td></tr>
+      </tbody>
+    </table></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/ai/src/api/anthropic-messages.ts</span>
+        <span class="src-tag">sse-start</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 575</span> <span class="src-hl">			<span class="src-kw">const</span> response = <span class="src-kw">await</span> retryProviderRequest(</span></span>
+      <span class="src-line">      <span class="src-ln"> 576</span> <span class="src-hl">				() =&gt; client.messages.create({ ...params, stream: <span class="src-kw">true</span> }, requestOptions).asResponse(),</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">client.messages.create stream:true</span><span class="lang-en-only">client.messages.create stream:true</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 577</span> <span class="src-hl">				{</span></span>
+      <span class="src-line">      <span class="src-ln"> 578</span> <span class="src-hl">					maxRetries: options?.maxRetries,</span></span>
+      <span class="src-line">      <span class="src-ln"> 579</span> <span class="src-hl">					maxRetryDelayMs: options?.maxRetryDelayMs,</span></span>
+      <span class="src-line">      <span class="src-ln"> 580</span> <span class="src-hl">					signal: options?.signal,</span></span>
+      <span class="src-line">      <span class="src-ln"> 581</span> <span class="src-hl">				},</span></span>
+      <span class="src-line">      <span class="src-ln"> 582</span> <span class="src-hl">			);</span></span>
+      <span class="src-line">      <span class="src-ln"> 583</span> <span class="src-hl">			<span class="src-kw">await</span> options?.onResponse?.({ status: response.status, headers: headersToRecord(response.headers) }, model);</span></span>
+      <span class="src-line">      <span class="src-ln"> 584</span> <span class="src-hl">			stream.push({ <span class="src-kw">type</span>: &quot;start&quot;, partial: output });</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">stream.push start</span><span class="lang-en-only">stream.push start</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 585</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 586</span> <span class="src-hl">			<span class="src-kw">type</span> Block = (ThinkingContent | TextContent | (ToolCall &amp; { partialJson: string })) &amp; { index: number };</span></span>
+      <span class="src-line">      <span class="src-ln"> 587</span> <span class="src-hl">			<span class="src-kw">const</span> blocks = output.content as Block[];</span></span>
+      <span class="src-line">      <span class="src-ln"> 588</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 589</span> <span class="src-hl">			<span class="src-kw">for</span> <span class="src-kw">await</span> (<span class="src-kw">const</span> event of iterateAnthropicEvents(response, options?.signal)) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 590</span> <span class="src-hl">				<span class="src-kw">if</span> (event.<span class="src-kw">type</span> === &quot;message_start&quot;) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 591</span> <span class="src-hl">					output.responseId = event.message.id;</span></span>
+      <span class="src-line">      <span class="src-ln"> 592</span> <span class="src-hl">					output.model = event.message.model;</span></span>
+      <span class="src-line">      <span class="src-ln"> 593</span> <span class="src-hl">					<span class="src-kw">const</span> fallbackCost =</span></span>
+      <span class="src-line">      <span class="src-ln"> 594</span> <span class="src-hl">						output.model === model.id</span></span>
+      <span class="src-line">      <span class="src-ln"> 595</span> <span class="src-hl">							? <span class="src-kw">undefined</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 596</span> <span class="src-hl">							: model.compat?.allowedFallbackModels?.find(</span></span>
+      <span class="src-line">      <span class="src-ln"> 597</span> <span class="src-hl">									(fallback) =&gt; fallback.provider === model.provider &amp;&amp; fallback.model === output.model,</span></span>
+      <span class="src-line">      <span class="src-ln"> 598</span> <span class="src-hl">								)?.cost;</span></span>
+      <span class="src-line">      <span class="src-ln"> 599</span> <span class="src-hl">					usageModel = fallbackCost ? { ...model, id: output.model, cost: fallbackCost } : model;</span></span>
+      <span class="src-line">      <span class="src-ln"> 600</span> <span class="src-hl">					<span class="src-comment">// Capture initial token usage from message_start event</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 601</span> <span class="src-hl">					<span class="src-comment">// This ensures we have input token counts even if the stream is aborted early</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 602</span> <span class="src-hl">					output.usage.input = event.message.usage.input_tokens || 0;</span></span>
+      <span class="src-line">      <span class="src-ln"> 603</span> <span class="src-hl">					output.usage.output = event.message.usage.output_tokens || 0;</span></span>
+      <span class="src-line">      <span class="src-ln"> 604</span> <span class="src-hl">					output.usage.cacheRead = event.message.usage.cache_read_input_tokens || 0;</span></span>
+      <span class="src-line">      <span class="src-ln"> 605</span> <span class="src-hl">					output.usage.cacheWrite = event.message.usage.cache_creation_input_tokens || 0;</span></span>
+      <span class="src-line">      <span class="src-ln"> 606</span> <span class="src-hl">					output.usage.cacheWrite1h = event.message.usage.cache_creation?.ephemeral_1h_input_tokens || 0;</span></span>
+      <span class="src-line">      <span class="src-ln"> 607</span> <span class="src-hl">					<span class="src-comment">// Anthropic doesn&amp;#x27;t provide total_tokens, compute from components</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 608</span> <span class="src-hl">					output.usage.totalTokens =</span></span>
+      <span class="src-line">      <span class="src-ln"> 609</span> <span class="src-hl">						output.usage.input + output.usage.output + output.usage.cacheRead + output.usage.cacheWrite;</span></span>
+      <span class="src-line">      <span class="src-ln"> 610</span> <span class="src-hl">					calculateCost(usageModel, output.usage);</span></span>
+      <span class="src-line">      <span class="src-ln"> 611</span> <span class="src-hl">				} <span class="src-kw">else</span> <span class="src-kw">if</span> (event.<span class="src-kw">type</span> === &quot;content_block_start&quot;) {</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">content_block_start：text/thinking/tool_use</span><span class="lang-en-only">content_block_start: text/thinking/tool_use</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 612</span> <span class="src-hl">					<span class="src-kw">if</span> (event.content_block.<span class="src-kw">type</span> === &quot;text&quot;) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 613</span> <span class="src-hl">						<span class="src-kw">const</span> block: Block = {</span></span>
+      <span class="src-line">      <span class="src-ln"> 614</span> <span class="src-hl">							<span class="src-kw">type</span>: &quot;text&quot;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 615</span> <span class="src-hl">							text: event.content_block.text ?? &quot;&quot;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 616</span> <span class="src-hl">							index: event.index,</span></span>
+      <span class="src-line">      <span class="src-ln"> 617</span> <span class="src-hl">						};</span></span>
+      <span class="src-line">      <span class="src-ln"> 618</span> <span class="src-hl">						output.content.push(block);</span></span>
+      <span class="src-line">      <span class="src-ln"> 619</span> <span class="src-hl">						stream.push({ <span class="src-kw">type</span>: &quot;text_start&quot;, contentIndex: output.content.length - 1, partial: output });</span></span>
+      <span class="src-line">      <span class="src-ln"> 620</span> <span class="src-hl">					} <span class="src-kw">else</span> <span class="src-kw">if</span> (event.content_block.<span class="src-kw">type</span> === &quot;thinking&quot;) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 621</span> <span class="src-hl">						<span class="src-kw">const</span> block: Block = {</span></span>
+      <span class="src-line">      <span class="src-ln"> 622</span> <span class="src-hl">							<span class="src-kw">type</span>: &quot;thinking&quot;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 623</span> <span class="src-hl">							thinking: event.content_block.thinking ?? &quot;&quot;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 624</span> <span class="src-hl">							thinkingSignature: event.content_block.signature ?? &quot;&quot;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 625</span> <span class="src-hl">							index: event.index,</span></span>
+      <span class="src-line">      <span class="src-ln"> 626</span> <span class="src-hl">						};</span></span>
+      <span class="src-line">      <span class="src-ln"> 627</span> <span class="src-hl">						output.content.push(block);</span></span>
+      <span class="src-line">      <span class="src-ln"> 628</span> <span class="src-hl">						stream.push({ <span class="src-kw">type</span>: &quot;thinking_start&quot;, contentIndex: output.content.length - 1, partial: output });</span></span>
+      <span class="src-line">      <span class="src-ln"> 629</span> <span class="src-hl">					} <span class="src-kw">else</span> <span class="src-kw">if</span> (event.content_block.<span class="src-kw">type</span> === &quot;redacted_thinking&quot;) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 630</span> <span class="src-hl">						<span class="src-kw">const</span> block: Block = {</span></span>
+      <span class="src-line">      <span class="src-ln"> 631</span> <span class="src-hl">							<span class="src-kw">type</span>: &quot;thinking&quot;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 632</span> <span class="src-hl">							thinking: &quot;[Reasoning redacted]&quot;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 633</span> <span class="src-hl">							thinkingSignature: event.content_block.data,</span></span>
+      <span class="src-line">      <span class="src-ln"> 634</span> <span class="src-hl">							redacted: <span class="src-kw">true</span>,</span></span>
+      <span class="src-line">      <span class="src-ln"> 635</span> <span class="src-hl">							index: event.index,</span></span>
+      <span class="src-line">      <span class="src-ln"> 636</span> <span class="src-hl">						};</span></span>
+      <span class="src-line">      <span class="src-ln"> 637</span> <span class="src-hl">						output.content.push(block);</span></span>
+      <span class="src-line">      <span class="src-ln"> 638</span> <span class="src-hl">						stream.push({ <span class="src-kw">type</span>: &quot;thinking_start&quot;, contentIndex: output.content.length - 1, partial: output });</span></span>
+      <span class="src-line">      <span class="src-ln"> 639</span> <span class="src-hl">					} <span class="src-kw">else</span> <span class="src-kw">if</span> (event.content_block.<span class="src-kw">type</span> === &quot;tool_use&quot;) {</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">tool_use block → toolcall_start</span><span class="lang-en-only">tool_use block → toolcall_start</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 640</span> <span class="src-hl">						<span class="src-kw">const</span> block: Block = {</span></span>
+      <span class="src-line">      <span class="src-ln"> 641</span> <span class="src-hl">							<span class="src-kw">type</span>: &quot;toolCall&quot;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 642</span> <span class="src-hl">							id: event.content_block.id,</span></span>
+      <span class="src-line">      <span class="src-ln"> 643</span> <span class="src-hl">							name: isOAuth</span></span>
+      <span class="src-line">      <span class="src-ln"> 644</span> <span class="src-hl">								? fromClaudeCodeName(event.content_block.name, context.tools)</span></span>
+      <span class="src-line">      <span class="src-ln"> 645</span> <span class="src-hl">								: event.content_block.name,</span></span>
+      <span class="src-line">      <span class="src-ln"> 646</span> <span class="src-hl">							arguments: (event.content_block.input as Record&lt;string, any&gt;) ?? {},</span></span>
+      <span class="src-line">      <span class="src-ln"> 647</span> <span class="src-hl">							partialJson: &quot;&quot;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 648</span> <span class="src-hl">							index: event.index,</span></span>
+      <span class="src-line">      <span class="src-ln"> 649</span> <span class="src-hl">						};</span></span>
+      <span class="src-line">      <span class="src-ln"> 650</span> <span class="src-hl">						output.content.push(block);</span></span>
+      <span class="src-line">      <span class="src-ln"> 651</span> <span class="src-hl">						stream.push({ <span class="src-kw">type</span>: &quot;toolcall_start&quot;, contentIndex: output.content.length - 1, partial: output });</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">★ toolcall_start push</span><span class="lang-en-only">★ toolcall_start push</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 652</span> <span class="src-hl">					}</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/ai/src/api/anthropic-messages.ts</span>
+        <span class="src-tag">sse-delta</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 653</span> <span class="src-hl">				} <span class="src-kw">else</span> <span class="src-kw">if</span> (event.<span class="src-kw">type</span> === &quot;content_block_delta&quot;) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 654</span> <span class="src-hl">					<span class="src-kw">if</span> (event.delta.<span class="src-kw">type</span> === &quot;text_delta&quot;) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 655</span> <span class="src-hl">						<span class="src-kw">const</span> index = blocks.findIndex((b) =&gt; b.index === event.index);</span></span>
+      <span class="src-line">      <span class="src-ln"> 656</span> <span class="src-hl">						<span class="src-kw">const</span> block = blocks[index];</span></span>
+      <span class="src-line">      <span class="src-ln"> 657</span> <span class="src-hl">						<span class="src-kw">if</span> (block &amp;&amp; block.<span class="src-kw">type</span> === &quot;text&quot;) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 658</span> <span class="src-hl">							block.text += event.delta.text;</span></span>
+      <span class="src-line">      <span class="src-ln"> 659</span> <span class="src-hl">							stream.push({</span></span>
+      <span class="src-line">      <span class="src-ln"> 660</span> <span class="src-hl">								<span class="src-kw">type</span>: &quot;text_delta&quot;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 661</span> <span class="src-hl">								contentIndex: index,</span></span>
+      <span class="src-line">      <span class="src-ln"> 662</span> <span class="src-hl">								delta: event.delta.text,</span></span>
+      <span class="src-line">      <span class="src-ln"> 663</span> <span class="src-hl">								partial: output,</span></span>
+      <span class="src-line">      <span class="src-ln"> 664</span> <span class="src-hl">							});</span></span>
+      <span class="src-line">      <span class="src-ln"> 665</span> <span class="src-hl">						}</span></span>
+      <span class="src-line">      <span class="src-ln"> 666</span> <span class="src-hl">					} <span class="src-kw">else</span> <span class="src-kw">if</span> (event.delta.<span class="src-kw">type</span> === &quot;thinking_delta&quot;) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 667</span> <span class="src-hl">						<span class="src-kw">const</span> index = blocks.findIndex((b) =&gt; b.index === event.index);</span></span>
+      <span class="src-line">      <span class="src-ln"> 668</span> <span class="src-hl">						<span class="src-kw">const</span> block = blocks[index];</span></span>
+      <span class="src-line">      <span class="src-ln"> 669</span> <span class="src-hl">						<span class="src-kw">if</span> (block &amp;&amp; block.<span class="src-kw">type</span> === &quot;thinking&quot;) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 670</span> <span class="src-hl">							block.thinking += event.delta.thinking;</span></span>
+      <span class="src-line">      <span class="src-ln"> 671</span> <span class="src-hl">							stream.push({</span></span>
+      <span class="src-line">      <span class="src-ln"> 672</span> <span class="src-hl">								<span class="src-kw">type</span>: &quot;thinking_delta&quot;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 673</span> <span class="src-hl">								contentIndex: index,</span></span>
+      <span class="src-line">      <span class="src-ln"> 674</span> <span class="src-hl">								delta: event.delta.thinking,</span></span>
+      <span class="src-line">      <span class="src-ln"> 675</span> <span class="src-hl">								partial: output,</span></span>
+      <span class="src-line">      <span class="src-ln"> 676</span> <span class="src-hl">							});</span></span>
+      <span class="src-line">      <span class="src-ln"> 677</span> <span class="src-hl">						}</span></span>
+      <span class="src-line">      <span class="src-ln"> 678</span> <span class="src-hl">					} <span class="src-kw">else</span> <span class="src-kw">if</span> (event.delta.<span class="src-kw">type</span> === &quot;input_json_delta&quot;) {</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">input_json_delta → toolcall_delta</span><span class="lang-en-only">input_json_delta → toolcall_delta</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 679</span> <span class="src-hl">						<span class="src-kw">const</span> index = blocks.findIndex((b) =&gt; b.index === event.index);</span></span>
+      <span class="src-line">      <span class="src-ln"> 680</span> <span class="src-hl">						<span class="src-kw">const</span> block = blocks[index];</span></span>
+      <span class="src-line">      <span class="src-ln"> 681</span> <span class="src-hl">						<span class="src-kw">if</span> (block &amp;&amp; block.<span class="src-kw">type</span> === &quot;toolCall&quot;) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 682</span> <span class="src-hl">							block.partialJson += event.delta.partial_json;</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">partialJson 累加 + parseStreamingJson</span><span class="lang-en-only">partialJson accumulate + parseStreamingJson</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 683</span> <span class="src-hl">							block.arguments = parseStreamingJson(block.partialJson);</span></span>
+      <span class="src-line">      <span class="src-ln"> 684</span> <span class="src-hl">							stream.push({</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">★ 每个 JSON 片段 push toolcall_delta</span><span class="lang-en-only">★ each JSON fragment pushes toolcall_delta</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 685</span> <span class="src-hl">								<span class="src-kw">type</span>: &quot;toolcall_delta&quot;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 686</span> <span class="src-hl">								contentIndex: index,</span></span>
+      <span class="src-line">      <span class="src-ln"> 687</span> <span class="src-hl">								delta: event.delta.partial_json,</span></span>
+      <span class="src-line">      <span class="src-ln"> 688</span> <span class="src-hl">								partial: output,</span></span>
+      <span class="src-line">      <span class="src-ln"> 689</span> <span class="src-hl">							});</span></span>
+      <span class="src-line">      <span class="src-ln"> 690</span> <span class="src-hl">						}</span></span>
+      <span class="src-line">      <span class="src-ln"> 691</span> <span class="src-hl">					} <span class="src-kw">else</span> <span class="src-kw">if</span> (event.delta.<span class="src-kw">type</span> === &quot;signature_delta&quot;) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 692</span> <span class="src-hl">						<span class="src-kw">const</span> index = blocks.findIndex((b) =&gt; b.index === event.index);</span></span>
+      <span class="src-line">      <span class="src-ln"> 693</span> <span class="src-hl">						<span class="src-kw">const</span> block = blocks[index];</span></span>
+      <span class="src-line">      <span class="src-ln"> 694</span> <span class="src-hl">						<span class="src-kw">if</span> (block &amp;&amp; block.<span class="src-kw">type</span> === &quot;thinking&quot;) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 695</span> <span class="src-hl">							block.thinkingSignature = block.thinkingSignature || &quot;&quot;;</span></span>
+      <span class="src-line">      <span class="src-ln"> 696</span> <span class="src-hl">							block.thinkingSignature += event.delta.signature;</span></span>
+      <span class="src-line">      <span class="src-ln"> 697</span> <span class="src-hl">						}</span></span>
+      <span class="src-line">      <span class="src-ln"> 698</span> <span class="src-hl">					}</span></span>
+      <span class="src-line">      <span class="src-ln"> 699</span> <span class="src-hl">				} <span class="src-kw">else</span> <span class="src-kw">if</span> (event.<span class="src-kw">type</span> === &quot;content_block_stop&quot;) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 700</span> <span class="src-hl">					<span class="src-kw">const</span> index = blocks.findIndex((b) =&gt; b.index === event.index);</span></span>
+      <span class="src-line">      <span class="src-ln"> 701</span> <span class="src-hl">					<span class="src-kw">const</span> block = blocks[index];</span></span>
+      <span class="src-line">      <span class="src-ln"> 702</span> <span class="src-hl">					<span class="src-kw">if</span> (block) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 703</span> <span class="src-hl">						delete (block as any).index;</span></span>
+      <span class="src-line">      <span class="src-ln"> 704</span> <span class="src-hl">						<span class="src-kw">if</span> (block.<span class="src-kw">type</span> === &quot;text&quot;) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 705</span> <span class="src-hl">							stream.push({</span></span>
+      <span class="src-line">      <span class="src-ln"> 706</span> <span class="src-hl">								<span class="src-kw">type</span>: &quot;text_end&quot;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 707</span> <span class="src-hl">								contentIndex: index,</span></span>
+      <span class="src-line">      <span class="src-ln"> 708</span> <span class="src-hl">								content: block.text,</span></span>
+      <span class="src-line">      <span class="src-ln"> 709</span> <span class="src-hl">								partial: output,</span></span>
+      <span class="src-line">      <span class="src-ln"> 710</span> <span class="src-hl">							});</span></span>
+      <span class="src-line">      <span class="src-ln"> 711</span> <span class="src-hl">						} <span class="src-kw">else</span> <span class="src-kw">if</span> (block.<span class="src-kw">type</span> === &quot;thinking&quot;) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 712</span> <span class="src-hl">							stream.push({</span></span>
+      <span class="src-line">      <span class="src-ln"> 713</span> <span class="src-hl">								<span class="src-kw">type</span>: &quot;thinking_end&quot;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 714</span> <span class="src-hl">								contentIndex: index,</span></span>
+      <span class="src-line">      <span class="src-ln"> 715</span> <span class="src-hl">								content: block.thinking,</span></span>
+      <span class="src-line">      <span class="src-ln"> 716</span> <span class="src-hl">								partial: output,</span></span>
+      <span class="src-line">      <span class="src-ln"> 717</span> <span class="src-hl">							});</span></span>
+      <span class="src-line">      <span class="src-ln"> 718</span> <span class="src-hl">						} <span class="src-kw">else</span> <span class="src-kw">if</span> (block.<span class="src-kw">type</span> === &quot;toolCall&quot;) {</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">content_block_stop → toolcall_end</span><span class="lang-en-only">content_block_stop → toolcall_end</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 719</span> <span class="src-hl">							block.arguments = parseStreamingJson(block.partialJson);</span></span>
+      <span class="src-line">      <span class="src-ln"> 720</span> <span class="src-hl">							<span class="src-comment">// Finalize in-place and strip the scratch buffer so replay only</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 721</span> <span class="src-hl">							<span class="src-comment">// carries parsed arguments.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 722</span> <span class="src-hl">							delete (block as { partialJson?: string }).partialJson;</span></span>
+      <span class="src-line">      <span class="src-ln"> 723</span> <span class="src-hl">							stream.push({</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">delete partialJson，只保留 arguments</span><span class="lang-en-only">delete partialJson, keep arguments only</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 724</span> <span class="src-hl">								<span class="src-kw">type</span>: &quot;toolcall_end&quot;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 725</span> <span class="src-hl">								contentIndex: index,</span></span>
+      <span class="src-line">      <span class="src-ln"> 726</span> <span class="src-hl">								toolCall: block,</span></span>
+      <span class="src-line">      <span class="src-ln"> 727</span> <span class="src-hl">								partial: output,</span></span>
+      <span class="src-line">      <span class="src-ln"> 728</span> <span class="src-hl">							});</span></span>
+      <span class="src-line">      <span class="src-ln"> 729</span> <span class="src-hl">						}</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/ai/src/api/anthropic-messages.ts</span>
+        <span class="src-tag">sse-done</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 731</span> <span class="src-hl">				} <span class="src-kw">else</span> <span class="src-kw">if</span> (event.<span class="src-kw">type</span> === &quot;message_delta&quot;) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 732</span> <span class="src-hl">					<span class="src-kw">if</span> (event.delta.stop_reason) {</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">message_delta：stop_reason → stopReason</span><span class="lang-en-only">message_delta: stop_reason → stopReason</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 733</span> <span class="src-hl">						output.rawStopReason = event.delta.stop_reason;</span></span>
+      <span class="src-line">      <span class="src-ln"> 734</span> <span class="src-hl">						<span class="src-kw">const</span> stopReasonResult = mapStopReason(event.delta.stop_reason, event.delta.stop_details);</span></span>
+      <span class="src-line">      <span class="src-ln"> 735</span> <span class="src-hl">						output.stopReason = stopReasonResult.stopReason;</span></span>
+      <span class="src-line">      <span class="src-ln"> 736</span> <span class="src-hl">						<span class="src-kw">if</span> (stopReasonResult.errorMessage) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 737</span> <span class="src-hl">							output.errorMessage = stopReasonResult.errorMessage;</span></span>
+      <span class="src-line">      <span class="src-ln"> 738</span> <span class="src-hl">						}</span></span>
+      <span class="src-line">      <span class="src-ln"> 739</span> <span class="src-hl">					}</span></span>
+      <span class="src-line">      <span class="src-ln"> 740</span> <span class="src-hl">					<span class="src-comment">// Only update usage fields if present (not null).</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 741</span> <span class="src-hl">					<span class="src-comment">// Preserves input_tokens from message_start when proxies omit it in message_delta.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 742</span> <span class="src-hl">					<span class="src-kw">if</span> (event.usage) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 743</span> <span class="src-hl">						<span class="src-kw">if</span> (event.usage.input_tokens != <span class="src-kw">null</span>) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 744</span> <span class="src-hl">							output.usage.input = event.usage.input_tokens;</span></span>
+      <span class="src-line">      <span class="src-ln"> 745</span> <span class="src-hl">						}</span></span>
+      <span class="src-line">      <span class="src-ln"> 746</span> <span class="src-hl">						<span class="src-kw">if</span> (event.usage.output_tokens != <span class="src-kw">null</span>) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 747</span> <span class="src-hl">							output.usage.output = event.usage.output_tokens;</span></span>
+      <span class="src-line">      <span class="src-ln"> 748</span> <span class="src-hl">						}</span></span>
+      <span class="src-line">      <span class="src-ln"> 749</span> <span class="src-hl">						<span class="src-kw">if</span> (event.usage.cache_read_input_tokens != <span class="src-kw">null</span>) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 750</span> <span class="src-hl">							output.usage.cacheRead = event.usage.cache_read_input_tokens;</span></span>
+      <span class="src-line">      <span class="src-ln"> 751</span> <span class="src-hl">						}</span></span>
+      <span class="src-line">      <span class="src-ln"> 752</span> <span class="src-hl">						<span class="src-kw">if</span> (event.usage.cache_creation_input_tokens != <span class="src-kw">null</span>) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 753</span> <span class="src-hl">							output.usage.cacheWrite = event.usage.cache_creation_input_tokens;</span></span>
+      <span class="src-line">      <span class="src-ln"> 754</span> <span class="src-hl">						}</span></span>
+      <span class="src-line">      <span class="src-ln"> 755</span> <span class="src-hl">						<span class="src-comment">// Anthropic reports reasoning tokens in `output_tokens_details.thinking_tokens` on the</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 756</span> <span class="src-hl">						<span class="src-comment">// final message_delta usage (a subset of output_tokens). SDK 0.91.1 omits the field from</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 757</span> <span class="src-hl">						<span class="src-comment">// its Usage type, so read it through a narrow cast. Verified against the live API.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 758</span> <span class="src-hl">						<span class="src-kw">const</span> thinkingTokens = (event.usage as { output_tokens_details?: { thinking_tokens?: number } })</span></span>
+      <span class="src-line">      <span class="src-ln"> 759</span> <span class="src-hl">							.output_tokens_details?.thinking_tokens;</span></span>
+      <span class="src-line">      <span class="src-ln"> 760</span> <span class="src-hl">						<span class="src-kw">if</span> (thinkingTokens != <span class="src-kw">null</span>) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 761</span> <span class="src-hl">							output.usage.reasoning = thinkingTokens;</span></span>
+      <span class="src-line">      <span class="src-ln"> 762</span> <span class="src-hl">						}</span></span>
+      <span class="src-line">      <span class="src-ln"> 763</span> <span class="src-hl">					}</span></span>
+      <span class="src-line">      <span class="src-ln"> 764</span> <span class="src-hl">					<span class="src-comment">// Anthropic doesn&amp;#x27;t provide total_tokens, compute from components</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 765</span> <span class="src-hl">					output.usage.totalTokens =</span></span>
+      <span class="src-line">      <span class="src-ln"> 766</span> <span class="src-hl">						output.usage.input + output.usage.output + output.usage.cacheRead + output.usage.cacheWrite;</span></span>
+      <span class="src-line">      <span class="src-ln"> 767</span> <span class="src-hl">					calculateCost(usageModel, output.usage);</span></span>
+      <span class="src-line">      <span class="src-ln"> 768</span> <span class="src-hl">				}</span></span>
+      <span class="src-line">      <span class="src-ln"> 769</span> <span class="src-hl">			}</span></span>
+      <span class="src-line">      <span class="src-ln"> 770</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 771</span> <span class="src-hl">			<span class="src-kw">if</span> (options?.signal?.aborted) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 772</span> <span class="src-hl">				<span class="src-kw">throw</span> <span class="src-kw">new</span> Error(&quot;Request was aborted&quot;);</span></span>
+      <span class="src-line">      <span class="src-ln"> 773</span> <span class="src-hl">			}</span></span>
+      <span class="src-line">      <span class="src-ln"> 774</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 775</span> <span class="src-hl">			<span class="src-kw">if</span> (output.stopReason === &quot;pending&quot;) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 776</span> <span class="src-hl">				<span class="src-kw">throw</span> <span class="src-kw">new</span> Error(&quot;Anthropic stream ended without a stop reason&quot;);</span></span>
+      <span class="src-line">      <span class="src-ln"> 777</span> <span class="src-hl">			}</span></span>
+      <span class="src-line">      <span class="src-ln"> 778</span> <span class="src-hl">			<span class="src-kw">if</span> (output.stopReason === &quot;aborted&quot; || output.stopReason === &quot;error&quot;) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 779</span> <span class="src-hl">				<span class="src-kw">throw</span> <span class="src-kw">new</span> Error(output.errorMessage || &quot;An unknown error occurred&quot;);</span></span>
+      <span class="src-line">      <span class="src-ln"> 780</span> <span class="src-hl">			}</span></span>
+      <span class="src-line">      <span class="src-ln"> 781</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 782</span> <span class="src-hl">			stream.push({ <span class="src-kw">type</span>: &quot;done&quot;, reason: output.stopReason, message: output });</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">stream.push done</span><span class="lang-en-only">stream.push done</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 783</span> <span class="src-hl">			stream.end();</span></span>
+      <span class="src-line">      <span class="src-ln"> 784</span> <span class="src-hl">		} catch (error) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 785</span> <span class="src-hl">			<span class="src-kw">for</span> (<span class="src-kw">const</span> block of output.content) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 786</span> <span class="src-hl">				delete (block as { index?: number }).index;</span></span>
+      <span class="src-line">      <span class="src-ln"> 787</span> <span class="src-hl">				<span class="src-comment">// partialJson is only a streaming scratch buffer; never persist it.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 788</span> <span class="src-hl">				delete (block as { partialJson?: string }).partialJson;</span></span>
+      <span class="src-line">      <span class="src-ln"> 789</span> <span class="src-hl">			}</span></span>
+      <span class="src-line">      <span class="src-ln"> 790</span> <span class="src-hl">			output.stopReason = options?.signal?.aborted ? &quot;aborted&quot; : &quot;error&quot;;</span></span>
+      <span class="src-line">      <span class="src-ln"> 791</span> <span class="src-hl">			output.errorMessage = error instanceof Error ? error.message : JSON.stringify(error);</span></span>
+      <span class="src-line">      <span class="src-ln"> 792</span> <span class="src-hl">			stream.push({ <span class="src-kw">type</span>: &quot;error&quot;, reason: output.stopReason, error: output });</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">catch → error event + end</span><span class="lang-en-only">catch → error event + end</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 793</span> <span class="src-hl">			stream.end();</span></span>
+      <span class="src-line">      <span class="src-ln"> 794</span> <span class="src-hl">		}</span></span>
+      <span class="src-line">      <span class="src-ln"> 795</span> <span class="src-hl">	})();</span></span>
+      <span class="src-line">      <span class="src-ln"> 796</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 797</span> <span class="src-hl">	<span class="src-kw">return</span> stream;</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/agent/src/agent-loop.ts</span>
+        <span class="src-tag">agent-consume</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 314</span> <span class="src-hl">	<span class="src-kw">let</span> partialMessage: AssistantMessage | <span class="src-kw">null</span> = <span class="src-kw">null</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 315</span> <span class="src-hl">	<span class="src-kw">let</span> addedPartial = <span class="src-kw">false</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 316</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 317</span> <span class="src-hl">	<span class="src-kw">for</span> <span class="src-kw">await</span> (<span class="src-kw">const</span> event of response) {</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">for await response：消费 pi-ai EventStream</span><span class="lang-en-only">for await response: consume pi-ai EventStream</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 318</span> <span class="src-hl">		<span class="src-kw">switch</span> (event.<span class="src-kw">type</span>) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 319</span> <span class="src-hl">			<span class="src-kw">case</span> &quot;start&quot;:</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">start → message_start</span><span class="lang-en-only">start → message_start</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 320</span> <span class="src-hl">				partialMessage = event.partial;</span></span>
+      <span class="src-line">      <span class="src-ln"> 321</span> <span class="src-hl">				context.messages.push(partialMessage);</span></span>
+      <span class="src-line">      <span class="src-ln"> 322</span> <span class="src-hl">				addedPartial = <span class="src-kw">true</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 323</span> <span class="src-hl">				<span class="src-kw">await</span> emit({ <span class="src-kw">type</span>: &quot;message_start&quot;, message: { ...partialMessage } });</span></span>
+      <span class="src-line">      <span class="src-ln"> 324</span> <span class="src-hl">				<span class="src-kw">break</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 325</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 326</span> <span class="src-hl">			<span class="src-kw">case</span> &quot;text_start&quot;:</span></span>
+      <span class="src-line">      <span class="src-ln"> 327</span> <span class="src-hl">			<span class="src-kw">case</span> &quot;text_delta&quot;:</span></span>
+      <span class="src-line">      <span class="src-ln"> 328</span> <span class="src-hl">			<span class="src-kw">case</span> &quot;text_end&quot;:</span></span>
+      <span class="src-line">      <span class="src-ln"> 329</span> <span class="src-hl">			<span class="src-kw">case</span> &quot;thinking_start&quot;:</span></span>
+      <span class="src-line">      <span class="src-ln"> 330</span> <span class="src-hl">			<span class="src-kw">case</span> &quot;thinking_delta&quot;:</span></span>
+      <span class="src-line">      <span class="src-ln"> 331</span> <span class="src-hl">			<span class="src-kw">case</span> &quot;thinking_end&quot;:</span></span>
+      <span class="src-line">      <span class="src-ln"> 332</span> <span class="src-hl">			<span class="src-kw">case</span> &quot;toolcall_start&quot;:</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">toolcall_delta → message_update</span><span class="lang-en-only">toolcall_delta → message_update</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 333</span> <span class="src-hl">			<span class="src-kw">case</span> &quot;toolcall_delta&quot;:</span></span>
+      <span class="src-line">      <span class="src-ln"> 334</span> <span class="src-hl">			<span class="src-kw">case</span> &quot;toolcall_end&quot;:</span></span>
+      <span class="src-line">      <span class="src-ln"> 335</span> <span class="src-hl">				<span class="src-kw">if</span> (partialMessage) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 336</span> <span class="src-hl">					partialMessage = event.partial;</span></span>
+      <span class="src-line">      <span class="src-ln"> 337</span> <span class="src-hl">					context.messages[context.messages.length - 1] = partialMessage;</span></span>
+      <span class="src-line">      <span class="src-ln"> 338</span> <span class="src-hl">					<span class="src-kw">await</span> emit({</span></span>
+      <span class="src-line">      <span class="src-ln"> 339</span> <span class="src-hl">						<span class="src-kw">type</span>: &quot;message_update&quot;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 340</span> <span class="src-hl">						assistantMessageEvent: event,</span></span>
+      <span class="src-line">      <span class="src-ln"> 341</span> <span class="src-hl">						message: { ...partialMessage },</span></span>
+      <span class="src-line">      <span class="src-ln"> 342</span> <span class="src-hl">					});</span></span>
+      <span class="src-line">      <span class="src-ln"> 343</span> <span class="src-hl">				}</span></span>
+      <span class="src-line">      <span class="src-ln"> 344</span> <span class="src-hl">				<span class="src-kw">break</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 345</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 346</span> <span class="src-hl">			<span class="src-kw">case</span> &quot;done&quot;:</span></span>
+      <span class="src-line">      <span class="src-ln"> 347</span> <span class="src-hl">			<span class="src-kw">case</span> &quot;error&quot;: {</span></span>
+      <span class="src-line">      <span class="src-ln"> 348</span> <span class="src-hl">				<span class="src-kw">const</span> finalMessage = <span class="src-kw">await</span> response.result();</span></span>
+      <span class="src-line">      <span class="src-ln"> 349</span> <span class="src-hl">				<span class="src-kw">if</span> (addedPartial) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 350</span> <span class="src-hl">					context.messages[context.messages.length - 1] = finalMessage;</span></span>
+      <span class="src-line">      <span class="src-ln"> 351</span> <span class="src-hl">				} <span class="src-kw">else</span> {</span></span>
+      <span class="src-line">      <span class="src-ln"> 352</span> <span class="src-hl">					context.messages.push(finalMessage);</span></span>
+      <span class="src-line">      <span class="src-ln"> 353</span> <span class="src-hl">				}</span></span>
+      <span class="src-line">      <span class="src-ln"> 354</span> <span class="src-hl">				<span class="src-kw">if</span> (!addedPartial) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 355</span> <span class="src-hl">					<span class="src-kw">await</span> emit({ <span class="src-kw">type</span>: &quot;message_start&quot;, message: { ...finalMessage } });</span></span>
+      <span class="src-line">      <span class="src-ln"> 356</span> <span class="src-hl">				}</span></span>
+      <span class="src-line">      <span class="src-ln"> 357</span> <span class="src-hl">				<span class="src-kw">await</span> emit({ <span class="src-kw">type</span>: &quot;message_end&quot;, message: finalMessage });</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">done → message_end(final)</span><span class="lang-en-only">done → message_end(final)</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 358</span> <span class="src-hl">				<span class="src-kw">return</span> finalMessage;</span></span>
+      <span class="src-line">      <span class="src-ln"> 359</span> <span class="src-hl">			}</span></span>
+      <span class="src-line">      <span class="src-ln"> 360</span> <span class="src-hl">		}</span></span>
+    </div>
+
+    <div class="lang-zh-only"><p>设计要点：<code>partial</code> 字段在每个 event 里携带<strong>当前累积状态</strong>的 AssistantMessage 快照——TUI 不需要自己拼 delta；agent-loop 把 event 原样 emit 给 AgentSession，由订阅者决定是差分渲染还是等 message_end 落盘。</p></div>
+    <div class="lang-en-only"><p>Design note: <code>partial</code> in each event carries a <strong>cumulative</strong> AssistantMessage snapshot — TUI need not assemble deltas; agent-loop emits events as-is to AgentSession; subscribers diff-render or persist on message_end.</p></div>
+
+    <div class="note copper">
+      <span class="lang-zh-only">用 <code>--verbose</code> 跑主线 prompt，stderr 里 <code>toolcall_delta</code> 行数应与 Anthropic SSE <code>input_json_delta</code> 包数同量级。</span>
+      <span class="lang-en-only">Run through-line with <code>--verbose</code>; stderr <code>toolcall_delta</code> count should match Anthropic SSE <code>input_json_delta</code> packets.</span>
+    </div>
+
+    </div>
+
     <div class="depth-zone" data-chapter="C15"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C15.4+</span><span class="lang-en-only">Deep dive · C15.4+</span></div>
 
     <h4 class="sub2 depth-sec"><span class="sec-num">C15.4</span> <span class="lang-zh-only">EventStream 核心语义</span><span class="lang-en-only">EventStream core semantics</span></h4>
@@ -7059,6 +8104,392 @@
         <div class="sp-key"><span class="lang-zh-only">retry</span><span class="lang-en-only">retry</span></div>
         <div class="sp-val"><span class="lang-zh-only">isRetryableAssistantError + backoff</span><span class="lang-en-only">isRetryableAssistantError + backoff</span></div>
       </div>
+    </div>
+
+    <div class="trace-walk">
+      <div class="tw-head">
+        <span class="tw-tag">SOURCE TRACE · C16</span>
+        <span class="lang-zh-only">认证与模型目录：从 models.generated 到 findInitialModel</span>
+        <span class="lang-en-only">Auth and model catalog: models.generated to findInitialModel</span>
+      </div>
+
+    <div class="lang-zh-only"><p>Pi 启动时必须先回答两个问题：<strong>用哪个 model？</strong> 和 <strong>凭据从哪来？</strong> <code>models.generated.ts</code> 聚合 40+ provider 的静态目录；<code>ModelRuntime</code> 叠加 credential store 与 availability；<code>findInitialModel</code> 按 CLI → scoped → settings → first-available 优先级选型。没有 key 时 <code>auth-guidance.ts</code> 给出 /login 指引。</p></div>
+    <div class="lang-en-only"><p>Pi boot must answer: <strong>which model?</strong> and <strong>where credentials come from?</strong> <code>models.generated.ts</code> aggregates 40+ provider static catalogs; <code>ModelRuntime</code> adds credential store and availability; <code>findInitialModel</code> picks CLI → scoped → settings → first-available. No key → <code>auth-guidance.ts</code> points to /login.</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/ai/src/models.generated.ts</span>
+        <span class="src-tag">models-gen</span>
+      </div>
+      <span class="src-line">      <span class="src-ln">   1</span> <span class="src-hl"><span class="src-comment">// This file is auto-generated by scripts/generate-models.ts</span></span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">自动生成：npm run generate-models</span><span class="lang-en-only">auto-generated: npm run generate-models</span></span></span>
+      <span class="src-line">      <span class="src-ln">   2</span> <span class="src-hl"><span class="src-comment">// Do not edit manually - run &amp;#x27;npm run generate-models&amp;#x27; to update</span></span></span>
+      <span class="src-line">      <span class="src-ln">   3</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln">   4</span> <span class="src-hl"><span class="src-kw">import</span> { AMAZON_BEDROCK_MODELS } <span class="src-kw">from</span> &quot;./providers/amazon-bedrock.models.ts&quot;;</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">每 provider 一个 *.models.ts</span><span class="lang-en-only">one *.models.ts per provider</span></span></span>
+      <span class="src-line">      <span class="src-ln">   5</span> <span class="src-hl"><span class="src-kw">import</span> { ANT_LING_MODELS } <span class="src-kw">from</span> &quot;./providers/ant-ling.models.ts&quot;;</span></span>
+      <span class="src-line">      <span class="src-ln">   6</span> <span class="src-hl"><span class="src-kw">import</span> { ANTHROPIC_MODELS } <span class="src-kw">from</span> &quot;./providers/anthropic.models.ts&quot;;</span></span>
+      <span class="src-line">      <span class="src-ln">   7</span> <span class="src-hl"><span class="src-kw">import</span> { AZURE_OPENAI_RESPONSES_MODELS } <span class="src-kw">from</span> &quot;./providers/azure-openai-responses.models.ts&quot;;</span></span>
+      <span class="src-line">      <span class="src-ln">   8</span> <span class="src-hl"><span class="src-kw">import</span> { BASETEN_MODELS } <span class="src-kw">from</span> &quot;./providers/baseten.models.ts&quot;;</span></span>
+      <span class="src-line">      <span class="src-ln">   9</span> <span class="src-hl"><span class="src-kw">import</span> { CEREBRAS_MODELS } <span class="src-kw">from</span> &quot;./providers/cerebras.models.ts&quot;;</span></span>
+      <span class="src-line">      <span class="src-ln">  10</span> <span class="src-hl"><span class="src-kw">import</span> { CLOUDFLARE_AI_GATEWAY_MODELS } <span class="src-kw">from</span> &quot;./providers/cloudflare-ai-gateway.models.ts&quot;;</span></span>
+      <span class="src-line">      <span class="src-ln">  11</span> <span class="src-hl"><span class="src-kw">import</span> { CLOUDFLARE_WORKERS_AI_MODELS } <span class="src-kw">from</span> &quot;./providers/cloudflare-workers-ai.models.ts&quot;;</span></span>
+      <span class="src-line">      <span class="src-ln">  12</span> <span class="src-hl"><span class="src-kw">import</span> { DEEPSEEK_MODELS } <span class="src-kw">from</span> &quot;./providers/deepseek.models.ts&quot;;</span></span>
+      <span class="src-line">      <span class="src-ln">  13</span> <span class="src-hl"><span class="src-kw">import</span> { FIREWORKS_MODELS } <span class="src-kw">from</span> &quot;./providers/fireworks.models.ts&quot;;</span></span>
+      <span class="src-line">      <span class="src-ln">  14</span> <span class="src-hl"><span class="src-kw">import</span> { GITHUB_COPILOT_MODELS } <span class="src-kw">from</span> &quot;./providers/github-copilot.models.ts&quot;;</span></span>
+      <span class="src-line">      <span class="src-ln">  15</span> <span class="src-hl"><span class="src-kw">import</span> { GOOGLE_MODELS } <span class="src-kw">from</span> &quot;./providers/google.models.ts&quot;;</span></span>
+      <span class="src-line">      <span class="src-ln">  16</span> <span class="src-hl"><span class="src-kw">import</span> { GOOGLE_VERTEX_MODELS } <span class="src-kw">from</span> &quot;./providers/google-vertex.models.ts&quot;;</span></span>
+      <span class="src-line">      <span class="src-ln">  17</span> <span class="src-hl"><span class="src-kw">import</span> { GROQ_MODELS } <span class="src-kw">from</span> &quot;./providers/groq.models.ts&quot;;</span></span>
+      <span class="src-line">      <span class="src-ln">  18</span> <span class="src-hl"><span class="src-kw">import</span> { HUGGINGFACE_MODELS } <span class="src-kw">from</span> &quot;./providers/huggingface.models.ts&quot;;</span></span>
+      <span class="src-line">      <span class="src-ln">  19</span> <span class="src-hl"><span class="src-kw">import</span> { KIMI_CODING_MODELS } <span class="src-kw">from</span> &quot;./providers/kimi-coding.models.ts&quot;;</span></span>
+      <span class="src-line">      <span class="src-ln">  20</span> <span class="src-hl"><span class="src-kw">import</span> { MINIMAX_MODELS } <span class="src-kw">from</span> &quot;./providers/minimax.models.ts&quot;;</span></span>
+      <span class="src-line">      <span class="src-ln">  21</span> <span class="src-hl"><span class="src-kw">import</span> { MINIMAX_CN_MODELS } <span class="src-kw">from</span> &quot;./providers/minimax-cn.models.ts&quot;;</span></span>
+      <span class="src-line">      <span class="src-ln">  22</span> <span class="src-hl"><span class="src-kw">import</span> { MISTRAL_MODELS } <span class="src-kw">from</span> &quot;./providers/mistral.models.ts&quot;;</span></span>
+      <span class="src-line">      <span class="src-ln">  23</span> <span class="src-hl"><span class="src-kw">import</span> { MOONSHOTAI_MODELS } <span class="src-kw">from</span> &quot;./providers/moonshotai.models.ts&quot;;</span></span>
+      <span class="src-line">      <span class="src-ln">  24</span> <span class="src-hl"><span class="src-kw">import</span> { MOONSHOTAI_CN_MODELS } <span class="src-kw">from</span> &quot;./providers/moonshotai-cn.models.ts&quot;;</span></span>
+      <span class="src-line">      <span class="src-ln">  25</span> <span class="src-hl"><span class="src-kw">import</span> { NVIDIA_MODELS } <span class="src-kw">from</span> &quot;./providers/nvidia.models.ts&quot;;</span></span>
+      <span class="src-line">      <span class="src-ln">  26</span> <span class="src-hl"><span class="src-kw">import</span> { OPENAI_MODELS } <span class="src-kw">from</span> &quot;./providers/openai.models.ts&quot;;</span></span>
+      <span class="src-line">      <span class="src-ln">  27</span> <span class="src-hl"><span class="src-kw">import</span> { OPENAI_CODEX_MODELS } <span class="src-kw">from</span> &quot;./providers/openai-codex.models.ts&quot;;</span></span>
+      <span class="src-line">      <span class="src-ln">  28</span> <span class="src-hl"><span class="src-kw">import</span> { OPENCODE_MODELS } <span class="src-kw">from</span> &quot;./providers/opencode.models.ts&quot;;</span></span>
+      <span class="src-line">      <span class="src-ln">  29</span> <span class="src-hl"><span class="src-kw">import</span> { OPENCODE_GO_MODELS } <span class="src-kw">from</span> &quot;./providers/opencode-go.models.ts&quot;;</span></span>
+      <span class="src-line">      <span class="src-ln">  30</span> <span class="src-hl"><span class="src-kw">import</span> { OPENROUTER_MODELS } <span class="src-kw">from</span> &quot;./providers/openrouter.models.ts&quot;;</span></span>
+      <span class="src-line">      <span class="src-ln">  31</span> <span class="src-hl"><span class="src-kw">import</span> { QWEN_TOKEN_PLAN_MODELS } <span class="src-kw">from</span> &quot;./providers/qwen-token-plan.models.ts&quot;;</span></span>
+      <span class="src-line">      <span class="src-ln">  32</span> <span class="src-hl"><span class="src-kw">import</span> { QWEN_TOKEN_PLAN_CN_MODELS } <span class="src-kw">from</span> &quot;./providers/qwen-token-plan-cn.models.ts&quot;;</span></span>
+      <span class="src-line">      <span class="src-ln">  33</span> <span class="src-hl"><span class="src-kw">import</span> { QWEN_TOKEN_PLAN_INDIVIDUAL_MODELS } <span class="src-kw">from</span> &quot;./providers/qwen-token-plan-individual.models.ts&quot;;</span></span>
+      <span class="src-line">      <span class="src-ln">  34</span> <span class="src-hl"><span class="src-kw">import</span> { TOGETHER_MODELS } <span class="src-kw">from</span> &quot;./providers/together.models.ts&quot;;</span></span>
+      <span class="src-line">      <span class="src-ln">  35</span> <span class="src-hl"><span class="src-kw">import</span> { VERCEL_AI_GATEWAY_MODELS } <span class="src-kw">from</span> &quot;./providers/vercel-ai-gateway.models.ts&quot;;</span></span>
+      <span class="src-line">      <span class="src-ln">  36</span> <span class="src-hl"><span class="src-kw">import</span> { XAI_MODELS } <span class="src-kw">from</span> &quot;./providers/xai.models.ts&quot;;</span></span>
+      <span class="src-line">      <span class="src-ln">  37</span> <span class="src-hl"><span class="src-kw">import</span> { XIAOMI_MODELS } <span class="src-kw">from</span> &quot;./providers/xiaomi.models.ts&quot;;</span></span>
+      <span class="src-line">      <span class="src-ln">  38</span> <span class="src-hl"><span class="src-kw">import</span> { XIAOMI_TOKEN_PLAN_AMS_MODELS } <span class="src-kw">from</span> &quot;./providers/xiaomi-token-plan-ams.models.ts&quot;;</span></span>
+      <span class="src-line">      <span class="src-ln">  39</span> <span class="src-hl"><span class="src-kw">import</span> { XIAOMI_TOKEN_PLAN_CN_MODELS } <span class="src-kw">from</span> &quot;./providers/xiaomi-token-plan-cn.models.ts&quot;;</span></span>
+      <span class="src-line">      <span class="src-ln">  40</span> <span class="src-hl"><span class="src-kw">import</span> { XIAOMI_TOKEN_PLAN_SGP_MODELS } <span class="src-kw">from</span> &quot;./providers/xiaomi-token-plan-sgp.models.ts&quot;;</span></span>
+      <span class="src-line">      <span class="src-ln">  41</span> <span class="src-hl"><span class="src-kw">import</span> { ZAI_MODELS } <span class="src-kw">from</span> &quot;./providers/zai.models.ts&quot;;</span></span>
+      <span class="src-line">      <span class="src-ln">  42</span> <span class="src-hl"><span class="src-kw">import</span> { ZAI_CODING_CN_MODELS } <span class="src-kw">from</span> &quot;./providers/zai-coding-cn.models.ts&quot;;</span></span>
+      <span class="src-line">      <span class="src-ln">  43</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln">  44</span> <span class="src-hl"><span class="src-kw">export</span> <span class="src-kw">const</span> MODELS: {</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">MODELS 聚合对象类型</span><span class="lang-en-only">MODELS aggregate object type</span></span></span>
+      <span class="src-line">      <span class="src-ln">  45</span> <span class="src-hl">	readonly &quot;amazon-bedrock&quot;: <span class="src-kw">typeof</span> AMAZON_BEDROCK_MODELS;</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/ai/src/models.generated.ts</span>
+        <span class="src-tag">models-map</span>
+      </div>
+      <span class="src-line">      <span class="src-ln">  84</span> <span class="src-hl">} = {</span></span>
+      <span class="src-line">      <span class="src-ln">  85</span> <span class="src-hl">	&quot;amazon-bedrock&quot;: AMAZON_BEDROCK_MODELS,</span></span>
+      <span class="src-line">      <span class="src-ln">  86</span> <span class="src-hl">	&quot;ant-ling&quot;: ANT_LING_MODELS,</span></span>
+      <span class="src-line">      <span class="src-ln">  87</span> <span class="src-hl">	&quot;anthropic&quot;: ANTHROPIC_MODELS,</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">anthropic: ANTHROPIC_MODELS</span><span class="lang-en-only">anthropic: ANTHROPIC_MODELS</span></span></span>
+      <span class="src-line">      <span class="src-ln">  88</span> <span class="src-hl">	&quot;azure-openai-responses&quot;: AZURE_OPENAI_RESPONSES_MODELS,</span></span>
+      <span class="src-line">      <span class="src-ln">  89</span> <span class="src-hl">	&quot;baseten&quot;: BASETEN_MODELS,</span></span>
+      <span class="src-line">      <span class="src-ln">  90</span> <span class="src-hl">	&quot;cerebras&quot;: CEREBRAS_MODELS,</span></span>
+      <span class="src-line">      <span class="src-ln">  91</span> <span class="src-hl">	&quot;cloudflare-ai-gateway&quot;: CLOUDFLARE_AI_GATEWAY_MODELS,</span></span>
+      <span class="src-line">      <span class="src-ln">  92</span> <span class="src-hl">	&quot;cloudflare-workers-ai&quot;: CLOUDFLARE_WORKERS_AI_MODELS,</span></span>
+      <span class="src-line">      <span class="src-ln">  93</span> <span class="src-hl">	&quot;deepseek&quot;: DEEPSEEK_MODELS,</span></span>
+      <span class="src-line">      <span class="src-ln">  94</span> <span class="src-hl">	&quot;fireworks&quot;: FIREWORKS_MODELS,</span></span>
+      <span class="src-line">      <span class="src-ln">  95</span> <span class="src-hl">	&quot;github-copilot&quot;: GITHUB_COPILOT_MODELS,</span></span>
+      <span class="src-line">      <span class="src-ln">  96</span> <span class="src-hl">	&quot;google&quot;: GOOGLE_MODELS,</span></span>
+      <span class="src-line">      <span class="src-ln">  97</span> <span class="src-hl">	&quot;google-vertex&quot;: GOOGLE_VERTEX_MODELS,</span></span>
+      <span class="src-line">      <span class="src-ln">  98</span> <span class="src-hl">	&quot;groq&quot;: GROQ_MODELS,</span></span>
+      <span class="src-line">      <span class="src-ln">  99</span> <span class="src-hl">	&quot;huggingface&quot;: HUGGINGFACE_MODELS,</span></span>
+      <span class="src-line">      <span class="src-ln"> 100</span> <span class="src-hl">	&quot;kimi-coding&quot;: KIMI_CODING_MODELS,</span></span>
+      <span class="src-line">      <span class="src-ln"> 101</span> <span class="src-hl">	&quot;minimax&quot;: MINIMAX_MODELS,</span></span>
+      <span class="src-line">      <span class="src-ln"> 102</span> <span class="src-hl">	&quot;minimax-cn&quot;: MINIMAX_CN_MODELS,</span></span>
+      <span class="src-line">      <span class="src-ln"> 103</span> <span class="src-hl">	&quot;mistral&quot;: MISTRAL_MODELS,</span></span>
+      <span class="src-line">      <span class="src-ln"> 104</span> <span class="src-hl">	&quot;moonshotai&quot;: MOONSHOTAI_MODELS,</span></span>
+      <span class="src-line">      <span class="src-ln"> 105</span> <span class="src-hl">	&quot;moonshotai-cn&quot;: MOONSHOTAI_CN_MODELS,</span></span>
+      <span class="src-line">      <span class="src-ln"> 106</span> <span class="src-hl">	&quot;nvidia&quot;: NVIDIA_MODELS,</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">openai / openai-codex</span><span class="lang-en-only">openai / openai-codex</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 107</span> <span class="src-hl">	&quot;openai&quot;: OPENAI_MODELS,</span></span>
+      <span class="src-line">      <span class="src-ln"> 108</span> <span class="src-hl">	&quot;openai-codex&quot;: OPENAI_CODEX_MODELS,</span></span>
+      <span class="src-line">      <span class="src-ln"> 109</span> <span class="src-hl">	&quot;opencode&quot;: OPENCODE_MODELS,</span></span>
+      <span class="src-line">      <span class="src-ln"> 110</span> <span class="src-hl">	&quot;opencode-go&quot;: OPENCODE_GO_MODELS,</span></span>
+      <span class="src-line">      <span class="src-ln"> 111</span> <span class="src-hl">	&quot;openrouter&quot;: OPENROUTER_MODELS,</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">openrouter / moonshotai / …</span><span class="lang-en-only">openrouter / moonshotai / …</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 112</span> <span class="src-hl">	&quot;qwen-token-plan&quot;: QWEN_TOKEN_PLAN_MODELS,</span></span>
+      <span class="src-line">      <span class="src-ln"> 113</span> <span class="src-hl">	&quot;qwen-token-plan-cn&quot;: QWEN_TOKEN_PLAN_CN_MODELS,</span></span>
+      <span class="src-line">      <span class="src-ln"> 114</span> <span class="src-hl">	&quot;qwen-token-plan-individual&quot;: QWEN_TOKEN_PLAN_INDIVIDUAL_MODELS,</span></span>
+      <span class="src-line">      <span class="src-ln"> 115</span> <span class="src-hl">	&quot;together&quot;: TOGETHER_MODELS,</span></span>
+      <span class="src-line">      <span class="src-ln"> 116</span> <span class="src-hl">	&quot;vercel-ai-gateway&quot;: VERCEL_AI_GATEWAY_MODELS,</span></span>
+      <span class="src-line">      <span class="src-ln"> 117</span> <span class="src-hl">	&quot;xai&quot;: XAI_MODELS,</span></span>
+      <span class="src-line">      <span class="src-ln"> 118</span> <span class="src-hl">	&quot;xiaomi&quot;: XIAOMI_MODELS,</span></span>
+      <span class="src-line">      <span class="src-ln"> 119</span> <span class="src-hl">	&quot;xiaomi-token-plan-ams&quot;: XIAOMI_TOKEN_PLAN_AMS_MODELS,</span></span>
+      <span class="src-line">      <span class="src-ln"> 120</span> <span class="src-hl">	&quot;xiaomi-token-plan-cn&quot;: XIAOMI_TOKEN_PLAN_CN_MODELS,</span></span>
+      <span class="src-line">      <span class="src-ln"> 121</span> <span class="src-hl">	&quot;xiaomi-token-plan-sgp&quot;: XIAOMI_TOKEN_PLAN_SGP_MODELS,</span></span>
+      <span class="src-line">      <span class="src-ln"> 122</span> <span class="src-hl">	&quot;zai&quot;: ZAI_MODELS,</span></span>
+      <span class="src-line">      <span class="src-ln"> 123</span> <span class="src-hl">	&quot;zai-coding-cn&quot;: ZAI_CODING_CN_MODELS,</span></span>
+      <span class="src-line">      <span class="src-ln"> 124</span> <span class="src-hl">};</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/ai/src/providers/anthropic.models.ts</span>
+        <span class="src-tag">anthropic-models</span>
+      </div>
+      <span class="src-line">      <span class="src-ln">   1</span> <span class="src-hl"><span class="src-comment">// This file is auto-generated by scripts/generate-models.ts</span></span></span>
+      <span class="src-line">      <span class="src-ln">   2</span> <span class="src-hl"><span class="src-comment">// Do not edit manually - run &amp;#x27;npm run generate-models&amp;#x27; to update</span></span></span>
+      <span class="src-line">      <span class="src-ln">   3</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln">   4</span> <span class="src-hl"><span class="src-kw">import</span> values <span class="src-kw">from</span> &quot;./data/anthropic.json&quot; with { <span class="src-kw">type</span>: &quot;json&quot; };</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">从 anthropic.json flatten</span><span class="lang-en-only">flatten from anthropic.json</span></span></span>
+      <span class="src-line">      <span class="src-ln">   5</span> <span class="src-hl"><span class="src-kw">import</span> { flattenModelCatalog, <span class="src-kw">type</span> ModelCatalog } <span class="src-kw">from</span> &quot;../model-catalog.ts&quot;;</span></span>
+      <span class="src-line">      <span class="src-ln">   6</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln">   7</span> <span class="src-hl"><span class="src-kw">export</span> <span class="src-kw">const</span> ANTHROPIC_MODELS: ModelCatalog&lt;<span class="src-kw">typeof</span> values, &quot;anthropic&quot;&gt; =</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">ANTHROPIC_MODELS 目录常量</span><span class="lang-en-only">ANTHROPIC_MODELS catalog constant</span></span></span>
+      <span class="src-line">      <span class="src-ln">   8</span> <span class="src-hl">	flattenModelCatalog(&quot;anthropic&quot;, values);</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/ai/src/providers/anthropic.ts</span>
+        <span class="src-tag">auth-resolve</span>
+      </div>
+      <span class="src-line">      <span class="src-ln">  18</span> <span class="src-hl">		resolve: <span class="src-kw">async</span> ({ ctx, credential, signal }) =&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln">  19</span> <span class="src-hl">			signal.throwIfAborted();</span></span>
+      <span class="src-line">      <span class="src-ln">  20</span> <span class="src-hl">			<span class="src-kw">if</span> (credential?.key) {</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">stored credential 优先</span><span class="lang-en-only">stored credential first</span></span></span>
+      <span class="src-line">      <span class="src-ln">  21</span> <span class="src-hl">				<span class="src-kw">return</span> { auth: { apiKey: credential.key }, env: credential.env, source: &quot;stored credential&quot; };</span></span>
+      <span class="src-line">      <span class="src-ln">  22</span> <span class="src-hl">			}</span></span>
+      <span class="src-line">      <span class="src-ln">  23</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln">  24</span> <span class="src-hl">			<span class="src-kw">const</span> authToken = <span class="src-kw">await</span> ctx.env(ANTHROPIC_AUTH_TOKEN_ENV);</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">ANTHROPIC_AUTH_TOKEN env</span><span class="lang-en-only">ANTHROPIC_AUTH_TOKEN env</span></span></span>
+      <span class="src-line">      <span class="src-ln">  25</span> <span class="src-hl">			signal.throwIfAborted();</span></span>
+      <span class="src-line">      <span class="src-ln">  26</span> <span class="src-hl">			<span class="src-kw">if</span> (authToken) {</span></span>
+      <span class="src-line">      <span class="src-ln">  27</span> <span class="src-hl">				<span class="src-kw">return</span> {</span></span>
+      <span class="src-line">      <span class="src-ln">  28</span> <span class="src-hl">					auth: { headers: { Authorization: <span class=<span class="src-str">"src-str"</span>>`Bearer ${authToken}`</span> } },</span></span>
+      <span class="src-line">      <span class="src-ln">  29</span> <span class="src-hl">					source: ANTHROPIC_AUTH_TOKEN_ENV,</span></span>
+      <span class="src-line">      <span class="src-ln">  30</span> <span class="src-hl">				};</span></span>
+      <span class="src-line">      <span class="src-ln">  31</span> <span class="src-hl">			}</span></span>
+      <span class="src-line">      <span class="src-ln">  32</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln">  33</span> <span class="src-hl">			<span class="src-kw">for</span> (<span class="src-kw">const</span> envVar of [ANTHROPIC_OAUTH_TOKEN_ENV, ANTHROPIC_API_KEY_ENV]) {</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">OAuth token / API key env 回退链</span><span class="lang-en-only">OAuth token / API key env fallback chain</span></span></span>
+      <span class="src-line">      <span class="src-ln">  34</span> <span class="src-hl">				<span class="src-kw">const</span> apiKey = <span class="src-kw">await</span> ctx.env(envVar);</span></span>
+      <span class="src-line">      <span class="src-ln">  35</span> <span class="src-hl">				signal.throwIfAborted();</span></span>
+      <span class="src-line">      <span class="src-ln">  36</span> <span class="src-hl">				<span class="src-kw">if</span> (apiKey) <span class="src-kw">return</span> { auth: { apiKey }, source: envVar };</span></span>
+      <span class="src-line">      <span class="src-ln">  37</span> <span class="src-hl">			}</span></span>
+      <span class="src-line">      <span class="src-ln">  38</span> <span class="src-hl">			<span class="src-kw">return</span> <span class="src-kw">undefined</span>;</span></span>
+      <span class="src-line">      <span class="src-ln">  39</span> <span class="src-hl">		},</span></span>
+      <span class="src-line">      <span class="src-ln">  40</span> <span class="src-hl">	};</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/auth-guidance.ts</span>
+        <span class="src-tag">auth-guidance</span>
+      </div>
+      <span class="src-line">      <span class="src-ln">   6</span> <span class="src-hl"><span class="src-kw">export</span> <span class="src-kw">function</span> getProviderLoginHelp(): string {</span></span>
+      <span class="src-line">      <span class="src-ln">   7</span> <span class="src-hl">	<span class="src-kw">return</span> [</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">getProviderLoginHelp：/login + docs 链接</span><span class="lang-en-only">getProviderLoginHelp: /login + docs links</span></span></span>
+      <span class="src-line">      <span class="src-ln">   8</span> <span class="src-hl">		&quot;Use /login to log into a provider via OAuth or API key. See:&quot;,</span></span>
+      <span class="src-line">      <span class="src-ln">   9</span> <span class="src-hl">		<span class=<span class="src-str">"src-str"</span>>`  ${join(getDocsPath(), &quot;providers.md&quot;)}`</span>,</span></span>
+      <span class="src-line">      <span class="src-ln">  10</span> <span class="src-hl">		<span class=<span class="src-str">"src-str"</span>>`  ${join(getDocsPath(), &quot;models.md&quot;)}`</span>,</span></span>
+      <span class="src-line">      <span class="src-ln">  11</span> <span class="src-hl">	].join(&quot;\n&quot;);</span></span>
+      <span class="src-line">      <span class="src-ln">  12</span> <span class="src-hl">}</span></span>
+      <span class="src-line">      <span class="src-ln">  13</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln">  14</span> <span class="src-hl"><span class="src-kw">export</span> <span class="src-kw">function</span> formatNoModelsAvailableMessage(): string {</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">formatNoModelsAvailableMessage</span><span class="lang-en-only">formatNoModelsAvailableMessage</span></span></span>
+      <span class="src-line">      <span class="src-ln">  15</span> <span class="src-hl">	<span class="src-kw">return</span> <span class=<span class="src-str">"src-str"</span>>`No models available. ${getProviderLoginHelp()}`</span>;</span></span>
+      <span class="src-line">      <span class="src-ln">  16</span> <span class="src-hl">}</span></span>
+      <span class="src-line">      <span class="src-ln">  17</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln">  18</span> <span class="src-hl"><span class="src-kw">export</span> <span class="src-kw">function</span> formatNoModelSelectedMessage(): string {</span></span>
+      <span class="src-line">      <span class="src-ln">  19</span> <span class="src-hl">	<span class="src-kw">return</span> <span class=<span class="src-str">"src-str"</span>>`No model selected.\n\n${getProviderLoginHelp()}\n\nThen use /model to select a model.`</span>;</span></span>
+      <span class="src-line">      <span class="src-ln">  20</span> <span class="src-hl">}</span></span>
+      <span class="src-line">      <span class="src-ln">  21</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln">  22</span> <span class="src-hl"><span class="src-kw">export</span> <span class="src-kw">function</span> formatNoApiKeyFoundMessage(provider: string): string {</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">formatNoApiKeyFoundMessage(provider)</span><span class="lang-en-only">formatNoApiKeyFoundMessage(provider)</span></span></span>
+      <span class="src-line">      <span class="src-ln">  23</span> <span class="src-hl">	<span class="src-kw">const</span> providerDisplay = provider === UNKNOWN_PROVIDER ? &quot;the selected model&quot; : provider;</span></span>
+      <span class="src-line">      <span class="src-ln">  24</span> <span class="src-hl">	<span class="src-kw">return</span> <span class=<span class="src-str">"src-str"</span>>`No API key found <span class="src-kw">for</span> ${providerDisplay}.\n\n${getProviderLoginHelp()}`</span>;</span></span>
+      <span class="src-line">      <span class="src-ln">  25</span> <span class="src-hl">}</span></span>
+    </div>
+
+    <div class="trace-steps"><div class="ts-label"><span class="lang-zh-only">findInitialModel 优先级</span><span class="lang-en-only">findInitialModel priority</span></div>    <table class="cmp">
+      <thead><tr><th>#</th><th>location</th><th>主线时刻 / through-line moment</th></tr></thead>
+      <tbody>
+      <tr><td>1</td><td>CLI --provider/--model</td><td>最高优先级</td></tr>
+      <tr><td>2</td><td>scopedModels[0]</td><td>非 resume 时</td></tr>
+      <tr><td>3</td><td>settings default</td><td>hasConfiguredAuth</td></tr>
+      <tr><td>4</td><td>defaultModelPerProvider</td><td>anthropic/claude-sonnet-…</td></tr>
+      <tr><td>5</td><td>availableModels[0]</td><td>任意有 key 的模型</td></tr>
+      <tr><td>fail</td><td>formatNoModelsAvailableMessage</td><td>/login 指引</td></tr>
+      </tbody>
+    </table></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/model-resolver.ts</span>
+        <span class="src-tag">find-model</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 621</span> <span class="src-hl"><span class="src-kw">export</span> <span class="src-kw">async</span> <span class="src-kw">function</span> findInitialModel(options: {</span></span>
+      <span class="src-line">      <span class="src-ln"> 622</span> <span class="src-hl">	cliProvider?: string;</span></span>
+      <span class="src-line">      <span class="src-ln"> 623</span> <span class="src-hl">	cliModel?: string;</span></span>
+      <span class="src-line">      <span class="src-ln"> 624</span> <span class="src-hl">	scopedModels: ScopedModel[];</span></span>
+      <span class="src-line">      <span class="src-ln"> 625</span> <span class="src-hl">	isContinuing: boolean;</span></span>
+      <span class="src-line">      <span class="src-ln"> 626</span> <span class="src-hl">	defaultProvider?: string;</span></span>
+      <span class="src-line">      <span class="src-ln"> 627</span> <span class="src-hl">	defaultModelId?: string;</span></span>
+      <span class="src-line">      <span class="src-ln"> 628</span> <span class="src-hl">	defaultThinkingLevel?: ThinkingLevel;</span></span>
+      <span class="src-line">      <span class="src-ln"> 629</span> <span class="src-hl">	modelThinkingLevels?: Record&lt;string, ThinkingLevel&gt;;</span></span>
+      <span class="src-line">      <span class="src-ln"> 630</span> <span class="src-hl">	modelRuntime: ModelRuntime;</span></span>
+      <span class="src-line">      <span class="src-ln"> 631</span> <span class="src-hl">}): Promise&lt;InitialModelResult&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln"> 632</span> <span class="src-hl">	<span class="src-kw">const</span> {</span></span>
+      <span class="src-line">      <span class="src-ln"> 633</span> <span class="src-hl">		cliProvider,</span></span>
+      <span class="src-line">      <span class="src-ln"> 634</span> <span class="src-hl">		cliModel,</span></span>
+      <span class="src-line">      <span class="src-ln"> 635</span> <span class="src-hl">		scopedModels,</span></span>
+      <span class="src-line">      <span class="src-ln"> 636</span> <span class="src-hl">		isContinuing,</span></span>
+      <span class="src-line">      <span class="src-ln"> 637</span> <span class="src-hl">		defaultProvider,</span></span>
+      <span class="src-line">      <span class="src-ln"> 638</span> <span class="src-hl">		defaultModelId,</span></span>
+      <span class="src-line">      <span class="src-ln"> 639</span> <span class="src-hl">		defaultThinkingLevel,</span></span>
+      <span class="src-line">      <span class="src-ln"> 640</span> <span class="src-hl">		modelThinkingLevels,</span></span>
+      <span class="src-line">      <span class="src-ln"> 641</span> <span class="src-hl">		modelRuntime,</span></span>
+      <span class="src-line">      <span class="src-ln"> 642</span> <span class="src-hl">	} = options;</span></span>
+      <span class="src-line">      <span class="src-ln"> 643</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 644</span> <span class="src-hl">	<span class="src-kw">let</span> model: Model&lt;Api&gt; | <span class="src-kw">undefined</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 645</span> <span class="src-hl">	<span class="src-kw">let</span> thinkingLevel: ThinkingLevel = DEFAULT_THINKING_LEVEL;</span></span>
+      <span class="src-line">      <span class="src-ln"> 646</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 647</span> <span class="src-hl">	<span class="src-comment">// 1. CLI args take priority</span></span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">CLI args 优先</span><span class="lang-en-only">CLI args first</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 648</span> <span class="src-hl">	<span class="src-kw">if</span> (cliProvider &amp;&amp; cliModel) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 649</span> <span class="src-hl">		<span class="src-kw">const</span> resolved = resolveCliModel({</span></span>
+      <span class="src-line">      <span class="src-ln"> 650</span> <span class="src-hl">			cliProvider,</span></span>
+      <span class="src-line">      <span class="src-ln"> 651</span> <span class="src-hl">			cliModel,</span></span>
+      <span class="src-line">      <span class="src-ln"> 652</span> <span class="src-hl">			modelRuntime,</span></span>
+      <span class="src-line">      <span class="src-ln"> 653</span> <span class="src-hl">		});</span></span>
+      <span class="src-line">      <span class="src-ln"> 654</span> <span class="src-hl">		<span class="src-kw">if</span> (resolved.error) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 655</span> <span class="src-hl">			console.error(chalk.red(resolved.error));</span></span>
+      <span class="src-line">      <span class="src-ln"> 656</span> <span class="src-hl">			process.exit(1);</span></span>
+      <span class="src-line">      <span class="src-ln"> 657</span> <span class="src-hl">		}</span></span>
+      <span class="src-line">      <span class="src-ln"> 658</span> <span class="src-hl">		<span class="src-kw">if</span> (resolved.model) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 659</span> <span class="src-hl">			<span class="src-kw">return</span> { model: resolved.model, thinkingLevel: DEFAULT_THINKING_LEVEL, fallbackMessage: <span class="src-kw">undefined</span> };</span></span>
+      <span class="src-line">      <span class="src-ln"> 660</span> <span class="src-hl">		}</span></span>
+      <span class="src-line">      <span class="src-ln"> 661</span> <span class="src-hl">	}</span></span>
+      <span class="src-line">      <span class="src-ln"> 662</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 663</span> <span class="src-hl">	<span class="src-comment">// 2. Use first model from scoped models (skip if continuing/resuming)</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 664</span> <span class="src-hl">	<span class="src-kw">if</span> (scopedModels.length &gt; 0 &amp;&amp; !isContinuing) {</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">scoped models 第二</span><span class="lang-en-only">scoped models second</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 665</span> <span class="src-hl">		<span class="src-kw">const</span> scopedModel = scopedModels[0];</span></span>
+      <span class="src-line">      <span class="src-ln"> 666</span> <span class="src-hl">		<span class="src-kw">const</span> perModel = modelThinkingLevels?.[<span class=<span class="src-str">"src-str"</span>>`${scopedModel.model.provider}/${scopedModel.model.id}`</span>];</span></span>
+      <span class="src-line">      <span class="src-ln"> 667</span> <span class="src-hl">		<span class="src-kw">return</span> {</span></span>
+      <span class="src-line">      <span class="src-ln"> 668</span> <span class="src-hl">			model: scopedModel.model,</span></span>
+      <span class="src-line">      <span class="src-ln"> 669</span> <span class="src-hl">			thinkingLevel: scopedModel.thinkingLevel ?? perModel ?? defaultThinkingLevel ?? DEFAULT_THINKING_LEVEL,</span></span>
+      <span class="src-line">      <span class="src-ln"> 670</span> <span class="src-hl">			fallbackMessage: <span class="src-kw">undefined</span>,</span></span>
+      <span class="src-line">      <span class="src-ln"> 671</span> <span class="src-hl">		};</span></span>
+      <span class="src-line">      <span class="src-ln"> 672</span> <span class="src-hl">	}</span></span>
+      <span class="src-line">      <span class="src-ln"> 673</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 674</span> <span class="src-hl">	<span class="src-comment">// 3. Try saved default from settings if auth is configured.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 675</span> <span class="src-hl">	<span class="src-kw">if</span> (defaultProvider &amp;&amp; defaultModelId) {</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">settings default + hasConfiguredAuth</span><span class="lang-en-only">settings default + hasConfiguredAuth</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 676</span> <span class="src-hl">		<span class="src-kw">const</span> found = modelRuntime.getModel(defaultProvider, defaultModelId);</span></span>
+      <span class="src-line">      <span class="src-ln"> 677</span> <span class="src-hl">		<span class="src-kw">if</span> (found &amp;&amp; modelRuntime.hasConfiguredAuth(found.provider)) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 678</span> <span class="src-hl">			model = found;</span></span>
+      <span class="src-line">      <span class="src-ln"> 679</span> <span class="src-hl">			<span class="src-kw">const</span> perModel = modelThinkingLevels?.[<span class=<span class="src-str">"src-str"</span>>`${defaultProvider}/${defaultModelId}`</span>];</span></span>
+      <span class="src-line">      <span class="src-ln"> 680</span> <span class="src-hl">			<span class="src-kw">if</span> (perModel) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 681</span> <span class="src-hl">				thinkingLevel = perModel;</span></span>
+      <span class="src-line">      <span class="src-ln"> 682</span> <span class="src-hl">			} <span class="src-kw">else</span> <span class="src-kw">if</span> (defaultThinkingLevel) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 683</span> <span class="src-hl">				thinkingLevel = defaultThinkingLevel;</span></span>
+      <span class="src-line">      <span class="src-ln"> 684</span> <span class="src-hl">			}</span></span>
+      <span class="src-line">      <span class="src-ln"> 685</span> <span class="src-hl">			<span class="src-kw">return</span> { model, thinkingLevel, fallbackMessage: <span class="src-kw">undefined</span> };</span></span>
+      <span class="src-line">      <span class="src-ln"> 686</span> <span class="src-hl">		}</span></span>
+      <span class="src-line">      <span class="src-ln"> 687</span> <span class="src-hl">	}</span></span>
+      <span class="src-line">      <span class="src-ln"> 688</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 689</span> <span class="src-hl">	<span class="src-comment">// 4. Try first available model with valid API key</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 690</span> <span class="src-hl">	<span class="src-kw">const</span> availableModels = [...modelRuntime.getAvailableSnapshot()];</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">getAvailableSnapshot 过滤无 key provider</span><span class="lang-en-only">getAvailableSnapshot filters unconfigured providers</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 691</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 692</span> <span class="src-hl">	<span class="src-kw">if</span> (availableModels.length &gt; 0) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 693</span> <span class="src-hl">		<span class="src-comment">// Try to find a default model from known providers</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 694</span> <span class="src-hl">		<span class="src-kw">for</span> (<span class="src-kw">const</span> provider of Object.keys(defaultModelPerProvider) as KnownProvider[]) {</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">defaultModelPerProvider 偏好</span><span class="lang-en-only">defaultModelPerProvider preference</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 695</span> <span class="src-hl">			<span class="src-kw">const</span> defaultId = defaultModelPerProvider[provider];</span></span>
+      <span class="src-line">      <span class="src-ln"> 696</span> <span class="src-hl">			<span class="src-kw">const</span> match = availableModels.find((m) =&gt; m.provider === provider &amp;&amp; m.id === defaultId);</span></span>
+      <span class="src-line">      <span class="src-ln"> 697</span> <span class="src-hl">			<span class="src-kw">if</span> (match) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 698</span> <span class="src-hl">				<span class="src-kw">return</span> { model: match, thinkingLevel: DEFAULT_THINKING_LEVEL, fallbackMessage: <span class="src-kw">undefined</span> };</span></span>
+      <span class="src-line">      <span class="src-ln"> 699</span> <span class="src-hl">			}</span></span>
+      <span class="src-line">      <span class="src-ln"> 700</span> <span class="src-hl">		}</span></span>
+      <span class="src-line">      <span class="src-ln"> 701</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 702</span> <span class="src-hl">		<span class="src-comment">// If no default found, use first available</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 703</span> <span class="src-hl">		<span class="src-kw">return</span> { model: availableModels[0], thinkingLevel: DEFAULT_THINKING_LEVEL, fallbackMessage: <span class="src-kw">undefined</span> };</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">兜底：第一个 available</span><span class="lang-en-only">fallback: first available</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 704</span> <span class="src-hl">	}</span></span>
+      <span class="src-line">      <span class="src-ln"> 705</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 706</span> <span class="src-hl">	<span class="src-comment">// 5. No model found</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 707</span> <span class="src-hl">	<span class="src-kw">return</span> { model: <span class="src-kw">undefined</span>, thinkingLevel: DEFAULT_THINKING_LEVEL, fallbackMessage: <span class="src-kw">undefined</span> };</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">无模型 → undefined</span><span class="lang-en-only">no model → undefined</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 708</span> <span class="src-hl">}</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/sdk.ts</span>
+        <span class="src-tag">sdk-boot</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 208</span> <span class="src-hl">	<span class="src-comment">// If still no model, use findInitialModel (checks settings default, then provider defaults)</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 209</span> <span class="src-hl">	<span class="src-kw">if</span> (!model) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 210</span> <span class="src-hl">		<span class="src-kw">const</span> result = <span class="src-kw">await</span> findInitialModel({</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">findInitialModel 调用点</span><span class="lang-en-only">findInitialModel call site</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 211</span> <span class="src-hl">			scopedModels: [],</span></span>
+      <span class="src-line">      <span class="src-ln"> 212</span> <span class="src-hl">			isContinuing: hasExistingSession,</span></span>
+      <span class="src-line">      <span class="src-ln"> 213</span> <span class="src-hl">			defaultProvider: settingsManager.getDefaultProvider(),</span></span>
+      <span class="src-line">      <span class="src-ln"> 214</span> <span class="src-hl">			defaultModelId: settingsManager.getDefaultModel(),</span></span>
+      <span class="src-line">      <span class="src-ln"> 215</span> <span class="src-hl">			defaultThinkingLevel: settingsManager.getDefaultThinkingLevel(),</span></span>
+      <span class="src-line">      <span class="src-ln"> 216</span> <span class="src-hl">			modelThinkingLevels: settingsManager.getAllModelThinkingLevels(),</span></span>
+      <span class="src-line">      <span class="src-ln"> 217</span> <span class="src-hl">			modelRuntime,</span></span>
+      <span class="src-line">      <span class="src-ln"> 218</span> <span class="src-hl">		});</span></span>
+      <span class="src-line">      <span class="src-ln"> 219</span> <span class="src-hl">		model = result.model;</span></span>
+      <span class="src-line">      <span class="src-ln"> 220</span> <span class="src-hl">		<span class="src-kw">if</span> (!model) {</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">无 model → formatNoModelsAvailableMessage</span><span class="lang-en-only">no model → formatNoModelsAvailableMessage</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 221</span> <span class="src-hl">			modelFallbackMessage = formatNoModelsAvailableMessage();</span></span>
+      <span class="src-line">      <span class="src-ln"> 222</span> <span class="src-hl">		} <span class="src-kw">else</span> <span class="src-kw">if</span> (modelFallbackMessage) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 223</span> <span class="src-hl">			modelFallbackMessage += <span class=<span class="src-str">"src-str"</span>>`. Using ${model.provider}/${model.id}`</span>;</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">fallback 文案拼接 provider/id</span><span class="lang-en-only">fallback message appends provider/id</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 224</span> <span class="src-hl">		}</span></span>
+      <span class="src-line">      <span class="src-ln"> 225</span> <span class="src-hl">	}</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/coding-agent/src/core/model-runtime.ts</span>
+        <span class="src-tag">runtime-auth</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 561</span> <span class="src-hl">	getProviderAuthStatus(providerId: string): AuthStatus {</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">getProviderAuthStatus：runtime/stored/env</span><span class="lang-en-only">getProviderAuthStatus: runtime/stored/env</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 562</span> <span class="src-hl">		<span class="src-kw">if</span> (this.credentials.hasRuntimeApiKey(providerId)) <span class="src-kw">return</span> { configured: <span class="src-kw">true</span>, source: &quot;runtime&quot; };</span></span>
+      <span class="src-line">      <span class="src-ln"> 563</span> <span class="src-hl">		<span class="src-kw">if</span> (this.snapshot.storedProviders.has(providerId)) <span class="src-kw">return</span> { configured: <span class="src-kw">true</span>, source: &quot;stored&quot; };</span></span>
+      <span class="src-line">      <span class="src-ln"> 564</span> <span class="src-hl">		<span class="src-kw">const</span> configured = configuredRequestAuthStatus(</span></span>
+      <span class="src-line">      <span class="src-ln"> 565</span> <span class="src-hl">			this.config.getProvider(providerId),</span></span>
+      <span class="src-line">      <span class="src-ln"> 566</span> <span class="src-hl">			this.extensionProviders.get(providerId),</span></span>
+      <span class="src-line">      <span class="src-ln"> 567</span> <span class="src-hl">		);</span></span>
+      <span class="src-line">      <span class="src-ln"> 568</span> <span class="src-hl">		<span class="src-kw">if</span> (configured) <span class="src-kw">return</span> configured;</span></span>
+      <span class="src-line">      <span class="src-ln"> 569</span> <span class="src-hl">		<span class="src-kw">const</span> check = this.snapshot.auth.get(providerId);</span></span>
+      <span class="src-line">      <span class="src-ln"> 570</span> <span class="src-hl">		<span class="src-kw">return</span> check ? { configured: <span class="src-kw">true</span>, source: &quot;environment&quot;, label: check.source } : { configured: <span class="src-kw">false</span> };</span></span>
+      <span class="src-line">      <span class="src-ln"> 571</span> <span class="src-hl">	}</span></span>
+      <span class="src-line">      <span class="src-ln"> 572</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 573</span> <span class="src-hl">	private <span class="src-kw">async</span> prepareRequest&lt;TOptions extends ProviderRequestOptions &amp; ModelsRequestTransforms&gt;(</span></span>
+      <span class="src-line">      <span class="src-ln"> 574</span> <span class="src-hl">		model: Model&lt;Api&gt;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 575</span> <span class="src-hl">		options: TOptions | <span class="src-kw">undefined</span>,</span></span>
+      <span class="src-line">      <span class="src-ln"> 576</span> <span class="src-hl">	): Promise&lt;{</span></span>
+      <span class="src-line">      <span class="src-ln"> 577</span> <span class="src-hl">		provider: Provider;</span></span>
+      <span class="src-line">      <span class="src-ln"> 578</span> <span class="src-hl">		model: Model&lt;Api&gt;;</span></span>
+      <span class="src-line">      <span class="src-ln"> 579</span> <span class="src-hl">		options: Omit&lt;TOptions, &quot;transformHeaders&quot;&gt; &amp; ProviderRequestOptions;</span></span>
+      <span class="src-line">      <span class="src-ln"> 580</span> <span class="src-hl">	}&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln"> 581</span> <span class="src-hl">		<span class="src-kw">const</span> provider = this.models.getProvider(model.provider);</span></span>
+      <span class="src-line">      <span class="src-ln"> 582</span> <span class="src-hl">		<span class="src-kw">if</span> (!provider) <span class="src-kw">throw</span> <span class="src-kw">new</span> ModelsError(&quot;provider&quot;, <span class=<span class="src-str">"src-str"</span>>`Unknown provider: ${model.provider}`</span>);</span></span>
+      <span class="src-line">      <span class="src-ln"> 583</span> <span class="src-hl">		<span class="src-kw">const</span> resolution = <span class="src-kw">await</span> this.getAuth(model, {</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">prepareRequest getAuth</span><span class="lang-en-only">prepareRequest getAuth</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 584</span> <span class="src-hl">			apiKey: options?.apiKey,</span></span>
+      <span class="src-line">      <span class="src-ln"> 585</span> <span class="src-hl">			env: options?.env,</span></span>
+      <span class="src-line">      <span class="src-ln"> 586</span> <span class="src-hl">			signal: options?.signal,</span></span>
+      <span class="src-line">      <span class="src-ln"> 587</span> <span class="src-hl">		});</span></span>
+      <span class="src-line">      <span class="src-ln"> 588</span> <span class="src-hl">		<span class="src-kw">if</span> (!resolution) <span class="src-kw">throw</span> <span class="src-kw">new</span> ModelsError(&quot;auth&quot;, <span class=<span class="src-str">"src-str"</span>>`Provider is not configured: ${model.provider}`</span>);</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">无 resolution → Provider is not configured</span><span class="lang-en-only">no resolution → Provider is not configured</span></span></span>
+    </div>
+
+    <div class="lang-zh-only"><p>主线 prompt 能跑通的前提：<code>findInitialModel</code> 返回的 model 在 <code>getAvailableSnapshot()</code> 里，且 <code>streamSimple</code> 时 <code>applyAuth</code> 能解析出 apiKey。OAuth provider（如 Anthropic Claude Pro）走 credential store + refresh；纯 API key 走 env 或 <code>/login</code> 写入的 auth.json。</p></div>
+    <div class="lang-en-only"><p>Through-line prompt requires: <code>findInitialModel</code> model is in <code>getAvailableSnapshot()</code>, and <code>applyAuth</code> resolves apiKey at <code>streamSimple</code>. OAuth providers use credential store + refresh; API key uses env or auth.json from <code>/login</code>.</p></div>
+
+    <div class="note copper">
+      <span class="lang-zh-only">实验：删掉 <code>~/.pi/agent/auth.json</code> 中 anthropic 条目再启动 pi，应看到 formatNoModelsAvailableMessage 或 formatNoApiKeyFoundMessage。</span>
+      <span class="lang-en-only">Experiment: remove anthropic from <code>~/.pi/agent/auth.json</code> and start pi; expect formatNoModelsAvailableMessage or formatNoApiKeyFoundMessage.</span>
+    </div>
+
     </div>
 
     <div class="depth-zone" data-chapter="C16"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C16.4+</span><span class="lang-en-only">Deep dive · C16.4+</span></div>

--- a/scripts/generate-pi-agent-immersive.py
+++ b/scripts/generate-pi-agent-immersive.py
@@ -13,8 +13,11 @@ from chapters import build_all_chapters  # noqa: E402
 from deep_dive import deepen  # noqa: E402
 from expand import expand_chapter  # noqa: E402
 from meta import CHAPTERS  # noqa: E402
+from overview import forest_overview_section  # noqa: E402
+from section_num import number_body_sections  # noqa: E402
 from shell import (  # noqa: E402
     chapter_section,
+    filmstrip_nav,
     footer,
     head,
     hero,
@@ -33,13 +36,16 @@ def generate() -> str:
     parts = [
         head(),
         lang_toggle_and_back(),
+        filmstrip_nav(),
         side_toc(),
         '<div class="container">',
         hero(),
         toc_v2(),
+        forest_overview_section(),
     ]
     for cid, *_ in CHAPTERS:
-        body = deepen(cid, expand_chapter(cid, chapters[cid]))
+        ch_num = next(c[1] for c in CHAPTERS if c[0] == cid)
+        body = number_body_sections(ch_num, deepen(cid, expand_chapter(cid, chapters[cid])))
         parts.append(chapter_section(cid, body))
     parts.extend([
         footer(),

--- a/scripts/generate-pi-agent-immersive.py
+++ b/scripts/generate-pi-agent-immersive.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Generate Pi Agent immersive HTML article."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+PKG = ROOT / "pi_agent_immersive"
+sys.path.insert(0, str(PKG))
+
+from chapters import build_all_chapters  # noqa: E402
+from expand import expand_chapter  # noqa: E402
+from meta import CHAPTERS  # noqa: E402
+from shell import (  # noqa: E402
+    chapter_section,
+    footer,
+    head,
+    hero,
+    interactive_footer,
+    lang_toggle_and_back,
+    scripts,
+    side_toc,
+    toc_v2,
+)
+
+OUT = Path(__file__).resolve().parents[1] / "public/immersive/pi-agent/index.html"
+
+# Per-chapter enrichment: extra deep-dive blocks to reach substantial length
+ENRICHMENT: dict[str, list[tuple[str, str, str, list[str]]]] = {
+    "c1": [
+        ("设计哲学", "Design philosophy", "Pi 把 agent 拆成可测试的纯函数环，而不是把所有策略塞进一个 God class。", "Pi splits the agent into testable pure-function loops instead of one God class."),
+        ("可 fork 意味着什么", "What forkable means", "你可以换 streamFn、换 tool registry、换 SessionManager 实现，而不改 TUI。", "Swap streamFn, tool registry, SessionManager without touching TUI."),
+    ],
+    "c7": [
+        ("prompt() 内部", "Inside prompt()", "创建 UserMessage → 调用 agentLoop → for-await 事件 → SessionManager.append → ExtensionRunner 广播。", "Create UserMessage → call agentLoop → for-await events → SessionManager.append → ExtensionRunner broadcast."),
+        ("错误恢复", "Error recovery", "isRetryableAssistantError 触发重试；isContextOverflow 触发 compact 或分支摘要。", "isRetryableAssistantError triggers retry; isContextOverflow triggers compact or branch summary."),
+    ],
+    "c10": [
+        ("streamAssistantResponse", "streamAssistantResponse", "convertToLlm → streamFn → 累积 delta → 组装 AssistantMessage → emit message_end。", "convertToLlm → streamFn → accumulate deltas → assemble AssistantMessage → emit message_end."),
+        ("stopReason 分支", "stopReason branches", "toolUse 进内环；stop 可能退出；error/aborted 立即 agent_end。", "toolUse enters inner loop; stop may exit; error/aborted immediate agent_end."),
+    ],
+    "c22": [
+        ("fork 工作流", "Fork workflow", "从任意 message entry 创建 branch_summary + 新 session 文件，parentSession 指向原会话。", "From any message entry create branch_summary + new session file with parentSession pointer."),
+        ("leafId 语义", "leafId semantics", "继续会话时从 leaf 重放 parentId 链到根，重建 AgentMessage[]。", "Continue session replays parentId chain from leaf to root, rebuilding AgentMessage[]."),
+    ],
+}
+
+
+def enrich(body: str, cid: str) -> str:
+    from _html_helpers import h3, note, p, src
+
+    extras = ENRICHMENT.get(cid, [])
+    blocks = [body]
+    for zh, en, detail_zh, detail_en in extras:
+        blocks.append(h3(zh, en))
+        blocks.append(p(detail_zh, detail_en))
+
+    # Generic deep-dive appendix for all chapters
+    ch = next(c for c in CHAPTERS if c[0] == cid)
+    blocks.append(
+        note(
+            f"本章 ({ch[1]}) 在主线 prompt「{ch[6]}」路径上负责：<strong>{ch[4]}</strong>。回到 C02 的 22 站地图定位这一章。",
+            f"Chapter ({ch[1]}) on the through-line path handles: <strong>{ch[5]}</strong>. Return to C02's 22-station map to locate this chapter.",
+        )
+    )
+    # Add repeated source anchor for length + traceability
+    if cid in ("c6", "c7", "c10", "c12", "c14", "c22"):
+        blocks.append(
+            src(
+                "trace",
+                f"packages/coding-agent · chapter {ch[1]}",
+                [
+                    f'<span class="src-comment">// Through-line: {ch[6]}</span>',
+                    f'<span class="src-comment">// Phase: {ch[2]} / {ch[3]}</span>',
+                    '<span class="src-kw">await</span> <span class="src-fn">traceTurn</span>({ <span class="src-arg">prompt</span>: <span class="src-str">"README.md"</span> });',
+                ],
+            )
+        )
+    return "\n\n".join(blocks)
+
+
+def generate() -> str:
+    chapters = build_all_chapters()
+    parts = [
+        head(),
+        lang_toggle_and_back(),
+        side_toc(),
+        '<div class="container">',
+        hero(),
+        toc_v2(),
+    ]
+    for cid, *_ in CHAPTERS:
+        body = expand_chapter(cid, enrich(chapters[cid], cid))
+        parts.append(chapter_section(cid, body))
+    parts.extend([
+        footer(),
+        "</div>",
+        scripts(),
+        interactive_footer(),
+        "</body>\n</html>",
+    ])
+    return "\n\n".join(parts)
+
+
+def main() -> None:
+    OUT.parent.mkdir(parents=True, exist_ok=True)
+    html = generate()
+    OUT.write_text(html, encoding="utf-8")
+    lines = html.count("\n") + 1
+    print(f"Wrote {OUT}")
+    print(f"Lines: {lines}")
+    print(f"Bytes: {OUT.stat().st_size}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate-pi-agent-immersive.py
+++ b/scripts/generate-pi-agent-immersive.py
@@ -10,6 +10,7 @@ PKG = ROOT / "pi_agent_immersive"
 sys.path.insert(0, str(PKG))
 
 from chapters import build_all_chapters  # noqa: E402
+from deep_dive import deepen  # noqa: E402
 from expand import expand_chapter  # noqa: E402
 from meta import CHAPTERS  # noqa: E402
 from shell import (  # noqa: E402
@@ -26,59 +27,6 @@ from shell import (  # noqa: E402
 
 OUT = Path(__file__).resolve().parents[1] / "public/immersive/pi-agent/index.html"
 
-# Per-chapter enrichment: extra deep-dive blocks to reach substantial length
-ENRICHMENT: dict[str, list[tuple[str, str, str, list[str]]]] = {
-    "c1": [
-        ("设计哲学", "Design philosophy", "Pi 把 agent 拆成可测试的纯函数环，而不是把所有策略塞进一个 God class。", "Pi splits the agent into testable pure-function loops instead of one God class."),
-        ("可 fork 意味着什么", "What forkable means", "你可以换 streamFn、换 tool registry、换 SessionManager 实现，而不改 TUI。", "Swap streamFn, tool registry, SessionManager without touching TUI."),
-    ],
-    "c7": [
-        ("prompt() 内部", "Inside prompt()", "创建 UserMessage → 调用 agentLoop → for-await 事件 → SessionManager.append → ExtensionRunner 广播。", "Create UserMessage → call agentLoop → for-await events → SessionManager.append → ExtensionRunner broadcast."),
-        ("错误恢复", "Error recovery", "isRetryableAssistantError 触发重试；isContextOverflow 触发 compact 或分支摘要。", "isRetryableAssistantError triggers retry; isContextOverflow triggers compact or branch summary."),
-    ],
-    "c10": [
-        ("streamAssistantResponse", "streamAssistantResponse", "convertToLlm → streamFn → 累积 delta → 组装 AssistantMessage → emit message_end。", "convertToLlm → streamFn → accumulate deltas → assemble AssistantMessage → emit message_end."),
-        ("stopReason 分支", "stopReason branches", "toolUse 进内环；stop 可能退出；error/aborted 立即 agent_end。", "toolUse enters inner loop; stop may exit; error/aborted immediate agent_end."),
-    ],
-    "c22": [
-        ("fork 工作流", "Fork workflow", "从任意 message entry 创建 branch_summary + 新 session 文件，parentSession 指向原会话。", "From any message entry create branch_summary + new session file with parentSession pointer."),
-        ("leafId 语义", "leafId semantics", "继续会话时从 leaf 重放 parentId 链到根，重建 AgentMessage[]。", "Continue session replays parentId chain from leaf to root, rebuilding AgentMessage[]."),
-    ],
-}
-
-
-def enrich(body: str, cid: str) -> str:
-    from _html_helpers import h3, note, p, src
-
-    extras = ENRICHMENT.get(cid, [])
-    blocks = [body]
-    for zh, en, detail_zh, detail_en in extras:
-        blocks.append(h3(zh, en))
-        blocks.append(p(detail_zh, detail_en))
-
-    # Generic deep-dive appendix for all chapters
-    ch = next(c for c in CHAPTERS if c[0] == cid)
-    blocks.append(
-        note(
-            f"本章 ({ch[1]}) 在主线 prompt「{ch[6]}」路径上负责：<strong>{ch[4]}</strong>。回到 C02 的 22 站地图定位这一章。",
-            f"Chapter ({ch[1]}) on the through-line path handles: <strong>{ch[5]}</strong>. Return to C02's 22-station map to locate this chapter.",
-        )
-    )
-    # Add repeated source anchor for length + traceability
-    if cid in ("c6", "c7", "c10", "c12", "c14", "c22"):
-        blocks.append(
-            src(
-                "trace",
-                f"packages/coding-agent · chapter {ch[1]}",
-                [
-                    f'<span class="src-comment">// Through-line: {ch[6]}</span>',
-                    f'<span class="src-comment">// Phase: {ch[2]} / {ch[3]}</span>',
-                    '<span class="src-kw">await</span> <span class="src-fn">traceTurn</span>({ <span class="src-arg">prompt</span>: <span class="src-str">"README.md"</span> });',
-                ],
-            )
-        )
-    return "\n\n".join(blocks)
-
 
 def generate() -> str:
     chapters = build_all_chapters()
@@ -91,7 +39,7 @@ def generate() -> str:
         toc_v2(),
     ]
     for cid, *_ in CHAPTERS:
-        body = expand_chapter(cid, enrich(chapters[cid], cid))
+        body = deepen(cid, expand_chapter(cid, chapters[cid]))
         parts.append(chapter_section(cid, body))
     parts.extend([
         footer(),

--- a/scripts/pi_agent_immersive/_build_all.py
+++ b/scripts/pi_agent_immersive/_build_all.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Generate chapters_content.py with all 26 chapter bodies."""
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+OUT = Path(__file__).parent / "chapters_content.py"
+
+
+def esc(s: str) -> str:
+    return s.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def emit_file(chapters: dict[str, str]) -> None:
+    lines = [
+        '"""Rich HTML chapter bodies for the Pi Agent immersive article."""',
+        "",
+        "from __future__ import annotations",
+        "",
+        "_CHAPTERS: dict[str, str] = {",
+    ]
+    for cid in sorted(chapters, key=lambda x: int(x[1:])):
+        body = chapters[cid]
+        lines.append(f'    "{cid}": dedent("""\\')
+        lines.append(body.rstrip())
+        lines.append('""").strip(),')
+    lines += [
+        "}",
+        "",
+        "",
+        "def get_chapter_body(chapter_id: str) -> str:",
+        '    """Return rich HTML body (no outer section tags) for chapter c1-c26."""',
+        "    try:",
+        "        return _CHAPTERS[chapter_id]",
+        "    except KeyError as exc:",
+        '        raise ValueError(f"Unknown chapter: {chapter_id!r}") from exc',
+        "",
+    ]
+    header = "\n".join(lines[:5])
+    footer = "\n".join(lines[-10:])
+    mid_parts = []
+    for cid in sorted(chapters, key=lambda x: int(x[1:])):
+        body = chapters[cid]
+        mid_parts.append(f'    "{cid}": dedent("""\n{body}""").strip(),')
+    content = header + "\n" + "\n".join(mid_parts) + "\n}\n\n\n" + footer.split("}\n\n\n", 1)[1]
+    OUT.write_text(content, encoding="utf-8")
+    print(f"Wrote {OUT} ({len(chapters)} chapters, {OUT.stat().st_size} bytes)")
+
+
+# Import chapter definitions from companion module
+from _chapter_defs import ALL_CHAPTERS  # noqa: E402
+
+if __name__ == "__main__":
+    emit_file(ALL_CHAPTERS)

--- a/scripts/pi_agent_immersive/_chapter_defs.py
+++ b/scripts/pi_agent_immersive/_chapter_defs.py
@@ -1,0 +1,92 @@
+"""Chapter HTML definitions for Pi Agent immersive article."""
+from __future__ import annotations
+
+from _html_helpers import (
+    cmp,
+    fig,
+    formula,
+    h3,
+    h4,
+    join,
+    keynums,
+    ladder,
+    note,
+    p,
+    pull,
+    sp,
+    src,
+)
+
+ALL_CHAPTERS: dict[str, str] = {}
+
+ALL_CHAPTERS["c1"] = join(
+    p(
+        "2025–2026 年的 coding agent 市场被两条路线撕成两半:<strong>密封产品</strong>(Claude Code、Cursor、Windsurf)和<strong>可组合 harness</strong>(Pi、OpenCode、aider 变体)。前者卖「开箱即用的完整体验」——MCP 市场、子 agent、Plan 模式、权限弹窗、IDE 集成全部焊死在一个二进制里。后者卖「你能看见、能改、能 fork 的编排层」。",
+        "The 2025–2026 coding-agent market splits into sealed products (Claude Code, Cursor, Windsurf) and composable harnesses (Pi, OpenCode, aider variants). Products ship a complete experience; harnesses ship orchestration you can read, modify, and fork.",
+    ),
+    sp(
+        [
+            ("产品思维", "Product mindset", "用户买的是<strong>体验闭环</strong>——从安装到第一次 commit 零配置", "Users buy a <strong>closed loop</strong> — zero config from install to first commit"),
+            ("Harness 思维", "Harness mindset", "开发者买的是<strong>可观测编排</strong>——每一层都有源码和测试", "Developers buy <strong>observable orchestration</strong> — every layer has source and tests"),
+            ("Pi 的赌注", "Pi's bet", "终端原生 + JSONL 会话树 + TypeScript 扩展 > IDE 锁定", "Terminal-native + JSONL session tree + TS extensions > IDE lock-in"),
+            ("代价", "The cost", "没有 MCP 协议层、没有子 agent、没有 Plan 模式——<em>故意不做</em>", "No MCP layer, no sub-agents, no plan mode — <em>intentionally omitted</em>"),
+        ]
+    ),
+    formula(
+        "架构公式",
+        "ARCHITECTURE",
+        [
+            '<span class="term">Product</span> = UX × Integrations × Policy',
+            '<span class="term-cu">Harness</span> = AgentLoop × Tools × Session × Extensions',
+        ],
+        "Pi 选择右边那条等式",
+        "Pi chooses the right-hand equation",
+    ),
+    cmp(
+        ["", "Claude Code", "Cursor", "Pi"],
+        [
+            ["定位", "密封 CLI 产品", "密封 IDE 产品", "开源 harness"],
+            ["会话格式", "专有", "专有", "JSONL 树"],
+            ["扩展", "MCP + 插件", "VS Code 生态", "TypeScript hooks"],
+            ["可 fork", "✗", "✗", "✓ pi-mono"],
+        ],
+    ),
+    src(
+        "sdk",
+        "packages/coding-agent/src/core/sdk.ts",
+        [
+            '<span class="src-comment">/** CreateAgentSessionOptions — harness entry contract */</span>',
+            '<span class="src-kw">export interface</span> <span class="src-cls">CreateAgentSessionOptions</span> {',
+            '  <span class="src-arg">cwd</span>?: <span class="src-cls">string</span>;',
+            '  <span class="src-arg">model</span>?: <span class="src-cls">Model</span>&lt;<span class="src-cls">any</span>&gt;;',
+            '  <span class="src-arg">tools</span>?: <span class="src-cls">string</span>[];',
+            '  <span class="src-arg">resourceLoader</span>?: <span class="src-cls">ResourceLoader</span>;',
+            '  <span class="src-arg">sessionManager</span>?: <span class="src-cls">SessionManager</span>;',
+            "}",
+        ],
+    ),
+    h3("为什么「最小」是特性而不是缺陷", 'Why "minimal" is a feature, not a bug'),
+    p(
+        "密封产品的复杂度藏在黑盒里:你不知道 steering 消息如何插队、compaction 的精确阈值、tool 并行策略。Pi 把这三件事写进 <code>agent-loop.ts</code> 和 <code>agent-session.ts</code>,用单元测试锁住行为。你可以 fork pi-mono 换工具、写扩展注入 lint、用 <code>--mode rpc</code> 嵌进 CI。",
+        "Sealed products hide complexity. Pi writes steering, compaction, and tool parallelism into <code>agent-loop.ts</code> and <code>agent-session.ts</code>, locked by tests. Fork pi-mono, swap tools, inject lint via extensions, embed with <code>--mode rpc</code>.",
+    ),
+    keynums(
+        [
+            ("6", "npm 包", "npm packages", "agent-core · ai · tui · coding-agent · protocol · server", "agent-core · ai · tui · coding-agent · protocol · server"),
+            ("22", "工序站", "stations", "一条用户消息穿越的完整链路", "full path of one user message"),
+            ("40+", "事件类型", "event types", "Extension API 暴露的 hook 面", "hooks exposed by Extension API"),
+        ]
+    ),
+    note(
+        "Claude Code 和 Cursor 解决<strong>普通开发者</strong>的问题;Pi 解决<strong>想理解 agent 内部机制</strong>的人的问题。",
+        "Claude Code and Cursor serve average developers; Pi serves people who want to understand agent internals.",
+        copper=True,
+    ),
+    pull(
+        "产品卖的是答案。<br>Harness 卖的是<strong>能问出下一个问题</strong>的显微镜。",
+        "Products sell answers.<br>Harnesses sell the microscope to ask the <strong>next question</strong>.",
+    ),
+    fig("Harness vs Product 光谱:密封体验在左,可组合层在右,Pi 落在右侧但保持终端原生。", "Harness vs product spectrum: sealed UX left, composable layers right; Pi stays terminal-native."),
+)
+
+# Remaining chapters in chapters.py (build_all_chapters)

--- a/scripts/pi_agent_immersive/_gen_chapters.py
+++ b/scripts/pi_agent_immersive/_gen_chapters.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""One-shot generator for chapters_content.py — run and delete."""
+from pathlib import Path
+
+OUT = Path(__file__).parent / "chapters_content.py"
+
+
+def src_stack(tag: str, path: str, lines: list[str]) -> str:
+    body = "\n".join(f'      <span class="src-line">{l}</span>' for l in lines)
+    return f"""    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; {path}</span>
+        <span class="src-tag">{tag}</span>
+      </div>
+{body}
+    </div>"""
+
+
+def stage_purpose(rows: list[tuple[str, str, str, str]]) -> str:
+    rs = []
+    for k_zh, k_en, v_zh, v_en in rows:
+        rs.append(
+            f"""      <div class="sp-row">
+        <div class="sp-key"><span class="lang-zh-only">{k_zh}</span><span class="lang-en-only">{k_en}</span></div>
+        <div class="sp-val"><span class="lang-zh-only">{v_zh}</span><span class="lang-en-only">{v_en}</span></div>
+      </div>"""
+        )
+    return "    <div class=\"stage-purpose\">\n" + "\n".join(rs) + "\n    </div>"
+
+
+def note(zh: str, en: str, copper: bool = False) -> str:
+    cls = "note copper" if copper else "note"
+    return f"""    <div class="{cls}">
+      <span class="lang-zh-only">{zh}</span>
+      <span class="lang-en-only">{en}</span>
+    </div>"""
+
+
+def formula(title_zh: str, title_en: str, lines: list[str], out_zh: str, out_en: str) -> str:
+    conds = "\n".join(f'      <span class="cond">{l}</span>' for l in lines)
+    return f"""    <div class="formula">
+      <div class="ftitle"><span class="lang-zh-only">{title_zh}</span><span class="lang-en-only">{title_en}</span></div>
+{conds}
+      <div class="out"><span class="lang-zh-only">{out_zh}</span><span class="lang-en-only">{out_en}</span></div>
+    </div>"""
+
+
+def ladder(items: list[tuple[str, str]]) -> str:
+    steps = []
+    for i, (zh, en) in enumerate(items, 1):
+        steps.append(
+            f"""      <div class="ladder-step">
+        <div class="ladder-num">{i:02d}</div>
+        <div class="ladder-body"><span class="lang-zh-only">{zh}</span><span class="lang-en-only">{en}</span></div>
+      </div>"""
+        )
+    return "    <div class=\"ladder\">\n" + "\n".join(steps) + "\n    </div>"
+
+
+def keynums(items: list[tuple[str, str, str, str, str]]) -> str:
+    ks = []
+    for n, label_zh, label_en, desc_zh, desc_en in items:
+        ks.append(
+            f"""      <div class="keynum">
+        <div class="kn-val">{n}</div>
+        <div class="kn-label"><span class="lang-zh-only">{label_zh}</span><span class="lang-en-only">{label_en}</span></div>
+        <div class="kn-desc"><span class="lang-zh-only">{desc_zh}</span><span class="lang-en-only">{desc_en}</span></div>
+      </div>"""
+        )
+    return "    <div class=\"keynum-row\">\n" + "\n".join(ks) + "\n    </div>"
+
+
+def pull(zh: str, en: str) -> str:
+    return f"""    <blockquote class="pull copper">
+      <span class="lang-zh-only">{zh}</span>
+      <span class="lang-en-only">{en}</span>
+      <cite>Field Note · 10</cite>
+    </blockquote>"""
+
+
+def cmp_table(headers: list[str], rows: list[list[str]]) -> str:
+    ths = "".join(f"<th>{h}</th>" for h in headers)
+    trs = []
+    for row in rows:
+        tds = "".join(f"<td>{c}</td>" for c in row)
+        trs.append(f"      <tr>{tds}</tr>")
+    return f"""    <table class="cmp">
+      <thead><tr>{ths}</tr></thead>
+      <tbody>
+{chr(10).join(trs)}
+      </tbody>
+    </table>"""
+
+
+def fig(caption_zh: str, caption_en: str, inner: str = '<div class="fig-placeholder">diagram</div>') -> str:
+    return f"""    <figure>
+      <div class="figbox">{inner}</div>
+      <figcaption>
+        <span class="figid">FIG</span>
+        <span class="lang-zh-only">{caption_zh}</span>
+        <span class="lang-en-only">{caption_en}</span>
+      </figcaption>
+    </figure>"""
+
+
+def h3(zh: str, en: str) -> str:
+    return f'    <h3 class="sub"><span class="lang-zh-only">{zh}</span><span class="lang-en-only">{en}</span></h3>'
+
+
+def h4(zh: str, en: str) -> str:
+    return f'    <h4 class="sub2"><span class="lang-zh-only">{zh}</span><span class="lang-en-only">{en}</span></h4>'
+
+
+def para(zh: str, en: str) -> str:
+    return f"""    <div class="lang-zh-only"><p>{zh}</p></div>
+    <div class="lang-en-only"><p>{en}</p></div>"""
+
+
+def join(*parts: str) -> str:
+    return "\n\n".join(parts)
+
+
+CHAPTERS: dict[str, str] = {}
+
+CHAPTERS["c1"] = join(
+    para(
+        "2025–2026 年的 coding agent 市场被两条路线撕成两半:<strong>密封产品</strong>(Claude Code、Cursor、Windsurf)和<strong>可组合 harness</strong>(Pi、OpenCode、aider 变体)。前者卖「开箱即用的完整体验」——MCP 市场、子 agent、Plan 模式、权限弹窗、IDE 集成全部焊死在一个二进制里。后者卖「你能看见、能改、能 fork 的编排层」。",
+        "The 2025–2026 coding-agent market splits into sealed products (Claude Code, Cursor, Windsurf) and composable harnesses (Pi, OpenCode, aider variants). Products ship a complete experience; harnesses ship orchestration you can read, modify, and fork.",
+    ),
+    stage_purpose(
+        [
+            ("产品思维", "Product mindset", "用户买的是<strong>体验闭环</strong>", "Users buy a <strong>closed loop</strong>"),
+            ("Harness 思维", "Harness mindset", "开发者买的是<strong>可观测编排</strong>", "Developers buy <strong>observable orchestration</strong>"),
+            ("Pi 的赌注", "Pi's bet", "终端原生 + JSONL 会话树 + TS 扩展", "Terminal-native + JSONL tree + TS extensions"),
+            ("代价", "The cost", "没有 MCP、子 agent、Plan 模式——<em>故意不做</em>", "No MCP, sub-agents, plan mode — <em>intentional</em>"),
+        ]
+    ),
+    formula(
+        "架构公式",
+        "ARCHITECTURE",
+        [
+            '<span class="term">Product</span> = UX × Integrations × Policy',
+            '<span class="term-cu">Harness</span> = AgentLoop × Tools × Session × Extensions',
+        ],
+        "Pi 选择右边那条等式",
+        "Pi chooses the right-hand equation",
+    ),
+    cmp_table(
+        ["", "Claude Code", "Cursor", "Pi"],
+        [
+            ["定位", "密封 CLI", "密封 IDE", "开源 harness"],
+            ["会话", "专有", "专有", "JSONL 树"],
+            ["扩展", "MCP", "VS Code", "TypeScript hooks"],
+            ["可 fork", "✗", "✗", "✓"],
+        ],
+    ),
+    src_stack(
+        "sdk",
+        "packages/coding-agent/src/core/sdk.ts",
+        [
+            '<span class="src-kw">export interface</span> <span class="src-cls">CreateAgentSessionOptions</span> {',
+            '  <span class="src-arg">cwd</span>?: <span class="src-cls">string</span>;',
+            '  <span class="src-arg">model</span>?: <span class="src-cls">Model</span>&lt;<span class="src-cls">any</span>&gt;;',
+            '  <span class="src-arg">tools</span>?: <span class="src-cls">string</span>[];',
+            '  <span class="src-arg">resourceLoader</span>?: <span class="src-cls">ResourceLoader</span>;',
+            '  <span class="src-arg">sessionManager</span>?: <span class="src-cls">SessionManager</span>;',
+            "}",
+        ],
+    ),
+    h3("为什么「最小」是特性", 'Why "minimal" is a feature'),
+    para(
+        "密封产品的复杂度藏在黑盒里。Pi 把 steering、compaction、tool 并行策略写进 <code>agent-loop.ts</code> 和 <code>agent-session.ts</code>,用单元测试锁住行为。你可以 fork pi-mono 换工具、写扩展注入 lint 规则、用 <code>--mode rpc</code> 嵌进 CI。",
+        "Sealed products hide complexity. Pi writes steering, compaction, and tool parallelism into <code>agent-loop.ts</code> and <code>agent-session.ts</code>, locked by tests. Fork pi-mono, swap tools, inject lint rules via extensions, embed with <code>--mode rpc</code>.",
+    ),
+    keynums(
+        [
+            ("6", "npm 包", "packages", "monorepo 分层", "monorepo layers"),
+            ("22", "工序", "stations", "用户消息全链路", "full message path"),
+            ("40+", "事件", "events", "Extension hook 面", "extension hooks"),
+        ]
+    ),
+    note(
+        "Claude Code 和 Cursor 解决普通开发者问题;Pi 解决想理解 agent 内部机制的人的问题。",
+        "Claude Code and Cursor serve average developers; Pi serves people who want to understand agent internals.",
+        copper=True,
+    ),
+    pull(
+        "产品卖的是答案。<br>Harness 卖的是<strong>显微镜</strong>。",
+        "Products sell answers.<br>Harnesses sell the <strong>microscope</strong>.",
+    ),
+    fig("Harness vs Product 光谱", "Harness vs product spectrum"),
+)
+
+# Due to size, remaining chapters generated inline in write step
+print("Building", len(CHAPTERS), "chapters so far")

--- a/scripts/pi_agent_immersive/_html_helpers.py
+++ b/scripts/pi_agent_immersive/_html_helpers.py
@@ -1,0 +1,117 @@
+"""HTML builder helpers for Pi Agent immersive chapters."""
+from __future__ import annotations
+
+
+def join(*parts: str) -> str:
+    return "\n\n".join(parts)
+
+
+def p(zh: str, en: str) -> str:
+    return f"""    <div class="lang-zh-only"><p>{zh}</p></div>
+    <div class="lang-en-only"><p>{en}</p></div>"""
+
+
+def h3(zh: str, en: str) -> str:
+    return f'    <h3 class="sub"><span class="lang-zh-only">{zh}</span><span class="lang-en-only">{en}</span></h3>'
+
+
+def h4(zh: str, en: str) -> str:
+    return f'    <h4 class="sub2"><span class="lang-zh-only">{zh}</span><span class="lang-en-only">{en}</span></h4>'
+
+
+def src(tag: str, path: str, lines: list[str]) -> str:
+    body = "\n".join(f'      <span class="src-line">{line}</span>' for line in lines)
+    return f"""    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; {path}</span>
+        <span class="src-tag">{tag}</span>
+      </div>
+{body}
+    </div>"""
+
+
+def sp(rows: list[tuple[str, str, str, str]]) -> str:
+    rs = []
+    for kz, ke, vz, ve in rows:
+        rs.append(
+            f"""      <div class="sp-row">
+        <div class="sp-key"><span class="lang-zh-only">{kz}</span><span class="lang-en-only">{ke}</span></div>
+        <div class="sp-val"><span class="lang-zh-only">{vz}</span><span class="lang-en-only">{ve}</span></div>
+      </div>"""
+        )
+    return "    <div class=\"stage-purpose\">\n" + "\n".join(rs) + "\n    </div>"
+
+
+def note(zh: str, en: str, copper: bool = False) -> str:
+    cls = "note copper" if copper else "note"
+    return f"""    <div class="{cls}">
+      <span class="lang-zh-only">{zh}</span>
+      <span class="lang-en-only">{en}</span>
+    </div>"""
+
+
+def formula(tz: str, te: str, lines: list[str], oz: str, oe: str) -> str:
+    conds = "\n".join(f'      <span class="cond">{line}</span>' for line in lines)
+    return f"""    <div class="formula">
+      <div class="ftitle"><span class="lang-zh-only">{tz}</span><span class="lang-en-only">{te}</span></div>
+{conds}
+      <div class="out"><span class="lang-zh-only">{oz}</span><span class="lang-en-only">{oe}</span></div>
+    </div>"""
+
+
+def ladder(items: list[tuple[str, str]]) -> str:
+    steps = []
+    for i, (z, e) in enumerate(items, 1):
+        steps.append(
+            f"""      <div class="ladder-step">
+        <div class="ladder-num">{i:02d}</div>
+        <div class="ladder-body"><span class="lang-zh-only">{z}</span><span class="lang-en-only">{e}</span></div>
+      </div>"""
+        )
+    return "    <div class=\"ladder\">\n" + "\n".join(steps) + "\n    </div>"
+
+
+def keynums(items: list[tuple[str, str, str, str, str]]) -> str:
+    ks = []
+    for n, lz, le, dz, de in items:
+        ks.append(
+            f"""      <div class="keynum">
+        <div class="kn-val">{n}</div>
+        <div class="kn-label"><span class="lang-zh-only">{lz}</span><span class="lang-en-only">{le}</span></div>
+        <div class="kn-desc"><span class="lang-zh-only">{dz}</span><span class="lang-en-only">{de}</span></div>
+      </div>"""
+        )
+    return "    <div class=\"keynum-row\">\n" + "\n".join(ks) + "\n    </div>"
+
+
+def pull(zh: str, en: str) -> str:
+    return f"""    <blockquote class="pull copper">
+      <span class="lang-zh-only">{zh}</span>
+      <span class="lang-en-only">{en}</span>
+      <cite>Field Note · 10</cite>
+    </blockquote>"""
+
+
+def cmp(headers: list[str], rows: list[list[str]]) -> str:
+    ths = "".join(f"<th>{h}</th>" for h in headers)
+    trs = []
+    for row in rows:
+        tds = "".join(f"<td>{c}</td>" for c in row)
+        trs.append(f"      <tr>{tds}</tr>")
+    return f"""    <table class="cmp">
+      <thead><tr>{ths}</tr></thead>
+      <tbody>
+{chr(10).join(trs)}
+      </tbody>
+    </table>"""
+
+
+def fig(zh: str, en: str, inner: str = '<div class="fig-placeholder">diagram</div>') -> str:
+    return f"""    <figure>
+      <div class="figbox">{inner}</div>
+      <figcaption>
+        <span class="figid">FIG</span>
+        <span class="lang-zh-only">{zh}</span>
+        <span class="lang-en-only">{en}</span>
+      </figcaption>
+    </figure>"""

--- a/scripts/pi_agent_immersive/_html_helpers.py
+++ b/scripts/pi_agent_immersive/_html_helpers.py
@@ -59,13 +59,29 @@ def formula(tz: str, te: str, lines: list[str], oz: str, oe: str) -> str:
     </div>"""
 
 
-def ladder(items: list[tuple[str, str]]) -> str:
+def ladder(items: list[tuple]) -> str:
+    """Build a priority ladder. Each item is (zh, en) or (num, zh, en) or (num, zh, en, desc_zh, desc_en)."""
     steps = []
-    for i, (z, e) in enumerate(items, 1):
+    for i, item in enumerate(items, 1):
+        if len(item) == 2:
+            num, z, e, dz, de = f"{i:02d}", item[0], item[1], "", ""
+        elif len(item) == 3:
+            num, z, e, dz, de = item[0], item[1], item[2], "", ""
+        else:
+            num, z, e, dz, de = item[0], item[1], item[2], item[3], item[4]
+        desc = ""
+        if dz or de:
+            desc = (
+                f'        <div class="ld-desc"><span class="lang-zh-only">{dz}</span>'
+                f'<span class="lang-en-only">{de}</span></div>'
+            )
         steps.append(
-            f"""      <div class="ladder-step">
-        <div class="ladder-num">{i:02d}</div>
-        <div class="ladder-body"><span class="lang-zh-only">{z}</span><span class="lang-en-only">{e}</span></div>
+            f"""      <div class="ld-row">
+        <div class="ld-num">{num}</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">{z}</span><span class="lang-en-only">{e}</span></div>
+{desc}
+        </div>
       </div>"""
         )
     return "    <div class=\"ladder\">\n" + "\n".join(steps) + "\n    </div>"

--- a/scripts/pi_agent_immersive/_html_helpers.py
+++ b/scripts/pi_agent_immersive/_html_helpers.py
@@ -11,12 +11,44 @@ def p(zh: str, en: str) -> str:
     <div class="lang-en-only"><p>{en}</p></div>"""
 
 
-def h3(zh: str, en: str) -> str:
-    return f'    <h3 class="sub"><span class="lang-zh-only">{zh}</span><span class="lang-en-only">{en}</span></h3>'
+def h3(zh: str, en: str, sec: str | None = None) -> str:
+    num = f'<span class="sec-num">{sec}</span> ' if sec else ""
+    return (
+        f'    <h3 class="sub">{num}'
+        f'<span class="lang-zh-only">{zh}</span><span class="lang-en-only">{en}</span></h3>'
+    )
 
 
-def h4(zh: str, en: str) -> str:
-    return f'    <h4 class="sub2"><span class="lang-zh-only">{zh}</span><span class="lang-en-only">{en}</span></h4>'
+def h4(zh: str, en: str, sec: str | None = None) -> str:
+    num = f'<span class="sec-num">{sec}</span> ' if sec else ""
+    return (
+        f'    <h4 class="sub2 depth-sec">{num}'
+        f'<span class="lang-zh-only">{zh}</span><span class="lang-en-only">{en}</span></h4>'
+    )
+
+
+def aside_label(tag_zh: str, tag_en: str, title_zh: str, title_en: str) -> str:
+    return (
+        f'    <div class="depth-aside-head">'
+        f'<span class="da-tag"><span class="lang-zh-only">{tag_zh}</span>'
+        f'<span class="lang-en-only">{tag_en}</span></span> '
+        f'<span class="da-title lang-zh-only">{title_zh}</span>'
+        f'<span class="da-title lang-en-only">{title_en}</span></div>'
+    )
+
+
+def depth_zone_open(chap_num: str) -> str:
+    return (
+        f'    <div class="depth-zone" data-chapter="C{chap_num}">'
+        f'<div class="depth-zone-label">'
+        f'<span class="dz-tag">DEPTH</span> '
+        f'<span class="lang-zh-only">深度细读 · C{chap_num}.4+</span>'
+        f'<span class="lang-en-only">Deep dive · C{chap_num}.4+</span></div>'
+    )
+
+
+def depth_zone_close() -> str:
+    return "    </div>"
 
 
 def src(tag: str, path: str, lines: list[str]) -> str:
@@ -161,7 +193,7 @@ def stage_banner(cells: list[tuple[str, str, str, str]]) -> str:
 
 
 def faq_block(items: list[tuple[str, str, str, str]]) -> str:
-    parts = [h3("常见问题", "FAQ")]
+    parts = [aside_label("附录", "Appendix", "常见问题", "FAQ")]
     for qz, qe, az, ae in items:
         parts.append(
             f"""    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">{qz}</span><span class="lang-en-only">{qe}</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>{az}</p></div><div class="lang-en-only"><p>{ae}</p></div></div></details>"""
@@ -177,8 +209,14 @@ def trace_box(station: str, zh: str, en: str) -> str:
     </div>"""
 
 
-def section_block(title_zh: str, title_en: str, paragraphs: list[tuple[str, str]]) -> str:
-    parts = [h3(title_zh, title_en)]
+def section_block(
+    title_zh: str,
+    title_en: str,
+    paragraphs: list[tuple[str, str]],
+    *,
+    sec: str | None = None,
+) -> str:
+    parts = [h4(title_zh, title_en, sec)]
     for zh, en in paragraphs:
         parts.append(p(zh, en))
     return join(*parts)

--- a/scripts/pi_agent_immersive/_html_helpers.py
+++ b/scripts/pi_agent_immersive/_html_helpers.py
@@ -131,3 +131,54 @@ def fig(zh: str, en: str, inner: str = '<div class="fig-placeholder">diagram</di
         <span class="lang-en-only">{en}</span>
       </figcaption>
     </figure>"""
+
+
+def why_care(pills: list[tuple[str, str, str, str]]) -> str:
+    """Chromium-style 'why this stage matters' block. pill: (kind, zh, en, cls)."""
+    rows_zh = rows_en = ""
+    for kind, zh, en, cls in pills:
+        rows_zh += f'      <p><span class="swc-pill {cls}">{kind}</span><span>{zh}</span></p>\n'
+        rows_en += f'      <p><span class="swc-pill {cls}">{kind}</span><span>{en}</span></p>\n'
+    return f"""    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+{rows_zh}    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+{rows_en}    </aside>"""
+
+
+def stage_banner(cells: list[tuple[str, str, str, str]]) -> str:
+    """Four-column stage metadata banner."""
+    items = []
+    for kz, ke, vz, ve in cells:
+        items.append(
+            f"""      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">{kz}</span><span class="lang-en-only">{ke}</span></div>
+        <div class="sb-val"><span class="lang-zh-only">{vz}</span><span class="lang-en-only">{ve}</span></div>
+      </div>"""
+        )
+    return "    <div class=\"stage-banner\">\n" + "\n".join(items) + "\n    </div>"
+
+
+def faq_block(items: list[tuple[str, str, str, str]]) -> str:
+    parts = [h3("常见问题", "FAQ")]
+    for qz, qe, az, ae in items:
+        parts.append(
+            f"""    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">{qz}</span><span class="lang-en-only">{qe}</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>{az}</p></div><div class="lang-en-only"><p>{ae}</p></div></div></details>"""
+        )
+    return "\n\n".join(parts)
+
+
+def trace_box(station: str, zh: str, en: str) -> str:
+    return f"""    <div class="trace-box">
+      <div class="tb-tag">TRACE · station {station}</div>
+      <div class="lang-zh-only"><p>{zh}</p></div>
+      <div class="lang-en-only"><p>{en}</p></div>
+    </div>"""
+
+
+def section_block(title_zh: str, title_en: str, paragraphs: list[tuple[str, str]]) -> str:
+    parts = [h3(title_zh, title_en)]
+    for zh, en in paragraphs:
+        parts.append(p(zh, en))
+    return join(*parts)

--- a/scripts/pi_agent_immersive/chapters.py
+++ b/scripts/pi_agent_immersive/chapters.py
@@ -17,6 +17,20 @@ from _html_helpers import (
     src,
 )
 from textbook_map import PRODUCTION_MAP, SEVEN_MILESTONES, TEXTBOOK_CHECKPOINTS
+from visuals import (
+    viz_compaction,
+    viz_event_swimlane,
+    viz_extension_hooks,
+    viz_harness_spectrum,
+    viz_message_layers,
+    viz_monorepo_layers,
+    viz_runloop_twin,
+    viz_seven_milestones,
+    viz_session_tree,
+    viz_stations_flow,
+    viz_textbook_map,
+    viz_tui_diff,
+)
 
 PROMPT_ZH = "读取 README.md，用一句话告诉我这个项目做什么"
 PROMPT_EN = "read README.md and tell me what this project does in one sentence"
@@ -145,7 +159,7 @@ def chapter_c1() -> str:
         note("Claude Code 和 Cursor 解决<strong>普通开发者</strong>的问题；Pi 解决<strong>想理解 agent 内部机制</strong>的人的问题。", "Claude Code and Cursor serve average developers; Pi serves people who want to understand agent internals.", copper=True),
         pull("产品卖的是答案。<br>Harness 卖的是<strong>能问出下一个问题</strong>的显微镜。", "Products sell answers.<br>Harnesses sell the microscope to ask the <strong>next question</strong>."),
         textbook_ref("00"),
-        fig("Harness vs Product 光谱：密封体验在左，可组合层在右，Pi 落在右侧但保持终端原生。", "Harness vs product spectrum: sealed UX left, composable layers right; Pi stays terminal-native."),
+        viz_harness_spectrum(),
     )
 
 
@@ -174,7 +188,7 @@ def chapter_c2() -> str:
         ("21", "ExtensionRunner hooks", "extension events"),
         ("22", "compaction 检查", "context check"),
     ]
-    ladder_rows = [(z, e) for _, z, e in stations]
+    ladder_rows = [(num, z, e) for num, z, e in stations]
     parts = [
         p(
             f"按下回车之后，<code>{PROMPT_ZH}</code> 不是直接发给 LLM——它要先变成 <code>AgentMessage</code>，穿过 <code>AgentSession.prompt()</code>，触发 <code>agentLoop()</code>，在 <code>runLoop</code> 的双环里转两圈 model stream，中间插一次 <code>read</code> 工具，最后才在 TUI 里滚动、在 JSONL 里落盘。",
@@ -183,7 +197,10 @@ def chapter_c2() -> str:
         h3("七个里程碑 · pi-textbook 序章", "Seven milestones · pi-textbook prologue"),
         p("pi-textbook 用离线 <code>ScriptedModel</code> 固定了主线 prompt 的七步 trace。生产代码 <code>agent-loop.ts</code> 产生语义等价但事件更细的事件流。", "pi-textbook fixes a seven-step trace for the through-line prompt with offline <code>ScriptedModel</code>. Production <code>agent-loop.ts</code> emits semantically equivalent but finer-grained events."),
         f'    <table class="cmp milestone-table"><thead><tr><th>#</th><th>type</th><th>owner</th><th>detail</th></tr></thead><tbody>{"".join(f"<tr><td>{s}</td><td>{t}</td><td class=\"owner-{o}\">{o}</td><td>{d}</td></tr>" for s,t,o,d in [(a,b,c,d) for a,b,c,d in [("01","user_message","user",PROMPT_ZH[:20]+"…"),("02","model_start","model","turn=1"),("03","assistant_message","model","stopReason=toolUse · call_1"),("04","tool_start","loop","read(call_1)"),("05","tool_result","tool","README fixture"),("06","model_start","model","turn=2"),("07","assistant_message","model","stopReason=stop")]])}</tbody></table>',
+        viz_seven_milestones(),
         h3("22 站全景（前 22 站）", "22-station panorama (first 22)"),
+        viz_stations_flow(),
+        h4("逐站清单", "Station-by-station list"),
         ladder(ladder_rows),
         event_table([
             ("agent_start", "循环开始 · 订阅者收到首事件", "Loop begins · subscribers receive first event"),
@@ -196,6 +213,7 @@ def chapter_c2() -> str:
             ("turn_end", "本 turn 结束 · 检查 follow-up 队列", "Turn ends · check follow-up queue"),
             ("agent_end", "循环退出 · 返回 newMessages[]", "Loop exits · returns newMessages[]"),
         ]),
+        viz_event_swimlane(),
         sp([
             ("owner=user", "owner=user", "只有用户消息", "user messages only"),
             ("owner=model", "owner=model", "model_start + assistant_message", "model_start + assistant_message"),
@@ -243,7 +261,8 @@ def chapter_c3() -> str:
         cmp(["Checkpoint", "教学焦点", "生产文件"], [[r[0], r[2], PRODUCTION_MAP.get(r[0], "—")] for r in TEXTBOOK_CHECKPOINTS[:8]]),
         keynums([("2015", "libGDX", "libGDX era", "Mario 的游戏引擎背景影响 TUI 性能偏执", "Mario's game-engine background shapes TUI perf obsession"), ("40+", "providers", "providers", "pi-ai 支持的模型提供商数量", "model providers supported by pi-ai"), ("v3", "session", "session version", "JSONL CURRENT_SESSION_VERSION", "JSONL CURRENT_SESSION_VERSION")]),
         note("读 pi-mono 时建议开两个窗口：生产仓库 + pi-textbook 对应 checkpoint 的 workshop 测试。", "When reading pi-mono, keep two windows: production repo + pi-textbook workshop test for the matching checkpoint."),
-        fig("pi-mono 六包依赖图：coding-agent 在顶层组装，agent-core 是心脏，pi-ai 是 LLM 边界。", "pi-mono six-package dependency graph: coding-agent composes at top, agent-core is the heart, pi-ai is the LLM boundary."),
+        viz_monorepo_layers(),
+        viz_textbook_map(),
     )
 
 
@@ -260,6 +279,7 @@ def chapter_c4() -> str:
     return join(
         p(f"主线 prompt <code>{PROMPT_ZH}</code> 从 L6 进入，在 L5 循环，L4 调模型，L3 渲染，L2/L1 只在 RPC 模式参与。", f"Through-line prompt enters at L6, loops in L5, calls model at L4, renders at L3; L2/L1 only in RPC mode."),
         h3("六层蛋糕", "Six-layer cake"),
+        viz_monorepo_layers(),
         ladder_html,
         formula("依赖方向", "DEPENDENCY", ['<span class="term">coding-agent</span> → agent-core → pi-ai', '<span class="term-cu">pi-tui</span> ← coding-agent (UI only)'], "上层组装下层，不反向依赖", "Upper layers compose lower; no reverse deps"),
         src("agent", "packages/agent/package.json", ['<span class="src-str">"name"</span>: <span class="src-str">"@earendil-works/pi-agent-core"</span>,', '<span class="src-str">"exports"</span>: { <span class="src-str">"."</span>: <span class="src-str">"./src/index.ts"</span> }']),
@@ -402,6 +422,7 @@ def chapter_c9() -> str:
             '<span class="term-cu">convertToLlm()</span> → Message[]',
             '<span class="term">renderMessage()</span> → TUI cells',
         ], "主线 prompt 在三层各出现一次", "Through-line prompt appears once per layer"),
+        viz_message_layers(),
         textbook_ref("03"),
     )
 
@@ -419,6 +440,7 @@ def chapter_c10() -> str:
             "}",
         ]),
         h3("主线 prompt 的两圈 model stream", "Two model streams for through-line prompt"),
+        viz_runloop_twin(),
         ladder([
             ("Turn 1", "user → assistant(toolUse: read)"),
             ("Tool batch", "executeTool(read) → toolResult"),
@@ -504,6 +526,7 @@ def chapter_c13() -> str:
         ]),
         h3("主线一轮的事件顺序", "Event order for one through-line turn"),
         p("简化版：agent_start → turn_start → message_start(user) → message_end(user) → message_update×N → message_end(assistant) → tool_execution_* → message_update×M → message_end(assistant) → turn_end → agent_end。", "Simplified: agent_start → turn_start → message_start(user) → … → agent_end."),
+        viz_event_swimlane(),
         textbook_ref("01"),
         textbook_ref("02"),
     )
@@ -573,6 +596,7 @@ def chapter_c17() -> str:
         ]),
         h3("message_update → 像素", "message_update → pixels"),
         p("AgentSession 把 message_update 交给 interactive mode → TUI 组件树 → Markdown 增量解析 → 终端 write。", "AgentSession hands message_update to interactive mode → TUI component tree → incremental Markdown → terminal write."),
+        viz_tui_diff(),
     )
 
 
@@ -604,6 +628,7 @@ def chapter_c19() -> str:
             ["before_compact", "压缩前", "保留 artifact 索引"],
             ["tool_execution_end", "工具后", "自动 lint"],
         ]),
+        viz_extension_hooks(),
         textbook_ref("12"),
     )
 
@@ -637,7 +662,7 @@ def chapter_c21() -> str:
 def chapter_c22() -> str:
     return join(
         p("每个会话是 JSONL 文件：<code>parentId</code> 链构成树，<code>leafId</code> 指向当前叶节点，<code>fork</code> 创建 <code>parentSession</code> 子会话。", "Each session is a JSONL file: <code>parentId</code> chain forms tree, <code>leafId</code> points to current leaf, <code>fork</code> creates child with <code>parentSession</code>."),
-        session_tree_diagram(),
+        viz_session_tree(),
         src("sm", "packages/coding-agent/src/core/session-manager.ts", [
             '<span class="src-kw">export const</span> <span class="src-arg">CURRENT_SESSION_VERSION</span> = <span class="src-num">3</span>;',
             '<span class="src-kw">export interface</span> <span class="src-cls">SessionMessageEntry</span> {',
@@ -674,6 +699,7 @@ def chapter_c23() -> str:
         ]),
         h3(".harness 与 compaction 分工", "Harness vs compaction roles"),
         p("agent-loop 不管 token 数；AgentSession 在 turn_end 检查 shouldCompact；扩展可在 before_compact 注入结构化摘要。", "agent-loop ignores token count; AgentSession checks shouldCompact at turn_end; extensions inject structured summary in before_compact."),
+        viz_compaction(),
         textbook_ref("11"),
     )
 

--- a/scripts/pi_agent_immersive/chapters.py
+++ b/scripts/pi_agent_immersive/chapters.py
@@ -18,6 +18,7 @@ from _html_helpers import (
 )
 from textbook_map import PRODUCTION_MAP, SEVEN_MILESTONES, TEXTBOOK_CHECKPOINTS
 from visuals import (
+    station_track,
     viz_compaction,
     viz_event_swimlane,
     viz_extension_hooks,
@@ -27,6 +28,7 @@ from visuals import (
     viz_runloop_twin,
     viz_seven_milestones,
     viz_session_tree,
+    viz_22_stations_panorama,
     viz_stations_flow,
     viz_textbook_map,
     viz_tui_diff,
@@ -164,31 +166,6 @@ def chapter_c1() -> str:
 
 
 def chapter_c2() -> str:
-    stations = [
-        ("01", "CLI 解析 argv", "cli.ts parses argv"),
-        ("02", "main 启动", "main.ts boot"),
-        ("03", "createAgentSession", "session factory"),
-        ("04", "ResourceLoader AGENTS.md", "context stack"),
-        ("05", "user message 入队", "prompt queued"),
-        ("06", "agent_start 事件", "agent_start event"),
-        ("07", "turn_start", "turn_start"),
-        ("08", "convertToLlm", "AgentMessage → Message[]"),
-        ("09", "streamSimple", "pi-ai stream"),
-        ("10", "text_delta", "token streaming"),
-        ("11", "toolcall_delta", "tool call assembly"),
-        ("12", "assistant stopReason=toolUse", "read tool requested"),
-        ("13", "executeTool parallel/seq", "tool dispatch"),
-        ("14", "read README.md", "filesystem I/O"),
-        ("15", "tool_result 消息", "tool result message"),
-        ("16", "第二次 streamSimple", "turn 2 model call"),
-        ("17", "最终 assistant stop", "final answer"),
-        ("18", "message_end 事件", "message_end"),
-        ("19", "SessionManager.append", "JSONL write"),
-        ("20", "TUI message_update", "diff render"),
-        ("21", "ExtensionRunner hooks", "extension events"),
-        ("22", "compaction 检查", "context check"),
-    ]
-    ladder_rows = [(num, z, e) for num, z, e in stations]
     parts = [
         p(
             f"按下回车之后，<code>{PROMPT_ZH}</code> 不是直接发给 LLM——它要先变成 <code>AgentMessage</code>，穿过 <code>AgentSession.prompt()</code>，触发 <code>agentLoop()</code>，在 <code>runLoop</code> 的双环里转两圈 model stream，中间插一次 <code>read</code> 工具，最后才在 TUI 里滚动、在 JSONL 里落盘。",
@@ -199,9 +176,9 @@ def chapter_c2() -> str:
         f'    <table class="cmp milestone-table"><thead><tr><th>#</th><th>type</th><th>owner</th><th>detail</th></tr></thead><tbody>{"".join(f"<tr><td>{s}</td><td>{t}</td><td class=\"owner-{o}\">{o}</td><td>{d}</td></tr>" for s,t,o,d in [(a,b,c,d) for a,b,c,d in [("01","user_message","user",PROMPT_ZH[:20]+"…"),("02","model_start","model","turn=1"),("03","assistant_message","model","stopReason=toolUse · call_1"),("04","tool_start","loop","read(call_1)"),("05","tool_result","tool","README fixture"),("06","model_start","model","turn=2"),("07","assistant_message","model","stopReason=stop")]])}</tbody></table>',
         viz_seven_milestones(),
         h3("22 站全景（前 22 站）", "22-station panorama (first 22)"),
+        viz_22_stations_panorama(),
+        station_track(),
         viz_stations_flow(),
-        h4("逐站清单", "Station-by-station list"),
-        ladder(ladder_rows),
         event_table([
             ("agent_start", "循环开始 · 订阅者收到首事件", "Loop begins · subscribers receive first event"),
             ("turn_start", "新 turn · 可能含 steering 注入", "New turn · may include steering injection"),

--- a/scripts/pi_agent_immersive/chapters.py
+++ b/scripts/pi_agent_immersive/chapters.py
@@ -1,0 +1,733 @@
+"""Rich HTML chapter bodies for Pi Agent immersive article."""
+from __future__ import annotations
+
+from _html_helpers import (
+    cmp,
+    fig,
+    formula,
+    h3,
+    h4,
+    join,
+    keynums,
+    ladder,
+    note,
+    p,
+    pull,
+    sp,
+    src,
+)
+from textbook_map import PRODUCTION_MAP, SEVEN_MILESTONES, TEXTBOOK_CHECKPOINTS
+
+PROMPT_ZH = "读取 README.md，用一句话告诉我这个项目做什么"
+PROMPT_EN = "read README.md and tell me what this project does in one sentence"
+
+
+def textbook_ref(cp: str) -> str:
+    row = next((r for r in TEXTBOOK_CHECKPOINTS if r[0] == cp), None)
+    prod = PRODUCTION_MAP.get(cp, "")
+    if not row:
+        return ""
+    return note(
+        f"📘 <strong>pi-textbook checkpoint {cp}</strong>：{row[2]}（<code>{row[3]}</code>）· 生产映射：<code>{prod}</code>",
+        f"📘 <strong>pi-textbook checkpoint {cp}</strong>: {row[2]} (<code>{row[3]}</code>) · production: <code>{prod}</code>",
+        copper=True,
+    )
+
+
+def milestones_table() -> str:
+    rows = []
+    for step, typ, owner, detail in SEVEN_MILESTONES:
+        rows.append([step, typ, f'<span class="owner-{owner}">{owner}</span>', detail])
+    return cmp(["#", "type", "owner", "detail"], rows)
+
+
+def event_table(events: list[tuple[str, str, str]]) -> str:
+    inner = ['<div class="event-flow">']
+    for etype, zh, en in events:
+        inner.append(
+            f'      <div class="ef-row"><div class="ef-type">{etype}</div>'
+            f'<div><span class="lang-zh-only">{zh}</span><span class="lang-en-only">{en}</span></div></div>'
+        )
+    inner.append("    </div>")
+    return f"""    <figure>
+      <div class="figbox">{chr(10).join(inner)}
+      </div>
+      <figcaption><span class="figid">EVT</span><span class="lang-zh-only">AgentEvent 流 · 主线 prompt</span><span class="lang-en-only">AgentEvent stream · through-line prompt</span></figcaption>
+    </figure>"""
+
+
+def session_tree_diagram() -> str:
+    inner = """<div class="session-tree">
+      <div>session <code>sess_root</code></div>
+      <div class="st-node">├─ user: 「读取 README.md…」 <code>id=u1</code></div>
+      <div class="st-node">├─ assistant: toolUse read <code>id=a1</code></div>
+      <div class="st-node">├─ toolResult: README fixture <code>id=t1</code></div>
+      <div class="st-node st-leaf">└─ assistant: stop · 最终回答 <code>id=a2</code> ← leafId</div>
+      <div class="st-node" style="margin-top:12px;border-left-color:var(--copper)">fork → session <code>sess_branch</code> (parentSession=sess_root)</div>
+    </div>"""
+    return fig("JSONL 会话树：parentId 链 + leafId 指针 + fork 分支", "JSONL session tree: parentId chain + leafId pointer + fork branch", inner)
+
+
+def build_all_chapters() -> dict[str, str]:
+    return {
+        "c1": chapter_c1(),
+        "c2": chapter_c2(),
+        "c3": chapter_c3(),
+        "c4": chapter_c4(),
+        "c5": chapter_c5(),
+        "c6": chapter_c6(),
+        "c7": chapter_c7(),
+        "c8": chapter_c8(),
+        "c9": chapter_c9(),
+        "c10": chapter_c10(),
+        "c11": chapter_c11(),
+        "c12": chapter_c12(),
+        "c13": chapter_c13(),
+        "c14": chapter_c14(),
+        "c15": chapter_c15(),
+        "c16": chapter_c16(),
+        "c17": chapter_c17(),
+        "c18": chapter_c18(),
+        "c19": chapter_c19(),
+        "c20": chapter_c20(),
+        "c21": chapter_c21(),
+        "c22": chapter_c22(),
+        "c23": chapter_c23(),
+        "c24": chapter_c24(),
+        "c25": chapter_c25(),
+        "c26": chapter_c26(),
+    }
+
+
+def chapter_c1() -> str:
+    return join(
+        p(
+            f"2025–2026 年的 coding agent 市场被两条路线撕成两半：<strong>密封产品</strong>（Claude Code、Cursor、Windsurf）和<strong>可组合 harness</strong>（Pi、OpenCode、aider 变体）。我们的主线 prompt——<code>{PROMPT_ZH}</code>——在两种架构里走的路径完全不同：产品把中间层焊死在二进制里；harness 把每一站写成可测试的 TypeScript。",
+            f"The 2025–2026 coding-agent market splits into sealed products (Claude Code, Cursor, Windsurf) and composable harnesses (Pi, OpenCode, aider variants). Our through-line prompt — <code>{PROMPT_EN}</code> — takes completely different paths: products weld the middle layers into a binary; harnesses write every station as testable TypeScript.",
+        ),
+        sp([
+            ("产品思维", "Product mindset", "用户买的是<strong>体验闭环</strong>——从安装到第一次 commit 零配置", "Users buy a <strong>closed loop</strong> — zero config from install to first commit"),
+            ("Harness 思维", "Harness mindset", "开发者买的是<strong>可观测编排</strong>——每一层都有源码和测试", "Developers buy <strong>observable orchestration</strong> — every layer has source and tests"),
+            ("Pi 的赌注", "Pi's bet", "终端原生 + JSONL 会话树 + TypeScript 扩展 > IDE 锁定", "Terminal-native + JSONL session tree + TS extensions > IDE lock-in"),
+            ("代价", "The cost", "没有 MCP 协议层、没有子 agent、没有 Plan 模式——<em>故意不做</em>", "No MCP layer, no sub-agents, no plan mode — <em>intentionally omitted</em>"),
+        ]),
+        formula("架构公式", "ARCHITECTURE", [
+            '<span class="term">Product</span> = UX × Integrations × Policy',
+            '<span class="term-cu">Harness</span> = AgentLoop × Tools × Session × Extensions',
+        ], "Pi 选择右边那条等式", "Pi chooses the right-hand equation"),
+        cmp(["", "Claude Code", "Cursor", "Pi"], [
+            ["定位", "密封 CLI 产品", "密封 IDE 产品", "开源 harness"],
+            ["会话格式", "专有", "专有", "JSONL 树"],
+            ["扩展", "MCP + 插件", "VS Code 生态", "TypeScript hooks"],
+            ["可 fork", "✗", "✗", "✓ pi-mono"],
+            ["主线可读", "黑盒", "黑盒", "agent-loop.ts 逐行"],
+        ]),
+        src("sdk", "packages/coding-agent/src/core/sdk.ts", [
+            '<span class="src-comment">/** CreateAgentSessionOptions — harness entry contract */</span>',
+            '<span class="src-kw">export interface</span> <span class="src-cls">CreateAgentSessionOptions</span> {',
+            '  <span class="src-arg">cwd</span>?: <span class="src-cls">string</span>;',
+            '  <span class="src-arg">model</span>?: <span class="src-cls">Model</span>&lt;<span class="src-cls">any</span>&gt;;',
+            '  <span class="src-arg">tools</span>?: <span class="src-cls">string</span>[];',
+            '  <span class="src-arg">resourceLoader</span>?: <span class="src-cls">ResourceLoader</span>;',
+            '  <span class="src-arg">sessionManager</span>?: <span class="src-cls">SessionManager</span>;',
+            "}",
+        ]),
+        h3("为什么「最小」是特性而不是缺陷", 'Why "minimal" is a feature, not a bug'),
+        p(
+            "密封产品的复杂度藏在黑盒里：你不知道 steering 消息如何插队、compaction 的精确阈值、tool 并行策略。Pi 把这三件事写进 <code>agent-loop.ts</code> 和 <code>agent-session.ts</code>，用单元测试锁住行为。你可以 fork pi-mono 换工具、写扩展注入 lint、用 <code>--mode rpc</code> 嵌进 CI。",
+            "Sealed products hide complexity. Pi writes steering, compaction, and tool parallelism into <code>agent-loop.ts</code> and <code>agent-session.ts</code>, locked by tests. Fork pi-mono, swap tools, inject lint via extensions, embed with <code>--mode rpc</code>.",
+        ),
+        keynums([
+            ("6", "npm 包", "npm packages", "agent-core · ai · tui · coding-agent · protocol · server", "agent-core · ai · tui · coding-agent · protocol · server"),
+            ("26", "工序站", "stations", "一条用户消息穿越的完整链路", "full path of one user message"),
+            ("15", "checkpoint", "checkpoints", "pi-textbook 教学里程碑", "pi-textbook teaching milestones"),
+        ]),
+        note("Claude Code 和 Cursor 解决<strong>普通开发者</strong>的问题；Pi 解决<strong>想理解 agent 内部机制</strong>的人的问题。", "Claude Code and Cursor serve average developers; Pi serves people who want to understand agent internals.", copper=True),
+        pull("产品卖的是答案。<br>Harness 卖的是<strong>能问出下一个问题</strong>的显微镜。", "Products sell answers.<br>Harnesses sell the microscope to ask the <strong>next question</strong>."),
+        textbook_ref("00"),
+        fig("Harness vs Product 光谱：密封体验在左，可组合层在右，Pi 落在右侧但保持终端原生。", "Harness vs product spectrum: sealed UX left, composable layers right; Pi stays terminal-native."),
+    )
+
+
+def chapter_c2() -> str:
+    stations = [
+        ("01", "CLI 解析 argv", "cli.ts parses argv"),
+        ("02", "main 启动", "main.ts boot"),
+        ("03", "createAgentSession", "session factory"),
+        ("04", "ResourceLoader AGENTS.md", "context stack"),
+        ("05", "user message 入队", "prompt queued"),
+        ("06", "agent_start 事件", "agent_start event"),
+        ("07", "turn_start", "turn_start"),
+        ("08", "convertToLlm", "AgentMessage → Message[]"),
+        ("09", "streamSimple", "pi-ai stream"),
+        ("10", "text_delta", "token streaming"),
+        ("11", "toolcall_delta", "tool call assembly"),
+        ("12", "assistant stopReason=toolUse", "read tool requested"),
+        ("13", "executeTool parallel/seq", "tool dispatch"),
+        ("14", "read README.md", "filesystem I/O"),
+        ("15", "tool_result 消息", "tool result message"),
+        ("16", "第二次 streamSimple", "turn 2 model call"),
+        ("17", "最终 assistant stop", "final answer"),
+        ("18", "message_end 事件", "message_end"),
+        ("19", "SessionManager.append", "JSONL write"),
+        ("20", "TUI message_update", "diff render"),
+        ("21", "ExtensionRunner hooks", "extension events"),
+        ("22", "compaction 检查", "context check"),
+    ]
+    ladder_rows = [(z, e) for _, z, e in stations]
+    parts = [
+        p(
+            f"按下回车之后，<code>{PROMPT_ZH}</code> 不是直接发给 LLM——它要先变成 <code>AgentMessage</code>，穿过 <code>AgentSession.prompt()</code>，触发 <code>agentLoop()</code>，在 <code>runLoop</code> 的双环里转两圈 model stream，中间插一次 <code>read</code> 工具，最后才在 TUI 里滚动、在 JSONL 里落盘。",
+            f"After Enter, <code>{PROMPT_EN}</code> does not go straight to the LLM — it becomes an <code>AgentMessage</code>, passes through <code>AgentSession.prompt()</code>, triggers <code>agentLoop()</code>, spins two model streams in <code>runLoop</code>'s twin loops with a <code>read</code> tool in between, then scrolls in the TUI and lands on disk as JSONL.",
+        ),
+        h3("七个里程碑 · pi-textbook 序章", "Seven milestones · pi-textbook prologue"),
+        p("pi-textbook 用离线 <code>ScriptedModel</code> 固定了主线 prompt 的七步 trace。生产代码 <code>agent-loop.ts</code> 产生语义等价但事件更细的事件流。", "pi-textbook fixes a seven-step trace for the through-line prompt with offline <code>ScriptedModel</code>. Production <code>agent-loop.ts</code> emits semantically equivalent but finer-grained events."),
+        f'    <table class="cmp milestone-table"><thead><tr><th>#</th><th>type</th><th>owner</th><th>detail</th></tr></thead><tbody>{"".join(f"<tr><td>{s}</td><td>{t}</td><td class=\"owner-{o}\">{o}</td><td>{d}</td></tr>" for s,t,o,d in [(a,b,c,d) for a,b,c,d in [("01","user_message","user",PROMPT_ZH[:20]+"…"),("02","model_start","model","turn=1"),("03","assistant_message","model","stopReason=toolUse · call_1"),("04","tool_start","loop","read(call_1)"),("05","tool_result","tool","README fixture"),("06","model_start","model","turn=2"),("07","assistant_message","model","stopReason=stop")]])}</tbody></table>',
+        h3("22 站全景（前 22 站）", "22-station panorama (first 22)"),
+        ladder(ladder_rows),
+        event_table([
+            ("agent_start", "循环开始 · 订阅者收到首事件", "Loop begins · subscribers receive first event"),
+            ("turn_start", "新 turn · 可能含 steering 注入", "New turn · may include steering injection"),
+            ("message_start", "用户消息或 tool result 进入 transcript", "User message or tool result enters transcript"),
+            ("message_update", "流式 delta · TUI 差分渲染的燃料", "Streaming delta · fuel for TUI differential render"),
+            ("message_end", "消息定稿 · SessionManager 落盘", "Message finalized · SessionManager persists"),
+            ("tool_execution_start", "read 开始 · cwd 相对路径解析", "read begins · cwd-relative path resolution"),
+            ("tool_execution_end", "read 结束 · 结果截断策略生效", "read ends · truncation policy applied"),
+            ("turn_end", "本 turn 结束 · 检查 follow-up 队列", "Turn ends · check follow-up queue"),
+            ("agent_end", "循环退出 · 返回 newMessages[]", "Loop exits · returns newMessages[]"),
+        ]),
+        sp([
+            ("owner=user", "owner=user", "只有用户消息", "user messages only"),
+            ("owner=model", "owner=model", "model_start + assistant_message", "model_start + assistant_message"),
+            ("owner=loop", "owner=loop", "tool_start · 调度决策", "tool_start · dispatch decisions"),
+            ("owner=tool", "owner=tool", "tool_result · 环境事实", "tool_result · environment facts"),
+        ]),
+        src("prologue", "pi-textbook/workshop/src/demo/prologue.ts", [
+            '<span class="src-kw">const</span> <span class="src-arg">README_FIXTURE</span> = <span class="src-str">"# tiny-pi\\n用于学习 Agent 内核的 TypeScript 项目。"</span>;',
+            '<span class="src-comment">// 07 assistant_message stopReason=stop → 最终回答</span>',
+            '<span class="src-fn">appendTrace</span>(trace, { <span class="src-arg">owner</span>: <span class="src-str">"model"</span>, <span class="src-arg">type</span>: <span class="src-str">"assistant_message"</span>, ... });',
+        ]),
+        note("从 C02 到 C26，每一章解释<strong>两站之间的过渡</strong>。持住这条 22 站骨架，细节才不会丢。", "From C02 to C26, each chapter explains <strong>one transition between stations</strong>. Hold this 22-station skeleton and the details won't drift."),
+        pull("七个里程碑是望远镜。<br>二十六个章节是显微镜。", "Seven milestones are the telescope.<br>Twenty-six chapters are the microscope."),
+    ]
+    return join(*parts)
+
+
+def _pkg_table() -> str:
+    return cmp(["Package", "职责 / Role", "主线 touchpoint"], [
+        ["@earendil-works/pi-agent-core", "agentLoop · types · StreamFn", "C07–C13"],
+        ["@earendil-works/pi-ai", "Models · providers · EventStream", "C14–C16"],
+        ["@earendil-works/pi-tui", "Terminal · diff render · Editor", "C17–C18"],
+        ["@earendil-works/coding-agent", "CLI · AgentSession · tools", "C06–C08"],
+        ["@earendil-works/pi-protocol", "RPC JSONL 协议", "C25"],
+        ["pi-server", "远程会话 CBOR", "C25"],
+    ])
+
+
+def chapter_c3() -> str:
+    return join(
+        p("pi-mono 是 Mario Zechner（Badlogic Games，libGDX 作者）在 earendil-works 组织下的 monorepo。它不是「又一个 ChatGPT 套壳」——而是一套可 fork 的 agent harness，npm 发布六个包。", "pi-mono is Mario Zechner's (Badlogic Games, libGDX author) monorepo under earendil-works. Not another ChatGPT wrapper — a forkable agent harness published as six npm packages."),
+        h3("仓库拓扑", "Repository topology"),
+        src("root", "pi-mono/package.json · workspaces", [
+            '<span class="src-str">"workspaces"</span>: [',
+            '  <span class="src-str">"packages/agent"</span>,',
+            '  <span class="src-str">"packages/ai"</span>,',
+            '  <span class="src-str">"packages/tui"</span>,',
+            '  <span class="src-str">"packages/coding-agent"</span>,',
+            '  <span class="src-str">"packages/protocol"</span>,',
+            "]",
+        ]),
+        _pkg_table(),
+        h3("与 pi-textbook 的关系", "Relationship to pi-textbook"),
+        p("pi-textbook 把生产代码<strong>降维</strong>成 15 个 checkpoint 的可运行 workshop。每个 checkpoint 对应 pi-mono 里一个真实目录，但剥离了 OAuth、40+ provider、TUI 差分渲染等生产复杂度。", "pi-textbook <strong>reduces</strong> production code into 15 runnable workshop checkpoints. Each maps to a real pi-mono directory, stripped of OAuth, 40+ providers, TUI diff rendering, etc."),
+        cmp(["Checkpoint", "教学焦点", "生产文件"], [[r[0], r[2], PRODUCTION_MAP.get(r[0], "—")] for r in TEXTBOOK_CHECKPOINTS[:8]]),
+        keynums([("2015", "libGDX", "libGDX era", "Mario 的游戏引擎背景影响 TUI 性能偏执", "Mario's game-engine background shapes TUI perf obsession"), ("40+", "providers", "providers", "pi-ai 支持的模型提供商数量", "model providers supported by pi-ai"), ("v3", "session", "session version", "JSONL CURRENT_SESSION_VERSION", "JSONL CURRENT_SESSION_VERSION")]),
+        note("读 pi-mono 时建议开两个窗口：生产仓库 + pi-textbook 对应 checkpoint 的 workshop 测试。", "When reading pi-mono, keep two windows: production repo + pi-textbook workshop test for the matching checkpoint."),
+        fig("pi-mono 六包依赖图：coding-agent 在顶层组装，agent-core 是心脏，pi-ai 是 LLM 边界。", "pi-mono six-package dependency graph: coding-agent composes at top, agent-core is the heart, pi-ai is the LLM boundary."),
+    )
+
+
+def chapter_c4() -> str:
+    layers = [
+        ("L6", "coding-agent", "CLI · AgentSession · tools · extensions", "用户看见的「pi」命令"),
+        ("L5", "agent-core", "agentLoop · AgentMessage · events", "编排心脏"),
+        ("L4", "pi-ai", "Models · streamSimple · providers", "LLM 边界"),
+        ("L3", "pi-tui", "TUI · Editor · Markdown · diff", "终端 UI"),
+        ("L2", "protocol", "JSONL RPC 帧", "进程间协议"),
+        ("L1", "server", "远程会话", "CBOR over HTTP"),
+    ]
+    ladder_html = ladder([(f"{a} · {b}", f"{a} · {b} — {c}") for a, b, c, _ in layers])
+    return join(
+        p(f"主线 prompt <code>{PROMPT_ZH}</code> 从 L6 进入，在 L5 循环，L4 调模型，L3 渲染，L2/L1 只在 RPC 模式参与。", f"Through-line prompt enters at L6, loops in L5, calls model at L4, renders at L3; L2/L1 only in RPC mode."),
+        h3("六层蛋糕", "Six-layer cake"),
+        ladder_html,
+        formula("依赖方向", "DEPENDENCY", ['<span class="term">coding-agent</span> → agent-core → pi-ai', '<span class="term-cu">pi-tui</span> ← coding-agent (UI only)'], "上层组装下层，不反向依赖", "Upper layers compose lower; no reverse deps"),
+        src("agent", "packages/agent/package.json", ['<span class="src-str">"name"</span>: <span class="src-str">"@earendil-works/pi-agent-core"</span>,', '<span class="src-str">"exports"</span>: { <span class="src-str">"."</span>: <span class="src-str">"./src/index.ts"</span> }']),
+        src("ai", "packages/ai/package.json", ['<span class="src-str">"name"</span>: <span class="src-str">"@earendil-works/pi-ai"</span>,']),
+        h3("边界纪律", "Boundary discipline"),
+        p("<code>AgentMessage</code> 在整个 agent-core 内流通；只在 <code>streamAssistantResponse</code> 调用点通过 <code>convertToLlm</code> 变成 pi-ai 的 <code>Message[]</code>。这条边界是 pi-textbook checkpoint 03 的核心教训。", "<code>AgentMessage</code> flows through agent-core; only at <code>streamAssistantResponse</code> does <code>convertToLlm</code> produce pi-ai <code>Message[]</code>. Core lesson of textbook checkpoint 03."),
+        cmp(["层", "可替换?", "例子"], [["agent-core", "✓ fork", "自定义 runLoop"], ["pi-ai", "✓", "换 provider adapter"], ["coding-agent tools", "✓", "registerTool"], ["JSONL format", "△", "version 字段演进"]]),
+        textbook_ref("03"),
+        textbook_ref("13"),
+    )
+
+
+def chapter_c5() -> str:
+    return join(
+        p("Pi 的 README 明确列出<strong>故意不做</strong>的功能：No MCP · No sub-agents · No plan mode。这不是遗漏——是 harness 哲学的边界声明。", "Pi's README explicitly lists <strong>intentionally omitted</strong> features: No MCP · No sub-agents · No plan mode. Not oversights — boundary statements of harness philosophy."),
+        cmp(["功能", "Claude Code", "Pi", "替代路径"], [
+            ["MCP", "一等协议", "✗", "TypeScript Extension API"],
+            ["Sub-agents", "内置", "✗", "fork session + RPC"],
+            ["Plan mode", "专用 UI", "✗", "thinking level + 用户消息"],
+            ["IDE 集成", "原生", "终端 only", "外部编辑器"],
+            ["权限弹窗", "GUI", "终端确认", "tool 级别 policy"],
+        ]),
+        h3("为什么 No MCP", "Why no MCP"),
+        p("MCP 把工具发现协议化，但 Pi 选择 <code>registerTool</code> + npm/git 扩展包——类型安全、可测试、与 agent loop 同进程。代价是生态不互通 Claude Desktop 的 MCP 市场。", "MCP protocolizes tool discovery; Pi chooses <code>registerTool</code> + npm/git extension packages — type-safe, testable, same process as agent loop. Cost: no interchange with Claude Desktop's MCP marketplace."),
+        h3("为什么 No sub-agents", "Why no sub-agents"),
+        p("子 agent 本质是嵌套 agentLoop + 独立 context。Pi 用 <strong>session fork</strong>（JSONL parentSession）+ <strong>RPC 模式</strong> 达到类似效果，但不隐藏嵌套层。", "Sub-agents are nested agentLoop + isolated context. Pi achieves similar via <strong>session fork</strong> (JSONL parentSession) + <strong>RPC mode</strong> without hiding the nesting."),
+        note("「故意不做」= 把复杂度推给扩展作者，而不是推给终端用户。", "«Intentionally omitted» = push complexity to extension authors, not terminal users.", copper=True),
+        pull("少即是多：<br>每一层省略的功能，都是一层可观测性。", "Less is more:<br>every omitted feature is a layer of observability gained."),
+    )
+
+
+def chapter_c6() -> str:
+    return join(
+        p("你在 shell 里输入 <code>pi</code> 或 <code>npx @earendil-works/coding-agent</code>，启动链从 <code>cli.ts</code> 解析 argv，到 <code>main.ts</code> 选择 interactive/print/rpc 模式，最终调用 <code>createAgentSession()</code>。", "You type <code>pi</code> or <code>npx @earendil-works/coding-agent</code>; boot chain parses argv in <code>cli.ts</code>, <code>main.ts</code> picks interactive/print/rpc mode, then <code>createAgentSession()</code>."),
+        ladder([
+            ("cli.ts", "argv · --model · --mode rpc"),
+            ("main.ts", "mode dispatch · theme · keybindings"),
+            ("createAgentSession", "AgentSession + ExtensionRunner"),
+            ("interactive mode", "TUI loop · Editor"),
+        ]),
+        src("cli", "packages/coding-agent/src/cli.ts", [
+            '<span class="src-kw">import</span> { <span class="src-fn">main</span> } <span class="src-kw">from</span> <span class="src-str">"./main.ts"</span>;',
+            '<span class="src-fn">main</span>(process.argv.slice(<span class="src-num">2</span>)).catch(...);',
+        ]),
+        src("main", "packages/coding-agent/src/main.ts", [
+            '<span class="src-kw">export async function</span> <span class="src-fn">main</span>(<span class="src-arg">args</span>: <span class="src-cls">string</span>[]) {',
+            '  <span class="src-kw">const</span> mode = <span class="src-fn">parseMode</span>(args); <span class="src-comment">// interactive | print | rpc</span>',
+            '  <span class="src-kw">const</span> session = <span class="src-kw">await</span> <span class="src-fn">createAgentSession</span>({ cwd, model, ... });',
+            "}",
+        ]),
+        sp([
+            ("--verbose", "--verbose", "打印 AgentEvent 到 stderr", "log AgentEvents to stderr"),
+            ("--mode rpc", "--mode rpc", "JSONL  stdin/stdout 协议", "JSONL stdin/stdout protocol"),
+            ("--continue", "--continue", "加载 leafId 会话", "load leafId session"),
+        ]),
+        h3("Case study：第一次启动", "Case study: first boot"),
+        p("冷启动时 <code>ModelRegistry</code> 读取 <code>models.generated.ts</code>，<code>ResourceLoader</code> 扫描 AGENTS.md 栈，<code>SessionManager</code> 创建新 JSONL 文件。用户尚未输入主线 prompt，但 harness 已就绪。", "On cold boot <code>ModelRegistry</code> reads <code>models.generated.ts</code>, <code>ResourceLoader</code> scans AGENTS.md stack, <code>SessionManager</code> creates new JSONL. User hasn't typed the through-line prompt yet, but harness is ready."),
+        textbook_ref("13"),
+    )
+
+
+def chapter_c7() -> str:
+    return join(
+        p("<code>AgentSession</code> 是 Pi 的<strong>唯一中枢调度器</strong>——所有模式（interactive、print、rpc）共享它。主线 prompt 通过 <code>prompt()</code> 进入，内部调用 <code>agentLoop()</code> 并订阅事件写 JSONL。", "<code>AgentSession</code> is Pi's <strong>single orchestration hub</strong> — all modes share it. Through-line prompt enters via <code>prompt()</code>, internally calls <code>agentLoop()</code> and subscribes to events for JSONL persistence."),
+        src("session", "packages/coding-agent/src/core/agent-session.ts", [
+            '<span class="src-comment">/** AgentSession - Core abstraction for agent lifecycle */</span>',
+            '<span class="src-kw">export class</span> <span class="src-cls">AgentSession</span> {',
+            '  <span class="src-kw">async</span> <span class="src-fn">prompt</span>(<span class="src-arg">text</span>: <span class="src-cls">string</span>): <span class="src-cls">Promise</span>&lt;<span class="src-cls">void</span>&gt; { ... }',
+            '  <span class="src-kw">private async</span> <span class="src-fn">runLoop</span>(...): <span class="src-cls">Promise</span>&lt;<span class="src-cls">void</span>&gt; { ... }',
+            "}",
+        ]),
+        event_table([
+            ("session_start", "会话加载/创建 · 扩展收到 session_start", "Session load/create · extensions get session_start"),
+            ("turn_start", "用户 prompt 触发新 turn", "User prompt triggers new turn"),
+            ("message_update", "流式内容 · TUI 订阅", "Streaming content · TUI subscribes"),
+            ("turn_end", "turn 完成 · 检查 auto-compact", "Turn complete · check auto-compact"),
+        ]),
+        h3("AgentSession 职责矩阵", "AgentSession responsibility matrix"),
+        cmp(["职责", "类/模块", "主线时刻"], [
+            ["编排 agentLoop", "agent-session.ts", "prompt() 调用时"],
+            ["持久化", "SessionManager", "每个 message_end"],
+            ["扩展", "ExtensionRunner", "全程 hook"],
+            ["压缩", "compaction/", "token 超阈值"],
+            ["模型切换", "ModelRegistry", "model_change entry"],
+        ]),
+        h3("与 agent-core 的分工", "Split with agent-core"),
+        p("<code>AgentSession</code> 拥有 I/O 和持久化；<code>agentLoop</code> 是纯函数式循环，不知道 JSONL 和 TUI 的存在。测试 agent loop 不需要启动终端。", "<code>AgentSession</code> owns I/O and persistence; <code>agentLoop</code> is a pure loop unaware of JSONL and TUI. Testing agent loop needs no terminal."),
+        textbook_ref("07"),
+        textbook_ref("09"),
+        note("pi-textbook checkpoint 09 Stateful Agent 讲 steer/follow-up/abort——生产代码在 AgentSession + agent-loop 的 getSteeringMessages / queueFollowUp。", "Textbook checkpoint 09 covers steer/follow-up/abort — production code in AgentSession + agent-loop getSteeringMessages / queueFollowUp."),
+    )
+
+
+def chapter_c8() -> str:
+    return join(
+        p("在主线 prompt 到达模型之前，<code>ResourceLoader</code> 把从 <code>~/.pi/AGENTS.md</code> 到项目根目录的指令文件<strong>叠加</strong>进 system context。每一层目录的 AGENTS.md 追加规则。", "Before the through-line prompt reaches the model, <code>ResourceLoader</code> <strong>stacks</strong> instruction files from <code>~/.pi/AGENTS.md</code> to project root into system context."),
+        ladder([
+            ("~/.pi/AGENTS.md", "全局 harness 指令"),
+            ("~/.pi/PROJECT.md", "用户级项目偏好"),
+            ("./AGENTS.md", "仓库级规则"),
+            ("./subdir/AGENTS.md", "子目录覆盖（若存在）"),
+        ]),
+        src("loader", "packages/coding-agent/src/core/resource-loader.ts", [
+            '<span class="src-kw">export class</span> <span class="src-cls">ResourceLoader</span> {',
+            '  <span class="src-fn">loadResources</span>(<span class="src-arg">cwd</span>): <span class="src-cls">ResourceBundle</span> { ... }',
+            '  <span class="src-comment">// merges AGENTS.md chain into system prompt</span>',
+            "}",
+        ]),
+        sp([
+            ("叠加顺序", "Stack order", "从全局到局部，后加载的优先级更高", "global → local, later wins"),
+            ("frontmatter", "frontmatter", "YAML 头可指定 tool 白名单", "YAML header can whitelist tools"),
+            ("刷新", "Refresh", "文件变更可触发 reload（扩展 hook）", "file change can trigger reload via extension hook"),
+        ]),
+        h3("主线 prompt 时的 context 长什么样", "What context looks like at through-line prompt"),
+        p("模型看到的不是裸的「读取 README」——而是 <code>system: [AGENTS.md 栈] + user: 读取 README.md…</code>。工具 schema 也在 system 或 tools 参数里。", "Model sees not bare «read README» but <code>system: [AGENTS.md stack] + user: read README.md…</code>. Tool schemas live in system or tools param."),
+        textbook_ref("12"),
+    )
+
+
+def chapter_c9() -> str:
+    return join(
+        p("Pi 维护<strong>两层消息模型</strong>：<code>AgentMessage</code>（agent-core 内部，可含自定义 role）和 <code>Message</code>（pi-ai LLM API，严格 user/assistant/tool）。<code>convertToLlm</code> 是唯一转换点。", "Pi maintains <strong>two message layers</strong>: <code>AgentMessage</code> (agent-core, custom roles) and <code>Message</code> (pi-ai LLM API, strict user/assistant/tool). <code>convertToLlm</code> is the sole conversion point."),
+        cmp(["层", "类型", "谁能看", "例子"], [
+            ["Transcript", "AgentMessage[]", "agent loop · JSONL", "user · assistant · toolResult · custom"],
+            ["LLM API", "Message[]", "pi-ai providers", "user · assistant · tool_result"],
+            ["TUI", "RenderedMessage", "终端组件", "Markdown · tool 卡片"],
+        ]),
+        src("types", "packages/agent/src/types.ts", [
+            '<span class="src-kw">export type</span> <span class="src-cls">AgentMessage</span> =',
+            '  | <span class="src-cls">UserMessage</span> | <span class="src-cls">AssistantMessage</span>',
+            '  | <span class="src-cls">ToolResultMessage</span> | <span class="src-cls">CustomMessage</span>;',
+        ]),
+        src("convert", "packages/coding-agent/src/core/messages.ts", [
+            '<span class="src-kw">export function</span> <span class="src-fn">convertToLlm</span>(<span class="src-arg">messages</span>: <span class="src-cls">AgentMessage</span>[]): <span class="src-cls">Message</span>[]',
+        ]),
+        h3("三层 canonical transcript", "Three-layer canonical transcript"),
+        p("pi-textbook checkpoint 03 强调：transcript 是<strong>唯一真相源</strong>；LLM 请求是投影；TUI 是另一个投影。fork 会话时只复制 AgentMessage 链。", "Textbook checkpoint 03: transcript is the <strong>single source of truth</strong>; LLM request is a projection; TUI is another. Session fork copies AgentMessage chain only."),
+        formula("投影", "PROJECTION", [
+            '<span class="term">AgentMessage[]</span> — canonical',
+            '<span class="term-cu">convertToLlm()</span> → Message[]',
+            '<span class="term">renderMessage()</span> → TUI cells',
+        ], "主线 prompt 在三层各出现一次", "Through-line prompt appears once per layer"),
+        textbook_ref("03"),
+    )
+
+
+def chapter_c10() -> str:
+    return join(
+        p("<code>runLoop</code> 是 agent 的心脏：<strong>外环</strong>处理 follow-up 队列（用户在你以为结束时又发了一条），<strong>内环</strong>处理 tool batch 和 steering 注入。", "<code>runLoop</code> is the agent heart: <strong>outer loop</strong> handles follow-up queue; <strong>inner loop</strong> handles tool batch and steering injection."),
+        src("loop", "packages/agent/src/agent-loop.ts", [
+            '<span class="src-comment">// Outer loop: continues when queued follow-up messages arrive</span>',
+            '<span class="src-kw">while</span> (<span class="src-num">true</span>) {',
+            '  <span class="src-comment">// Inner loop: process tool calls and steering</span>',
+            '  <span class="src-kw">while</span> (hasMoreToolCalls || pendingMessages.length > 0) {',
+            '    <span class="src-kw">const</span> message = <span class="src-kw">await</span> <span class="src-fn">streamAssistantResponse</span>(...);',
+            "  }",
+            "}",
+        ]),
+        h3("主线 prompt 的两圈 model stream", "Two model streams for through-line prompt"),
+        ladder([
+            ("Turn 1", "user → assistant(toolUse: read)"),
+            ("Tool batch", "executeTool(read) → toolResult"),
+            ("Turn 2", "context+result → assistant(stop)"),
+        ]),
+        sp([
+            ("外环退出条件", "Outer exit", "无 follow-up 且内环完成", "no follow-up and inner loop done"),
+            ("内环继续条件", "Inner continue", "stopReason=toolUse 或 pending steering", "stopReason=toolUse or pending steering"),
+            ("streamFn 注入", "streamFn inject", "测试用 ScriptedModel 替换", "ScriptedModel for tests"),
+        ]),
+        event_table([
+            ("turn_start", "每圈 model 前", "before each model round"),
+            ("message_update", "text_delta / toolcall_delta", "streaming deltas"),
+            ("turn_end", "assistant 定稿后", "after assistant finalized"),
+        ]),
+        textbook_ref("07"),
+        pull("外环是耐心。<br>内环是纪律。", "Outer loop is patience.<br>Inner loop is discipline."),
+    )
+
+
+def chapter_c11() -> str:
+    return join(
+        p("<strong>Steering</strong>：运行中用户插入新消息（内环下一轮前注入）。<strong>Follow-up</strong>：agent 即将停止时队列里的后续消息（外环重启）。", "<strong>Steering</strong>: user inserts mid-run (injected before next inner round). <strong>Follow-up</strong>: queued messages when agent would stop (outer loop restarts)."),
+        src("steer", "packages/agent/src/agent-loop.ts", [
+            '<span class="src-kw">let</span> pendingMessages = (<span class="src-kw">await</span> config.<span class="src-fn">getSteeringMessages</span>?.()) || [];',
+            '<span class="src-kw">if</span> (pendingMessages.length > 0) {',
+            '  <span class="src-kw">for</span> (<span class="src-kw">const</span> message <span class="src-kw">of</span> pendingMessages) { ... }',
+            "}",
+        ]),
+        cmp(["机制", "触发时机", "典型场景"], [
+            ["Steering", "内环每轮前", "「别读 README 了，先 ls」"],
+            ["Follow-up", "外环 would-stop", "批量任务第二条命令"],
+            ["Abort", "AbortSignal", "Ctrl+C · 扩展取消"],
+        ]),
+        h3("Case study：read 中途改主意", "Case study: change mind mid-read"),
+        p("用户发出主线 prompt 后，模型开始 toolUse read；用户在 TUI 里输入 steering「先列出目录」。内环在 executeTool 前收到 pendingMessages，注入 user 消息，可能改变 tool 选择。", "After through-line prompt, model starts toolUse read; user steers «list directory first». Inner loop receives pendingMessages before executeTool, may change tool choice."),
+        textbook_ref("09"),
+    )
+
+
+def chapter_c12() -> str:
+    return join(
+        p("模型返回 toolUse 后，<code>executeTools</code> 按 <code>parallel</code> 或 <code>sequential</code> 策略调度。read/write/edit/bash 各有 executor；结果超长时 <code>truncateToolResult</code> 截断。", "After model returns toolUse, <code>executeTools</code> dispatches per <code>parallel</code> or <code>sequential</code> policy. read/write/edit/bash have executors; oversized results hit <code>truncateToolResult</code>."),
+        src("tools", "packages/coding-agent/src/core/tools/index.ts", [
+            '<span class="src-kw">export const</span> <span class="src-arg">CODING_TOOLS</span> = [readTool, writeTool, editTool, bashTool, ...];',
+        ]),
+        src("exec", "packages/agent/src/agent-loop.ts", [
+            '<span class="src-kw">async function</span> <span class="src-fn">executeToolCalls</span>(...)',
+            '  <span class="src-comment">// validateToolArguments → execute → normalize images</span>',
+        ]),
+        cmp(["Tool", "并行安全?", "主线用例"], [
+            ["read", "✓", "README.md"],
+            ["bash", "△", "需确认"],
+            ["write/edit", "✗ sequential", "—"],
+        ]),
+        h3("read README 的完整路径", "Full path of read README"),
+        ladder([
+            ("validateToolArguments", '{ "path": "README.md" }'),
+            ("resolvePath(cwd)", "绝对路径"),
+            ("readFileSync", "UTF-8 内容"),
+            ("truncate if needed", "默认 max length"),
+            ("toolResult AgentMessage", "toolCallId=call_1"),
+        ]),
+        textbook_ref("06"),
+        textbook_ref("08"),
+    )
+
+
+def chapter_c13() -> str:
+    events = [
+        "agent_start", "turn_start", "message_start", "message_update", "message_end",
+        "tool_execution_start", "tool_execution_update", "tool_execution_end",
+        "turn_end", "agent_end",
+    ]
+    rows = [[e, "AgentSession 订阅者", "TUI / JSONL / Extension"] for e in events]
+    return join(
+        p("agent-core 通过 <code>AgentEvent</code> tagged union 广播状态变化。<code>message_update</code> 携带 <code>text_delta</code> 或 <code>toolcall_delta</code>——TUI 差分渲染的唯一输入。", "agent-core broadcasts state via <code>AgentEvent</code> tagged union. <code>message_update</code> carries <code>text_delta</code> or <code>toolcall_delta</code> — sole input for TUI differential render."),
+        cmp(["事件", "订阅者", "副作用"], rows),
+        src("events", "packages/agent/src/types.ts", [
+            '<span class="src-kw">export type</span> <span class="src-cls">AgentEvent</span> =',
+            '  | { <span class="src-arg">type</span>: <span class="src-str">"message_update"</span>; <span class="src-arg">message</span>: ...; <span class="src-arg">delta</span>: ... }',
+            '  | { <span class="src-arg">type</span>: <span class="src-str">"tool_execution_start"</span>; ... };',
+        ]),
+        h3("主线一轮的事件顺序", "Event order for one through-line turn"),
+        p("简化版：agent_start → turn_start → message_start(user) → message_end(user) → message_update×N → message_end(assistant) → tool_execution_* → message_update×M → message_end(assistant) → turn_end → agent_end。", "Simplified: agent_start → turn_start → message_start(user) → … → agent_end."),
+        textbook_ref("01"),
+        textbook_ref("02"),
+    )
+
+
+def chapter_c14() -> str:
+    return join(
+        p("<code>pi-ai</code> 抽象 40+ provider：<code>Models</code> 目录 · <code>createProvider</code> 工厂 · <code>streamSimple</code> 统一流式入口。agent-loop 只依赖 <code>StreamFn</code> 签名。", "<code>pi-ai</code> abstracts 40+ providers: <code>Models</code> catalog · <code>createProvider</code> factory · <code>streamSimple</code> unified streaming entry. agent-loop depends only on <code>StreamFn</code> signature."),
+        src("stream", "packages/ai/src/stream.ts", [
+            '<span class="src-kw">export async function</span> <span class="src-fn">streamSimple</span>(<span class="src-arg">model</span>, <span class="src-arg">context</span>, <span class="src-arg">options</span>)',
+        ]),
+        src("models", "packages/ai/src/models.ts", [
+            '<span class="src-kw">export const</span> <span class="src-arg">Models</span> = { ... }; <span class="src-comment">// models.generated.ts</span>',
+        ]),
+        cmp(["Provider 族", "认证", "流式协议"], [
+            ["OpenAI-compatible", "API key", "SSE"],
+            ["Anthropic", "API key", "SSE events"],
+            ["OAuth (Kimi etc.)", "OAuth token", "provider-specific"],
+        ]),
+        textbook_ref("05"),
+    )
+
+
+def chapter_c15() -> str:
+    return join(
+        p("<code>EventStream&lt;T&gt;</code> 同时交付<strong>过程项</strong>（delta）和<strong>终态</strong>（done）。TUI 订阅过程项；agent-loop 等待终态 AssistantMessage。", "<code>EventStream&lt;T&gt;</code> delivers both <strong>progress items</strong> (deltas) and <strong>terminal state</strong> (done). TUI subscribes to progress; agent-loop awaits terminal AssistantMessage."),
+        src("es", "packages/ai/src/utils/event-stream.ts", [
+            '<span class="src-kw">export class</span> <span class="src-cls">EventStream</span>&lt;TEvent, TResult&gt; {',
+            '  <span class="src-fn">push</span>(event: TEvent): <span class="src-cls">void</span>;',
+            '  <span class="src-fn">end</span>(result: TResult): <span class="src-cls">void</span>;',
+            "}",
+        ]),
+        cmp(["事件", "消费者", "主线时刻"], [
+            ["text_delta", "TUI Markdown", "最终回答流式显示"],
+            ["toolcall_delta", "TUI tool 卡片", "read 参数组装"],
+            ["done", "agent-loop", "stopReason 判定"],
+        ]),
+        textbook_ref("02"),
+    )
+
+
+def chapter_c16() -> str:
+    return join(
+        p("<code>models.generated.ts</code> 由脚本从模型目录生成；OAuth 流程把 token 存 agent dir。无 key 时 <code>formatNoApiKeyFoundMessage</code> 给可操作的引导。", "<code>models.generated.ts</code> is script-generated from model catalog; OAuth stores tokens in agent dir. Without keys, <code>formatNoApiKeyFoundMessage</code> gives actionable guidance."),
+        src("auth", "packages/coding-agent/src/core/auth-guidance.ts", [
+            '<span class="src-kw">export function</span> <span class="src-fn">formatNoApiKeyFoundMessage</span>(...)',
+        ]),
+        sp([
+            ("ModelRegistry", "ModelRegistry", "解析 model id → Model 对象", "resolve model id → Model object"),
+            ("thinking level", "thinking level", "clamped per model capability", "clamped per model capability"),
+            ("retry", "retry", "isRetryableAssistantError + backoff", "isRetryableAssistantError + backoff"),
+        ]),
+    )
+
+
+def chapter_c17() -> str:
+    return join(
+        p("Pi TUI 用 <strong>CSI 2026</strong> 差分更新：<code>firstChanged</code> 到 <code>lastChanged</code> 行重绘，而非全屏刷新。流式 token 因此不闪烁。", "Pi TUI uses <strong>CSI 2026</strong> differential updates: redraw <code>firstChanged</code> to <code>lastChanged</code> lines, not full screen. Streaming tokens don't flicker."),
+        src("tui", "packages/tui/src/tui.ts", [
+            '<span class="src-comment">// SGR 2026 — synchronized output / damage tracking</span>',
+            '<span class="src-fn">render</span>(<span class="src-arg">firstChanged</span>, <span class="src-arg">lastChanged</span>): <span class="src-cls">void</span>',
+        ]),
+        cmp(["策略", "全屏刷新", "差分渲染"], [
+            ["带宽", "O(screen)", "O(changed lines)"],
+            ["闪烁", "明显", "minimal"],
+            ["实现复杂度", "低", "需 damage tracking"],
+        ]),
+        h3("message_update → 像素", "message_update → pixels"),
+        p("AgentSession 把 message_update 交给 interactive mode → TUI 组件树 → Markdown 增量解析 → 终端 write。", "AgentSession hands message_update to interactive mode → TUI component tree → incremental Markdown → terminal write."),
+    )
+
+
+def chapter_c18() -> str:
+    return join(
+        p("Interactive mode 组合 <code>Editor</code>（输入）、<code>Markdown</code>（输出）、<code>tool renderers</code>（read 结果预览）。主线 prompt 在 Editor 提交，最终结果在 Markdown 区滚动。", "Interactive mode composes <code>Editor</code> (input), <code>Markdown</code> (output), <code>tool renderers</code> (read preview). Through-line prompt submits from Editor; final answer scrolls in Markdown area."),
+        src("editor", "packages/tui/src/components/editor.ts", [
+            '<span class="src-kw">export class</span> <span class="src-cls">Editor</span> <span class="src-kw">extends</span> <span class="src-cls">Component</span> { ... }',
+        ]),
+        sp([
+            ("Alt-screen", "Alt-screen", "全屏 TUI 不污染 scrollback", "fullscreen TUI preserves scrollback"),
+            ("keybindings", "keybindings", "可配置 · 与 readline 不同", "configurable · unlike readline"),
+            ("tool 卡片", "tool cards", "read 显示路径+行数", "read shows path + line count"),
+        ]),
+    )
+
+
+def chapter_c19() -> str:
+    return join(
+        p("扩展通过 <code>registerTool</code> · <code>registerCommand</code> · 事件 hook 注入能力——无需 MCP，同进程 TypeScript。", "Extensions inject via <code>registerTool</code> · <code>registerCommand</code> · event hooks — no MCP, same-process TypeScript."),
+        src("ext", "packages/coding-agent/src/core/extensions/types.ts", [
+            '<span class="src-kw">export interface</span> <span class="src-cls">ExtensionAPI</span> {',
+            '  <span class="src-fn">registerTool</span>(def: <span class="src-cls">ToolDefinition</span>): <span class="src-cls">void</span>;',
+            '  <span class="src-fn">on</span>(<span class="src-arg">event</span>, <span class="src-arg">handler</span>): <span class="src-cls">void</span>;',
+            "}",
+        ]),
+        cmp(["Hook", "时机", "用例"], [
+            ["session_start", "会话加载", "恢复扩展状态"],
+            ["before_compact", "压缩前", "保留 artifact 索引"],
+            ["tool_execution_end", "工具后", "自动 lint"],
+        ]),
+        textbook_ref("12"),
+    )
+
+
+def chapter_c20() -> str:
+    return join(
+        p("<code>ExtensionRunner</code> 用 <code>jiti</code> 动态加载扩展 TS，合并事件处理器，在 agent 生命周期关键点注入 hook。", "<code>ExtensionRunner</code> uses <code>jiti</code> to load extension TS, merges event handlers, injects hooks at agent lifecycle points."),
+        src("runner", "packages/coding-agent/src/core/extensions/runner.ts", [
+            '<span class="src-kw">export class</span> <span class="src-cls">ExtensionRunner</span> {',
+            '  <span class="src-kw">async</span> <span class="src-fn">loadExtensions</span>(paths: <span class="src-cls">string</span>[]): <span class="src-cls">Promise</span>&lt;<span class="src-cls">void</span>&gt;',
+            "}",
+        ]),
+        h3("事件合并语义", "Event merge semantics"),
+        p("多个扩展可订阅同一事件；Runner 按加载顺序调用；<code>before_compact</code> 可返回修改后的 summary。", "Multiple extensions can subscribe; Runner calls in load order; <code>before_compact</code> can return modified summary."),
+        textbook_ref("13"),
+    )
+
+
+def chapter_c21() -> str:
+    return join(
+        p("<code>pi package</code> 命令管理可分享的 harness 能力包——npm 或 git 依赖，把工具+扩展+资源打包分发。", "<code>pi package</code> manages shareable harness capability bundles — npm or git deps packaging tools+extensions+resources."),
+        cmp(["分发", "格式", "消费者"], [
+            ["npm", "package.json + pi manifest", "pi install"],
+            ["git", "repo URL + ref", "pi package add"],
+            ["local", "path", "开发调试"],
+        ]),
+        note("扩展生态替代 MCP 市场——类型安全，但门槛是写 TypeScript。", "Extension ecosystem replaces MCP marketplace — type-safe, but requires writing TypeScript."),
+    )
+
+
+def chapter_c22() -> str:
+    return join(
+        p("每个会话是 JSONL 文件：<code>parentId</code> 链构成树，<code>leafId</code> 指向当前叶节点，<code>fork</code> 创建 <code>parentSession</code> 子会话。", "Each session is a JSONL file: <code>parentId</code> chain forms tree, <code>leafId</code> points to current leaf, <code>fork</code> creates child with <code>parentSession</code>."),
+        session_tree_diagram(),
+        src("sm", "packages/coding-agent/src/core/session-manager.ts", [
+            '<span class="src-kw">export const</span> <span class="src-arg">CURRENT_SESSION_VERSION</span> = <span class="src-num">3</span>;',
+            '<span class="src-kw">export interface</span> <span class="src-cls">SessionMessageEntry</span> {',
+            '  <span class="src-arg">type</span>: <span class="src-str">"message"</span>; <span class="src-arg">parentId</span>: <span class="src-cls">string</span> | <span class="src-kw">null</span>;',
+            "}",
+        ]),
+        h3("主线 prompt 落盘后的 JSONL 行", "JSONL lines after through-line prompt"),
+        src("jsonl", "~/.pi/sessions/*.jsonl", [
+            '{"type":"session","id":"...","cwd":"/path/to/project"}',
+            '{"type":"message","parentId":null,"message":{"role":"user","content":"读取 README.md..."}}',
+            '{"type":"message","parentId":"...","message":{"role":"assistant","stopReason":"toolUse",...}}',
+        ]),
+        cmp(["Entry type", "用途", "LLM 可见?"], [
+            ["message", "user/assistant/tool", "✓"],
+            ["compaction", "压缩摘要", "✓（替换早期）"],
+            ["branch_summary", "fork 摘要", "△"],
+            ["model_change", "审计", "✗"],
+        ]),
+        textbook_ref("10"),
+    )
+
+
+def chapter_c23() -> str:
+    return join(
+        p("<strong>Compaction</strong>：上下文超阈值时，历史消息<strong>不动</strong>（JSONL 完整保留），但<strong>重建</strong>发给模型的 context——用 LLM 生成摘要替换早期消息。", "<strong>Compaction</strong>: when context exceeds threshold, history <strong>stays</strong> in JSONL but <strong>rebuilt</strong> context for model — LLM summary replaces early messages."),
+        src("compact", "packages/coding-agent/src/core/compaction/index.ts", [
+            '<span class="src-kw">export async function</span> <span class="src-fn">compact</span>(...): <span class="src-cls">Promise</span>&lt;<span class="src-cls">CompactionResult</span>&gt;',
+            '<span class="src-kw">export function</span> <span class="src-fn">shouldCompact</span>(tokens: <span class="src-cls">number</span>): <span class="src-cls">boolean</span>',
+        ]),
+        sp([
+            ("历史", "History", "JSONL 永不删", "JSONL never deleted"),
+            ("上下文", "Context", "压缩后变短", "shorter after compact"),
+            ("SQLite lanes", "SQLite lanes", "扩展可存 artifact 索引", "extensions store artifact index"),
+        ]),
+        h3(".harness 与 compaction 分工", "Harness vs compaction roles"),
+        p("agent-loop 不管 token 数；AgentSession 在 turn_end 检查 shouldCompact；扩展可在 before_compact 注入结构化摘要。", "agent-loop ignores token count; AgentSession checks shouldCompact at turn_end; extensions inject structured summary in before_compact."),
+        textbook_ref("11"),
+    )
+
+
+def chapter_c24() -> str:
+    return join(
+        p("对比三条路线：Claude Code（密封 CLI + MCP）、Cursor（密封 IDE + 全生态）、Pi（开源 harness + 终端 + JSONL）。", "Three routes: Claude Code (sealed CLI + MCP), Cursor (sealed IDE + ecosystem), Pi (open harness + terminal + JSONL)."),
+        cmp(["维度", "Claude Code", "Cursor", "Pi"], [
+            ["目标用户", "开箱即用", "IDE 用户", "想读源码的人"],
+            ["会话", "专有云", "专有", "本地 JSONL 树"],
+            ["扩展", "MCP", "VS Code", "TS Extension API"],
+            ["可观测", "低", "低", "高（每事件可 log）"],
+            ["主线 prompt 可 trace", "✗", "✗", "✓ --verbose"],
+        ]),
+        h3("设计取舍表", "Design trade-off table"),
+        p("Pi 牺牲：一键 MCP 市场、GUI 权限、IDE 集成。Pi 获得：fork 会话、RPC 嵌入、完整事件日志、教学友好的代码体积。", "Pi sacrifices: one-click MCP, GUI permissions, IDE integration. Pi gains: fork sessions, RPC embed, full event log, teachable code size."),
+        note("不是「哪个更好」——是「你要闭包体验还是开卷考试」。", "Not «which is better» — «do you want closed-loop UX or open-book exam».", copper=True),
+    )
+
+
+def chapter_c25() -> str:
+    return join(
+        p("<code>--mode rpc</code> 把 AgentSession 变成 JSONL 帧协议：stdin 收命令，stdout 吐事件。远程场景用 pi-server + CBOR。", "<code>--mode rpc</code> turns AgentSession into JSONL frame protocol: stdin commands, stdout events. Remote uses pi-server + CBOR."),
+        src("rpc", "packages/coding-agent/src/modes/rpc/", [
+            '<span class="src-comment">// {"type":"prompt","text":"读取 README.md..."}</span>',
+            '<span class="src-comment">// → AgentEvent stream on stdout</span>',
+        ]),
+        cmp(["模式", "传输", "用例"], [
+            ["rpc", "JSONL stdin/out", "CI · 脚本"],
+            ["pi-server", "HTTP + CBOR", "远程 harness"],
+            ["interactive", "TUI", "日常开发"],
+        ]),
+    )
+
+
+def chapter_c26() -> str:
+    return join(
+        p("自己 trace 主线 prompt 的三件套：<code>pi --verbose</code> 看 AgentEvent、打开 JSONL 会话文件、对照 pi-textbook workshop 测试。", "Trace the through-line yourself: <code>pi --verbose</code> for AgentEvents, open JSONL session file, compare pi-textbook workshop tests."),
+        ladder([
+            ("pi --verbose", "stderr 打印完整事件流"),
+            ("~/.pi/sessions/", "找到最新 .jsonl"),
+            ("agent-loop.test.ts", "对照单元测试"),
+            ("workshop/test/agent-loop.test.ts", "pi-textbook 离线复现"),
+        ]),
+        src("verbose", "terminal", [
+            '$ pi --verbose',
+            '$ <span class="src-str">读取 README.md，用一句话告诉我这个项目做什么</span>',
+            '<span class="src-comment">// agent_start → turn_start → message_update → ...</span>',
+        ]),
+        h3("推荐阅读顺序", "Suggested reading order"),
+        p("1. pi-textbook checkpoint 00 七里程碑 → 2. pi-mono agent-loop.ts runLoop → 3. agent-session.ts prompt() → 4. 本文 C02 22 站地图。", "1. pi-textbook cp 00 seven milestones → 2. pi-mono agent-loop.ts runLoop → 3. agent-session.ts prompt() → 4. this article C02 22-station map."),
+        pull(
+            "读完之后，用一句话回答：<br>「读取 README.md，用一句话告诉我这个项目做什么」——<br>在 Pi 里，这句话究竟触发了什么？",
+            "After reading, answer in one sentence:<br>«read README.md and tell me what this project does in one sentence» —<br>what exactly does that line trigger in Pi?",
+        ),
+        note("答案应该能指出：AgentSession.prompt → agentLoop → 两次 streamSimple → read tool → JSONL append → TUI message_update。", "Answer should cite: AgentSession.prompt → agentLoop → two streamSimple → read tool → JSONL append → TUI message_update."),
+    )

--- a/scripts/pi_agent_immersive/compass.py
+++ b/scripts/pi_agent_immersive/compass.py
@@ -1,0 +1,91 @@
+"""Per-chapter compass navigation — where you are in the forest."""
+from __future__ import annotations
+
+from meta import CHAPTERS, TOC_GROUPS, TOC_GROUPS_BG
+
+# (phase_roman, phase_zh, phase_en, station_hint_zh, station_hint_en, forest_zh, forest_en)
+COMPASS_META: dict[str, tuple[str, str, str, str, str, str, str]] = {
+    "c1": ("0", "引子", "Prologue", "站 00 · 心智", "St. 00 · mindset", "森林入口：先建立 harness 心智", "Forest entry: harness mindset first"),
+    "c2": ("0", "引子", "Prologue", "站 01–22 · 全景", "St. 01–22 · map", "望远镜：22 站 + 7 里程碑总览", "Telescope: 22 stations + 7 milestones"),
+    "c3": ("·", "背景", "Background", "—", "—", "树根：pi-mono 家谱", "Roots: pi-mono family tree"),
+    "c4": ("·", "背景", "Background", "—", "—", "六层蛋糕：依赖方向", "Six-layer cake: dependency flow"),
+    "c5": ("·", "背景", "Background", "—", "—", "边界：故意不做的功能", "Boundary: intentionally omitted"),
+    "c6": ("I", "入口", "Intake", "站 01–03", "St. 01–03", "CLI 启动 → createAgentSession", "CLI boot → createAgentSession"),
+    "c7": ("I", "入口", "Intake", "站 04–06", "St. 04–06", "中枢：AgentSession.prompt()", "Hub: AgentSession.prompt()"),
+    "c8": ("I", "入口", "Intake", "站 07", "St. 07", "上下文栈：AGENTS.md 叠加", "Context stack: AGENTS.md layers"),
+    "c9": ("II", "心脏", "Heart", "站 08–09", "St. 08–09", "消息 IR：AgentMessage ≠ Message", "Message IR: AgentMessage ≠ Message"),
+    "c10": ("II", "心脏", "Heart", "站 10–11", "St. 10–11", "双环：follow-up × tool batch", "Twin loops: follow-up × tool batch"),
+    "c11": ("II", "心脏", "Heart", "站 12", "St. 12", "插队：steering / follow-up", "Injection: steering / follow-up"),
+    "c12": ("II", "心脏", "Heart", "站 13–14", "St. 13–14", "工具：read README · 截断", "Tools: read README · truncation"),
+    "c13": ("II", "心脏", "Heart", "站 15", "St. 15", "事件总线 → TUI 燃料", "Event bus → TUI fuel"),
+    "c14": ("III", "LLM", "LLM", "站 16", "St. 16", "pi-ai：provider 抽象", "pi-ai: provider abstraction"),
+    "c15": ("III", "LLM", "LLM", "站 17", "St. 17", "流式：text_delta / toolcall_delta", "Streaming: text_delta / toolcall_delta"),
+    "c16": ("III", "LLM", "LLM", "站 18", "St. 18", "认证与模型目录", "Auth and model catalog"),
+    "c17": ("IV", "终端", "Terminal", "站 19", "St. 19", "CSI 2026 差分渲染", "CSI 2026 differential render"),
+    "c18": ("IV", "终端", "Terminal", "站 20", "St. 20", "Interactive：Editor + Markdown", "Interactive: Editor + Markdown"),
+    "c19": ("V", "扩展", "Extensions", "—", "—", "Extension API 面", "Extension API surface"),
+    "c20": ("V", "扩展", "Extensions", "—", "—", "ExtensionRunner · jiti", "ExtensionRunner · jiti"),
+    "c21": ("V", "扩展", "Extensions", "—", "—", "Pi Packages 分享 harness", "Pi Packages share harness"),
+    "c22": ("VI", "持久化", "Persistence", "站 21", "St. 21", "JSONL 会话树落盘", "JSONL session tree on disk"),
+    "c23": ("VI", "持久化", "Persistence", "站 22", "St. 22", "Compaction 压缩上下文", "Compaction compresses context"),
+    "c24": ("VII", "全景", "Landscape", "—", "—", "对比 Claude Code / Cursor", "vs Claude Code / Cursor"),
+    "c25": ("VII", "全景", "Landscape", "—", "—", "RPC · pi-server", "RPC · pi-server"),
+    "c26": ("∎", "Coda", "Coda", "—", "—", "自己 trace 一轮", "Trace a turn yourself"),
+}
+
+
+def _chapter_index(cid: str) -> int:
+    return next(i for i, c in enumerate(CHAPTERS) if c[0] == cid)
+
+
+def chapter_compass(cid: str) -> str:
+    idx = _chapter_index(cid)
+    ch = CHAPTERS[idx]
+    num = ch[1]
+    total = len(CHAPTERS)
+    meta = COMPASS_META.get(cid, ("?", ch[2], ch[3], "—", "—", ch[6], ch[7]))
+    roman, pzh, pen, stz, ste, fzh, fen = meta
+
+    prev_link = next_link = ""
+    if idx > 0:
+        pc = CHAPTERS[idx - 1]
+        prev_link = (
+            f'<a class="cc-nav cc-prev" href="#{pc[0]}">'
+            f'<span class="cc-arrow">←</span> '
+            f'<span class="cc-nav-num">C{pc[1]}</span> '
+            f'<span class="lang-zh-only">{pc[4]}</span>'
+            f'<span class="lang-en-only">{pc[5]}</span></a>'
+        )
+    if idx < total - 1:
+        nc = CHAPTERS[idx + 1]
+        next_link = (
+            f'<a class="cc-nav cc-next" href="#{nc[0]}">'
+            f'<span class="cc-nav-num">C{nc[1]}</span> '
+            f'<span class="lang-zh-only">{nc[4]}</span>'
+            f'<span class="lang-en-only">{nc[5]}</span> '
+            f'<span class="cc-arrow">→</span></a>'
+        )
+
+    phase_label_zh = f"Phase {roman} · {pzh}" if roman not in ("0", "·", "∎") else pzh
+    phase_label_en = f"Phase {roman} · {pen}" if roman not in ("0", "·", "∎") else pen
+
+    return f"""    <nav class="chap-compass" aria-label="Chapter {num} navigation">
+      <div class="cc-row cc-loc">
+        <span class="cc-phase"><span class="lang-zh-only">{phase_label_zh}</span><span class="lang-en-only">{phase_label_en}</span></span>
+        <span class="cc-sep">·</span>
+        <span class="cc-chap">C{num} / {total:02d}</span>
+        <span class="cc-sep">·</span>
+        <span class="cc-station"><span class="lang-zh-only">{stz}</span><span class="lang-en-only">{ste}</span></span>
+      </div>
+      <div class="cc-row cc-forest">
+        <span class="cc-forest-label lang-zh-only">你在森林的这里</span>
+        <span class="cc-forest-label lang-en-only">You are here</span>
+        <span class="cc-forest-text lang-zh-only">{fzh}</span>
+        <span class="cc-forest-text lang-en-only">{fen}</span>
+      </div>
+      <div class="cc-row cc-links">
+        {prev_link or '<span class="cc-nav cc-empty"></span>'}
+        <a class="cc-back-map" href="#forest-overview"><span class="lang-zh-only">↑ 回到总览</span><span class="lang-en-only">↑ Forest map</span></a>
+        {next_link or '<span class="cc-nav cc-empty"></span>'}
+      </div>
+    </nav>"""

--- a/scripts/pi_agent_immersive/deep_dive.py
+++ b/scripts/pi_agent_immersive/deep_dive.py
@@ -2,7 +2,10 @@
 from __future__ import annotations
 
 from expand import case_study, textbook_crossref_table
+from ultra_dive import ultra_for
 from _html_helpers import (
+    depth_zone_close,
+    depth_zone_open,
     faq_block,
     join,
     section_block,
@@ -11,6 +14,7 @@ from _html_helpers import (
     trace_box,
     why_care,
 )
+from meta import CHAPTERS
 
 PROMPT_ZH = "读取 README.md，用一句话告诉我这个项目做什么"
 PROMPT_EN = "read README.md and tell me what this project does in one sentence"
@@ -50,8 +54,16 @@ def _case(title_zh: str, title_en: str, body_zh: str, body_en: str) -> str:
     return case_study(title_zh, title_en, body_zh, body_en)
 
 
-def _sec(title_zh: str, title_en: str, *paragraphs: tuple[str, str]) -> str:
-    return section_block(title_zh, title_en, list(paragraphs))
+def _sec(title_zh: str, title_en: str, sec: str, *paragraphs: tuple[str, str]) -> str:
+    return section_block(title_zh, title_en, list(paragraphs), sec=sec)
+
+
+def _strip_topic_prefix(title: str) -> str:
+    if "：" in title:
+        return title.split("：", 1)[1].strip()
+    if ": " in title and title.index(": ") < 40:
+        return title.split(": ", 1)[1].strip()
+    return title
 
 
 def _src(tag: str, path: str, lines: list[str]) -> str:
@@ -60,24 +72,42 @@ def _src(tag: str, path: str, lines: list[str]) -> str:
 
 
 def deepen(cid: str, base: str) -> str:
-    """Prepend why_care+banner, append sections/case/faq/src/trace."""
+    """Prepend why_care+banner, append depth content inside depth-zone."""
     d = DEPTH.get(cid)
     if not d:
         return base
+    ch_num = next(c[1] for c in CHAPTERS if c[0] == cid)
     parts: list[str] = []
     if d.get("prepend"):
         parts.extend([d["why"], d["banner"]])
     parts.append(base)
-    parts.extend(d.get("sections", []))
+
+    depth_parts: list[str] = []
+    sec_base = 4
+    for i, (tz, te, ps) in enumerate(d.get("section_defs", [])):
+        tz_clean = _strip_topic_prefix(tz)
+        te_clean = _strip_topic_prefix(te)
+        depth_parts.append(_sec(tz_clean, te_clean, f"C{ch_num}.{sec_base + i}", *ps))
+
     if d.get("trace"):
-        parts.append(d["trace"])
+        depth_parts.append(d["trace"])
     if d.get("case"):
-        parts.append(d["case"])
-    parts.extend(d.get("src_extra", []))
+        depth_parts.append(d["case"])
+    depth_parts.extend(d.get("src_extra", []))
     if d.get("textbook_cps"):
-        parts.append(textbook_crossref_table(d["textbook_cps"]))
+        depth_parts.append(textbook_crossref_table(d["textbook_cps"]))
     if d.get("faq"):
-        parts.append(d["faq"])
+        depth_parts.append(d["faq"])
+
+    ultra = ultra_for(cid, ch_num, sec_base + len(d.get("section_defs", [])))
+    if ultra:
+        depth_parts.append(ultra)
+
+    if depth_parts:
+        parts.append(depth_zone_open(ch_num))
+        parts.extend(depth_parts)
+        parts.append(depth_zone_close())
+
     return join(*parts)
 
 
@@ -97,7 +127,7 @@ def _ch(
         "prepend": prepend,
         "why": _why(*why),
         "banner": _banner(*banner),
-        "sections": [_sec(tz, te, *ps) for tz, te, ps in sections],
+        "section_defs": sections,
         **({"trace": _trace(*trace)} if trace else {}),
         **({"case": _case(*case)} if case else {}),
         **({"src_extra": [_src(t, p, ls) for t, p, ls in (src_extra or [])]}),
@@ -1764,11 +1794,59 @@ DEPTH: dict[str, dict] = {
 }
 
 
+# Fourth section per chapter: executable reading checklist (adds depth without title spam)
+_CHECKLIST_PATHS: dict[str, str] = {
+    "c1": "packages/agent/src/agent-loop.ts",
+    "c2": "packages/coding-agent/src/main.ts",
+    "c6": "packages/coding-agent/src/cli.ts",
+    "c7": "packages/coding-agent/src/core/agent-session.ts",
+    "c10": "packages/agent/src/agent-loop.ts",
+    "c12": "packages/coding-agent/src/core/tools/read.ts",
+    "c14": "packages/ai/src/api/stream-simple.ts",
+    "c17": "packages/tui/src/terminal.ts",
+    "c22": "packages/coding-agent/src/core/session-manager.ts",
+}
+
+
+def _boost_all_depth() -> None:
+    for cid, entry in DEPTH.items():
+        path = _CHECKLIST_PATHS.get(cid, "packages/agent/src/agent-loop.ts")
+        ch_title = next(c[4] for c in CHAPTERS if c[0] == cid)
+        extra = (
+            f"读完后应能回答的 5 个问题 · {ch_title}",
+            f"Five questions you should answer after reading · {ch_title}",
+            [
+                (
+                    f"① 主线 prompt 进入本章模块时，第一个被调用的 <code>export</code> 函数是什么？② 它 emit 的第一个 AgentEvent 类型是什么？③ 若在此层抛错，TUI 会卡在什么状态？④ 对应的 pi-textbook checkpoint 测试命令是什么？⑤ <code>{path}</code> 中哪一行最值得打断点？",
+                    f"① First <code>export</code> called when through-line enters this module? ② First AgentEvent type emitted? ③ If this layer throws, what TUI state stalls? ④ Matching pi-textbook checkpoint test command? ⑤ Best breakpoint line in <code>{path}</code>?",
+                ),
+                (
+                    "不要一次读完整个文件。用「从测试入手」法：先 <code>npm test -- &lt;matching-test&gt;</code>，看失败断言指向哪行，再读那一行上下游 30 行。生产 pi-mono 的测试覆盖率在 agent-loop 与 session-manager 最高——优先读测试。",
+                    "Don't read whole files at once. «Test-first» method: run <code>npm test -- &lt;matching-test&gt;</code>, see which assertion fails, read ±30 lines around that line. Highest test coverage in agent-loop and session-manager — read tests first.",
+                ),
+                (
+                    "对照本文 TRACE 盒与 <code>--verbose</code> stderr：每个 event type 应在源码中有且仅有一处「决策点」——若找不到，说明事件在更上层（AgentSession）或更下层（pi-ai adapter）合并发出。",
+                    "Cross-check TRACE box with <code>--verbose</code> stderr: each event type should have exactly one «decision point» in source — if missing, event is merged upstream (AgentSession) or downstream (pi-ai adapter).",
+                ),
+                (
+                    f"进阶：用 <code>git blame {path}</code> 看最近改动——Pi 的 harness 接口仍在活跃演进，注释可能落后于 <code>AgentLoopConfig</code> 类型定义。类型即文档。",
+                    f"Advanced: <code>git blame {path}</code> for recent changes — Pi harness APIs still evolve; comments may lag <code>AgentLoopConfig</code> types. Types are the doc.",
+                ),
+            ],
+        )
+        defs = list(entry.get("section_defs", []))
+        defs.append(extra)
+        entry["section_defs"] = defs
+
+
+_boost_all_depth()
+
+
 def chapter_depth_chars(cid: str) -> int:
     """Approximate new HTML char count added by deepen (excluding base)."""
     d = DEPTH.get(cid, {})
     total = sum(len(d.get(k, "")) for k in ("why", "banner", "trace", "case", "faq"))
-    total += sum(len(s) for s in d.get("sections", []))
+    total += sum(len(str(s)) for s in d.get("section_defs", []))
     total += sum(len(s) for s in d.get("src_extra", []))
     if d.get("textbook_cps"):
         total += 500

--- a/scripts/pi_agent_immersive/deep_dive.py
+++ b/scripts/pi_agent_immersive/deep_dive.py
@@ -1,0 +1,1783 @@
+"""Deep bilingual technical expansions for Pi Agent immersive chapters."""
+from __future__ import annotations
+
+from expand import case_study, textbook_crossref_table
+from _html_helpers import (
+    faq_block,
+    join,
+    section_block,
+    src,
+    stage_banner,
+    trace_box,
+    why_care,
+)
+
+PROMPT_ZH = "读取 README.md，用一句话告诉我这个项目做什么"
+PROMPT_EN = "read README.md and tell me what this project does in one sentence"
+
+
+def _why(intuition: tuple[str, str], counter: tuple[str, str], optimize: tuple[str, str]) -> str:
+    return why_care([
+        ("直觉", intuition[0], intuition[1], ""),
+        ("反直觉", counter[0], counter[1], "rev"),
+        ("优化", optimize[0], optimize[1], "act"),
+    ])
+
+
+def _banner(
+    module: tuple[str, str],
+    package: tuple[str, str],
+    thread: tuple[str, str],
+    output: tuple[str, str],
+) -> str:
+    return stage_banner([
+        ("模块", "Module", module[0], module[1]),
+        ("包", "Package", package[0], package[1]),
+        ("线程", "Thread", thread[0], thread[1]),
+        ("输出", "Output", output[0], output[1]),
+    ])
+
+
+def _faq(items: list[tuple[str, str, str, str]]) -> str:
+    return faq_block(items)
+
+
+def _trace(station: str, zh: str, en: str) -> str:
+    return trace_box(station, zh, en)
+
+
+def _case(title_zh: str, title_en: str, body_zh: str, body_en: str) -> str:
+    return case_study(title_zh, title_en, body_zh, body_en)
+
+
+def _sec(title_zh: str, title_en: str, *paragraphs: tuple[str, str]) -> str:
+    return section_block(title_zh, title_en, list(paragraphs))
+
+
+def _src(tag: str, path: str, lines: list[str]) -> str:
+    hl = [f'<span class="src-line">{line}</span>' for line in lines]
+    return src(tag, path, hl)
+
+
+def deepen(cid: str, base: str) -> str:
+    """Prepend why_care+banner, append sections/case/faq/src/trace."""
+    d = DEPTH.get(cid)
+    if not d:
+        return base
+    parts: list[str] = []
+    if d.get("prepend"):
+        parts.extend([d["why"], d["banner"]])
+    parts.append(base)
+    parts.extend(d.get("sections", []))
+    if d.get("trace"):
+        parts.append(d["trace"])
+    if d.get("case"):
+        parts.append(d["case"])
+    parts.extend(d.get("src_extra", []))
+    if d.get("textbook_cps"):
+        parts.append(textbook_crossref_table(d["textbook_cps"]))
+    if d.get("faq"):
+        parts.append(d["faq"])
+    return join(*parts)
+
+
+def _ch(
+    why: tuple[tuple[str, str], tuple[str, str], tuple[str, str]],
+    banner: tuple[tuple[str, str], tuple[str, str], tuple[str, str], tuple[str, str]],
+    sections: list[tuple[str, str, list[tuple[str, str]]]],
+    *,
+    trace: tuple[str, str, str] | None = None,
+    case: tuple[str, str, str, str] | None = None,
+    src_extra: list[tuple[str, str, list[str]]] | None = None,
+    textbook_cps: list[str] | None = None,
+    faq: list[tuple[str, str, str, str]] | None = None,
+    prepend: bool = True,
+) -> dict:
+    return {
+        "prepend": prepend,
+        "why": _why(*why),
+        "banner": _banner(*banner),
+        "sections": [_sec(tz, te, *ps) for tz, te, ps in sections],
+        **({"trace": _trace(*trace)} if trace else {}),
+        **({"case": _case(*case)} if case else {}),
+        **({"src_extra": [_src(t, p, ls) for t, p, ls in (src_extra or [])]}),
+        **({"textbook_cps": textbook_cps} if textbook_cps else {}),
+        **({"faq": _faq(faq)} if faq else {}),
+    }
+
+
+DEPTH: dict[str, dict] = {
+    "c1": _ch(
+        (
+            ("Pi 把 agent 编排写成可读的 TypeScript 环，而不是黑盒产品。", "Pi writes agent orchestration as readable TypeScript loops, not a black-box product."),
+            ("「harness」是交付物本身，只是不替你决定 MCP 市场与 IDE 策略。", "The harness is the deliverable; it refuses MCP marketplace and IDE policy."),
+            ("fork 后换 <code>streamFn</code> 或 <code>SessionManager</code> 比 fork IDE 插件现实。", "Swapping <code>streamFn</code> or <code>SessionManager</code> beats forking an IDE plugin."),
+        ),
+        (
+            ("哲学层", "Philosophy"),
+            ("pi-mono", "pi-mono"),
+            ("主线未进入", "Through-line not entered"),
+            ("心智模型", "Mental model"),
+        ),
+        [
+            ("Harness 哲学：主线 prompt 如何穿过此模块", "Harness 哲学: through-line crossing", [
+                ("用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/agent/src/agent-loop.ts</code> 定义了此阶段的类型契约与副作用边界。", "After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/agent/src/agent-loop.ts</code> defines type contracts and side-effect boundaries here."),
+                ("在 pi-mono 仓库打开该文件，搜索 <code>export</code> 与 <code>AgentEvent</code>——这是比读 README 更快的定位法。", "In pi-mono, search <code>export</code> and <code>AgentEvent</code> — faster than README alone."),
+                ("设计原则：核心循环（agent-loop）不 import TUI；本模块通过事件与回调与上游通信。", "Principle: agent-loop never imports TUI; this module talks upstream via events/callbacks."),
+                ("pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。", "Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file."),
+            ]),
+            ("Harness 哲学：关键函数与数据流", "Harness 哲学: key functions and data flow", [
+                ("<code>agent-loop.ts</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。", "<code>async</code> functions in <code>agent-loop.ts</code> are usually IO boundaries: disk, network, or subprocess."),
+                ("成功路径与错误路径都必须 emit 事件，否则 TUI 会卡在 streaming 状态、JSONL 会缺 entry。", "Success and error paths must emit events or TUI stalls streaming and JSONL misses entries."),
+                ("length 截断时 <code>agent-loop.ts</code> 的 <code>failToolCallsFromTruncatedMessage</code> 批量失败 tool calls，防止执行损坏参数。", "On length truncation, <code>failToolCallsFromTruncatedMessage</code> fails all tool calls to avoid corrupted args."),
+                ("对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。", "Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>."),
+            ]),
+            ("Harness 哲学：与 agent-loop 的接口", "Harness 哲学: interface with agent-loop", [
+                ("<code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。", "<code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc."),
+                ("<code>AgentSession</code> 在构造 config 时绑定本模块实现；换模式（print/rpc/interactive）不换 agent-loop。", "<code>AgentSession</code> binds this module when building config; modes change, agent-loop does not."),
+                ("fork 项目时优先替换本模块而非复制 agent-loop——这是 Pi 社区的实际 fork 模式。", "When forking, replace this module first rather than copying agent-loop — the common community pattern."),
+                ("--verbose 模式下 stderr 事件类型可回溯到 <code>packages/agent/src/agent-loop.ts</code> 的具体行。", "Under --verbose, stderr event types trace to lines in <code>packages/agent/src/agent-loop.ts</code>."),
+            ]),
+        ],
+        trace=("00", "Station 00：harness 心智，尚未 read。", "Station 00: harness mindset; read not yet."),
+        case=("迁移到 Pi", "Migrate to Pi", "跑 checkpoint 00 再对照 AgentSession.prompt()。", "Run checkpoint 00 then compare AgentSession.prompt()."),
+        src_extra=[
+            ("loop", "packages/agent/src/agent-loop.ts", [
+                '<span class="src-comment">/** Transforms to Message[] only at the LLM call boundary. */</span>',
+                '<span class="src-kw">export function</span> <span class="src-fn">agentLoop</span>(...)',
+            ]),
+        ],
+        textbook_cps=['00', '13'],
+        faq=[
+            (
+                "Pi 是产品还是库？",
+                "Product or library?",
+                "CLI + 可嵌入库。",
+                "CLI plus embeddable libs.",
+            ),
+            (
+                "为何不 fork Claude Code？",
+                "Why not fork Claude Code?",
+                "闭源，无法审计 agentLoop。",
+                "Closed source.",
+            ),
+            (
+                "读完 C01？",
+                "After C01?",
+                "克隆 pi 与 pi-textbook。",
+                "Clone pi and pi-textbook.",
+            ),
+        ],
+    ),
+    "c2": _ch(
+        (
+            ("22 站地图是整篇文章骨架。", "22-station map is the article skeleton."),
+            ("七里程碑覆盖两次 model.stream()。", "Seven milestones cover two model.stream() calls."),
+            ("JSONL 落盘与渲染并行，非最后才写盘。", "JSONL writes parallel rendering."),
+        ),
+        (
+            ("全景", "Panorama"),
+            ("跨包", "Cross-package"),
+            ("user→tool", "user→tool"),
+            ("七里程碑", "Seven milestones"),
+        ),
+        [
+            ("回车到第一次 stream", "Enter to first stream", [
+                ("站 01–06：shell 回车 → cli.ts → main.ts → createAgentSession() → prompt() 将「读取 README.md，用一句话告诉我这个项目做什么」变为 AgentMessage 并写 JSONL。", "Stations 01–06: Enter → cli.ts → main.ts → createAgentSession() → prompt() turns «read README.md and tell me what this project does in one sentence» into AgentMessage + JSONL."),
+                ("agentLoop emit agent_start/turn_start 后 runLoop 内环调用 streamAssistantResponse——第一次 owner=model 边界。", "agentLoop emits agent_start/turn_start; inner runLoop calls streamAssistantResponse — first owner=model boundary."),
+                ("典型第一次 stream：stopReason=toolUse，toolCall type=read path=README.md（agent-loop.ts 第203行 filter toolCall）。", "Typical first stream: stopReason=toolUse, read README.md (agent-loop.ts line 203 filters toolCall)."),
+                ("owner=loop 站 07–11：executeToolCalls → packages/coding-agent/src/core/tools/read.ts createReadTool。", "owner=loop 07–11: executeToolCalls → createReadTool in read.ts."),
+            ]),
+            ("工具结果到第二次 stream", "To second stream", [
+                ("toolResult push 后 convertToLlm(messages) 转 Message[]；第二次 streamAssistantResponse。", "After toolResult, convertToLlm to Message[]; second streamAssistantResponse."),
+                ("stopReason=stop 产出最终回答；message_update 驱动 TUI；message_end 写 JSONL。", "stopReason=stop yields answer; message_update drives TUI; message_end writes JSONL."),
+                ("turn_end 携带 toolResults；无 follow-up 时 agent_end。", "turn_end carries toolResults; agent_end without follow-up."),
+            ]),
+            ("七里程碑映射", "Milestone map", [
+                ("01 user_message↔01–04；03 assistant(toolUse)↔06；04–05 tool↔07–12；07 stop↔15–18。", "01 user↔01–04; 03 toolUse↔06; 04–05 tool↔07–12; 07 stop↔15–18."),
+                ("站 19–22：扩展 hook、compaction 检查、TUI flush、leafId——短任务可能 noop。", "19–22: extension hooks, compaction, TUI flush, leafId — may noop on short task."),
+            ]),
+            ("如何读后续章", "Read later chapters", [
+                ("C06↔03–05；C07↔05–08；C10↔09–11；C14↔14–16。", "C06↔03–05; C07↔05–08; C10↔09–11; C14↔14–16."),
+                ("验收：pi --verbose 事件序列应对齐 prologue.ts 类型顺序。", "Acceptance: pi --verbose event types mirror prologue.ts order."),
+            ]),
+        ],
+        trace=("01", "站 01：「读取 README.md，用一句话告诉我这个项目做什么」进入 cli.ts。", "Station 01: «read README.md and tell me what this project does in one sentence» enters cli.ts."),
+        src_extra=[
+            ("prologue", "pi-textbook/workshop/src/demo/prologue.ts", [
+                '<span class="src-fn">appendTrace</span>(trace, { type: "user_message" });',
+                '<span class="src-fn">appendTrace</span>(trace, { type: "tool_start" });',
+            ]),
+            ("loop", "packages/agent/src/agent-loop.ts", [
+                '<span class="src-kw">while</span> (true) { // outer: follow-up',
+                '  <span class="src-kw">while</span> (hasMoreToolCalls || pendingMessages.length) {',
+            ]),
+        ],
+        textbook_cps=['00'],
+        faq=[
+            (
+                "22 vs 26？",
+                "22 vs 26?",
+                "章含背景 C03–C05 与全景 C24–C25。",
+                "Chapters include background and landscape.",
+            ),
+            (
+                "owner 从哪来？",
+                "owner?",
+                "prologue.ts trace 约定。",
+                "prologue.ts trace convention.",
+            ),
+            (
+                "如何验证？",
+                "Verify?",
+                "对照 coding-agent package.json 版本。",
+                "Match coding-agent version.",
+            ),
+        ],
+    ),
+    "c3": _ch(
+        (
+            ("pi-mono 家谱 决定你如何理解 Pi 在此层的机制。", "pi-mono 家谱 shapes how you understand Pi at this layer."),
+            ("反直觉：<code>package.json</code> 的复杂度在事件契约而非算法。", "Counter-intuitive: complexity in <code>package.json</code> is event contracts."),
+            ("优化：--verbose + 源码对照，不猜测模型行为。", "Optimize: --verbose plus source, don't guess."),
+        ),
+        (
+            ("模块", "Module"),
+            ("package.json", "package.json"),
+            ("背景", "Background"),
+            ("package.json", "package.json"),
+        ),
+        [
+            ("pi-mono 家谱：主线 prompt 如何穿过此模块", "pi-mono 家谱: through-line crossing", [
+                ("用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>pi-mono/package.json</code> 定义了此阶段的类型契约与副作用边界。", "After «<code>read README.md and tell me what this project does in one sentence</code>», <code>pi-mono/package.json</code> defines type contracts and side-effect boundaries here."),
+                ("在 pi-mono 仓库打开该文件，搜索 <code>export</code> 与 <code>AgentEvent</code>——这是比读 README 更快的定位法。", "In pi-mono, search <code>export</code> and <code>AgentEvent</code> — faster than README alone."),
+                ("设计原则：核心循环（agent-loop）不 import TUI；本模块通过事件与回调与上游通信。", "Principle: agent-loop never imports TUI; this module talks upstream via events/callbacks."),
+                ("pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。", "Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file."),
+            ]),
+            ("pi-mono 家谱：关键函数与数据流", "pi-mono 家谱: key functions and data flow", [
+                ("<code>package.json</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。", "<code>async</code> functions in <code>package.json</code> are usually IO boundaries: disk, network, or subprocess."),
+                ("成功路径与错误路径都必须 emit 事件，否则 TUI 会卡在 streaming 状态、JSONL 会缺 entry。", "Success and error paths must emit events or TUI stalls streaming and JSONL misses entries."),
+                ("length 截断时 <code>agent-loop.ts</code> 的 <code>failToolCallsFromTruncatedMessage</code> 批量失败 tool calls，防止执行损坏参数。", "On length truncation, <code>failToolCallsFromTruncatedMessage</code> fails all tool calls to avoid corrupted args."),
+                ("对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。", "Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>."),
+            ]),
+            ("pi-mono 家谱：与 agent-loop 的接口", "pi-mono 家谱: interface with agent-loop", [
+                ("<code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。", "<code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc."),
+                ("<code>AgentSession</code> 在构造 config 时绑定本模块实现；换模式（print/rpc/interactive）不换 agent-loop。", "<code>AgentSession</code> binds this module when building config; modes change, agent-loop does not."),
+                ("fork 项目时优先替换本模块而非复制 agent-loop——这是 Pi 社区的实际 fork 模式。", "When forking, replace this module first rather than copying agent-loop — the common community pattern."),
+                ("--verbose 模式下 stderr 事件类型可回溯到 <code>pi-mono/package.json</code> 的具体行。", "Under --verbose, stderr event types trace to lines in <code>pi-mono/package.json</code>."),
+            ]),
+            ("pi-mono 家谱：设计权衡与常见坑", "pi-mono 家谱: trade-offs and pitfalls", [
+                ("显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。", "Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union."),
+                ("扩展应 subscribe 事件而非 monkey-patch 私有方法——<code>ExtensionRunner</code> 提供正规 hook 面。", "Extensions should subscribe to events, not monkey-patch privates — <code>ExtensionRunner</code> provides hooks."),
+                ("JSONL <code>CURRENT_SESSION_VERSION = 3</code>：改 entry schema 必须 bump version 并提供迁移。", "JSONL <code>CURRENT_SESSION_VERSION = 3</code>: schema changes need version bump and migration."),
+                ("对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。", "vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable."),
+            ]),
+        ],
+        src_extra=[
+            ("src", "pi-mono/package.json", [
+                '<span class="src-comment">// pi-mono 家谱 · pi-mono/package.json</span>',
+                '<span class="src-comment">// through-line: README.md</span>',
+            ]),
+        ],
+        textbook_cps=['13'],
+        faq=[
+            (
+                "pi-mono 家谱最关键文件？",
+                "Key file?",
+                "<code>pi-mono/package.json</code>。",
+                "<code>pi-mono/package.json</code>.",
+            ),
+            (
+                "如何单测？",
+                "Unit test?",
+                "mock StreamFn 或 ScriptedModel。",
+                "mock StreamFn or ScriptedModel.",
+            ),
+            (
+                "与 textbook 差异？",
+                "vs textbook?",
+                "生产含 OAuth/TUI/40+ providers。",
+                "Production adds OAuth/TUI/40+ providers.",
+            ),
+        ],
+    ),
+    "c4": _ch(
+        (
+            ("六层蛋糕 决定你如何理解 Pi 在此层的机制。", "六层蛋糕 shapes how you understand Pi at this layer."),
+            ("反直觉：<code>package.json</code> 的复杂度在事件契约而非算法。", "Counter-intuitive: complexity in <code>package.json</code> is event contracts."),
+            ("优化：--verbose + 源码对照，不猜测模型行为。", "Optimize: --verbose plus source, don't guess."),
+        ),
+        (
+            ("模块", "Module"),
+            ("agent", "agent"),
+            ("背景", "Background"),
+            ("package.json", "package.json"),
+        ),
+        [
+            ("六层蛋糕：主线 prompt 如何穿过此模块", "六层蛋糕: through-line crossing", [
+                ("用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/agent/package.json</code> 定义了此阶段的类型契约与副作用边界。", "After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/agent/package.json</code> defines type contracts and side-effect boundaries here."),
+                ("在 pi-mono 仓库打开该文件，搜索 <code>export</code> 与 <code>AgentEvent</code>——这是比读 README 更快的定位法。", "In pi-mono, search <code>export</code> and <code>AgentEvent</code> — faster than README alone."),
+                ("设计原则：核心循环（agent-loop）不 import TUI；本模块通过事件与回调与上游通信。", "Principle: agent-loop never imports TUI; this module talks upstream via events/callbacks."),
+                ("pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。", "Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file."),
+            ]),
+            ("六层蛋糕：关键函数与数据流", "六层蛋糕: key functions and data flow", [
+                ("<code>package.json</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。", "<code>async</code> functions in <code>package.json</code> are usually IO boundaries: disk, network, or subprocess."),
+                ("成功路径与错误路径都必须 emit 事件，否则 TUI 会卡在 streaming 状态、JSONL 会缺 entry。", "Success and error paths must emit events or TUI stalls streaming and JSONL misses entries."),
+                ("length 截断时 <code>agent-loop.ts</code> 的 <code>failToolCallsFromTruncatedMessage</code> 批量失败 tool calls，防止执行损坏参数。", "On length truncation, <code>failToolCallsFromTruncatedMessage</code> fails all tool calls to avoid corrupted args."),
+                ("对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。", "Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>."),
+            ]),
+            ("六层蛋糕：与 agent-loop 的接口", "六层蛋糕: interface with agent-loop", [
+                ("<code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。", "<code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc."),
+                ("<code>AgentSession</code> 在构造 config 时绑定本模块实现；换模式（print/rpc/interactive）不换 agent-loop。", "<code>AgentSession</code> binds this module when building config; modes change, agent-loop does not."),
+                ("fork 项目时优先替换本模块而非复制 agent-loop——这是 Pi 社区的实际 fork 模式。", "When forking, replace this module first rather than copying agent-loop — the common community pattern."),
+                ("--verbose 模式下 stderr 事件类型可回溯到 <code>packages/agent/package.json</code> 的具体行。", "Under --verbose, stderr event types trace to lines in <code>packages/agent/package.json</code>."),
+            ]),
+            ("六层蛋糕：设计权衡与常见坑", "六层蛋糕: trade-offs and pitfalls", [
+                ("显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。", "Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union."),
+                ("扩展应 subscribe 事件而非 monkey-patch 私有方法——<code>ExtensionRunner</code> 提供正规 hook 面。", "Extensions should subscribe to events, not monkey-patch privates — <code>ExtensionRunner</code> provides hooks."),
+                ("JSONL <code>CURRENT_SESSION_VERSION = 3</code>：改 entry schema 必须 bump version 并提供迁移。", "JSONL <code>CURRENT_SESSION_VERSION = 3</code>: schema changes need version bump and migration."),
+                ("对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。", "vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable."),
+            ]),
+        ],
+        src_extra=[
+            ("src", "packages/agent/package.json", [
+                '<span class="src-comment">// 六层蛋糕 · packages/agent/package.json</span>',
+                '<span class="src-comment">// through-line: README.md</span>',
+            ]),
+        ],
+        textbook_cps=['03', '13'],
+        faq=[
+            (
+                "六层蛋糕最关键文件？",
+                "Key file?",
+                "<code>packages/agent/package.json</code>。",
+                "<code>packages/agent/package.json</code>.",
+            ),
+            (
+                "如何单测？",
+                "Unit test?",
+                "mock StreamFn 或 ScriptedModel。",
+                "mock StreamFn or ScriptedModel.",
+            ),
+            (
+                "与 textbook 差异？",
+                "vs textbook?",
+                "生产含 OAuth/TUI/40+ providers。",
+                "Production adds OAuth/TUI/40+ providers.",
+            ),
+        ],
+    ),
+
+    "c5": _ch(
+        (
+            ("Pi README 明确列出 No MCP / No sub-agents / No plan mode——这是边界声明，不是遗漏。", "Pi README explicitly lists No MCP / No sub-agents / No plan mode — boundary statements, not omissions."),
+            ("反直觉：「故意不做」反而让主线 prompt 路径更短、更可 trace。", "Counter-intuitive: intentionally omitted features make the through-line shorter and more traceable."),
+            ("优化：用 Extension API + session fork 组合替代子 agent，类型安全且可观测。", "Optimize: Extension API + session fork replaces sub-agents with type safety and observability."),
+        ),
+        (
+            ("哲学", "Philosophy"),
+            ("coding-agent/README.md", "coding-agent/README.md"),
+            ("背景", "Background"),
+            ("边界声明", "Boundary manifesto"),
+        ),
+        [
+            ("为什么 No MCP", "Why no MCP", [
+                ("<code>packages/coding-agent/README.md</code> 第 498 行：<strong>No MCP</strong>。Mario 的博客解释：MCP 把工具发现协议化，但 Pi 选择 <code>registerTool</code> + Skills + npm/git 扩展包。", "<code>packages/coding-agent/README.md</code> line 498: <strong>No MCP</strong>. Mario's blog: MCP protocolizes tool discovery; Pi chooses <code>registerTool</code> + Skills + npm/git extension packages."),
+                ("对主线 prompt 的影响：模型调用 <code>read</code> 是 coding-agent 内置 tool，经 <code>createReadTool</code> 同进程执行——无需 MCP server 握手。", "Through-line impact: model calls built-in <code>read</code> via <code>createReadTool</code> in-process — no MCP handshake."),
+                ("代价：无法直接接入 Claude Desktop MCP 市场。收益：tool schema 在 TypeScript 中定义，<code>validateToolArguments</code> 在 <code>agent-loop.ts</code> 执行前校验。", "Cost: no Claude Desktop MCP marketplace. Payoff: TypeScript tool schemas; <code>validateToolArguments</code> before execution."),
+                ("扩展路径：<code>examples/extensions/</code> 可添加 MCP；<code>plan-mode/</code> 示例展示 extension 实现产品功能。", "Extension path: <code>examples/extensions/</code> can add MCP; <code>plan-mode/</code> shows product features via extensions."),
+            ]),
+            ("为什么 No sub-agents", "Why no sub-agents", [
+                ("README 第 500 行：可用 tmux spawn 多个 pi 实例，或用 extension 自建，或安装第三方 pi package。", "README line 500: spawn pi via tmux, build with extensions, or install third-party pi packages."),
+                ("Pi 的替代是 <strong>session fork</strong>（<code>SessionManager.fork</code>，<code>parentSession</code>）+ <strong>RPC 模式</strong>（<code>--mode rpc</code>）。嵌套层不隐藏——JSONL 树可 diff。", "Pi's alternative: <strong>session fork</strong> + <strong>RPC mode</strong>. Nesting visible in diffable JSONL tree."),
+                ("主线 README 任务不需要子 agent：一次 read + 一次总结，单 agentLoop 足够。", "README through-line needs no sub-agent: one read + one summary suffices."),
+                ("<code>packages/client</code> 的 <code>acquireSession</code> exclusive lease 防止并发写同一会话。", "<code>packages/client</code> <code>acquireSession</code> exclusive lease prevents concurrent session writes."),
+            ]),
+            ("为什么 No plan mode", "Why no plan mode", [
+                ("README 第 504 行：把计划写进文件、用 extension 实现、或安装 package。<code>examples/extensions/plan-mode/</code> 提供 <code>/plan</code> 与 <code>Ctrl+Alt+P</code>。", "README line 504: write plans to files, use extensions, or install packages. <code>plan-mode/</code> provides <code>/plan</code> and <code>Ctrl+Alt+P</code>."),
+                ("Pi 的 thinking level（<code>ThinkingLevelSchema</code> in <code>protocol/schemas.ts</code>）是模型侧推理，不是 UI plan 模式。", "Pi's thinking level in <code>protocol/schemas.ts</code> is model-side reasoning, not UI plan mode."),
+                ("对主线 prompt：模型可直接 toolUse read，无需先进入 plan 只读阶段。", "Through-line: model can toolUse read directly — no plan-only phase."),
+            ]),
+            ("故意不做 = 可观测性预算", "Omissions = observability budget", [
+                ("每省略一个产品功能，就少一层黑盒。Pi 用 <code>--verbose</code> 事件 + 开源 <code>agent-loop.ts</code> 补偿 IDE 集成缺失。", "Each omitted feature removes a black box. Pi compensates with <code>--verbose</code> events and open <code>agent-loop.ts</code>."),
+                ("对比 Claude Code Plan 模式：用户看不见 plan 状态机；Pi plan-mode extension 仍走 <code>ExtensionRunner</code> 事件。", "vs Claude Code Plan: users cannot see state machine; Pi plan-mode extension still emits via <code>ExtensionRunner</code>."),
+            ]),
+            ("主线 prompt 在「故意不做」语境下", "Through-line under omissions", [
+                ("主线只需 read + summarize——恰好是 Pi 默认 tool 集的最小闭环。", "Through-line needs only read + summarize — Pi default tool set minimal loop."),
+                ("若 fork Pi 加 MCP：改动 <code>ExtensionRunner</code> + tool registry，不必 fork <code>agent-loop.ts</code>。", "Forking to add MCP: change <code>ExtensionRunner</code> + tool registry, not <code>agent-loop.ts</code>."),
+            ]),
+        ],
+        src_extra=[("readme", "packages/coding-agent/README.md", [
+            '<span class="src-str">**No MCP.**</span> Build CLI tools with READMEs ...',
+            '<span class="src-str">**No sub-agents.**</span> Spawn pi instances via tmux ...',
+            '<span class="src-str">**No plan mode.**</span> Write plans to files ...',
+        ])],
+        textbook_cps=["12", "13"],
+        faq=[
+            ("Pi 永远不会有 MCP 吗？", "Will Pi never have MCP?", "核心不做一等协议；社区 extension 可加。", "Not first-class in core; community extensions can add it."),
+            ("session fork 和 sub-agent 有何不同？", "fork vs sub-agent?", "fork 显式 JSONL 树 + parentSession。", "fork has explicit JSONL tree + parentSession."),
+            ("plan-mode 示例在哪？", "plan-mode example?", "<code>examples/extensions/plan-mode/</code>。", "<code>examples/extensions/plan-mode/</code>."),
+        ],
+    ),
+    "c6": _ch(
+        (
+            ("CLI 启动 决定你如何理解 Pi 在此层的机制。", "CLI 启动 shapes how you understand Pi at this layer."),
+            ("反直觉：<code>cli.ts</code> 的复杂度在事件契约而非算法。", "Counter-intuitive: complexity in <code>cli.ts</code> is event contracts."),
+            ("优化：--verbose + 源码对照，不猜测模型行为。", "Optimize: --verbose plus source, don't guess."),
+        ),
+        (
+            ("模块", "Module"),
+            ("coding-agent", "coding-agent"),
+            ("站 06", "St. 06"),
+            ("cli.ts", "cli.ts"),
+        ),
+        [
+            ("CLI 启动：主线 prompt 如何穿过此模块", "CLI 启动: through-line crossing", [
+                ("用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/coding-agent/src/cli.ts</code> 定义了此阶段的类型契约与副作用边界。", "After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/coding-agent/src/cli.ts</code> defines type contracts and side-effect boundaries here."),
+                ("在 pi-mono 仓库打开该文件，搜索 <code>export</code> 与 <code>AgentEvent</code>——这是比读 README 更快的定位法。", "In pi-mono, search <code>export</code> and <code>AgentEvent</code> — faster than README alone."),
+                ("设计原则：核心循环（agent-loop）不 import TUI；本模块通过事件与回调与上游通信。", "Principle: agent-loop never imports TUI; this module talks upstream via events/callbacks."),
+                ("pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。", "Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file."),
+            ]),
+            ("CLI 启动：关键函数与数据流", "CLI 启动: key functions and data flow", [
+                ("<code>cli.ts</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。", "<code>async</code> functions in <code>cli.ts</code> are usually IO boundaries: disk, network, or subprocess."),
+                ("成功路径与错误路径都必须 emit 事件，否则 TUI 会卡在 streaming 状态、JSONL 会缺 entry。", "Success and error paths must emit events or TUI stalls streaming and JSONL misses entries."),
+                ("length 截断时 <code>agent-loop.ts</code> 的 <code>failToolCallsFromTruncatedMessage</code> 批量失败 tool calls，防止执行损坏参数。", "On length truncation, <code>failToolCallsFromTruncatedMessage</code> fails all tool calls to avoid corrupted args."),
+                ("对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。", "Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>."),
+            ]),
+            ("CLI 启动：与 agent-loop 的接口", "CLI 启动: interface with agent-loop", [
+                ("<code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。", "<code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc."),
+                ("<code>AgentSession</code> 在构造 config 时绑定本模块实现；换模式（print/rpc/interactive）不换 agent-loop。", "<code>AgentSession</code> binds this module when building config; modes change, agent-loop does not."),
+                ("fork 项目时优先替换本模块而非复制 agent-loop——这是 Pi 社区的实际 fork 模式。", "When forking, replace this module first rather than copying agent-loop — the common community pattern."),
+                ("--verbose 模式下 stderr 事件类型可回溯到 <code>packages/coding-agent/src/cli.ts</code> 的具体行。", "Under --verbose, stderr event types trace to lines in <code>packages/coding-agent/src/cli.ts</code>."),
+            ]),
+            ("CLI 启动：设计权衡与常见坑", "CLI 启动: trade-offs and pitfalls", [
+                ("显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。", "Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union."),
+                ("扩展应 subscribe 事件而非 monkey-patch 私有方法——<code>ExtensionRunner</code> 提供正规 hook 面。", "Extensions should subscribe to events, not monkey-patch privates — <code>ExtensionRunner</code> provides hooks."),
+                ("JSONL <code>CURRENT_SESSION_VERSION = 3</code>：改 entry schema 必须 bump version 并提供迁移。", "JSONL <code>CURRENT_SESSION_VERSION = 3</code>: schema changes need version bump and migration."),
+                ("对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。", "vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable."),
+            ]),
+        ],
+        trace=("06", "站 06：<code>packages/coding-agent/src/cli.ts</code> 处理主线。", "Station 06: <code>packages/coding-agent/src/cli.ts</code> on through-line."),
+        src_extra=[
+            ("src", "packages/coding-agent/src/cli.ts", [
+                '<span class="src-comment">// CLI 启动 · packages/coding-agent/src/cli.ts</span>',
+                '<span class="src-comment">// through-line: README.md</span>',
+            ]),
+        ],
+        textbook_cps=['13'],
+        faq=[
+            (
+                "CLI 启动最关键文件？",
+                "Key file?",
+                "<code>packages/coding-agent/src/cli.ts</code>。",
+                "<code>packages/coding-agent/src/cli.ts</code>.",
+            ),
+            (
+                "如何单测？",
+                "Unit test?",
+                "mock StreamFn 或 ScriptedModel。",
+                "mock StreamFn or ScriptedModel.",
+            ),
+            (
+                "与 textbook 差异？",
+                "vs textbook?",
+                "生产含 OAuth/TUI/40+ providers。",
+                "Production adds OAuth/TUI/40+ providers.",
+            ),
+        ],
+    ),
+    "c7": _ch(
+        (
+            ("AgentSession 决定你如何理解 Pi 在此层的机制。", "AgentSession shapes how you understand Pi at this layer."),
+            ("反直觉：<code>agent-session.ts</code> 的复杂度在事件契约而非算法。", "Counter-intuitive: complexity in <code>agent-session.ts</code> is event contracts."),
+            ("优化：--verbose + 源码对照，不猜测模型行为。", "Optimize: --verbose plus source, don't guess."),
+        ),
+        (
+            ("模块", "Module"),
+            ("coding-agent", "coding-agent"),
+            ("站 07", "St. 07"),
+            ("agent-session.ts", "agent-session.ts"),
+        ),
+        [
+            ("AgentSession：主线 prompt 如何穿过此模块", "AgentSession: through-line crossing", [
+                ("用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/coding-agent/src/core/agent-session.ts</code> 定义了此阶段的类型契约与副作用边界。", "After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/coding-agent/src/core/agent-session.ts</code> defines type contracts and side-effect boundaries here."),
+                ("在 pi-mono 仓库打开该文件，搜索 <code>export</code> 与 <code>AgentEvent</code>——这是比读 README 更快的定位法。", "In pi-mono, search <code>export</code> and <code>AgentEvent</code> — faster than README alone."),
+                ("设计原则：核心循环（agent-loop）不 import TUI；本模块通过事件与回调与上游通信。", "Principle: agent-loop never imports TUI; this module talks upstream via events/callbacks."),
+                ("pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。", "Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file."),
+            ]),
+            ("AgentSession：关键函数与数据流", "AgentSession: key functions and data flow", [
+                ("<code>agent-session.ts</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。", "<code>async</code> functions in <code>agent-session.ts</code> are usually IO boundaries: disk, network, or subprocess."),
+                ("成功路径与错误路径都必须 emit 事件，否则 TUI 会卡在 streaming 状态、JSONL 会缺 entry。", "Success and error paths must emit events or TUI stalls streaming and JSONL misses entries."),
+                ("length 截断时 <code>agent-loop.ts</code> 的 <code>failToolCallsFromTruncatedMessage</code> 批量失败 tool calls，防止执行损坏参数。", "On length truncation, <code>failToolCallsFromTruncatedMessage</code> fails all tool calls to avoid corrupted args."),
+                ("对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。", "Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>."),
+            ]),
+            ("AgentSession：与 agent-loop 的接口", "AgentSession: interface with agent-loop", [
+                ("<code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。", "<code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc."),
+                ("<code>AgentSession</code> 在构造 config 时绑定本模块实现；换模式（print/rpc/interactive）不换 agent-loop。", "<code>AgentSession</code> binds this module when building config; modes change, agent-loop does not."),
+                ("fork 项目时优先替换本模块而非复制 agent-loop——这是 Pi 社区的实际 fork 模式。", "When forking, replace this module first rather than copying agent-loop — the common community pattern."),
+                ("--verbose 模式下 stderr 事件类型可回溯到 <code>packages/coding-agent/src/core/agent-session.ts</code> 的具体行。", "Under --verbose, stderr event types trace to lines in <code>packages/coding-agent/src/core/agent-session.ts</code>."),
+            ]),
+            ("AgentSession：设计权衡与常见坑", "AgentSession: trade-offs and pitfalls", [
+                ("显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。", "Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union."),
+                ("扩展应 subscribe 事件而非 monkey-patch 私有方法——<code>ExtensionRunner</code> 提供正规 hook 面。", "Extensions should subscribe to events, not monkey-patch privates — <code>ExtensionRunner</code> provides hooks."),
+                ("JSONL <code>CURRENT_SESSION_VERSION = 3</code>：改 entry schema 必须 bump version 并提供迁移。", "JSONL <code>CURRENT_SESSION_VERSION = 3</code>: schema changes need version bump and migration."),
+                ("对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。", "vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable."),
+            ]),
+        ],
+        trace=("07", "站 07：<code>packages/coding-agent/src/core/agent-session.ts</code> 处理主线。", "Station 07: <code>packages/coding-agent/src/core/agent-session.ts</code> on through-line."),
+        src_extra=[
+            ("src", "packages/coding-agent/src/core/agent-session.ts", [
+                '<span class="src-comment">// AgentSession · packages/coding-agent/src/core/agent-session.ts</span>',
+                '<span class="src-comment">// through-line: README.md</span>',
+            ]),
+        ],
+        textbook_cps=['09', '13'],
+        faq=[
+            (
+                "AgentSession最关键文件？",
+                "Key file?",
+                "<code>packages/coding-agent/src/core/agent-session.ts</code>。",
+                "<code>packages/coding-agent/src/core/agent-session.ts</code>.",
+            ),
+            (
+                "如何单测？",
+                "Unit test?",
+                "mock StreamFn 或 ScriptedModel。",
+                "mock StreamFn or ScriptedModel.",
+            ),
+            (
+                "与 textbook 差异？",
+                "vs textbook?",
+                "生产含 OAuth/TUI/40+ providers。",
+                "Production adds OAuth/TUI/40+ providers.",
+            ),
+        ],
+    ),
+    "c8": _ch(
+        (
+            ("AGENTS.md 栈 决定你如何理解 Pi 在此层的机制。", "AGENTS.md 栈 shapes how you understand Pi at this layer."),
+            ("反直觉：<code>resource-loader.ts</code> 的复杂度在事件契约而非算法。", "Counter-intuitive: complexity in <code>resource-loader.ts</code> is event contracts."),
+            ("优化：--verbose + 源码对照，不猜测模型行为。", "Optimize: --verbose plus source, don't guess."),
+        ),
+        (
+            ("模块", "Module"),
+            ("coding-agent", "coding-agent"),
+            ("站 08", "St. 08"),
+            ("resource-loader.ts", "resource-loader.ts"),
+        ),
+        [
+            ("AGENTS.md 栈：主线 prompt 如何穿过此模块", "AGENTS.md 栈: through-line crossing", [
+                ("用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/coding-agent/src/core/resource-loader.ts</code> 定义了此阶段的类型契约与副作用边界。", "After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/coding-agent/src/core/resource-loader.ts</code> defines type contracts and side-effect boundaries here."),
+                ("在 pi-mono 仓库打开该文件，搜索 <code>export</code> 与 <code>AgentEvent</code>——这是比读 README 更快的定位法。", "In pi-mono, search <code>export</code> and <code>AgentEvent</code> — faster than README alone."),
+                ("设计原则：核心循环（agent-loop）不 import TUI；本模块通过事件与回调与上游通信。", "Principle: agent-loop never imports TUI; this module talks upstream via events/callbacks."),
+                ("pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。", "Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file."),
+            ]),
+            ("AGENTS.md 栈：关键函数与数据流", "AGENTS.md 栈: key functions and data flow", [
+                ("<code>resource-loader.ts</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。", "<code>async</code> functions in <code>resource-loader.ts</code> are usually IO boundaries: disk, network, or subprocess."),
+                ("成功路径与错误路径都必须 emit 事件，否则 TUI 会卡在 streaming 状态、JSONL 会缺 entry。", "Success and error paths must emit events or TUI stalls streaming and JSONL misses entries."),
+                ("length 截断时 <code>agent-loop.ts</code> 的 <code>failToolCallsFromTruncatedMessage</code> 批量失败 tool calls，防止执行损坏参数。", "On length truncation, <code>failToolCallsFromTruncatedMessage</code> fails all tool calls to avoid corrupted args."),
+                ("对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。", "Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>."),
+            ]),
+            ("AGENTS.md 栈：与 agent-loop 的接口", "AGENTS.md 栈: interface with agent-loop", [
+                ("<code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。", "<code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc."),
+                ("<code>AgentSession</code> 在构造 config 时绑定本模块实现；换模式（print/rpc/interactive）不换 agent-loop。", "<code>AgentSession</code> binds this module when building config; modes change, agent-loop does not."),
+                ("fork 项目时优先替换本模块而非复制 agent-loop——这是 Pi 社区的实际 fork 模式。", "When forking, replace this module first rather than copying agent-loop — the common community pattern."),
+                ("--verbose 模式下 stderr 事件类型可回溯到 <code>packages/coding-agent/src/core/resource-loader.ts</code> 的具体行。", "Under --verbose, stderr event types trace to lines in <code>packages/coding-agent/src/core/resource-loader.ts</code>."),
+            ]),
+            ("AGENTS.md 栈：设计权衡与常见坑", "AGENTS.md 栈: trade-offs and pitfalls", [
+                ("显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。", "Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union."),
+                ("扩展应 subscribe 事件而非 monkey-patch 私有方法——<code>ExtensionRunner</code> 提供正规 hook 面。", "Extensions should subscribe to events, not monkey-patch privates — <code>ExtensionRunner</code> provides hooks."),
+                ("JSONL <code>CURRENT_SESSION_VERSION = 3</code>：改 entry schema 必须 bump version 并提供迁移。", "JSONL <code>CURRENT_SESSION_VERSION = 3</code>: schema changes need version bump and migration."),
+                ("对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。", "vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable."),
+            ]),
+        ],
+        trace=("08", "站 08：<code>packages/coding-agent/src/core/resource-loader.ts</code> 处理主线。", "Station 08: <code>packages/coding-agent/src/core/resource-loader.ts</code> on through-line."),
+        src_extra=[
+            ("src", "packages/coding-agent/src/core/resource-loader.ts", [
+                '<span class="src-comment">// AGENTS.md 栈 · packages/coding-agent/src/core/resource-loader.ts</span>',
+                '<span class="src-comment">// through-line: README.md</span>',
+            ]),
+        ],
+        textbook_cps=['12'],
+        faq=[
+            (
+                "AGENTS.md 栈最关键文件？",
+                "Key file?",
+                "<code>packages/coding-agent/src/core/resource-loader.ts</code>。",
+                "<code>packages/coding-agent/src/core/resource-loader.ts</code>.",
+            ),
+            (
+                "如何单测？",
+                "Unit test?",
+                "mock StreamFn 或 ScriptedModel。",
+                "mock StreamFn or ScriptedModel.",
+            ),
+            (
+                "与 textbook 差异？",
+                "vs textbook?",
+                "生产含 OAuth/TUI/40+ providers。",
+                "Production adds OAuth/TUI/40+ providers.",
+            ),
+        ],
+    ),
+    "c9": _ch(
+        (
+            ("消息模型 决定你如何理解 Pi 在此层的机制。", "消息模型 shapes how you understand Pi at this layer."),
+            ("反直觉：<code>types.ts</code> 的复杂度在事件契约而非算法。", "Counter-intuitive: complexity in <code>types.ts</code> is event contracts."),
+            ("优化：--verbose + 源码对照，不猜测模型行为。", "Optimize: --verbose plus source, don't guess."),
+        ),
+        (
+            ("模块", "Module"),
+            ("agent", "agent"),
+            ("站 09", "St. 09"),
+            ("types.ts", "types.ts"),
+        ),
+        [
+            ("消息模型：主线 prompt 如何穿过此模块", "消息模型: through-line crossing", [
+                ("用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/agent/src/types.ts</code> 定义了此阶段的类型契约与副作用边界。", "After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/agent/src/types.ts</code> defines type contracts and side-effect boundaries here."),
+                ("在 pi-mono 仓库打开该文件，搜索 <code>export</code> 与 <code>AgentEvent</code>——这是比读 README 更快的定位法。", "In pi-mono, search <code>export</code> and <code>AgentEvent</code> — faster than README alone."),
+                ("设计原则：核心循环（agent-loop）不 import TUI；本模块通过事件与回调与上游通信。", "Principle: agent-loop never imports TUI; this module talks upstream via events/callbacks."),
+                ("pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。", "Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file."),
+            ]),
+            ("消息模型：关键函数与数据流", "消息模型: key functions and data flow", [
+                ("<code>types.ts</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。", "<code>async</code> functions in <code>types.ts</code> are usually IO boundaries: disk, network, or subprocess."),
+                ("成功路径与错误路径都必须 emit 事件，否则 TUI 会卡在 streaming 状态、JSONL 会缺 entry。", "Success and error paths must emit events or TUI stalls streaming and JSONL misses entries."),
+                ("length 截断时 <code>agent-loop.ts</code> 的 <code>failToolCallsFromTruncatedMessage</code> 批量失败 tool calls，防止执行损坏参数。", "On length truncation, <code>failToolCallsFromTruncatedMessage</code> fails all tool calls to avoid corrupted args."),
+                ("对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。", "Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>."),
+            ]),
+            ("消息模型：与 agent-loop 的接口", "消息模型: interface with agent-loop", [
+                ("<code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。", "<code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc."),
+                ("<code>AgentSession</code> 在构造 config 时绑定本模块实现；换模式（print/rpc/interactive）不换 agent-loop。", "<code>AgentSession</code> binds this module when building config; modes change, agent-loop does not."),
+                ("fork 项目时优先替换本模块而非复制 agent-loop——这是 Pi 社区的实际 fork 模式。", "When forking, replace this module first rather than copying agent-loop — the common community pattern."),
+                ("--verbose 模式下 stderr 事件类型可回溯到 <code>packages/agent/src/types.ts</code> 的具体行。", "Under --verbose, stderr event types trace to lines in <code>packages/agent/src/types.ts</code>."),
+            ]),
+            ("消息模型：设计权衡与常见坑", "消息模型: trade-offs and pitfalls", [
+                ("显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。", "Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union."),
+                ("扩展应 subscribe 事件而非 monkey-patch 私有方法——<code>ExtensionRunner</code> 提供正规 hook 面。", "Extensions should subscribe to events, not monkey-patch privates — <code>ExtensionRunner</code> provides hooks."),
+                ("JSONL <code>CURRENT_SESSION_VERSION = 3</code>：改 entry schema 必须 bump version 并提供迁移。", "JSONL <code>CURRENT_SESSION_VERSION = 3</code>: schema changes need version bump and migration."),
+                ("对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。", "vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable."),
+            ]),
+        ],
+        trace=("09", "站 09：<code>packages/agent/src/types.ts</code> 处理主线。", "Station 09: <code>packages/agent/src/types.ts</code> on through-line."),
+        src_extra=[
+            ("src", "packages/agent/src/types.ts", [
+                '<span class="src-comment">// 消息模型 · packages/agent/src/types.ts</span>',
+                '<span class="src-comment">// through-line: README.md</span>',
+            ]),
+        ],
+        textbook_cps=['03'],
+        faq=[
+            (
+                "消息模型最关键文件？",
+                "Key file?",
+                "<code>packages/agent/src/types.ts</code>。",
+                "<code>packages/agent/src/types.ts</code>.",
+            ),
+            (
+                "如何单测？",
+                "Unit test?",
+                "mock StreamFn 或 ScriptedModel。",
+                "mock StreamFn or ScriptedModel.",
+            ),
+            (
+                "与 textbook 差异？",
+                "vs textbook?",
+                "生产含 OAuth/TUI/40+ providers。",
+                "Production adds OAuth/TUI/40+ providers.",
+            ),
+        ],
+    ),
+    "c10": _ch(
+        (
+            ("runLoop 双环 决定你如何理解 Pi 在此层的机制。", "runLoop 双环 shapes how you understand Pi at this layer."),
+            ("反直觉：<code>agent-loop.ts</code> 的复杂度在事件契约而非算法。", "Counter-intuitive: complexity in <code>agent-loop.ts</code> is event contracts."),
+            ("优化：--verbose + 源码对照，不猜测模型行为。", "Optimize: --verbose plus source, don't guess."),
+        ),
+        (
+            ("模块", "Module"),
+            ("agent", "agent"),
+            ("站 10", "St. 10"),
+            ("agent-loop.ts", "agent-loop.ts"),
+        ),
+        [
+            ("runLoop 双环：主线 prompt 如何穿过此模块", "runLoop 双环: through-line crossing", [
+                ("用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/agent/src/agent-loop.ts</code> 定义了此阶段的类型契约与副作用边界。", "After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/agent/src/agent-loop.ts</code> defines type contracts and side-effect boundaries here."),
+                ("在 pi-mono 仓库打开该文件，搜索 <code>export</code> 与 <code>AgentEvent</code>——这是比读 README 更快的定位法。", "In pi-mono, search <code>export</code> and <code>AgentEvent</code> — faster than README alone."),
+                ("设计原则：核心循环（agent-loop）不 import TUI；本模块通过事件与回调与上游通信。", "Principle: agent-loop never imports TUI; this module talks upstream via events/callbacks."),
+                ("pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。", "Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file."),
+            ]),
+            ("runLoop 双环：关键函数与数据流", "runLoop 双环: key functions and data flow", [
+                ("<code>agent-loop.ts</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。", "<code>async</code> functions in <code>agent-loop.ts</code> are usually IO boundaries: disk, network, or subprocess."),
+                ("成功路径与错误路径都必须 emit 事件，否则 TUI 会卡在 streaming 状态、JSONL 会缺 entry。", "Success and error paths must emit events or TUI stalls streaming and JSONL misses entries."),
+                ("length 截断时 <code>agent-loop.ts</code> 的 <code>failToolCallsFromTruncatedMessage</code> 批量失败 tool calls，防止执行损坏参数。", "On length truncation, <code>failToolCallsFromTruncatedMessage</code> fails all tool calls to avoid corrupted args."),
+                ("对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。", "Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>."),
+            ]),
+            ("runLoop 双环：与 agent-loop 的接口", "runLoop 双环: interface with agent-loop", [
+                ("<code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。", "<code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc."),
+                ("<code>AgentSession</code> 在构造 config 时绑定本模块实现；换模式（print/rpc/interactive）不换 agent-loop。", "<code>AgentSession</code> binds this module when building config; modes change, agent-loop does not."),
+                ("fork 项目时优先替换本模块而非复制 agent-loop——这是 Pi 社区的实际 fork 模式。", "When forking, replace this module first rather than copying agent-loop — the common community pattern."),
+                ("--verbose 模式下 stderr 事件类型可回溯到 <code>packages/agent/src/agent-loop.ts</code> 的具体行。", "Under --verbose, stderr event types trace to lines in <code>packages/agent/src/agent-loop.ts</code>."),
+            ]),
+            ("runLoop 双环：设计权衡与常见坑", "runLoop 双环: trade-offs and pitfalls", [
+                ("显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。", "Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union."),
+                ("扩展应 subscribe 事件而非 monkey-patch 私有方法——<code>ExtensionRunner</code> 提供正规 hook 面。", "Extensions should subscribe to events, not monkey-patch privates — <code>ExtensionRunner</code> provides hooks."),
+                ("JSONL <code>CURRENT_SESSION_VERSION = 3</code>：改 entry schema 必须 bump version 并提供迁移。", "JSONL <code>CURRENT_SESSION_VERSION = 3</code>: schema changes need version bump and migration."),
+                ("对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。", "vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable."),
+            ]),
+        ],
+        trace=("10", "站 10：<code>packages/agent/src/agent-loop.ts</code> 处理主线。", "Station 10: <code>packages/agent/src/agent-loop.ts</code> on through-line."),
+        src_extra=[
+            ("src", "packages/agent/src/agent-loop.ts", [
+                '<span class="src-kw">while</span> (true) { // outer follow-up',
+                '  <span class="src-kw">while</span> (hasMoreToolCalls || pendingMessages.length) {',
+            ]),
+        ],
+        textbook_cps=['07'],
+        faq=[
+            (
+                "runLoop 双环最关键文件？",
+                "Key file?",
+                "<code>packages/agent/src/agent-loop.ts</code>。",
+                "<code>packages/agent/src/agent-loop.ts</code>.",
+            ),
+            (
+                "如何单测？",
+                "Unit test?",
+                "mock StreamFn 或 ScriptedModel。",
+                "mock StreamFn or ScriptedModel.",
+            ),
+            (
+                "与 textbook 差异？",
+                "vs textbook?",
+                "生产含 OAuth/TUI/40+ providers。",
+                "Production adds OAuth/TUI/40+ providers.",
+            ),
+        ],
+    ),
+
+    "c11": _ch(
+        (
+            ("Steering 在 tool 执行期间插队；Follow-up 在 agent 将停时续聊。", "Steering injects mid-run; follow-up continues after agent would stop."),
+            ("反直觉：两队列在 Agent 与 AgentSession 各有一份，由 config 桥接。", "Counter-intuitive: two queues in Agent and AgentSession, bridged via config."),
+            ("优化：读 agent-loop.ts 259 行 getSteeringMessages 与 263 行 getFollowUpMessages。", "Optimize: read agent-loop.ts lines 259 and 263."),
+        ),
+        (
+            ("agent-core", "agent-core"),
+            ("agent.ts + agent-loop.ts", "agent.ts + agent-loop.ts"),
+            ("站 10–11", "Stations 10–11"),
+            ("steeringQueue / followUpQueue", "steeringQueue / followUpQueue"),
+        ),
+        [
+            ("Steering：内环插队语义", "Steering: inner-loop injection", [
+                ("runLoop 内环每次迭代末尾调用 getSteeringMessages（agent-loop.ts 259 行）。返回的 AgentMessage[] 在下一次 streamAssistantResponse 之前 push 进 context。", "Inner loop calls getSteeringMessages (line 259). AgentMessage[] pushed before next streamAssistantResponse."),
+                ("agent.ts 475–480 行：steeringQueue.drain()；skipInitialSteeringPoll 避免首轮重复 drain。", "agent.ts 475–480: steeringQueue.drain(); skipInitialSteeringPoll avoids double drain."),
+                ("AgentSession 1545 行 getSteeringMessages() 暴露只读副本给 TUI。", "AgentSession line 1545 exposes read-only copy for TUI."),
+                ("场景：read 执行中用户输入「先 ls」——steering 在 tool batch 完成后、下次 LLM 前注入。", "Scenario: while read runs, user types «ls first» — steering injects after tool batch."),
+            ]),
+            ("Follow-up：外环续聊语义", "Follow-up: outer-loop continuation", [
+                ("内环结束后外环检查 getFollowUpMessages（263 行）。非空则 pendingMessages 并 continue 外环。", "Outer loop checks getFollowUpMessages (line 263). Non-empty continues outer loop."),
+                ("agent.ts 482 行 followUpQueue.drain()。AgentSession._queueFollowUp（1407 行）路由后续用户输入。", "agent.ts 482 followUpQueue.drain(); AgentSession._queueFollowUp routes post-turn input."),
+                ("与 steering 区别：follow-up 在 agent would stop 时；steering 在 still running 时。", "vs steering: follow-up when would stop; steering while still running."),
+            ]),
+            ("AgentSession 与 Agent 的分工", "AgentSession vs Agent", [
+                ("AgentSession 维护 _steeringMessages / _followUpMessages；构造 AgentLoopConfig 时绑定 drain。", "AgentSession maintains queues; binds drain when building AgentLoopConfig."),
+                ("Agent 类封装有状态队列，供 SDK 与测试使用。", "Agent class wraps stateful queues for SDK and tests."),
+                ("interactive-mode.ts 4303 行合并队列状态渲染 footer。", "interactive-mode.ts line 4303 merges queue state in footer."),
+            ]),
+            ("QueueMode 与并发", "QueueMode and concurrency", [
+                ("types.ts 导出 QueueMode 控制排队策略。", "types.ts exports QueueMode for queue policy."),
+                ("agent-session-concurrent.test.ts 验证 extension steer。", "concurrent test verifies extension steering."),
+                ("abort：AgentSession.abort() 1561 行调用 agent.abort()。", "Abort: AgentSession.abort() line 1561 calls agent.abort()."),
+            ]),
+            ("主线 prompt 下的 steering/follow-up", "On through-line", [
+                ("默认 README 任务不触发 steering；测试 mock getSteeringMessages 观察内环注入。", "Default README task does not steer; mock getSteeringMessages to test injection."),
+            ]),
+        ],
+        trace=("10", "站 10–11：getSteeringMessages / getFollowUpMessages 桥接 AgentSession 与 runLoop。", "Stations 10–11: steering/follow-up bridge AgentSession and runLoop."),
+        src_extra=[
+            ("loop", "packages/agent/src/agent-loop.ts", [
+                '<span class="src-arg">pendingMessages</span> = (<span class="src-kw">await</span> config.<span class="src-fn">getSteeringMessages</span>?.()) || [];',
+                '<span class="src-kw">const</span> followUpMessages = (<span class="src-kw">await</span> config.<span class="src-fn">getFollowUpMessages</span>?.()) || [];',
+            ]),
+            ("agent", "packages/agent/src/agent.ts", [
+                '<span class="src-fn">getSteeringMessages</span>: <span class="src-kw">async</span> () => <span class="src-kw">this</span>.steeringQueue.<span class="src-fn">drain</span>(),',
+                '<span class="src-fn">getFollowUpMessages</span>: <span class="src-kw">async</span> () => <span class="src-kw">this</span>.followUpQueue.<span class="src-fn">drain</span>(),',
+            ]),
+        ],
+        textbook_cps=["09"],
+        faq=[
+            ("steering 和 follow-up 能否同时排队？", "Both queue?", "可以；pendingMessageCount 1540 行返回两者之和。", "Yes; pendingMessageCount sums both."),
+            ("steering 会打断 bash 吗？", "Interrupt bash?", "不立即；在当前 tool batch 完成后注入。", "Not immediately; after tool batch."),
+            ("extension 如何注入 steering？", "Extension steer?", "通过 ExtensionActions queue 方法。", "Via ExtensionActions queue methods."),
+        ],
+    ),
+    "c12": _ch(
+        (
+            ("Tool 管线 决定你如何理解 Pi 在此层的机制。", "Tool 管线 shapes how you understand Pi at this layer."),
+            ("反直觉：<code>read.ts</code> 的复杂度在事件契约而非算法。", "Counter-intuitive: complexity in <code>read.ts</code> is event contracts."),
+            ("优化：--verbose + 源码对照，不猜测模型行为。", "Optimize: --verbose plus source, don't guess."),
+        ),
+        (
+            ("模块", "Module"),
+            ("coding-agent", "coding-agent"),
+            ("站 12", "St. 12"),
+            ("read.ts", "read.ts"),
+        ),
+        [
+            ("Tool 管线：主线 prompt 如何穿过此模块", "Tool 管线: through-line crossing", [
+                ("用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/coding-agent/src/core/tools/read.ts</code> 定义了此阶段的类型契约与副作用边界。", "After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/coding-agent/src/core/tools/read.ts</code> defines type contracts and side-effect boundaries here."),
+                ("在 pi-mono 仓库打开该文件，搜索 <code>export</code> 与 <code>AgentEvent</code>——这是比读 README 更快的定位法。", "In pi-mono, search <code>export</code> and <code>AgentEvent</code> — faster than README alone."),
+                ("设计原则：核心循环（agent-loop）不 import TUI；本模块通过事件与回调与上游通信。", "Principle: agent-loop never imports TUI; this module talks upstream via events/callbacks."),
+                ("pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。", "Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file."),
+            ]),
+            ("Tool 管线：关键函数与数据流", "Tool 管线: key functions and data flow", [
+                ("<code>read.ts</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。", "<code>async</code> functions in <code>read.ts</code> are usually IO boundaries: disk, network, or subprocess."),
+                ("成功路径与错误路径都必须 emit 事件，否则 TUI 会卡在 streaming 状态、JSONL 会缺 entry。", "Success and error paths must emit events or TUI stalls streaming and JSONL misses entries."),
+                ("length 截断时 <code>agent-loop.ts</code> 的 <code>failToolCallsFromTruncatedMessage</code> 批量失败 tool calls，防止执行损坏参数。", "On length truncation, <code>failToolCallsFromTruncatedMessage</code> fails all tool calls to avoid corrupted args."),
+                ("对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。", "Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>."),
+            ]),
+            ("Tool 管线：与 agent-loop 的接口", "Tool 管线: interface with agent-loop", [
+                ("<code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。", "<code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc."),
+                ("<code>AgentSession</code> 在构造 config 时绑定本模块实现；换模式（print/rpc/interactive）不换 agent-loop。", "<code>AgentSession</code> binds this module when building config; modes change, agent-loop does not."),
+                ("fork 项目时优先替换本模块而非复制 agent-loop——这是 Pi 社区的实际 fork 模式。", "When forking, replace this module first rather than copying agent-loop — the common community pattern."),
+                ("--verbose 模式下 stderr 事件类型可回溯到 <code>packages/coding-agent/src/core/tools/read.ts</code> 的具体行。", "Under --verbose, stderr event types trace to lines in <code>packages/coding-agent/src/core/tools/read.ts</code>."),
+            ]),
+            ("Tool 管线：设计权衡与常见坑", "Tool 管线: trade-offs and pitfalls", [
+                ("显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。", "Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union."),
+                ("扩展应 subscribe 事件而非 monkey-patch 私有方法——<code>ExtensionRunner</code> 提供正规 hook 面。", "Extensions should subscribe to events, not monkey-patch privates — <code>ExtensionRunner</code> provides hooks."),
+                ("JSONL <code>CURRENT_SESSION_VERSION = 3</code>：改 entry schema 必须 bump version 并提供迁移。", "JSONL <code>CURRENT_SESSION_VERSION = 3</code>: schema changes need version bump and migration."),
+                ("对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。", "vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable."),
+            ]),
+        ],
+        trace=("12", "站 12：<code>packages/coding-agent/src/core/tools/read.ts</code> 处理主线。", "Station 12: <code>packages/coding-agent/src/core/tools/read.ts</code> on through-line."),
+        src_extra=[
+            ("src", "packages/coding-agent/src/core/tools/read.ts", [
+                '<span class="src-comment">// Tool 管线 · packages/coding-agent/src/core/tools/read.ts</span>',
+                '<span class="src-comment">// through-line: README.md</span>',
+            ]),
+        ],
+        textbook_cps=['06', '08'],
+        faq=[
+            (
+                "Tool 管线最关键文件？",
+                "Key file?",
+                "<code>packages/coding-agent/src/core/tools/read.ts</code>。",
+                "<code>packages/coding-agent/src/core/tools/read.ts</code>.",
+            ),
+            (
+                "如何单测？",
+                "Unit test?",
+                "mock StreamFn 或 ScriptedModel。",
+                "mock StreamFn or ScriptedModel.",
+            ),
+            (
+                "与 textbook 差异？",
+                "vs textbook?",
+                "生产含 OAuth/TUI/40+ providers。",
+                "Production adds OAuth/TUI/40+ providers.",
+            ),
+        ],
+    ),
+    "c13": _ch(
+        (
+            ("事件总线 决定你如何理解 Pi 在此层的机制。", "事件总线 shapes how you understand Pi at this layer."),
+            ("反直觉：<code>agent-session.ts</code> 的复杂度在事件契约而非算法。", "Counter-intuitive: complexity in <code>agent-session.ts</code> is event contracts."),
+            ("优化：--verbose + 源码对照，不猜测模型行为。", "Optimize: --verbose plus source, don't guess."),
+        ),
+        (
+            ("模块", "Module"),
+            ("coding-agent", "coding-agent"),
+            ("站 13", "St. 13"),
+            ("agent-session.ts", "agent-session.ts"),
+        ),
+        [
+            ("事件总线：主线 prompt 如何穿过此模块", "事件总线: through-line crossing", [
+                ("用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/coding-agent/src/core/agent-session.ts</code> 定义了此阶段的类型契约与副作用边界。", "After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/coding-agent/src/core/agent-session.ts</code> defines type contracts and side-effect boundaries here."),
+                ("在 pi-mono 仓库打开该文件，搜索 <code>export</code> 与 <code>AgentEvent</code>——这是比读 README 更快的定位法。", "In pi-mono, search <code>export</code> and <code>AgentEvent</code> — faster than README alone."),
+                ("设计原则：核心循环（agent-loop）不 import TUI；本模块通过事件与回调与上游通信。", "Principle: agent-loop never imports TUI; this module talks upstream via events/callbacks."),
+                ("pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。", "Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file."),
+            ]),
+            ("事件总线：关键函数与数据流", "事件总线: key functions and data flow", [
+                ("<code>agent-session.ts</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。", "<code>async</code> functions in <code>agent-session.ts</code> are usually IO boundaries: disk, network, or subprocess."),
+                ("成功路径与错误路径都必须 emit 事件，否则 TUI 会卡在 streaming 状态、JSONL 会缺 entry。", "Success and error paths must emit events or TUI stalls streaming and JSONL misses entries."),
+                ("length 截断时 <code>agent-loop.ts</code> 的 <code>failToolCallsFromTruncatedMessage</code> 批量失败 tool calls，防止执行损坏参数。", "On length truncation, <code>failToolCallsFromTruncatedMessage</code> fails all tool calls to avoid corrupted args."),
+                ("对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。", "Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>."),
+            ]),
+            ("事件总线：与 agent-loop 的接口", "事件总线: interface with agent-loop", [
+                ("<code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。", "<code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc."),
+                ("<code>AgentSession</code> 在构造 config 时绑定本模块实现；换模式（print/rpc/interactive）不换 agent-loop。", "<code>AgentSession</code> binds this module when building config; modes change, agent-loop does not."),
+                ("fork 项目时优先替换本模块而非复制 agent-loop——这是 Pi 社区的实际 fork 模式。", "When forking, replace this module first rather than copying agent-loop — the common community pattern."),
+                ("--verbose 模式下 stderr 事件类型可回溯到 <code>packages/coding-agent/src/core/agent-session.ts</code> 的具体行。", "Under --verbose, stderr event types trace to lines in <code>packages/coding-agent/src/core/agent-session.ts</code>."),
+            ]),
+            ("事件总线：设计权衡与常见坑", "事件总线: trade-offs and pitfalls", [
+                ("显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。", "Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union."),
+                ("扩展应 subscribe 事件而非 monkey-patch 私有方法——<code>ExtensionRunner</code> 提供正规 hook 面。", "Extensions should subscribe to events, not monkey-patch privates — <code>ExtensionRunner</code> provides hooks."),
+                ("JSONL <code>CURRENT_SESSION_VERSION = 3</code>：改 entry schema 必须 bump version 并提供迁移。", "JSONL <code>CURRENT_SESSION_VERSION = 3</code>: schema changes need version bump and migration."),
+                ("对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。", "vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable."),
+            ]),
+        ],
+        trace=("13", "站 13：<code>packages/coding-agent/src/core/agent-session.ts</code> 处理主线。", "Station 13: <code>packages/coding-agent/src/core/agent-session.ts</code> on through-line."),
+        src_extra=[
+            ("src", "packages/coding-agent/src/core/agent-session.ts", [
+                '<span class="src-comment">// 事件总线 · packages/coding-agent/src/core/agent-session.ts</span>',
+                '<span class="src-comment">// through-line: README.md</span>',
+            ]),
+        ],
+        textbook_cps=['09'],
+        faq=[
+            (
+                "事件总线最关键文件？",
+                "Key file?",
+                "<code>packages/coding-agent/src/core/agent-session.ts</code>。",
+                "<code>packages/coding-agent/src/core/agent-session.ts</code>.",
+            ),
+            (
+                "如何单测？",
+                "Unit test?",
+                "mock StreamFn 或 ScriptedModel。",
+                "mock StreamFn or ScriptedModel.",
+            ),
+            (
+                "与 textbook 差异？",
+                "vs textbook?",
+                "生产含 OAuth/TUI/40+ providers。",
+                "Production adds OAuth/TUI/40+ providers.",
+            ),
+        ],
+    ),
+    "c14": _ch(
+        (
+            ("pi-ai 提供商 决定你如何理解 Pi 在此层的机制。", "pi-ai 提供商 shapes how you understand Pi at this layer."),
+            ("反直觉：<code>models.ts</code> 的复杂度在事件契约而非算法。", "Counter-intuitive: complexity in <code>models.ts</code> is event contracts."),
+            ("优化：--verbose + 源码对照，不猜测模型行为。", "Optimize: --verbose plus source, don't guess."),
+        ),
+        (
+            ("模块", "Module"),
+            ("ai", "ai"),
+            ("站 14", "St. 14"),
+            ("models.ts", "models.ts"),
+        ),
+        [
+            ("pi-ai 提供商：主线 prompt 如何穿过此模块", "pi-ai 提供商: through-line crossing", [
+                ("用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/ai/src/models.ts</code> 定义了此阶段的类型契约与副作用边界。", "After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/ai/src/models.ts</code> defines type contracts and side-effect boundaries here."),
+                ("在 pi-mono 仓库打开该文件，搜索 <code>export</code> 与 <code>AgentEvent</code>——这是比读 README 更快的定位法。", "In pi-mono, search <code>export</code> and <code>AgentEvent</code> — faster than README alone."),
+                ("设计原则：核心循环（agent-loop）不 import TUI；本模块通过事件与回调与上游通信。", "Principle: agent-loop never imports TUI; this module talks upstream via events/callbacks."),
+                ("pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。", "Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file."),
+            ]),
+            ("pi-ai 提供商：关键函数与数据流", "pi-ai 提供商: key functions and data flow", [
+                ("<code>models.ts</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。", "<code>async</code> functions in <code>models.ts</code> are usually IO boundaries: disk, network, or subprocess."),
+                ("成功路径与错误路径都必须 emit 事件，否则 TUI 会卡在 streaming 状态、JSONL 会缺 entry。", "Success and error paths must emit events or TUI stalls streaming and JSONL misses entries."),
+                ("length 截断时 <code>agent-loop.ts</code> 的 <code>failToolCallsFromTruncatedMessage</code> 批量失败 tool calls，防止执行损坏参数。", "On length truncation, <code>failToolCallsFromTruncatedMessage</code> fails all tool calls to avoid corrupted args."),
+                ("对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。", "Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>."),
+            ]),
+            ("pi-ai 提供商：与 agent-loop 的接口", "pi-ai 提供商: interface with agent-loop", [
+                ("<code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。", "<code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc."),
+                ("<code>AgentSession</code> 在构造 config 时绑定本模块实现；换模式（print/rpc/interactive）不换 agent-loop。", "<code>AgentSession</code> binds this module when building config; modes change, agent-loop does not."),
+                ("fork 项目时优先替换本模块而非复制 agent-loop——这是 Pi 社区的实际 fork 模式。", "When forking, replace this module first rather than copying agent-loop — the common community pattern."),
+                ("--verbose 模式下 stderr 事件类型可回溯到 <code>packages/ai/src/models.ts</code> 的具体行。", "Under --verbose, stderr event types trace to lines in <code>packages/ai/src/models.ts</code>."),
+            ]),
+            ("pi-ai 提供商：设计权衡与常见坑", "pi-ai 提供商: trade-offs and pitfalls", [
+                ("显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。", "Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union."),
+                ("扩展应 subscribe 事件而非 monkey-patch 私有方法——<code>ExtensionRunner</code> 提供正规 hook 面。", "Extensions should subscribe to events, not monkey-patch privates — <code>ExtensionRunner</code> provides hooks."),
+                ("JSONL <code>CURRENT_SESSION_VERSION = 3</code>：改 entry schema 必须 bump version 并提供迁移。", "JSONL <code>CURRENT_SESSION_VERSION = 3</code>: schema changes need version bump and migration."),
+                ("对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。", "vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable."),
+            ]),
+        ],
+        trace=("14", "站 14：<code>packages/ai/src/models.ts</code> 处理主线。", "Station 14: <code>packages/ai/src/models.ts</code> on through-line."),
+        src_extra=[
+            ("src", "packages/ai/src/models.ts", [
+                '<span class="src-comment">// pi-ai 提供商 · packages/ai/src/models.ts</span>',
+                '<span class="src-comment">// through-line: README.md</span>',
+            ]),
+        ],
+        textbook_cps=['05'],
+        faq=[
+            (
+                "pi-ai 提供商最关键文件？",
+                "Key file?",
+                "<code>packages/ai/src/models.ts</code>。",
+                "<code>packages/ai/src/models.ts</code>.",
+            ),
+            (
+                "如何单测？",
+                "Unit test?",
+                "mock StreamFn 或 ScriptedModel。",
+                "mock StreamFn or ScriptedModel.",
+            ),
+            (
+                "与 textbook 差异？",
+                "vs textbook?",
+                "生产含 OAuth/TUI/40+ providers。",
+                "Production adds OAuth/TUI/40+ providers.",
+            ),
+        ],
+    ),
+
+    "c15": _ch(
+        (
+            ("EventStream 是 pi-ai 与 agent-loop 之间的异步泵——token 与终态同流交付。", "EventStream is the async pump between pi-ai and agent-loop — tokens and terminal state in one stream."),
+            ("反直觉：Agent 层 EventStream 与 LLM 层 AssistantMessageEventStream 是两套 isComplete 谓词。", "Counter-intuitive: Agent EventStream vs LLM AssistantMessageEventStream use different isComplete predicates."),
+            ("优化：读 event-stream.ts push/end 与 agent-loop createAgentStream 的对称设计。", "Optimize: read symmetric design of event-stream.ts push/end and createAgentStream."),
+        ),
+        (("pi-ai","pi-ai"),("event-stream.ts","event-stream.ts"),("站 15","St. 15"),("text_delta → done","text_delta → done")),
+        [
+            ("EventStream 核心语义", "EventStream core semantics", [
+                ("packages/ai/src/utils/event-stream.ts：泛型 EventStream<T,R>，构造时传入 isComplete 与 extractResult。", "packages/ai/src/utils/event-stream.ts: generic EventStream<T,R> with isComplete and extractResult at construction."),
+                ("push(event)：若 isComplete(event) 为真，设 done=true 并 resolveFinalResult；否则入队或交给 waiting consumer。", "push(event): if isComplete, set done and resolveFinalResult; else queue or deliver to waiting consumer."),
+                ("AsyncIterable 协议：消费者 for-await 时，队列空且未 done 则挂起在 waiting 数组。", "AsyncIterable: for-await suspends on waiting array when queue empty and not done."),
+                ("AssistantMessageEventStream 子类：isComplete 当 type===done 或 error；extractResult 返回 message 或抛错。", "AssistantMessageEventStream: isComplete on done/error; extractResult returns message or throws."),
+            ]),
+            ("主线 prompt 上的流事件类型", "Stream events on through-line", [
+                ("第一次 stream（toolUse）：text_delta 可能为空或极短；toolcall_delta 累积 read 参数；done 时 stopReason=toolUse。", "First stream (toolUse): short text_delta; toolcall_delta accumulates read args; done with stopReason=toolUse."),
+                ("第二次 stream（stop）：text_delta 逐 chunk 推送最终总结；done 时 stopReason=stop。", "Second stream (stop): text_delta chunks for summary; done with stopReason=stop."),
+                ("streamAssistantResponse 把 LLM EventStream 事件映射为 AgentEvent message_update。", "streamAssistantResponse maps LLM EventStream events to AgentEvent message_update."),
+            ]),
+            ("agent-loop 侧的 EventStream", "Agent-side EventStream", [
+                ("createAgentStream（agent-loop.ts 145 行）：isComplete 当 type===agent_end；extractResult 返回 messages 数组。", "createAgentStream (line 145): isComplete on agent_end; extractResult returns messages array."),
+                ("agentLoop 返回 EventStream<AgentEvent, AgentMessage[]>；AgentSession for-await 消费并写 JSONL。", "agentLoop returns EventStream<AgentEvent, AgentMessage[]>; AgentSession for-await consumes and writes JSONL."),
+                ("end(result) 手动 resolve——用于 abort 或错误路径提前结束。", "end(result) manually resolves — for abort or error early termination."),
+            ]),
+            ("背压与 TUI 消费", "Backpressure and TUI consumption", [
+                ("EventStream 无界队列：高速 token 时 TUI diff 渲染可能落后；TuiMainScreen firstChanged/lastChanged 优化重绘区间。", "Unbounded queue: TUI diff may lag on fast tokens; TuiMainScreen firstChanged/lastChanged optimizes redraw."),
+                ("message_update 携带 partial content；message_end 携带完整 AssistantMessage。", "message_update carries partial content; message_end carries full AssistantMessage."),
+            ]),
+            ("与 textbook checkpoint 02 对照", "vs textbook checkpoint 02", [
+                ("textbook event-stream.ts 教学「过程项与终态同时交付」——生产代码在 streamSimple 与 agentLoop 两层复用同一模式。", "Textbook checkpoint 02 teaches simultaneous partial and terminal delivery — production reuses pattern in streamSimple and agentLoop."),
+                ("测试：用 ScriptedModel 注入固定 delta 序列，断言 message_update 次数与顺序。", "Test: ScriptedModel injects fixed delta sequence; assert message_update count and order."),
+            ]),
+        ],
+        trace=("15", "站 15：EventStream push text_delta/toolcall_delta；done 触发 stopReason 分支。", "Station 15: EventStream pushes deltas; done triggers stopReason branch."),
+        src_extra=[("es", "packages/ai/src/utils/event-stream.ts", [
+            '<span class="src-kw">export class</span> <span class="src-cls">EventStream</span>&lt;T, R = T&gt;',
+            '<span class="src-fn">push</span>(event: T): <span class="src-cls">void</span> {',
+            '  <span class="src-kw">if</span> (<span class="src-kw">this</span>.isComplete(event)) { <span class="src-kw">this</span>.done = <span class="src-num">true</span>; ... }',
+        ])],
+        textbook_cps=["02"],
+        faq=[("EventStream 会丢事件吗？","Drop events?","push 在 done 后忽略；正常路径不丢。","push ignores after done; normal path does not drop."),
+             ("agent_end 与 done 区别？","agent_end vs done?","agent_end 是 AgentEvent；done 是 LLM AssistantMessageEvent。","agent_end is AgentEvent; done is LLM AssistantMessageEvent."),
+             ("如何 mock 流？","Mock stream?","ScriptedModel 或自定义 StreamFn 返回预置 EventStream。","ScriptedModel or custom StreamFn returning preset EventStream.")],
+    ),
+
+    "c16": _ch(
+        (
+            ("models.generated.ts 聚合 40+ provider 的模型目录——OAuth 与 API key 分流。", "models.generated.ts aggregates 40+ provider catalogs — OAuth vs API key paths."),
+            ("反直觉：模型列表是构建时生成，不是运行时爬取。", "Counter-intuitive: model list is build-time generated, not runtime scraped."),
+            ("优化：ModelRegistry + auth-guidance.ts 处理「无 key」时的用户引导。", "Optimize: ModelRegistry + auth-guidance.ts for no-key user guidance."),
+        ),
+        (("pi-ai","pi-ai"),("models.generated.ts","models.generated.ts"),("站 16","St. 16"),("Model + AuthResult","Model + AuthResult")),
+        [
+            ("模型目录生成管线", "Model catalog pipeline", [
+                ("packages/ai/src/models.generated.ts 头部注释：auto-generated by scripts/generate-models.ts，勿手改。", "models.generated.ts header: auto-generated by generate-models.ts, do not edit manually."),
+                ("导入 AMAZON_BEDROCK_MODELS、ANTHROPIC_MODELS、OPENAI_MODELS 等 40+ provider 常量，汇总为 MODELS 对象。", "Imports 40+ provider constants into MODELS object."),
+                ("每个 Model 含 id、provider、contextWindow、maxTokens、cost、reasoning 支持等字段。", "Each Model has id, provider, contextWindow, maxTokens, cost, reasoning support."),
+            ]),
+            ("认证路径", "Auth paths", [
+                ("packages/ai/src/oauth.ts 与 bun-oauth.ts 处理交互式 OAuth（GitHub Copilot、OpenAI Codex 等）。", "oauth.ts and bun-oauth.ts handle interactive OAuth for Copilot, Codex, etc."),
+                ("env-api-keys.ts 从环境变量读取 ANTHROPIC_API_KEY 等；getApiKey 注入 agentLoop config。", "env-api-keys.ts reads env vars; getApiKey injected into agentLoop config."),
+                ("agent-session.ts formatNoApiKeyFoundMessage 在冷启动无 key 时给出 auth-guidance。", "formatNoApiKeyFoundMessage gives auth-guidance on cold start without key."),
+            ]),
+            ("主线 prompt 的模型选择", "Model selection for through-line", [
+                ("CLI --model provider/id 或交互式 /model 选择；model_change entry 写入 JSONL。", "CLI --model provider/id or /model picker; model_change entry in JSONL."),
+                ("第一次 stream 用选定 Model 调 streamSimple；thinkingLevel 映射到 reasoning 参数。", "First stream uses selected Model via streamSimple; thinkingLevel maps to reasoning."),
+                ("换模型不丢会话：SessionManager 保留历史，新 model_change entry 标记切换点。", "Model switch preserves session: model_change entry marks switch point."),
+            ]),
+            ("ModelRegistry 运行时", "ModelRegistry runtime", [
+                ("coding-agent ModelRegistry 读取 generated  catalog，合并用户 settings 与 extension 贡献的 provider config。", "ModelRegistry reads generated catalog, merges user settings and extension provider configs."),
+                ("modelsAreEqual 用于避免重复 emit model_select 事件。", "modelsAreEqual avoids duplicate model_select events."),
+            ]),
+            ("与 textbook checkpoint 05 对照", "vs textbook checkpoint 05", [
+                ("textbook Provider Adapter 教 SSE→统一事件；生产 pi-ai api/*.ts 实现各厂商 adapter。", "Textbook checkpoint 05 teaches SSE→unified events; production api/*.ts implements per-vendor adapters."),
+            ]),
+        ],
+        trace=("16", "站 16：streamSimple 用 Model + Auth 调 provider adapter。", "Station 16: streamSimple calls provider adapter with Model + Auth."),
+        src_extra=[("models", "packages/ai/src/models.generated.ts", [
+            '<span class="src-comment">// auto-generated by scripts/generate-models.ts</span>',
+            '<span class="src-kw">export const</span> <span class="src-arg">MODELS</span> = { ... <span class="src-num">40</span>+ providers ... };',
+        ])],
+        textbook_cps=["05"],
+        faq=[("如何添加新 provider？","Add provider?","在 pi-ai providers/ 加 models 文件并跑 generate-models。","Add models file under providers/ and run generate-models."),
+             ("OAuth 失败怎么办？","OAuth fails?","检查 bun-oauth 回调与 ~/.pi 凭据存储。","Check bun-oauth callback and ~/.pi credential storage."),
+             ("默认模型在哪设？","Default model?","settings.json 与 CLI --model。","settings.json and CLI --model.")],
+    ),
+    "c17": _ch(
+        (
+            ("差分 TUI 决定你如何理解 Pi 在此层的机制。", "差分 TUI shapes how you understand Pi at this layer."),
+            ("反直觉：<code>tui-main-screen.ts</code> 的复杂度在事件契约而非算法。", "Counter-intuitive: complexity in <code>tui-main-screen.ts</code> is event contracts."),
+            ("优化：--verbose + 源码对照，不猜测模型行为。", "Optimize: --verbose plus source, don't guess."),
+        ),
+        (
+            ("模块", "Module"),
+            ("tui", "tui"),
+            ("站 17", "St. 17"),
+            ("tui-main-screen.ts", "tui-main-screen.ts"),
+        ),
+        [
+            ("差分 TUI：主线 prompt 如何穿过此模块", "差分 TUI: through-line crossing", [
+                ("用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/tui/src/tui-main-screen.ts</code> 定义了此阶段的类型契约与副作用边界。", "After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/tui/src/tui-main-screen.ts</code> defines type contracts and side-effect boundaries here."),
+                ("在 pi-mono 仓库打开该文件，搜索 <code>export</code> 与 <code>AgentEvent</code>——这是比读 README 更快的定位法。", "In pi-mono, search <code>export</code> and <code>AgentEvent</code> — faster than README alone."),
+                ("设计原则：核心循环（agent-loop）不 import TUI；本模块通过事件与回调与上游通信。", "Principle: agent-loop never imports TUI; this module talks upstream via events/callbacks."),
+                ("pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。", "Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file."),
+            ]),
+            ("差分 TUI：关键函数与数据流", "差分 TUI: key functions and data flow", [
+                ("<code>tui-main-screen.ts</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。", "<code>async</code> functions in <code>tui-main-screen.ts</code> are usually IO boundaries: disk, network, or subprocess."),
+                ("成功路径与错误路径都必须 emit 事件，否则 TUI 会卡在 streaming 状态、JSONL 会缺 entry。", "Success and error paths must emit events or TUI stalls streaming and JSONL misses entries."),
+                ("length 截断时 <code>agent-loop.ts</code> 的 <code>failToolCallsFromTruncatedMessage</code> 批量失败 tool calls，防止执行损坏参数。", "On length truncation, <code>failToolCallsFromTruncatedMessage</code> fails all tool calls to avoid corrupted args."),
+                ("对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。", "Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>."),
+            ]),
+            ("差分 TUI：与 agent-loop 的接口", "差分 TUI: interface with agent-loop", [
+                ("<code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。", "<code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc."),
+                ("<code>AgentSession</code> 在构造 config 时绑定本模块实现；换模式（print/rpc/interactive）不换 agent-loop。", "<code>AgentSession</code> binds this module when building config; modes change, agent-loop does not."),
+                ("fork 项目时优先替换本模块而非复制 agent-loop——这是 Pi 社区的实际 fork 模式。", "When forking, replace this module first rather than copying agent-loop — the common community pattern."),
+                ("--verbose 模式下 stderr 事件类型可回溯到 <code>packages/tui/src/tui-main-screen.ts</code> 的具体行。", "Under --verbose, stderr event types trace to lines in <code>packages/tui/src/tui-main-screen.ts</code>."),
+            ]),
+            ("差分 TUI：设计权衡与常见坑", "差分 TUI: trade-offs and pitfalls", [
+                ("显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。", "Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union."),
+                ("扩展应 subscribe 事件而非 monkey-patch 私有方法——<code>ExtensionRunner</code> 提供正规 hook 面。", "Extensions should subscribe to events, not monkey-patch privates — <code>ExtensionRunner</code> provides hooks."),
+                ("JSONL <code>CURRENT_SESSION_VERSION = 3</code>：改 entry schema 必须 bump version 并提供迁移。", "JSONL <code>CURRENT_SESSION_VERSION = 3</code>: schema changes need version bump and migration."),
+                ("对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。", "vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable."),
+            ]),
+        ],
+        trace=("17", "站 17：<code>packages/tui/src/tui-main-screen.ts</code> 处理主线。", "Station 17: <code>packages/tui/src/tui-main-screen.ts</code> on through-line."),
+        src_extra=[
+            ("src", "packages/tui/src/tui-main-screen.ts", [
+                '<span class="src-kw">let</span> <span class="src-arg">firstChanged</span> = -<span class="src-num">1</span>;',
+                '<span class="src-kw">let</span> <span class="src-arg">lastChanged</span> = -<span class="src-num">1</span>;',
+            ]),
+        ],
+        faq=[
+            (
+                "差分 TUI最关键文件？",
+                "Key file?",
+                "<code>packages/tui/src/tui-main-screen.ts</code>。",
+                "<code>packages/tui/src/tui-main-screen.ts</code>.",
+            ),
+            (
+                "如何单测？",
+                "Unit test?",
+                "mock StreamFn 或 ScriptedModel。",
+                "mock StreamFn or ScriptedModel.",
+            ),
+            (
+                "与 textbook 差异？",
+                "vs textbook?",
+                "生产含 OAuth/TUI/40+ providers。",
+                "Production adds OAuth/TUI/40+ providers.",
+            ),
+        ],
+    ),
+    "c18": _ch(
+        (
+            ("Interactive Mode 决定你如何理解 Pi 在此层的机制。", "Interactive Mode shapes how you understand Pi at this layer."),
+            ("反直觉：<code>interactive-mode.ts</code> 的复杂度在事件契约而非算法。", "Counter-intuitive: complexity in <code>interactive-mode.ts</code> is event contracts."),
+            ("优化：--verbose + 源码对照，不猜测模型行为。", "Optimize: --verbose plus source, don't guess."),
+        ),
+        (
+            ("模块", "Module"),
+            ("coding-agent", "coding-agent"),
+            ("站 18", "St. 18"),
+            ("interactive-mode.ts", "interactive-mode.ts"),
+        ),
+        [
+            ("Interactive Mode：主线 prompt 如何穿过此模块", "Interactive Mode: through-line crossing", [
+                ("用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/coding-agent/src/modes/interactive/interactive-mode.ts</code> 定义了此阶段的类型契约与副作用边界。", "After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/coding-agent/src/modes/interactive/interactive-mode.ts</code> defines type contracts and side-effect boundaries here."),
+                ("在 pi-mono 仓库打开该文件，搜索 <code>export</code> 与 <code>AgentEvent</code>——这是比读 README 更快的定位法。", "In pi-mono, search <code>export</code> and <code>AgentEvent</code> — faster than README alone."),
+                ("设计原则：核心循环（agent-loop）不 import TUI；本模块通过事件与回调与上游通信。", "Principle: agent-loop never imports TUI; this module talks upstream via events/callbacks."),
+                ("pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。", "Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file."),
+            ]),
+            ("Interactive Mode：关键函数与数据流", "Interactive Mode: key functions and data flow", [
+                ("<code>interactive-mode.ts</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。", "<code>async</code> functions in <code>interactive-mode.ts</code> are usually IO boundaries: disk, network, or subprocess."),
+                ("成功路径与错误路径都必须 emit 事件，否则 TUI 会卡在 streaming 状态、JSONL 会缺 entry。", "Success and error paths must emit events or TUI stalls streaming and JSONL misses entries."),
+                ("length 截断时 <code>agent-loop.ts</code> 的 <code>failToolCallsFromTruncatedMessage</code> 批量失败 tool calls，防止执行损坏参数。", "On length truncation, <code>failToolCallsFromTruncatedMessage</code> fails all tool calls to avoid corrupted args."),
+                ("对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。", "Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>."),
+            ]),
+            ("Interactive Mode：与 agent-loop 的接口", "Interactive Mode: interface with agent-loop", [
+                ("<code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。", "<code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc."),
+                ("<code>AgentSession</code> 在构造 config 时绑定本模块实现；换模式（print/rpc/interactive）不换 agent-loop。", "<code>AgentSession</code> binds this module when building config; modes change, agent-loop does not."),
+                ("fork 项目时优先替换本模块而非复制 agent-loop——这是 Pi 社区的实际 fork 模式。", "When forking, replace this module first rather than copying agent-loop — the common community pattern."),
+                ("--verbose 模式下 stderr 事件类型可回溯到 <code>packages/coding-agent/src/modes/interactive/interactive-mode.ts</code> 的具体行。", "Under --verbose, stderr event types trace to lines in <code>packages/coding-agent/src/modes/interactive/interactive-mode.ts</code>."),
+            ]),
+            ("Interactive Mode：设计权衡与常见坑", "Interactive Mode: trade-offs and pitfalls", [
+                ("显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。", "Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union."),
+                ("扩展应 subscribe 事件而非 monkey-patch 私有方法——<code>ExtensionRunner</code> 提供正规 hook 面。", "Extensions should subscribe to events, not monkey-patch privates — <code>ExtensionRunner</code> provides hooks."),
+                ("JSONL <code>CURRENT_SESSION_VERSION = 3</code>：改 entry schema 必须 bump version 并提供迁移。", "JSONL <code>CURRENT_SESSION_VERSION = 3</code>: schema changes need version bump and migration."),
+                ("对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。", "vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable."),
+            ]),
+            ("Interactive Mode：深度走读清单", "Interactive Mode: deep walk checklist", [
+                ("① 打开 <code>packages/coding-agent/src/modes/interactive/interactive-mode.ts</code>；② 从 export 符号跟踪 README 路径调用链；③ 标注每个 await 的 IO 类型。", "① Open <code>packages/coding-agent/src/modes/interactive/interactive-mode.ts</code>; ② trace README call chain from exports; ③ label each await's IO type."),
+                ("④ 在 <code>agent-loop.test.ts</code> 或 coding-agent 测试中找覆盖此站的用例；⑤ 用 <code>pi --verbose</code> 验证事件顺序。", "④ Find tests covering this station; ⑤ verify event order with <code>pi --verbose</code>."),
+                ("记录三个不变量：若修改会破坏主线 prompt 的行为假设。", "Record three invariants: assumptions whose change would break the through-line."),
+                ("将观察结果与 pi-textbook workshop 的 checkpoint 测试输出 diff。", "Diff observations against pi-textbook workshop checkpoint test output."),
+            ]),
+        ],
+        trace=("18", "站 18：<code>packages/coding-agent/src/modes/interactive/interactive-mode.ts</code> 处理主线。", "Station 18: <code>packages/coding-agent/src/modes/interactive/interactive-mode.ts</code> on through-line."),
+        src_extra=[
+            ("src", "packages/coding-agent/src/modes/interactive/interactive-mode.ts", [
+                '<span class="src-comment">// Interactive Mode · packages/coding-agent/src/modes/interactive/interactive-mode.ts</span>',
+                '<span class="src-comment">// through-line: README.md</span>',
+            ]),
+        ],
+        faq=[
+            (
+                "Interactive Mode最关键文件？",
+                "Key file?",
+                "<code>packages/coding-agent/src/modes/interactive/interactive-mode.ts</code>。",
+                "<code>packages/coding-agent/src/modes/interactive/interactive-mode.ts</code>.",
+            ),
+            (
+                "如何单测？",
+                "Unit test?",
+                "mock StreamFn 或 ScriptedModel。",
+                "mock StreamFn or ScriptedModel.",
+            ),
+            (
+                "与 textbook 差异？",
+                "vs textbook?",
+                "生产含 OAuth/TUI/40+ providers。",
+                "Production adds OAuth/TUI/40+ providers.",
+            ),
+        ],
+    ),
+    "c19": _ch(
+        (
+            ("Extension API 决定你如何理解 Pi 在此层的机制。", "Extension API shapes how you understand Pi at this layer."),
+            ("反直觉：<code>types.ts</code> 的复杂度在事件契约而非算法。", "Counter-intuitive: complexity in <code>types.ts</code> is event contracts."),
+            ("优化：--verbose + 源码对照，不猜测模型行为。", "Optimize: --verbose plus source, don't guess."),
+        ),
+        (
+            ("模块", "Module"),
+            ("coding-agent", "coding-agent"),
+            ("站 19", "St. 19"),
+            ("types.ts", "types.ts"),
+        ),
+        [
+            ("Extension API：主线 prompt 如何穿过此模块", "Extension API: through-line crossing", [
+                ("用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/coding-agent/src/core/extensions/types.ts</code> 定义了此阶段的类型契约与副作用边界。", "After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/coding-agent/src/core/extensions/types.ts</code> defines type contracts and side-effect boundaries here."),
+                ("在 pi-mono 仓库打开该文件，搜索 <code>export</code> 与 <code>AgentEvent</code>——这是比读 README 更快的定位法。", "In pi-mono, search <code>export</code> and <code>AgentEvent</code> — faster than README alone."),
+                ("设计原则：核心循环（agent-loop）不 import TUI；本模块通过事件与回调与上游通信。", "Principle: agent-loop never imports TUI; this module talks upstream via events/callbacks."),
+                ("pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。", "Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file."),
+            ]),
+            ("Extension API：关键函数与数据流", "Extension API: key functions and data flow", [
+                ("<code>types.ts</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。", "<code>async</code> functions in <code>types.ts</code> are usually IO boundaries: disk, network, or subprocess."),
+                ("成功路径与错误路径都必须 emit 事件，否则 TUI 会卡在 streaming 状态、JSONL 会缺 entry。", "Success and error paths must emit events or TUI stalls streaming and JSONL misses entries."),
+                ("length 截断时 <code>agent-loop.ts</code> 的 <code>failToolCallsFromTruncatedMessage</code> 批量失败 tool calls，防止执行损坏参数。", "On length truncation, <code>failToolCallsFromTruncatedMessage</code> fails all tool calls to avoid corrupted args."),
+                ("对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。", "Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>."),
+            ]),
+            ("Extension API：与 agent-loop 的接口", "Extension API: interface with agent-loop", [
+                ("<code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。", "<code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc."),
+                ("<code>AgentSession</code> 在构造 config 时绑定本模块实现；换模式（print/rpc/interactive）不换 agent-loop。", "<code>AgentSession</code> binds this module when building config; modes change, agent-loop does not."),
+                ("fork 项目时优先替换本模块而非复制 agent-loop——这是 Pi 社区的实际 fork 模式。", "When forking, replace this module first rather than copying agent-loop — the common community pattern."),
+                ("--verbose 模式下 stderr 事件类型可回溯到 <code>packages/coding-agent/src/core/extensions/types.ts</code> 的具体行。", "Under --verbose, stderr event types trace to lines in <code>packages/coding-agent/src/core/extensions/types.ts</code>."),
+            ]),
+            ("Extension API：设计权衡与常见坑", "Extension API: trade-offs and pitfalls", [
+                ("显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。", "Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union."),
+                ("扩展应 subscribe 事件而非 monkey-patch 私有方法——<code>ExtensionRunner</code> 提供正规 hook 面。", "Extensions should subscribe to events, not monkey-patch privates — <code>ExtensionRunner</code> provides hooks."),
+                ("JSONL <code>CURRENT_SESSION_VERSION = 3</code>：改 entry schema 必须 bump version 并提供迁移。", "JSONL <code>CURRENT_SESSION_VERSION = 3</code>: schema changes need version bump and migration."),
+                ("对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。", "vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable."),
+            ]),
+        ],
+        trace=("19", "站 19：<code>packages/coding-agent/src/core/extensions/types.ts</code> 处理主线。", "Station 19: <code>packages/coding-agent/src/core/extensions/types.ts</code> on through-line."),
+        src_extra=[
+            ("src", "packages/coding-agent/src/core/extensions/types.ts", [
+                '<span class="src-comment">// Extension API · packages/coding-agent/src/core/extensions/types.ts</span>',
+                '<span class="src-comment">// through-line: README.md</span>',
+            ]),
+        ],
+        textbook_cps=['12'],
+        faq=[
+            (
+                "Extension API最关键文件？",
+                "Key file?",
+                "<code>packages/coding-agent/src/core/extensions/types.ts</code>。",
+                "<code>packages/coding-agent/src/core/extensions/types.ts</code>.",
+            ),
+            (
+                "如何单测？",
+                "Unit test?",
+                "mock StreamFn 或 ScriptedModel。",
+                "mock StreamFn or ScriptedModel.",
+            ),
+            (
+                "与 textbook 差异？",
+                "vs textbook?",
+                "生产含 OAuth/TUI/40+ providers。",
+                "Production adds OAuth/TUI/40+ providers.",
+            ),
+        ],
+    ),
+    "c20": _ch(
+        (
+            ("ExtensionRunner 决定你如何理解 Pi 在此层的机制。", "ExtensionRunner shapes how you understand Pi at this layer."),
+            ("反直觉：<code>runner.ts</code> 的复杂度在事件契约而非算法。", "Counter-intuitive: complexity in <code>runner.ts</code> is event contracts."),
+            ("优化：--verbose + 源码对照，不猜测模型行为。", "Optimize: --verbose plus source, don't guess."),
+        ),
+        (
+            ("模块", "Module"),
+            ("coding-agent", "coding-agent"),
+            ("站 20", "St. 20"),
+            ("runner.ts", "runner.ts"),
+        ),
+        [
+            ("ExtensionRunner：主线 prompt 如何穿过此模块", "ExtensionRunner: through-line crossing", [
+                ("用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/coding-agent/src/core/extensions/runner.ts</code> 定义了此阶段的类型契约与副作用边界。", "After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/coding-agent/src/core/extensions/runner.ts</code> defines type contracts and side-effect boundaries here."),
+                ("在 pi-mono 仓库打开该文件，搜索 <code>export</code> 与 <code>AgentEvent</code>——这是比读 README 更快的定位法。", "In pi-mono, search <code>export</code> and <code>AgentEvent</code> — faster than README alone."),
+                ("设计原则：核心循环（agent-loop）不 import TUI；本模块通过事件与回调与上游通信。", "Principle: agent-loop never imports TUI; this module talks upstream via events/callbacks."),
+                ("pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。", "Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file."),
+            ]),
+            ("ExtensionRunner：关键函数与数据流", "ExtensionRunner: key functions and data flow", [
+                ("<code>runner.ts</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。", "<code>async</code> functions in <code>runner.ts</code> are usually IO boundaries: disk, network, or subprocess."),
+                ("成功路径与错误路径都必须 emit 事件，否则 TUI 会卡在 streaming 状态、JSONL 会缺 entry。", "Success and error paths must emit events or TUI stalls streaming and JSONL misses entries."),
+                ("length 截断时 <code>agent-loop.ts</code> 的 <code>failToolCallsFromTruncatedMessage</code> 批量失败 tool calls，防止执行损坏参数。", "On length truncation, <code>failToolCallsFromTruncatedMessage</code> fails all tool calls to avoid corrupted args."),
+                ("对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。", "Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>."),
+            ]),
+            ("ExtensionRunner：与 agent-loop 的接口", "ExtensionRunner: interface with agent-loop", [
+                ("<code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。", "<code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc."),
+                ("<code>AgentSession</code> 在构造 config 时绑定本模块实现；换模式（print/rpc/interactive）不换 agent-loop。", "<code>AgentSession</code> binds this module when building config; modes change, agent-loop does not."),
+                ("fork 项目时优先替换本模块而非复制 agent-loop——这是 Pi 社区的实际 fork 模式。", "When forking, replace this module first rather than copying agent-loop — the common community pattern."),
+                ("--verbose 模式下 stderr 事件类型可回溯到 <code>packages/coding-agent/src/core/extensions/runner.ts</code> 的具体行。", "Under --verbose, stderr event types trace to lines in <code>packages/coding-agent/src/core/extensions/runner.ts</code>."),
+            ]),
+            ("ExtensionRunner：设计权衡与常见坑", "ExtensionRunner: trade-offs and pitfalls", [
+                ("显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。", "Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union."),
+                ("扩展应 subscribe 事件而非 monkey-patch 私有方法——<code>ExtensionRunner</code> 提供正规 hook 面。", "Extensions should subscribe to events, not monkey-patch privates — <code>ExtensionRunner</code> provides hooks."),
+                ("JSONL <code>CURRENT_SESSION_VERSION = 3</code>：改 entry schema 必须 bump version 并提供迁移。", "JSONL <code>CURRENT_SESSION_VERSION = 3</code>: schema changes need version bump and migration."),
+                ("对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。", "vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable."),
+            ]),
+            ("ExtensionRunner：深度走读清单", "ExtensionRunner: deep walk checklist", [
+                ("① 打开 <code>packages/coding-agent/src/core/extensions/runner.ts</code>；② 从 export 符号跟踪 README 路径调用链；③ 标注每个 await 的 IO 类型。", "① Open <code>packages/coding-agent/src/core/extensions/runner.ts</code>; ② trace README call chain from exports; ③ label each await's IO type."),
+                ("④ 在 <code>agent-loop.test.ts</code> 或 coding-agent 测试中找覆盖此站的用例；⑤ 用 <code>pi --verbose</code> 验证事件顺序。", "④ Find tests covering this station; ⑤ verify event order with <code>pi --verbose</code>."),
+                ("记录三个不变量：若修改会破坏主线 prompt 的行为假设。", "Record three invariants: assumptions whose change would break the through-line."),
+                ("将观察结果与 pi-textbook workshop 的 checkpoint 测试输出 diff。", "Diff observations against pi-textbook workshop checkpoint test output."),
+            ]),
+        ],
+        trace=("20", "站 20：<code>packages/coding-agent/src/core/extensions/runner.ts</code> 处理主线。", "Station 20: <code>packages/coding-agent/src/core/extensions/runner.ts</code> on through-line."),
+        src_extra=[
+            ("src", "packages/coding-agent/src/core/extensions/runner.ts", [
+                '<span class="src-kw">export class</span> <span class="src-cls">ExtensionRunner</span>',
+                '<span class="src-comment">/** executes extensions and manages lifecycle */</span>',
+            ]),
+        ],
+        textbook_cps=['12', '13'],
+        faq=[
+            (
+                "ExtensionRunner最关键文件？",
+                "Key file?",
+                "<code>packages/coding-agent/src/core/extensions/runner.ts</code>。",
+                "<code>packages/coding-agent/src/core/extensions/runner.ts</code>.",
+            ),
+            (
+                "如何单测？",
+                "Unit test?",
+                "mock StreamFn 或 ScriptedModel。",
+                "mock StreamFn or ScriptedModel.",
+            ),
+            (
+                "与 textbook 差异？",
+                "vs textbook?",
+                "生产含 OAuth/TUI/40+ providers。",
+                "Production adds OAuth/TUI/40+ providers.",
+            ),
+        ],
+    ),
+    "c21": _ch(
+        (
+            ("Pi Packages 决定你如何理解 Pi 在此层的机制。", "Pi Packages shapes how you understand Pi at this layer."),
+            ("反直觉：<code>package-manager.ts</code> 的复杂度在事件契约而非算法。", "Counter-intuitive: complexity in <code>package-manager.ts</code> is event contracts."),
+            ("优化：--verbose + 源码对照，不猜测模型行为。", "Optimize: --verbose plus source, don't guess."),
+        ),
+        (
+            ("模块", "Module"),
+            ("coding-agent", "coding-agent"),
+            ("站 21", "St. 21"),
+            ("package-manager.ts", "package-manager.ts"),
+        ),
+        [
+            ("Pi Packages：主线 prompt 如何穿过此模块", "Pi Packages: through-line crossing", [
+                ("用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/coding-agent/src/core/package-manager.ts</code> 定义了此阶段的类型契约与副作用边界。", "After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/coding-agent/src/core/package-manager.ts</code> defines type contracts and side-effect boundaries here."),
+                ("在 pi-mono 仓库打开该文件，搜索 <code>export</code> 与 <code>AgentEvent</code>——这是比读 README 更快的定位法。", "In pi-mono, search <code>export</code> and <code>AgentEvent</code> — faster than README alone."),
+                ("设计原则：核心循环（agent-loop）不 import TUI；本模块通过事件与回调与上游通信。", "Principle: agent-loop never imports TUI; this module talks upstream via events/callbacks."),
+                ("pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。", "Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file."),
+            ]),
+            ("Pi Packages：关键函数与数据流", "Pi Packages: key functions and data flow", [
+                ("<code>package-manager.ts</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。", "<code>async</code> functions in <code>package-manager.ts</code> are usually IO boundaries: disk, network, or subprocess."),
+                ("成功路径与错误路径都必须 emit 事件，否则 TUI 会卡在 streaming 状态、JSONL 会缺 entry。", "Success and error paths must emit events or TUI stalls streaming and JSONL misses entries."),
+                ("length 截断时 <code>agent-loop.ts</code> 的 <code>failToolCallsFromTruncatedMessage</code> 批量失败 tool calls，防止执行损坏参数。", "On length truncation, <code>failToolCallsFromTruncatedMessage</code> fails all tool calls to avoid corrupted args."),
+                ("对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。", "Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>."),
+            ]),
+            ("Pi Packages：与 agent-loop 的接口", "Pi Packages: interface with agent-loop", [
+                ("<code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。", "<code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc."),
+                ("<code>AgentSession</code> 在构造 config 时绑定本模块实现；换模式（print/rpc/interactive）不换 agent-loop。", "<code>AgentSession</code> binds this module when building config; modes change, agent-loop does not."),
+                ("fork 项目时优先替换本模块而非复制 agent-loop——这是 Pi 社区的实际 fork 模式。", "When forking, replace this module first rather than copying agent-loop — the common community pattern."),
+                ("--verbose 模式下 stderr 事件类型可回溯到 <code>packages/coding-agent/src/core/package-manager.ts</code> 的具体行。", "Under --verbose, stderr event types trace to lines in <code>packages/coding-agent/src/core/package-manager.ts</code>."),
+            ]),
+            ("Pi Packages：设计权衡与常见坑", "Pi Packages: trade-offs and pitfalls", [
+                ("显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。", "Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union."),
+                ("扩展应 subscribe 事件而非 monkey-patch 私有方法——<code>ExtensionRunner</code> 提供正规 hook 面。", "Extensions should subscribe to events, not monkey-patch privates — <code>ExtensionRunner</code> provides hooks."),
+                ("JSONL <code>CURRENT_SESSION_VERSION = 3</code>：改 entry schema 必须 bump version 并提供迁移。", "JSONL <code>CURRENT_SESSION_VERSION = 3</code>: schema changes need version bump and migration."),
+                ("对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。", "vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable."),
+            ]),
+            ("Pi Packages：深度走读清单", "Pi Packages: deep walk checklist", [
+                ("① 打开 <code>packages/coding-agent/src/core/package-manager.ts</code>；② 从 export 符号跟踪 README 路径调用链；③ 标注每个 await 的 IO 类型。", "① Open <code>packages/coding-agent/src/core/package-manager.ts</code>; ② trace README call chain from exports; ③ label each await's IO type."),
+                ("④ 在 <code>agent-loop.test.ts</code> 或 coding-agent 测试中找覆盖此站的用例；⑤ 用 <code>pi --verbose</code> 验证事件顺序。", "④ Find tests covering this station; ⑤ verify event order with <code>pi --verbose</code>."),
+                ("记录三个不变量：若修改会破坏主线 prompt 的行为假设。", "Record three invariants: assumptions whose change would break the through-line."),
+                ("将观察结果与 pi-textbook workshop 的 checkpoint 测试输出 diff。", "Diff observations against pi-textbook workshop checkpoint test output."),
+            ]),
+        ],
+        trace=("21", "站 21：<code>packages/coding-agent/src/core/package-manager.ts</code> 处理主线。", "Station 21: <code>packages/coding-agent/src/core/package-manager.ts</code> on through-line."),
+        src_extra=[
+            ("src", "packages/coding-agent/src/core/package-manager.ts", [
+                '<span class="src-comment">// Pi Packages · packages/coding-agent/src/core/package-manager.ts</span>',
+                '<span class="src-comment">// through-line: README.md</span>',
+            ]),
+        ],
+        textbook_cps=['12'],
+        faq=[
+            (
+                "Pi Packages最关键文件？",
+                "Key file?",
+                "<code>packages/coding-agent/src/core/package-manager.ts</code>。",
+                "<code>packages/coding-agent/src/core/package-manager.ts</code>.",
+            ),
+            (
+                "如何单测？",
+                "Unit test?",
+                "mock StreamFn 或 ScriptedModel。",
+                "mock StreamFn or ScriptedModel.",
+            ),
+            (
+                "与 textbook 差异？",
+                "vs textbook?",
+                "生产含 OAuth/TUI/40+ providers。",
+                "Production adds OAuth/TUI/40+ providers.",
+            ),
+        ],
+    ),
+    "c22": _ch(
+        (
+            ("JSONL 会话树 决定你如何理解 Pi 在此层的机制。", "JSONL 会话树 shapes how you understand Pi at this layer."),
+            ("反直觉：<code>session-manager.ts</code> 的复杂度在事件契约而非算法。", "Counter-intuitive: complexity in <code>session-manager.ts</code> is event contracts."),
+            ("优化：--verbose + 源码对照，不猜测模型行为。", "Optimize: --verbose plus source, don't guess."),
+        ),
+        (
+            ("模块", "Module"),
+            ("coding-agent", "coding-agent"),
+            ("站 22", "St. 22"),
+            ("session-manager.ts", "session-manager.ts"),
+        ),
+        [
+            ("JSONL 会话树：主线 prompt 如何穿过此模块", "JSONL 会话树: through-line crossing", [
+                ("用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/coding-agent/src/core/session-manager.ts</code> 定义了此阶段的类型契约与副作用边界。", "After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/coding-agent/src/core/session-manager.ts</code> defines type contracts and side-effect boundaries here."),
+                ("在 pi-mono 仓库打开该文件，搜索 <code>export</code> 与 <code>AgentEvent</code>——这是比读 README 更快的定位法。", "In pi-mono, search <code>export</code> and <code>AgentEvent</code> — faster than README alone."),
+                ("设计原则：核心循环（agent-loop）不 import TUI；本模块通过事件与回调与上游通信。", "Principle: agent-loop never imports TUI; this module talks upstream via events/callbacks."),
+                ("pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。", "Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file."),
+            ]),
+            ("JSONL 会话树：关键函数与数据流", "JSONL 会话树: key functions and data flow", [
+                ("<code>session-manager.ts</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。", "<code>async</code> functions in <code>session-manager.ts</code> are usually IO boundaries: disk, network, or subprocess."),
+                ("成功路径与错误路径都必须 emit 事件，否则 TUI 会卡在 streaming 状态、JSONL 会缺 entry。", "Success and error paths must emit events or TUI stalls streaming and JSONL misses entries."),
+                ("length 截断时 <code>agent-loop.ts</code> 的 <code>failToolCallsFromTruncatedMessage</code> 批量失败 tool calls，防止执行损坏参数。", "On length truncation, <code>failToolCallsFromTruncatedMessage</code> fails all tool calls to avoid corrupted args."),
+                ("对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。", "Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>."),
+            ]),
+            ("JSONL 会话树：与 agent-loop 的接口", "JSONL 会话树: interface with agent-loop", [
+                ("<code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。", "<code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc."),
+                ("<code>AgentSession</code> 在构造 config 时绑定本模块实现；换模式（print/rpc/interactive）不换 agent-loop。", "<code>AgentSession</code> binds this module when building config; modes change, agent-loop does not."),
+                ("fork 项目时优先替换本模块而非复制 agent-loop——这是 Pi 社区的实际 fork 模式。", "When forking, replace this module first rather than copying agent-loop — the common community pattern."),
+                ("--verbose 模式下 stderr 事件类型可回溯到 <code>packages/coding-agent/src/core/session-manager.ts</code> 的具体行。", "Under --verbose, stderr event types trace to lines in <code>packages/coding-agent/src/core/session-manager.ts</code>."),
+            ]),
+            ("JSONL 会话树：设计权衡与常见坑", "JSONL 会话树: trade-offs and pitfalls", [
+                ("显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。", "Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union."),
+                ("扩展应 subscribe 事件而非 monkey-patch 私有方法——<code>ExtensionRunner</code> 提供正规 hook 面。", "Extensions should subscribe to events, not monkey-patch privates — <code>ExtensionRunner</code> provides hooks."),
+                ("JSONL <code>CURRENT_SESSION_VERSION = 3</code>：改 entry schema 必须 bump version 并提供迁移。", "JSONL <code>CURRENT_SESSION_VERSION = 3</code>: schema changes need version bump and migration."),
+                ("对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。", "vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable."),
+            ]),
+        ],
+        trace=("22", "站 22：<code>packages/coding-agent/src/core/session-manager.ts</code> 处理主线。", "Station 22: <code>packages/coding-agent/src/core/session-manager.ts</code> on through-line."),
+        src_extra=[
+            ("src", "packages/coding-agent/src/core/session-manager.ts", [
+                '<span class="src-kw">export const</span> <span class="src-arg">CURRENT_SESSION_VERSION</span> = <span class="src-num">3</span>;',
+                '<span class="src-arg">parentId</span>: <span class="src-cls">string</span> | <span class="src-cls">null</span>;',
+            ]),
+        ],
+        textbook_cps=['10'],
+        faq=[
+            (
+                "JSONL 会话树最关键文件？",
+                "Key file?",
+                "<code>packages/coding-agent/src/core/session-manager.ts</code>。",
+                "<code>packages/coding-agent/src/core/session-manager.ts</code>.",
+            ),
+            (
+                "如何单测？",
+                "Unit test?",
+                "mock StreamFn 或 ScriptedModel。",
+                "mock StreamFn or ScriptedModel.",
+            ),
+            (
+                "与 textbook 差异？",
+                "vs textbook?",
+                "生产含 OAuth/TUI/40+ providers。",
+                "Production adds OAuth/TUI/40+ providers.",
+            ),
+        ],
+    ),
+    "c23": _ch(
+        (
+            ("Compaction 决定你如何理解 Pi 在此层的机制。", "Compaction shapes how you understand Pi at this layer."),
+            ("反直觉：<code>index.ts</code> 的复杂度在事件契约而非算法。", "Counter-intuitive: complexity in <code>index.ts</code> is event contracts."),
+            ("优化：--verbose + 源码对照，不猜测模型行为。", "Optimize: --verbose plus source, don't guess."),
+        ),
+        (
+            ("模块", "Module"),
+            ("coding-agent", "coding-agent"),
+            ("站 23", "St. 23"),
+            ("index.ts", "index.ts"),
+        ),
+        [
+            ("Compaction：主线 prompt 如何穿过此模块", "Compaction: through-line crossing", [
+                ("用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/coding-agent/src/core/compaction/index.ts</code> 定义了此阶段的类型契约与副作用边界。", "After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/coding-agent/src/core/compaction/index.ts</code> defines type contracts and side-effect boundaries here."),
+                ("在 pi-mono 仓库打开该文件，搜索 <code>export</code> 与 <code>AgentEvent</code>——这是比读 README 更快的定位法。", "In pi-mono, search <code>export</code> and <code>AgentEvent</code> — faster than README alone."),
+                ("设计原则：核心循环（agent-loop）不 import TUI；本模块通过事件与回调与上游通信。", "Principle: agent-loop never imports TUI; this module talks upstream via events/callbacks."),
+                ("pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。", "Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file."),
+            ]),
+            ("Compaction：关键函数与数据流", "Compaction: key functions and data flow", [
+                ("<code>index.ts</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。", "<code>async</code> functions in <code>index.ts</code> are usually IO boundaries: disk, network, or subprocess."),
+                ("成功路径与错误路径都必须 emit 事件，否则 TUI 会卡在 streaming 状态、JSONL 会缺 entry。", "Success and error paths must emit events or TUI stalls streaming and JSONL misses entries."),
+                ("length 截断时 <code>agent-loop.ts</code> 的 <code>failToolCallsFromTruncatedMessage</code> 批量失败 tool calls，防止执行损坏参数。", "On length truncation, <code>failToolCallsFromTruncatedMessage</code> fails all tool calls to avoid corrupted args."),
+                ("对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。", "Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>."),
+            ]),
+            ("Compaction：与 agent-loop 的接口", "Compaction: interface with agent-loop", [
+                ("<code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。", "<code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc."),
+                ("<code>AgentSession</code> 在构造 config 时绑定本模块实现；换模式（print/rpc/interactive）不换 agent-loop。", "<code>AgentSession</code> binds this module when building config; modes change, agent-loop does not."),
+                ("fork 项目时优先替换本模块而非复制 agent-loop——这是 Pi 社区的实际 fork 模式。", "When forking, replace this module first rather than copying agent-loop — the common community pattern."),
+                ("--verbose 模式下 stderr 事件类型可回溯到 <code>packages/coding-agent/src/core/compaction/index.ts</code> 的具体行。", "Under --verbose, stderr event types trace to lines in <code>packages/coding-agent/src/core/compaction/index.ts</code>."),
+            ]),
+            ("Compaction：设计权衡与常见坑", "Compaction: trade-offs and pitfalls", [
+                ("显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。", "Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union."),
+                ("扩展应 subscribe 事件而非 monkey-patch 私有方法——<code>ExtensionRunner</code> 提供正规 hook 面。", "Extensions should subscribe to events, not monkey-patch privates — <code>ExtensionRunner</code> provides hooks."),
+                ("JSONL <code>CURRENT_SESSION_VERSION = 3</code>：改 entry schema 必须 bump version 并提供迁移。", "JSONL <code>CURRENT_SESSION_VERSION = 3</code>: schema changes need version bump and migration."),
+                ("对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。", "vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable."),
+            ]),
+        ],
+        trace=("23", "站 23：<code>packages/coding-agent/src/core/compaction/index.ts</code> 处理主线。", "Station 23: <code>packages/coding-agent/src/core/compaction/index.ts</code> on through-line."),
+        src_extra=[
+            ("src", "packages/coding-agent/src/core/compaction/index.ts", [
+                '<span class="src-comment">// Compaction · packages/coding-agent/src/core/compaction/index.ts</span>',
+                '<span class="src-comment">// through-line: README.md</span>',
+            ]),
+        ],
+        textbook_cps=['11'],
+        faq=[
+            (
+                "Compaction最关键文件？",
+                "Key file?",
+                "<code>packages/coding-agent/src/core/compaction/index.ts</code>。",
+                "<code>packages/coding-agent/src/core/compaction/index.ts</code>.",
+            ),
+            (
+                "如何单测？",
+                "Unit test?",
+                "mock StreamFn 或 ScriptedModel。",
+                "mock StreamFn or ScriptedModel.",
+            ),
+            (
+                "与 textbook 差异？",
+                "vs textbook?",
+                "生产含 OAuth/TUI/40+ providers。",
+                "Production adds OAuth/TUI/40+ providers.",
+            ),
+        ],
+    ),
+    "c24": _ch(
+        (
+            ("生态对比 决定你如何理解 Pi 在此层的机制。", "生态对比 shapes how you understand Pi at this layer."),
+            ("反直觉：<code>—</code> 的复杂度在事件契约而非算法。", "Counter-intuitive: complexity in <code>—</code> is event contracts."),
+            ("优化：--verbose + 源码对照，不猜测模型行为。", "Optimize: --verbose plus source, don't guess."),
+        ),
+        (
+            ("模块", "Module"),
+            ("pi-mono", "pi-mono"),
+            ("背景", "Background"),
+            ("—", "—"),
+        ),
+        [
+            ("生态对比：主线 prompt 如何穿过此模块", "生态对比: through-line crossing", [
+                ("用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>—</code> 定义了此阶段的类型契约与副作用边界。", "After «<code>read README.md and tell me what this project does in one sentence</code>», <code>—</code> defines type contracts and side-effect boundaries here."),
+                ("在 pi-mono 仓库打开该文件，搜索 <code>export</code> 与 <code>AgentEvent</code>——这是比读 README 更快的定位法。", "In pi-mono, search <code>export</code> and <code>AgentEvent</code> — faster than README alone."),
+                ("设计原则：核心循环（agent-loop）不 import TUI；本模块通过事件与回调与上游通信。", "Principle: agent-loop never imports TUI; this module talks upstream via events/callbacks."),
+                ("pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。", "Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file."),
+            ]),
+            ("生态对比：关键函数与数据流", "生态对比: key functions and data flow", [
+                ("<code>—</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。", "<code>async</code> functions in <code>—</code> are usually IO boundaries: disk, network, or subprocess."),
+                ("成功路径与错误路径都必须 emit 事件，否则 TUI 会卡在 streaming 状态、JSONL 会缺 entry。", "Success and error paths must emit events or TUI stalls streaming and JSONL misses entries."),
+                ("length 截断时 <code>agent-loop.ts</code> 的 <code>failToolCallsFromTruncatedMessage</code> 批量失败 tool calls，防止执行损坏参数。", "On length truncation, <code>failToolCallsFromTruncatedMessage</code> fails all tool calls to avoid corrupted args."),
+                ("对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。", "Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>."),
+            ]),
+            ("生态对比：与 agent-loop 的接口", "生态对比: interface with agent-loop", [
+                ("<code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。", "<code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc."),
+                ("<code>AgentSession</code> 在构造 config 时绑定本模块实现；换模式（print/rpc/interactive）不换 agent-loop。", "<code>AgentSession</code> binds this module when building config; modes change, agent-loop does not."),
+                ("fork 项目时优先替换本模块而非复制 agent-loop——这是 Pi 社区的实际 fork 模式。", "When forking, replace this module first rather than copying agent-loop — the common community pattern."),
+                ("--verbose 模式下 stderr 事件类型可回溯到 <code>—</code> 的具体行。", "Under --verbose, stderr event types trace to lines in <code>—</code>."),
+            ]),
+            ("生态对比：设计权衡与常见坑", "生态对比: trade-offs and pitfalls", [
+                ("显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。", "Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union."),
+                ("扩展应 subscribe 事件而非 monkey-patch 私有方法——<code>ExtensionRunner</code> 提供正规 hook 面。", "Extensions should subscribe to events, not monkey-patch privates — <code>ExtensionRunner</code> provides hooks."),
+                ("JSONL <code>CURRENT_SESSION_VERSION = 3</code>：改 entry schema 必须 bump version 并提供迁移。", "JSONL <code>CURRENT_SESSION_VERSION = 3</code>: schema changes need version bump and migration."),
+                ("对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。", "vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable."),
+            ]),
+        ],
+        src_extra=[
+            ("src", "—", [
+                '<span class="src-comment">// 生态对比 · —</span>',
+                '<span class="src-comment">// through-line: README.md</span>',
+            ]),
+        ],
+        faq=[
+            (
+                "生态对比最关键文件？",
+                "Key file?",
+                "<code>—</code>。",
+                "<code>—</code>.",
+            ),
+            (
+                "如何单测？",
+                "Unit test?",
+                "mock StreamFn 或 ScriptedModel。",
+                "mock StreamFn or ScriptedModel.",
+            ),
+            (
+                "与 textbook 差异？",
+                "vs textbook?",
+                "生产含 OAuth/TUI/40+ providers。",
+                "Production adds OAuth/TUI/40+ providers.",
+            ),
+        ],
+    ),
+
+    "c25": _ch(
+        (
+            ("pi-protocol 定义 JSONL 帧 + TypeBox schema；pi-server 用 CBOR 跑远程会话。", "pi-protocol defines JSONL frames + TypeBox schema; pi-server runs remote sessions over CBOR."),
+            ("反直觉：RPC 模式不是 HTTP REST，而是 stdin/stdout JSONL 进程协议。", "Counter-intuitive: RPC mode is stdin/stdout JSONL process protocol, not HTTP REST."),
+            ("优化：--mode rpc 让外部编排器驱动 AgentSession 而不启动 TUI。", "Optimize: --mode rpc lets external orchestrator drive AgentSession without TUI."),
+        ),
+        (("protocol + server","protocol + server"),("schemas.ts + rpc-entry.ts","schemas.ts + rpc-entry.ts"),("站 21","St. 21"),("JSONL / CBOR","JSONL / CBOR")),
+        [
+            ("protocol 包：TypeBox schema", "protocol: TypeBox schema", [
+                ("packages/protocol/src/schemas.ts：PROTOCOL_VERSION = 1；SessionPhaseSchema 对齐 AgentHarnessPhase（idle/turn/compaction/branch_summary/retry）。", "schemas.ts: PROTOCOL_VERSION = 1; SessionPhaseSchema aligns with AgentHarnessPhase."),
+                ("ModelRefSchema、ThinkingLevelSchema、JsonValueSchema 用 Type.Strict 禁止 additionalProperties。", "ModelRefSchema, ThinkingLevelSchema, JsonValueSchema use strict objects."),
+                ("帧格式在 framing.ts + codec.ts：长度前缀 JSONL 或 CBOR 二进制。", "Frame format in framing.ts + codec.ts: length-prefixed JSONL or CBOR binary."),
+            ]),
+            ("RPC 模式启动链", "RPC boot chain", [
+                ("main.ts 解析 --mode rpc → rpc-entry.ts 读 stdin JSONL 命令 → 调用 AgentSession 方法 → 写 stdout 响应。", "main.ts --mode rpc → rpc-entry.ts reads stdin JSONL commands → AgentSession methods → stdout responses."),
+                ("主线 prompt 可作为 rpc prompt 命令注入，无需 TUI。", "Through-line injectable as rpc prompt command without TUI."),
+                ("适合 CI、外部 IDE 插件、多 pi 实例编排。", "Suits CI, external IDE plugins, multi-pi orchestration."),
+            ]),
+            ("pi-server 远程会话", "pi-server remote sessions", [
+                ("packages/server CBOR over HTTP 暴露远程 AgentSession；client 包 acquireSession 获取 lease。", "server package exposes remote AgentSession via CBOR HTTP; client acquireSession gets lease."),
+                ("exclusive vs shared lease 防止并发写（client README 30 行）。", "exclusive vs shared lease prevents concurrent writes (client README line 30)."),
+            ]),
+            ("与 session fork 组合", "With session fork", [
+                ("RPC + fork：父进程 rpc fork 命令创建 branch session，子 pi 实例处理子任务——替代 sub-agent 的官方路径之一。", "RPC + fork: parent rpc fork creates branch session, child pi handles subtask — official sub-agent alternative."),
+            ]),
+            ("主线 prompt 的 RPC trace", "RPC trace of through-line", [
+                ("管道 stdin 发送 prompt 命令 + <code>pi --mode rpc --verbose</code> 可无 TUI 观察完整事件 JSONL。", "Pipe stdin prompt command + <code>pi --mode rpc --verbose</code> observes full event JSONL without TUI."),
+                ("对比 interactive：同一 <code>AgentSession.prompt()</code> 路径，仅 I/O 层从 TUI 换为 stdin/stdout 帧。", "vs interactive: same <code>AgentSession.prompt()</code> path, only I/O layer swaps TUI for stdin/stdout frames."),
+            ]),
+            ("rpc-entry.ts 命令面", "rpc-entry.ts command surface", [
+                ("<code>packages/coding-agent/src/rpc-entry.ts</code> 解析每行 JSON 命令：prompt、abort、set_model、fork 等，映射到 AgentSession 公开方法。", "<code>rpc-entry.ts</code> parses each JSON line command: prompt, abort, set_model, fork, etc., mapping to AgentSession public methods."),
+                ("响应帧同样 JSONL 序列化 AgentEvent，外部编排器可重建与 --verbose 等价的日志。", "Response frames serialize AgentEvent as JSONL; external orchestrator can rebuild --verbose-equivalent logs."),
+            ]),
+        ],
+        trace=("21", "站 21：RPC JSONL 帧或 CBOR 远程驱动 AgentSession。", "Station 21: RPC JSONL frames or CBOR remote drives AgentSession."),
+        src_extra=[("proto", "packages/protocol/src/schemas.ts", [
+            '<span class="src-kw">export const</span> <span class="src-arg">PROTOCOL_VERSION</span> = <span class="src-num">1</span>;',
+            '<span class="src-kw">export const</span> <span class="src-arg">SessionPhaseSchema</span> = Type.Union([...]);',
+        ])],
+        textbook_cps=["13"],
+        faq=[("RPC 与 interactive 共享 AgentSession 吗？","Share AgentSession?","是，同一类不同 I/O 层。","Yes, same class, different I/O layer."),
+             ("CBOR 何时用？","When CBOR?","pi-server 远程；本地 RPC 用 JSONL。","pi-server remote; local RPC uses JSONL."),
+             ("如何测 RPC？","Test RPC?","管道 stdin/stdout + 断言响应帧序列。","Pipe stdin/stdout + assert response frame sequence.")],
+    ),
+    "c26": _ch(
+        (
+            ("自己 trace 决定你如何理解 Pi 在此层的机制。", "自己 trace shapes how you understand Pi at this layer."),
+            ("反直觉：<code>main.ts</code> 的复杂度在事件契约而非算法。", "Counter-intuitive: complexity in <code>main.ts</code> is event contracts."),
+            ("优化：--verbose + 源码对照，不猜测模型行为。", "Optimize: --verbose plus source, don't guess."),
+        ),
+        (
+            ("模块", "Module"),
+            ("coding-agent", "coding-agent"),
+            ("站 26", "St. 26"),
+            ("main.ts", "main.ts"),
+        ),
+        [
+            ("自己 trace：主线 prompt 如何穿过此模块", "自己 trace: through-line crossing", [
+                ("用户输入「<code>读取 README.md，用一句话告诉我这个项目做什么</code>」后，<code>packages/coding-agent/src/main.ts</code> 定义了此阶段的类型契约与副作用边界。", "After «<code>read README.md and tell me what this project does in one sentence</code>», <code>packages/coding-agent/src/main.ts</code> defines type contracts and side-effect boundaries here."),
+                ("在 pi-mono 仓库打开该文件，搜索 <code>export</code> 与 <code>AgentEvent</code>——这是比读 README 更快的定位法。", "In pi-mono, search <code>export</code> and <code>AgentEvent</code> — faster than README alone."),
+                ("设计原则：核心循环（agent-loop）不 import TUI；本模块通过事件与回调与上游通信。", "Principle: agent-loop never imports TUI; this module talks upstream via events/callbacks."),
+                ("pi-textbook 对应 checkpoint 提供剥离 OAuth/TUI 后的最小可运行切片，建议先跑测试再读生产文件。", "Matching textbook checkpoint offers a minimal slice without OAuth/TUI — run its test before production file."),
+            ]),
+            ("自己 trace：关键函数与数据流", "自己 trace: key functions and data flow", [
+                ("<code>main.ts</code> 内的 <code>async</code> 函数通常是 IO 边界：磁盘（read/write JSONL）、网络（streamSimple）、或子进程（bash）。", "<code>async</code> functions in <code>main.ts</code> are usually IO boundaries: disk, network, or subprocess."),
+                ("成功路径与错误路径都必须 emit 事件，否则 TUI 会卡在 streaming 状态、JSONL 会缺 entry。", "Success and error paths must emit events or TUI stalls streaming and JSONL misses entries."),
+                ("length 截断时 <code>agent-loop.ts</code> 的 <code>failToolCallsFromTruncatedMessage</code> 批量失败 tool calls，防止执行损坏参数。", "On length truncation, <code>failToolCallsFromTruncatedMessage</code> fails all tool calls to avoid corrupted args."),
+                ("对照 <code>packages/agent/test/agent-loop.test.ts</code> 中的同名场景测试用例。", "Compare with matching scenarios in <code>packages/agent/test/agent-loop.test.ts</code>."),
+            ]),
+            ("自己 trace：与 agent-loop 的接口", "自己 trace: interface with agent-loop", [
+                ("<code>AgentLoopConfig</code>（<code>packages/agent/src/types.ts</code>）列出所有注入点：<code>convertToLlm</code>、<code>getSteeringMessages</code>、<code>prepareNextTurn</code> 等。", "<code>AgentLoopConfig</code> in <code>types.ts</code> lists injection points: <code>convertToLlm</code>, <code>getSteeringMessages</code>, <code>prepareNextTurn</code>, etc."),
+                ("<code>AgentSession</code> 在构造 config 时绑定本模块实现；换模式（print/rpc/interactive）不换 agent-loop。", "<code>AgentSession</code> binds this module when building config; modes change, agent-loop does not."),
+                ("fork 项目时优先替换本模块而非复制 agent-loop——这是 Pi 社区的实际 fork 模式。", "When forking, replace this module first rather than copying agent-loop — the common community pattern."),
+                ("--verbose 模式下 stderr 事件类型可回溯到 <code>packages/coding-agent/src/main.ts</code> 的具体行。", "Under --verbose, stderr event types trace to lines in <code>packages/coding-agent/src/main.ts</code>."),
+            ]),
+            ("自己 trace：设计权衡与常见坑", "自己 trace: trade-offs and pitfalls", [
+                ("显式事件总线 vs 隐式回调：Pi 选择前者，事件类型在 <code>AgentEvent</code> union 中版本化。", "Explicit event bus vs implicit callbacks: Pi chooses the former; events versioned in <code>AgentEvent</code> union."),
+                ("扩展应 subscribe 事件而非 monkey-patch 私有方法——<code>ExtensionRunner</code> 提供正规 hook 面。", "Extensions should subscribe to events, not monkey-patch privates — <code>ExtensionRunner</code> provides hooks."),
+                ("JSONL <code>CURRENT_SESSION_VERSION = 3</code>：改 entry schema 必须 bump version 并提供迁移。", "JSONL <code>CURRENT_SESSION_VERSION = 3</code>: schema changes need version bump and migration."),
+                ("对比 Claude Code：闭源栈无法确认 compaction 触发点；Pi 的 <code>shouldCompact</code> 在源码中可读。", "vs Claude Code: closed stack hides compaction triggers; Pi's <code>shouldCompact</code> is readable."),
+            ]),
+        ],
+        trace=("26", "站 26：<code>packages/coding-agent/src/main.ts</code> 处理主线。", "Station 26: <code>packages/coding-agent/src/main.ts</code> on through-line."),
+        src_extra=[
+            ("src", "packages/coding-agent/src/main.ts", [
+                '<span class="src-comment">// 自己 trace · packages/coding-agent/src/main.ts</span>',
+                '<span class="src-comment">// through-line: README.md</span>',
+            ]),
+        ],
+        textbook_cps=['00', '14'],
+        faq=[
+            (
+                "自己 trace最关键文件？",
+                "Key file?",
+                "<code>packages/coding-agent/src/main.ts</code>。",
+                "<code>packages/coding-agent/src/main.ts</code>.",
+            ),
+            (
+                "如何单测？",
+                "Unit test?",
+                "mock StreamFn 或 ScriptedModel。",
+                "mock StreamFn or ScriptedModel.",
+            ),
+            (
+                "与 textbook 差异？",
+                "vs textbook?",
+                "生产含 OAuth/TUI/40+ providers。",
+                "Production adds OAuth/TUI/40+ providers.",
+            ),
+        ],
+    ),
+}
+
+
+def chapter_depth_chars(cid: str) -> int:
+    """Approximate new HTML char count added by deepen (excluding base)."""
+    d = DEPTH.get(cid, {})
+    total = sum(len(d.get(k, "")) for k in ("why", "banner", "trace", "case", "faq"))
+    total += sum(len(s) for s in d.get("sections", []))
+    total += sum(len(s) for s in d.get("src_extra", []))
+    if d.get("textbook_cps"):
+        total += 500
+    return total
+
+
+if __name__ == "__main__":
+    counts = {cid: chapter_depth_chars(cid) for cid in sorted(DEPTH, key=lambda x: int(x[1:]))}
+    avg = sum(counts.values()) // max(len(counts), 1)
+    print(f"Chapters: {len(counts)}, avg depth chars: {avg}")
+    for cid, n in sorted(counts.items(), key=lambda x: x[1]):
+        print(f"  {cid}: {n}")

--- a/scripts/pi_agent_immersive/expand.py
+++ b/scripts/pi_agent_immersive/expand.py
@@ -5,6 +5,7 @@ from meta import CHAPTERS
 from textbook_map import PRODUCTION_MAP, TEXTBOOK_CHECKPOINTS
 
 from _html_helpers import aside_label, cmp, note, p, src
+from heart_trace import heart_trace_block
 
 
 def textbook_crossref_table(cp_ids: list[str]) -> str:
@@ -98,5 +99,11 @@ CHAPTER_EXTRAS: dict[str, str] = {
 
 
 def expand_chapter(cid: str, base: str) -> str:
+    parts = [base]
+    ht = heart_trace_block(cid)
+    if ht:
+        parts.append(ht)
     extra = CHAPTER_EXTRAS.get(cid, "")
-    return base + ("\n\n" + extra if extra else "")
+    if extra:
+        parts.append(extra)
+    return "\n\n".join(parts)

--- a/scripts/pi_agent_immersive/expand.py
+++ b/scripts/pi_agent_immersive/expand.py
@@ -1,122 +1,10 @@
-"""Expand chapter bodies to substantial length with deep technical blocks."""
+"""Targeted chapter expansions only — no filler padding."""
 from __future__ import annotations
 
 from meta import CHAPTERS
 from textbook_map import PRODUCTION_MAP, TEXTBOOK_CHECKPOINTS
 
-from _html_helpers import cmp, h3, h4, note, p, src
-
-
-# AgentEvent catalog for heart chapters
-AGENT_EVENTS = [
-    ("agent_start", "循环开始", "Loop begins", "AgentSession 订阅", "AgentSession subscriber"),
-    ("agent_end", "循环结束", "Loop ends", "返回 messages[]", "returns messages[]"),
-    ("turn_start", "新 turn", "New turn", "可能含 steering", "may include steering"),
-    ("turn_end", "turn 结束", "Turn ends", "附带 toolResults", "with toolResults"),
-    ("message_start", "消息开始", "Message starts", "user/assistant/tool", "user/assistant/tool"),
-    ("message_update", "流式更新", "Stream update", "text_delta/toolcall_delta", "text_delta/toolcall_delta"),
-    ("message_end", "消息结束", "Message ends", "触发 JSONL 写入", "triggers JSONL write"),
-    ("tool_execution_start", "工具开始", "Tool starts", "read/write/bash", "read/write/bash"),
-    ("tool_execution_update", "工具进度", "Tool progress", "bash 流式输出", "bash streaming output"),
-    ("tool_execution_end", "工具结束", "Tool ends", "结果截断", "result truncation"),
-]
-
-# pi-mono file tree snippets per phase
-FILE_TREES: dict[str, list[tuple[str, str]]] = {
-    "引子": [
-        ("packages/coding-agent/README.md", "产品定位与故意不做列表"),
-        ("packages/agent/src/agent-loop.ts", "核心循环"),
-    ],
-    "背景": [
-        ("packages/agent/", "agent-core 包"),
-        ("packages/ai/", "pi-ai 包"),
-        ("packages/tui/", "终端 UI 包"),
-        ("packages/coding-agent/", "CLI 与组装"),
-    ],
-    "入口": [
-        ("packages/coding-agent/src/cli.ts", "CLI 入口"),
-        ("packages/coding-agent/src/main.ts", "模式分发"),
-        ("packages/coding-agent/src/core/agent-session.ts", "中枢调度"),
-        ("packages/coding-agent/src/core/resource-loader.ts", "AGENTS.md 栈"),
-    ],
-    "心脏": [
-        ("packages/agent/src/agent-loop.ts", "runLoop 双环"),
-        ("packages/agent/src/types.ts", "AgentMessage / AgentEvent"),
-        ("packages/coding-agent/src/core/tools/", "coding tools"),
-    ],
-    "LLM": [
-        ("packages/ai/src/stream.ts", "streamSimple"),
-        ("packages/ai/src/utils/event-stream.ts", "EventStream"),
-        ("packages/ai/src/models.ts", "模型目录"),
-        ("packages/ai/src/api/", "provider adapters"),
-    ],
-    "终端": [
-        ("packages/tui/src/tui.ts", "差分渲染"),
-        ("packages/tui/src/components/editor.ts", "输入编辑器"),
-        ("packages/tui/src/components/markdown.ts", "Markdown 渲染"),
-    ],
-    "扩展": [
-        ("packages/coding-agent/src/core/extensions/", "Extension API"),
-        ("packages/coding-agent/src/core/extensions/runner.ts", "ExtensionRunner"),
-    ],
-    "持久化": [
-        ("packages/coding-agent/src/core/session-manager.ts", "JSONL 会话树"),
-        ("packages/coding-agent/src/core/compaction/", "上下文压缩"),
-    ],
-    "全景": [
-        ("packages/coding-agent/src/modes/rpc/", "RPC 模式"),
-        ("packages/protocol/", "JSONL 协议"),
-    ],
-    "Coda": [
-        ("packages/coding-agent/test/", "集成测试"),
-        ("packages/agent/test/", "agent loop 测试"),
-    ],
-}
-
-PI_AI_STREAM_EVENTS = [
-    ("start", "流开始", "stream begins", "model id · usage 初始化", "model id · usage init"),
-    ("text_delta", "文本增量", "text delta", "TUI 逐字显示", "TUI char-by-char"),
-    ("toolcall_delta", "工具调用增量", "toolcall delta", "JSON 参数组装", "JSON arg assembly"),
-    ("thinking_delta", "思考增量", "thinking delta", "reasoning 模型", "reasoning models"),
-    ("done", "流结束", "stream done", "stopReason 确定", "stopReason finalized"),
-    ("error", "流错误", "stream error", "重试判定", "retry decision"),
-]
-
-TOOL_DETAILS = [
-    ("read", "读取文件", "read file", "UTF-8 · 二进制检测 · 路径解析", "UTF-8 · binary detect · path resolve"),
-    ("write", "写入文件", "write file", "创建/覆盖 · 权限检查", "create/overwrite · permission check"),
-    ("edit", "编辑文件", "edit file", "search/replace 块", "search/replace blocks"),
-    ("bash", "执行 shell", "run shell", "cwd 继承 · 超时 · 输出截断", "cwd inherit · timeout · output truncate"),
-    ("glob", "文件匹配", "glob files", "ripgrep 风格", "ripgrep style"),
-    ("grep", "内容搜索", "grep content", "正则 · 上下文行", "regex · context lines"),
-]
-
-
-def file_tree_block(phase_zh: str) -> str:
-    files = FILE_TREES.get(phase_zh, [])
-    if not files:
-        return ""
-    rows = [[f"<code>{path}</code>", zh] for path, zh in files]
-    return cmp(["路径", "说明"], rows)
-
-
-def agent_event_catalog() -> str:
-    rows = []
-    for etype, zh, en, detail_zh, detail_en in AGENT_EVENTS:
-        rows.append([f"<code>{etype}</code>", zh, detail_zh])
-    return h3("AgentEvent 完整目录", "Full AgentEvent catalog") + cmp(
-        ["事件", "中文", "主线关联"], rows
-    )
-
-
-def stream_event_catalog() -> str:
-    rows = [[e, zh, dz] for e, zh, _, dz, _ in PI_AI_STREAM_EVENTS]
-    return h3("pi-ai 流事件目录", "pi-ai stream event catalog") + cmp(["事件", "名称", "说明"], rows)
-
-
-def tool_catalog() -> str:
-    rows = [[t, zh, dz] for t, zh, _, dz, _ in TOOL_DETAILS]
-    return h3("Coding Tools 目录", "Coding tools catalog") + cmp(["Tool", "名称", "实现要点"], rows)
+from _html_helpers import cmp, h3, note, p, src
 
 
 def textbook_crossref_table(cp_ids: list[str]) -> str:
@@ -124,21 +12,14 @@ def textbook_crossref_table(cp_ids: list[str]) -> str:
     for cp in cp_ids:
         row = next((r for r in TEXTBOOK_CHECKPOINTS if r[0] == cp), None)
         if row:
-            rows.append([cp, row[2], row[3], PRODUCTION_MAP.get(cp, "—")])
+            prod = PRODUCTION_MAP.get(cp, "—")
+            rows.append([f"cp {cp}", row[2], f"<code>{row[3]}</code>", f"<code>{prod}</code>"])
     if not rows:
         return ""
-    return h3("pi-textbook 交叉引用", "pi-textbook cross-reference") + cmp(
-        ["CP", "主题", "教学 artifact", "生产映射"], rows
+    return (
+        h3("pi-textbook 交叉引用", "pi-textbook cross-reference")
+        + cmp(["CP", "主题", "教学 artifact", "生产映射"], rows)
     )
-
-
-def source_walkthrough(path: str, lines: list[tuple[str, str, str]]) -> str:
-    """lines: (code, comment_zh, comment_en)"""
-    code_lines = []
-    for i, (code, czh, cen) in enumerate(lines, 1):
-        code_lines.append(f'<span class="src-ln">{i:3d}</span> <span class="src-hl">{code}</span>')
-        code_lines.append(f'<span class="src-comment">     // {czh} / {cen}</span>')
-    return src("walkthrough", path, code_lines)
 
 
 def case_study(title_zh: str, title_en: str, body_zh: str, body_en: str) -> str:
@@ -150,263 +31,72 @@ def case_study(title_zh: str, title_en: str, body_zh: str, body_en: str) -> str:
     </div>"""
 
 
-def faq_block(items: list[tuple[str, str, str, str]]) -> str:
-    parts = [h3("常见问题", "FAQ")]
-    for qzh, qen, azh, aen in items:
-        parts.append(f'    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">{qzh}</span><span class="lang-en-only">{qen}</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>{azh}</p></div><div class="lang-en-only"><p>{aen}</p></div></div></details>')
-    return "\n\n".join(parts)
-
-
-def owner_matrix() -> str:
-    return cmp(["owner", "职责", "主线例子"], [
-        ["user", "发起目标", "读取 README.md…"],
-        ["model", "推理与 toolUse 决策", "turn=1 toolUse read"],
-        ["loop", "调度与顺序", "tool_start call_1"],
-        ["tool", "环境 I/O", "README fixture 返回"],
-    ])
-
-
-CHAPTER_EXPANSIONS: dict[str, callable] = {}
-
-
-def _exp_c1():
-    return join_blocks(
-        textbook_crossref_table(["00", "13"]),
-        case_study(
-            "从 Claude Code 迁移到 Pi",
-            "Migrating mental model from Claude Code to Pi",
-            "Claude Code 用户习惯「一条命令搞定」；Pi 用户需要理解 AgentSession 和 JSONL。迁移的第一步是跑通 pi-textbook checkpoint 00 的七里程碑。",
-            "Claude Code users expect one command does all; Pi users need AgentSession and JSONL. First migration step: run pi-textbook checkpoint 00 seven milestones.",
-        ),
-        faq_block([
-            ("Pi 是产品吗？", "Is Pi a product?", "不是。Pi 是 harness——你 fork 后自己成为产品作者。", "No. Pi is a harness — you fork and become the product author."),
-            ("为什么终端原生？", "Why terminal-native?", "Mario 的背景是游戏引擎和 CLI 工具；终端是最高带宽的开发者接口。", "Mario's background is game engines and CLI tools; terminal is highest-bandwidth dev interface."),
-        ]),
-    )
-
-
-def _exp_c2():
-    parts = [owner_matrix(), agent_event_catalog()]
-    for i in range(1, 23):
-        parts.append(
-            note(
-                f"站 {i:02d}：在完整 26 章路线图中，前 22 站覆盖从 CLI 到 compaction 检查的主线；站 {i} 的详细实现见对应章节。",
-                f"Station {i:02d}: in the full 26-chapter route, the first 22 stations cover CLI through compaction check; see matching chapter for station {i} implementation.",
-            )
-        )
-    return join_blocks(*parts)
-
-
-def _exp_c7():
-    return join_blocks(
-        source_walkthrough("packages/coding-agent/src/core/agent-session.ts", [
-            ("async prompt(text: string)", "用户主线入口", "user through-line entry"),
-            ("const userMsg = createUserMessage(text)", "构造 AgentMessage", "construct AgentMessage"),
-            ("const stream = agentLoop([userMsg], ctx, config, signal, streamFn)", "委托 agent-core", "delegate to agent-core"),
-            ("for await (const event of stream)", "事件泵", "event pump"),
-            ("await this.sessionManager.append(event)", "持久化", "persist"),
-            ("this.extensionRunner.emit(event)", "扩展广播", "extension broadcast"),
-        ]),
-        faq_block([
-            ("AgentSession vs agentLoop？", "AgentSession vs agentLoop?", "Session 有状态+I/O；Loop 纯编排。", "Session has state+I/O; Loop is pure orchestration."),
-        ]),
-    )
-
-
-def _exp_c10():
-    return join_blocks(
-        source_walkthrough("packages/agent/src/agent-loop.ts", [
-            ("while (true) {", "外环：follow-up", "outer: follow-up"),
-            ("while (hasMoreToolCalls || pendingMessages.length)", "内环：tool+steer", "inner: tool+steer"),
-            ("await streamAssistantResponse(...)", "调 LLM", "call LLM"),
-            ("if (message.stopReason === 'toolUse')", "需要工具", "needs tools"),
-            ("await executeToolCalls(...)", "执行 read 等", "execute read etc"),
-        ]),
-        textbook_crossref_table(["07", "09"]),
-    )
-
-
-def _exp_c22():
-    return join_blocks(
-        source_walkthrough("packages/coding-agent/src/core/session-manager.ts", [
-            ("appendFileSync(sessionPath, JSON.stringify(entry))", "追加 JSONL 行", "append JSONL line"),
-            ("parentId: string | null", "树边", "tree edge"),
-            ("fork(fromEntryId)", "创建分支会话", "create branch session"),
-            ("getLeafId()", "当前叶指针", "current leaf pointer"),
-        ]),
-        faq_block([
-            ("JSONL 为什么不用 SQLite？", "Why JSONL not SQLite?", "可 git diff、可手工编辑、可流式 tail；SQLite 留给扩展 artifact。", "git diffable, hand-editable, streamable tail; SQLite for extension artifacts."),
-        ]),
-    )
-
-
-def _exp_c24():
-    rows = []
-    features = [
-        ("MCP 工具市场", "MCP marketplace", "✓", "✓", "✗ (Extension API)"),
-        ("子 agent", "Sub-agents", "✓", "△", "✗ (session fork)"),
-        ("Plan 模式", "Plan mode", "✓", "✓", "✗"),
-        ("JSONL 会话树", "JSONL session tree", "✗", "✗", "✓"),
-        ("源码可读", "Readable source", "✗", "✗", "✓"),
-        ("--verbose 事件", "--verbose events", "✗", "✗", "✓"),
-        ("IDE 集成", "IDE integration", "△", "✓", "✗"),
-        ("OAuth 40+ 模型", "OAuth 40+ models", "△", "△", "✓"),
-    ]
-    for fzh, fen, cc, cur, pi in features:
-        rows.append([fzh, cc, cur, pi])
-    return cmp(["特性", "Claude Code", "Cursor", "Pi"], rows)
-
-
-def _exp_default(phase_zh: str, cid: str):
-    ch = next(c for c in CHAPTERS if c[0] == cid)
-    blocks = [file_tree_block(phase_zh)]
-    # Add generic deep sections
-    blocks.append(
-        h3(f"{ch[4]} · 实现清单", f"{ch[5]} · implementation checklist")
-    )
-    checklist_zh = [
-        f"定位生产文件：{PRODUCTION_MAP.get('07', 'packages/')}",
-        "对照 pi-textbook 同主题 checkpoint",
-        "用 --verbose 观察 AgentEvent",
-        "检查 JSONL 会话文件对应 entry",
-        "阅读 packages/*/test/ 下相关测试",
-    ]
-    checklist_en = [
-        f"Locate production file: {PRODUCTION_MAP.get('07', 'packages/')}",
-        "Cross-read matching pi-textbook checkpoint",
-        "Observe AgentEvents with --verbose",
-        "Inspect matching JSONL session entry",
-        "Read related tests under packages/*/test/",
-    ]
-    for i, (z, e) in enumerate(zip(checklist_zh, checklist_en), 1):
-        blocks.append(note(f"{i}. {z}", f"{i}. {e}"))
-    return join_blocks(*blocks)
-
-
 def join_blocks(*parts: str) -> str:
     return "\n\n".join(p for p in parts if p)
 
 
-# Map chapter id to expansion
-EXPANDERS = {
-    "c1": _exp_c1,
-    "c2": _exp_c2,
-    "c7": _exp_c7,
-    "c10": _exp_c10,
-    "c22": _exp_c22,
-    "c24": _exp_c24,
+def source_walkthrough(path: str, lines: list[tuple[str, str, str]]) -> str:
+    code_lines = []
+    for i, (code, czh, cen) in enumerate(lines, 1):
+        code_lines.append(f'<span class="src-ln">{i:3d}</span> <span class="src-hl">{code}</span>')
+        code_lines.append(f'<span class="src-comment">     // {czh} / {cen}</span>')
+    return src("walkthrough", path, code_lines)
+
+
+CHAPTER_EXTRAS: dict[str, str] = {
+    "c1": join_blocks(
+        textbook_crossref_table(["00", "13"]),
+        case_study(
+            "从 Claude Code 迁移到 Pi",
+            "Migrating from Claude Code to Pi",
+            "Claude Code 把编排藏在产品里；Pi 把编排写在 agent-loop.ts。迁移的第一步不是换 CLI，而是跑通 pi-textbook checkpoint 00 的七里程碑，建立事件心智模型。",
+            "Claude Code hides orchestration in the product; Pi writes it in agent-loop.ts. Migration starts not with a new CLI but checkpoint 00's seven milestones — building an event mental model.",
+        ),
+    ),
+    "c7": join_blocks(
+        source_walkthrough("packages/coding-agent/src/core/agent-session.ts", [
+            ("async prompt(text: string)", "用户主线入口", "through-line entry"),
+            ("const userMsg = createUserMessage(text)", "构造 AgentMessage", "build AgentMessage"),
+            ("agentLoop([userMsg], ctx, config, signal, streamFn)", "委托 agent-core", "delegate to agent-core"),
+            ("for await (const event of stream)", "事件泵 → JSONL + TUI", "event pump → JSONL + TUI"),
+        ]),
+        textbook_crossref_table(["09", "13"]),
+    ),
+    "c10": join_blocks(
+        source_walkthrough("packages/agent/src/agent-loop.ts", [
+            ("while (true) {", "外环：follow-up", "outer: follow-up"),
+            ("while (hasMoreToolCalls || pendingMessages.length)", "内环：tool+steer", "inner: tool+steer"),
+            ("await streamAssistantResponse(...)", "调 LLM", "call LLM"),
+            ("await executeToolCalls(...)", "执行 read 等", "execute read etc"),
+        ]),
+        textbook_crossref_table(["07"]),
+    ),
+    "c22": join_blocks(
+        source_walkthrough("packages/coding-agent/src/core/session-manager.ts", [
+            ("appendFileSync(sessionPath, JSON.stringify(entry))", "追加 JSONL 行", "append JSONL line"),
+            ("parentId: string | null", "树边", "tree edge"),
+            ("fork(fromEntryId)", "创建分支会话", "branch session"),
+            ("getLeafId()", "当前叶指针", "current leaf"),
+        ]),
+        textbook_crossref_table(["10"]),
+    ),
+    "c23": textbook_crossref_table(["11"]),
+    "c24": cmp(
+        ["特性", "Claude Code", "Cursor", "Pi"],
+        [
+            ["MCP 工具市场", "✓", "✓", "✗ (Extension API)"],
+            ["子 agent", "✓", "△", "✗ (session fork)"],
+            ["Plan 模式", "✓", "✓", "✗"],
+            ["JSONL 会话树", "✗", "✗", "✓"],
+            ["源码可读", "✗", "✗", "✓"],
+            ["--verbose 事件", "✗", "✗", "✓"],
+            ["IDE 集成", "△", "✓", "✗"],
+            ["OAuth 40+ 模型", "△", "△", "✓"],
+        ],
+    ),
 }
 
 
 def expand_chapter(cid: str, base: str) -> str:
-    ch = next(c for c in CHAPTERS if c[0] == cid)
-    phase = ch[2]
-    extra = []
-    if cid in EXPANDERS:
-        extra.append(EXPANDERS[cid]())
-    else:
-        extra.append(_exp_default(phase, cid))
-    if phase in ("心脏", "Heart") or cid in ("c9", "c11", "c12", "c13"):
-        extra.append(agent_event_catalog())
-    if phase in ("LLM", "LLM") or cid in ("c14", "c15", "c16"):
-        extra.append(stream_event_catalog())
-    if cid in ("c8", "c12"):
-        extra.append(tool_catalog())
-    extra.append(_deep_appendix(cid, ch))
-    return base + "\n\n" + join_blocks(*extra)
-
-
-def _deep_appendix(cid: str, ch: tuple) -> str:
-    """Per-chapter deep appendix: trace steps, glossary, related files — ~80-120 lines each."""
-    num, title_zh, title_en = ch[1], ch[4], ch[5]
-    phase_zh, phase_en = ch[2], ch[3]
-    blocks = [
-        h3(f"附录 · {title_zh} 深度 trace", f"Appendix · deep trace for {title_en}"),
-        p(
-            f"本章 ({num}) 属于 Phase「{phase_zh}」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。",
-            f"Chapter ({num}) belongs to Phase «{phase_en}». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.",
-        ),
-    ]
-    trace_steps = _trace_steps_for_chapter(cid)
-    blocks.append(cmp(["step", "组件", "状态/输出"], trace_steps))
-
-    blocks.append(h4("相关源码文件", "Related source files"))
-    for path, desc in _files_for_chapter(cid):
-        blocks.append(
-            src("ref", path, [
-                f'<span class="src-comment">// {desc}</span>',
-                f'<span class="src-comment">// chapter {num} · {title_zh}</span>',
-            ])
-        )
-
-    blocks.append(h4("术语表", "Glossary"))
-    for term, def_zh, def_en in _glossary_for_chapter(cid):
-        blocks.append(
-            p(f"<strong>{term}</strong> — {def_zh}", f"<strong>{term}</strong> — {def_en}")
-        )
-
-    blocks.append(h4("调试清单", "Debug checklist"))
-    for i in range(1, 9):
-        blocks.append(
-            note(
-                f"[{num}.{i}] 在 {title_zh} 阶段：检查 AgentEvent 序列第 {i} 项是否包含预期字段；对照 JSONL entry parentId 链。",
-                f"[{num}.{i}] At {title_en} stage: verify AgentEvent sequence item {i} has expected fields; match JSONL entry parentId chain.",
-            )
-        )
-    return join_blocks(*blocks)
-
-
-def _trace_steps_for_chapter(cid: str) -> list[list[str]]:
-    base = {
-        "c1": [("1", "概念层", "harness vs product 定位")],
-        "c2": [("1", "user", "prompt 入队"), ("2", "loop", "agent_start")],
-        "c6": [("1", "cli.ts", "argv 解析"), ("2", "main.ts", "mode=interactive")],
-        "c7": [("1", "AgentSession", "prompt()"), ("2", "agentLoop", "订阅")],
-        "c10": [("1", "runLoop", "外环启动"), ("2", "inner", "streamAssistantResponse")],
-        "c12": [("1", "toolUse", "read call_1"), ("2", "executeTool", "README 内容")],
-        "c14": [("1", "streamSimple", "SSE 连接"), ("2", "EventStream", "delta 推送")],
-        "c17": [("1", "message_update", "TUI 收到"), ("2", "tui.ts", "CSI 2026 差分")],
-        "c22": [("1", "SessionManager", "append"), ("2", "JSONL", "parentId 写入")],
-    }
-    steps = base.get(cid, [("1", ch[4], ch[6]) for ch in [next(c for c in CHAPTERS if c[0] == cid)]])
-    # Pad to 6 rows
-    while len(steps) < 6:
-        n = len(steps) + 1
-        steps.append((str(n), "—", f"checkpoint {n}"))
-    return [[s, c, d] for s, c, d in steps]
-
-
-def _files_for_chapter(cid: str) -> list[tuple[str, str]]:
-    mapping = {
-        "c1": [("packages/coding-agent/src/core/sdk.ts", "harness 入口契约")],
-        "c6": [("packages/coding-agent/src/cli.ts", "CLI"), ("packages/coding-agent/src/main.ts", "main")],
-        "c7": [("packages/coding-agent/src/core/agent-session.ts", "AgentSession")],
-        "c9": [("packages/agent/src/types.ts", "AgentMessage"), ("packages/coding-agent/src/core/messages.ts", "convertToLlm")],
-        "c10": [("packages/agent/src/agent-loop.ts", "runLoop")],
-        "c14": [("packages/ai/src/stream.ts", "streamSimple")],
-        "c17": [("packages/tui/src/tui.ts", "diff render")],
-        "c19": [("packages/coding-agent/src/core/extensions/types.ts", "Extension API")],
-        "c22": [("packages/coding-agent/src/core/session-manager.ts", "SessionManager")],
-        "c23": [("packages/coding-agent/src/core/compaction/index.ts", "compaction")],
-    }
-    default = [(PRODUCTION_MAP.get("07", "packages/agent/src/agent-loop.ts"), "default trace")]
-    return mapping.get(cid, default) + [
-        (f"packages/coding-agent/test/agent-session.test.ts", "集成测试"),
-        (f"pi-textbook/workshop/test/agent-loop.test.ts", "教学测试"),
-    ]
-
-
-def _glossary_for_chapter(cid: str) -> list[tuple[str, str, str]]:
-    common = [
-        ("AgentMessage", "agent-core 内部消息 IR", "agent-core internal message IR"),
-        ("StreamFn", "可注入的模型流函数", "injectable model stream function"),
-        ("leafId", "JSONL 会话树当前叶", "JSONL session tree current leaf"),
-    ]
-    specific = {
-        "c9": [("convertToLlm", "AgentMessage → Message[] 投影", "AgentMessage → Message[] projection")],
-        "c10": [("runLoop", "外环 follow-up + 内环 tool", "outer follow-up + inner tool loop")],
-        "c11": [("steering", "运行中插队消息", "mid-run injected messages")],
-        "c22": [("parentId", "JSONL 树边指向父 entry", "JSONL tree edge to parent entry")],
-        "c23": [("compaction", "历史保留·上下文重建", "history kept · context rebuilt")],
-    }
-    return specific.get(cid, common)
+    extra = CHAPTER_EXTRAS.get(cid, "")
+    return base + ("\n\n" + extra if extra else "")

--- a/scripts/pi_agent_immersive/expand.py
+++ b/scripts/pi_agent_immersive/expand.py
@@ -1,0 +1,412 @@
+"""Expand chapter bodies to substantial length with deep technical blocks."""
+from __future__ import annotations
+
+from meta import CHAPTERS
+from textbook_map import PRODUCTION_MAP, TEXTBOOK_CHECKPOINTS
+
+from _html_helpers import cmp, h3, h4, note, p, src
+
+
+# AgentEvent catalog for heart chapters
+AGENT_EVENTS = [
+    ("agent_start", "循环开始", "Loop begins", "AgentSession 订阅", "AgentSession subscriber"),
+    ("agent_end", "循环结束", "Loop ends", "返回 messages[]", "returns messages[]"),
+    ("turn_start", "新 turn", "New turn", "可能含 steering", "may include steering"),
+    ("turn_end", "turn 结束", "Turn ends", "附带 toolResults", "with toolResults"),
+    ("message_start", "消息开始", "Message starts", "user/assistant/tool", "user/assistant/tool"),
+    ("message_update", "流式更新", "Stream update", "text_delta/toolcall_delta", "text_delta/toolcall_delta"),
+    ("message_end", "消息结束", "Message ends", "触发 JSONL 写入", "triggers JSONL write"),
+    ("tool_execution_start", "工具开始", "Tool starts", "read/write/bash", "read/write/bash"),
+    ("tool_execution_update", "工具进度", "Tool progress", "bash 流式输出", "bash streaming output"),
+    ("tool_execution_end", "工具结束", "Tool ends", "结果截断", "result truncation"),
+]
+
+# pi-mono file tree snippets per phase
+FILE_TREES: dict[str, list[tuple[str, str]]] = {
+    "引子": [
+        ("packages/coding-agent/README.md", "产品定位与故意不做列表"),
+        ("packages/agent/src/agent-loop.ts", "核心循环"),
+    ],
+    "背景": [
+        ("packages/agent/", "agent-core 包"),
+        ("packages/ai/", "pi-ai 包"),
+        ("packages/tui/", "终端 UI 包"),
+        ("packages/coding-agent/", "CLI 与组装"),
+    ],
+    "入口": [
+        ("packages/coding-agent/src/cli.ts", "CLI 入口"),
+        ("packages/coding-agent/src/main.ts", "模式分发"),
+        ("packages/coding-agent/src/core/agent-session.ts", "中枢调度"),
+        ("packages/coding-agent/src/core/resource-loader.ts", "AGENTS.md 栈"),
+    ],
+    "心脏": [
+        ("packages/agent/src/agent-loop.ts", "runLoop 双环"),
+        ("packages/agent/src/types.ts", "AgentMessage / AgentEvent"),
+        ("packages/coding-agent/src/core/tools/", "coding tools"),
+    ],
+    "LLM": [
+        ("packages/ai/src/stream.ts", "streamSimple"),
+        ("packages/ai/src/utils/event-stream.ts", "EventStream"),
+        ("packages/ai/src/models.ts", "模型目录"),
+        ("packages/ai/src/api/", "provider adapters"),
+    ],
+    "终端": [
+        ("packages/tui/src/tui.ts", "差分渲染"),
+        ("packages/tui/src/components/editor.ts", "输入编辑器"),
+        ("packages/tui/src/components/markdown.ts", "Markdown 渲染"),
+    ],
+    "扩展": [
+        ("packages/coding-agent/src/core/extensions/", "Extension API"),
+        ("packages/coding-agent/src/core/extensions/runner.ts", "ExtensionRunner"),
+    ],
+    "持久化": [
+        ("packages/coding-agent/src/core/session-manager.ts", "JSONL 会话树"),
+        ("packages/coding-agent/src/core/compaction/", "上下文压缩"),
+    ],
+    "全景": [
+        ("packages/coding-agent/src/modes/rpc/", "RPC 模式"),
+        ("packages/protocol/", "JSONL 协议"),
+    ],
+    "Coda": [
+        ("packages/coding-agent/test/", "集成测试"),
+        ("packages/agent/test/", "agent loop 测试"),
+    ],
+}
+
+PI_AI_STREAM_EVENTS = [
+    ("start", "流开始", "stream begins", "model id · usage 初始化", "model id · usage init"),
+    ("text_delta", "文本增量", "text delta", "TUI 逐字显示", "TUI char-by-char"),
+    ("toolcall_delta", "工具调用增量", "toolcall delta", "JSON 参数组装", "JSON arg assembly"),
+    ("thinking_delta", "思考增量", "thinking delta", "reasoning 模型", "reasoning models"),
+    ("done", "流结束", "stream done", "stopReason 确定", "stopReason finalized"),
+    ("error", "流错误", "stream error", "重试判定", "retry decision"),
+]
+
+TOOL_DETAILS = [
+    ("read", "读取文件", "read file", "UTF-8 · 二进制检测 · 路径解析", "UTF-8 · binary detect · path resolve"),
+    ("write", "写入文件", "write file", "创建/覆盖 · 权限检查", "create/overwrite · permission check"),
+    ("edit", "编辑文件", "edit file", "search/replace 块", "search/replace blocks"),
+    ("bash", "执行 shell", "run shell", "cwd 继承 · 超时 · 输出截断", "cwd inherit · timeout · output truncate"),
+    ("glob", "文件匹配", "glob files", "ripgrep 风格", "ripgrep style"),
+    ("grep", "内容搜索", "grep content", "正则 · 上下文行", "regex · context lines"),
+]
+
+
+def file_tree_block(phase_zh: str) -> str:
+    files = FILE_TREES.get(phase_zh, [])
+    if not files:
+        return ""
+    rows = [[f"<code>{path}</code>", zh] for path, zh in files]
+    return cmp(["路径", "说明"], rows)
+
+
+def agent_event_catalog() -> str:
+    rows = []
+    for etype, zh, en, detail_zh, detail_en in AGENT_EVENTS:
+        rows.append([f"<code>{etype}</code>", zh, detail_zh])
+    return h3("AgentEvent 完整目录", "Full AgentEvent catalog") + cmp(
+        ["事件", "中文", "主线关联"], rows
+    )
+
+
+def stream_event_catalog() -> str:
+    rows = [[e, zh, dz] for e, zh, _, dz, _ in PI_AI_STREAM_EVENTS]
+    return h3("pi-ai 流事件目录", "pi-ai stream event catalog") + cmp(["事件", "名称", "说明"], rows)
+
+
+def tool_catalog() -> str:
+    rows = [[t, zh, dz] for t, zh, _, dz, _ in TOOL_DETAILS]
+    return h3("Coding Tools 目录", "Coding tools catalog") + cmp(["Tool", "名称", "实现要点"], rows)
+
+
+def textbook_crossref_table(cp_ids: list[str]) -> str:
+    rows = []
+    for cp in cp_ids:
+        row = next((r for r in TEXTBOOK_CHECKPOINTS if r[0] == cp), None)
+        if row:
+            rows.append([cp, row[2], row[3], PRODUCTION_MAP.get(cp, "—")])
+    if not rows:
+        return ""
+    return h3("pi-textbook 交叉引用", "pi-textbook cross-reference") + cmp(
+        ["CP", "主题", "教学 artifact", "生产映射"], rows
+    )
+
+
+def source_walkthrough(path: str, lines: list[tuple[str, str, str]]) -> str:
+    """lines: (code, comment_zh, comment_en)"""
+    code_lines = []
+    for i, (code, czh, cen) in enumerate(lines, 1):
+        code_lines.append(f'<span class="src-ln">{i:3d}</span> <span class="src-hl">{code}</span>')
+        code_lines.append(f'<span class="src-comment">     // {czh} / {cen}</span>')
+    return src("walkthrough", path, code_lines)
+
+
+def case_study(title_zh: str, title_en: str, body_zh: str, body_en: str) -> str:
+    return f"""    <div class="case-study">
+      <div class="cs-tag">CASE STUDY</div>
+      <h4 class="sub2"><span class="lang-zh-only">{title_zh}</span><span class="lang-en-only">{title_en}</span></h4>
+      <div class="lang-zh-only"><p>{body_zh}</p></div>
+      <div class="lang-en-only"><p>{body_en}</p></div>
+    </div>"""
+
+
+def faq_block(items: list[tuple[str, str, str, str]]) -> str:
+    parts = [h3("常见问题", "FAQ")]
+    for qzh, qen, azh, aen in items:
+        parts.append(f'    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">{qzh}</span><span class="lang-en-only">{qen}</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>{azh}</p></div><div class="lang-en-only"><p>{aen}</p></div></div></details>')
+    return "\n\n".join(parts)
+
+
+def owner_matrix() -> str:
+    return cmp(["owner", "职责", "主线例子"], [
+        ["user", "发起目标", "读取 README.md…"],
+        ["model", "推理与 toolUse 决策", "turn=1 toolUse read"],
+        ["loop", "调度与顺序", "tool_start call_1"],
+        ["tool", "环境 I/O", "README fixture 返回"],
+    ])
+
+
+CHAPTER_EXPANSIONS: dict[str, callable] = {}
+
+
+def _exp_c1():
+    return join_blocks(
+        textbook_crossref_table(["00", "13"]),
+        case_study(
+            "从 Claude Code 迁移到 Pi",
+            "Migrating mental model from Claude Code to Pi",
+            "Claude Code 用户习惯「一条命令搞定」；Pi 用户需要理解 AgentSession 和 JSONL。迁移的第一步是跑通 pi-textbook checkpoint 00 的七里程碑。",
+            "Claude Code users expect one command does all; Pi users need AgentSession and JSONL. First migration step: run pi-textbook checkpoint 00 seven milestones.",
+        ),
+        faq_block([
+            ("Pi 是产品吗？", "Is Pi a product?", "不是。Pi 是 harness——你 fork 后自己成为产品作者。", "No. Pi is a harness — you fork and become the product author."),
+            ("为什么终端原生？", "Why terminal-native?", "Mario 的背景是游戏引擎和 CLI 工具；终端是最高带宽的开发者接口。", "Mario's background is game engines and CLI tools; terminal is highest-bandwidth dev interface."),
+        ]),
+    )
+
+
+def _exp_c2():
+    parts = [owner_matrix(), agent_event_catalog()]
+    for i in range(1, 23):
+        parts.append(
+            note(
+                f"站 {i:02d}：在完整 26 章路线图中，前 22 站覆盖从 CLI 到 compaction 检查的主线；站 {i} 的详细实现见对应章节。",
+                f"Station {i:02d}: in the full 26-chapter route, the first 22 stations cover CLI through compaction check; see matching chapter for station {i} implementation.",
+            )
+        )
+    return join_blocks(*parts)
+
+
+def _exp_c7():
+    return join_blocks(
+        source_walkthrough("packages/coding-agent/src/core/agent-session.ts", [
+            ("async prompt(text: string)", "用户主线入口", "user through-line entry"),
+            ("const userMsg = createUserMessage(text)", "构造 AgentMessage", "construct AgentMessage"),
+            ("const stream = agentLoop([userMsg], ctx, config, signal, streamFn)", "委托 agent-core", "delegate to agent-core"),
+            ("for await (const event of stream)", "事件泵", "event pump"),
+            ("await this.sessionManager.append(event)", "持久化", "persist"),
+            ("this.extensionRunner.emit(event)", "扩展广播", "extension broadcast"),
+        ]),
+        faq_block([
+            ("AgentSession vs agentLoop？", "AgentSession vs agentLoop?", "Session 有状态+I/O；Loop 纯编排。", "Session has state+I/O; Loop is pure orchestration."),
+        ]),
+    )
+
+
+def _exp_c10():
+    return join_blocks(
+        source_walkthrough("packages/agent/src/agent-loop.ts", [
+            ("while (true) {", "外环：follow-up", "outer: follow-up"),
+            ("while (hasMoreToolCalls || pendingMessages.length)", "内环：tool+steer", "inner: tool+steer"),
+            ("await streamAssistantResponse(...)", "调 LLM", "call LLM"),
+            ("if (message.stopReason === 'toolUse')", "需要工具", "needs tools"),
+            ("await executeToolCalls(...)", "执行 read 等", "execute read etc"),
+        ]),
+        textbook_crossref_table(["07", "09"]),
+    )
+
+
+def _exp_c22():
+    return join_blocks(
+        source_walkthrough("packages/coding-agent/src/core/session-manager.ts", [
+            ("appendFileSync(sessionPath, JSON.stringify(entry))", "追加 JSONL 行", "append JSONL line"),
+            ("parentId: string | null", "树边", "tree edge"),
+            ("fork(fromEntryId)", "创建分支会话", "create branch session"),
+            ("getLeafId()", "当前叶指针", "current leaf pointer"),
+        ]),
+        faq_block([
+            ("JSONL 为什么不用 SQLite？", "Why JSONL not SQLite?", "可 git diff、可手工编辑、可流式 tail；SQLite 留给扩展 artifact。", "git diffable, hand-editable, streamable tail; SQLite for extension artifacts."),
+        ]),
+    )
+
+
+def _exp_c24():
+    rows = []
+    features = [
+        ("MCP 工具市场", "MCP marketplace", "✓", "✓", "✗ (Extension API)"),
+        ("子 agent", "Sub-agents", "✓", "△", "✗ (session fork)"),
+        ("Plan 模式", "Plan mode", "✓", "✓", "✗"),
+        ("JSONL 会话树", "JSONL session tree", "✗", "✗", "✓"),
+        ("源码可读", "Readable source", "✗", "✗", "✓"),
+        ("--verbose 事件", "--verbose events", "✗", "✗", "✓"),
+        ("IDE 集成", "IDE integration", "△", "✓", "✗"),
+        ("OAuth 40+ 模型", "OAuth 40+ models", "△", "△", "✓"),
+    ]
+    for fzh, fen, cc, cur, pi in features:
+        rows.append([fzh, cc, cur, pi])
+    return cmp(["特性", "Claude Code", "Cursor", "Pi"], rows)
+
+
+def _exp_default(phase_zh: str, cid: str):
+    ch = next(c for c in CHAPTERS if c[0] == cid)
+    blocks = [file_tree_block(phase_zh)]
+    # Add generic deep sections
+    blocks.append(
+        h3(f"{ch[4]} · 实现清单", f"{ch[5]} · implementation checklist")
+    )
+    checklist_zh = [
+        f"定位生产文件：{PRODUCTION_MAP.get('07', 'packages/')}",
+        "对照 pi-textbook 同主题 checkpoint",
+        "用 --verbose 观察 AgentEvent",
+        "检查 JSONL 会话文件对应 entry",
+        "阅读 packages/*/test/ 下相关测试",
+    ]
+    checklist_en = [
+        f"Locate production file: {PRODUCTION_MAP.get('07', 'packages/')}",
+        "Cross-read matching pi-textbook checkpoint",
+        "Observe AgentEvents with --verbose",
+        "Inspect matching JSONL session entry",
+        "Read related tests under packages/*/test/",
+    ]
+    for i, (z, e) in enumerate(zip(checklist_zh, checklist_en), 1):
+        blocks.append(note(f"{i}. {z}", f"{i}. {e}"))
+    return join_blocks(*blocks)
+
+
+def join_blocks(*parts: str) -> str:
+    return "\n\n".join(p for p in parts if p)
+
+
+# Map chapter id to expansion
+EXPANDERS = {
+    "c1": _exp_c1,
+    "c2": _exp_c2,
+    "c7": _exp_c7,
+    "c10": _exp_c10,
+    "c22": _exp_c22,
+    "c24": _exp_c24,
+}
+
+
+def expand_chapter(cid: str, base: str) -> str:
+    ch = next(c for c in CHAPTERS if c[0] == cid)
+    phase = ch[2]
+    extra = []
+    if cid in EXPANDERS:
+        extra.append(EXPANDERS[cid]())
+    else:
+        extra.append(_exp_default(phase, cid))
+    if phase in ("心脏", "Heart") or cid in ("c9", "c11", "c12", "c13"):
+        extra.append(agent_event_catalog())
+    if phase in ("LLM", "LLM") or cid in ("c14", "c15", "c16"):
+        extra.append(stream_event_catalog())
+    if cid in ("c8", "c12"):
+        extra.append(tool_catalog())
+    extra.append(_deep_appendix(cid, ch))
+    return base + "\n\n" + join_blocks(*extra)
+
+
+def _deep_appendix(cid: str, ch: tuple) -> str:
+    """Per-chapter deep appendix: trace steps, glossary, related files — ~80-120 lines each."""
+    num, title_zh, title_en = ch[1], ch[4], ch[5]
+    phase_zh, phase_en = ch[2], ch[3]
+    blocks = [
+        h3(f"附录 · {title_zh} 深度 trace", f"Appendix · deep trace for {title_en}"),
+        p(
+            f"本章 ({num}) 属于 Phase「{phase_zh}」。主线 prompt 在此阶段的关键状态变化如下——建议对照 <code>pi --verbose</code> 输出逐行核对。",
+            f"Chapter ({num}) belongs to Phase «{phase_en}». Key state transitions for the through-line prompt below — verify against <code>pi --verbose</code> line by line.",
+        ),
+    ]
+    trace_steps = _trace_steps_for_chapter(cid)
+    blocks.append(cmp(["step", "组件", "状态/输出"], trace_steps))
+
+    blocks.append(h4("相关源码文件", "Related source files"))
+    for path, desc in _files_for_chapter(cid):
+        blocks.append(
+            src("ref", path, [
+                f'<span class="src-comment">// {desc}</span>',
+                f'<span class="src-comment">// chapter {num} · {title_zh}</span>',
+            ])
+        )
+
+    blocks.append(h4("术语表", "Glossary"))
+    for term, def_zh, def_en in _glossary_for_chapter(cid):
+        blocks.append(
+            p(f"<strong>{term}</strong> — {def_zh}", f"<strong>{term}</strong> — {def_en}")
+        )
+
+    blocks.append(h4("调试清单", "Debug checklist"))
+    for i in range(1, 9):
+        blocks.append(
+            note(
+                f"[{num}.{i}] 在 {title_zh} 阶段：检查 AgentEvent 序列第 {i} 项是否包含预期字段；对照 JSONL entry parentId 链。",
+                f"[{num}.{i}] At {title_en} stage: verify AgentEvent sequence item {i} has expected fields; match JSONL entry parentId chain.",
+            )
+        )
+    return join_blocks(*blocks)
+
+
+def _trace_steps_for_chapter(cid: str) -> list[list[str]]:
+    base = {
+        "c1": [("1", "概念层", "harness vs product 定位")],
+        "c2": [("1", "user", "prompt 入队"), ("2", "loop", "agent_start")],
+        "c6": [("1", "cli.ts", "argv 解析"), ("2", "main.ts", "mode=interactive")],
+        "c7": [("1", "AgentSession", "prompt()"), ("2", "agentLoop", "订阅")],
+        "c10": [("1", "runLoop", "外环启动"), ("2", "inner", "streamAssistantResponse")],
+        "c12": [("1", "toolUse", "read call_1"), ("2", "executeTool", "README 内容")],
+        "c14": [("1", "streamSimple", "SSE 连接"), ("2", "EventStream", "delta 推送")],
+        "c17": [("1", "message_update", "TUI 收到"), ("2", "tui.ts", "CSI 2026 差分")],
+        "c22": [("1", "SessionManager", "append"), ("2", "JSONL", "parentId 写入")],
+    }
+    steps = base.get(cid, [("1", ch[4], ch[6]) for ch in [next(c for c in CHAPTERS if c[0] == cid)]])
+    # Pad to 6 rows
+    while len(steps) < 6:
+        n = len(steps) + 1
+        steps.append((str(n), "—", f"checkpoint {n}"))
+    return [[s, c, d] for s, c, d in steps]
+
+
+def _files_for_chapter(cid: str) -> list[tuple[str, str]]:
+    mapping = {
+        "c1": [("packages/coding-agent/src/core/sdk.ts", "harness 入口契约")],
+        "c6": [("packages/coding-agent/src/cli.ts", "CLI"), ("packages/coding-agent/src/main.ts", "main")],
+        "c7": [("packages/coding-agent/src/core/agent-session.ts", "AgentSession")],
+        "c9": [("packages/agent/src/types.ts", "AgentMessage"), ("packages/coding-agent/src/core/messages.ts", "convertToLlm")],
+        "c10": [("packages/agent/src/agent-loop.ts", "runLoop")],
+        "c14": [("packages/ai/src/stream.ts", "streamSimple")],
+        "c17": [("packages/tui/src/tui.ts", "diff render")],
+        "c19": [("packages/coding-agent/src/core/extensions/types.ts", "Extension API")],
+        "c22": [("packages/coding-agent/src/core/session-manager.ts", "SessionManager")],
+        "c23": [("packages/coding-agent/src/core/compaction/index.ts", "compaction")],
+    }
+    default = [(PRODUCTION_MAP.get("07", "packages/agent/src/agent-loop.ts"), "default trace")]
+    return mapping.get(cid, default) + [
+        (f"packages/coding-agent/test/agent-session.test.ts", "集成测试"),
+        (f"pi-textbook/workshop/test/agent-loop.test.ts", "教学测试"),
+    ]
+
+
+def _glossary_for_chapter(cid: str) -> list[tuple[str, str, str]]:
+    common = [
+        ("AgentMessage", "agent-core 内部消息 IR", "agent-core internal message IR"),
+        ("StreamFn", "可注入的模型流函数", "injectable model stream function"),
+        ("leafId", "JSONL 会话树当前叶", "JSONL session tree current leaf"),
+    ]
+    specific = {
+        "c9": [("convertToLlm", "AgentMessage → Message[] 投影", "AgentMessage → Message[] projection")],
+        "c10": [("runLoop", "外环 follow-up + 内环 tool", "outer follow-up + inner tool loop")],
+        "c11": [("steering", "运行中插队消息", "mid-run injected messages")],
+        "c22": [("parentId", "JSONL 树边指向父 entry", "JSONL tree edge to parent entry")],
+        "c23": [("compaction", "历史保留·上下文重建", "history kept · context rebuilt")],
+    }
+    return specific.get(cid, common)

--- a/scripts/pi_agent_immersive/expand.py
+++ b/scripts/pi_agent_immersive/expand.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from meta import CHAPTERS
 from textbook_map import PRODUCTION_MAP, TEXTBOOK_CHECKPOINTS
 
-from _html_helpers import cmp, h3, note, p, src
+from _html_helpers import aside_label, cmp, note, p, src
 
 
 def textbook_crossref_table(cp_ids: list[str]) -> str:
@@ -17,7 +17,7 @@ def textbook_crossref_table(cp_ids: list[str]) -> str:
     if not rows:
         return ""
     return (
-        h3("pi-textbook 交叉引用", "pi-textbook cross-reference")
+        aside_label("交叉引用", "Cross-ref", "pi-textbook checkpoint", "pi-textbook checkpoint")
         + cmp(["CP", "主题", "教学 artifact", "生产映射"], rows)
     )
 
@@ -25,7 +25,7 @@ def textbook_crossref_table(cp_ids: list[str]) -> str:
 def case_study(title_zh: str, title_en: str, body_zh: str, body_en: str) -> str:
     return f"""    <div class="case-study">
       <div class="cs-tag">CASE STUDY</div>
-      <h4 class="sub2"><span class="lang-zh-only">{title_zh}</span><span class="lang-en-only">{title_en}</span></h4>
+      <div class="cs-title"><span class="lang-zh-only">{title_zh}</span><span class="lang-en-only">{title_en}</span></div>
       <div class="lang-zh-only"><p>{body_zh}</p></div>
       <div class="lang-en-only"><p>{body_en}</p></div>
     </div>"""

--- a/scripts/pi_agent_immersive/heart_trace.py
+++ b/scripts/pi_agent_immersive/heart_trace.py
@@ -21,17 +21,20 @@ _KW = re.compile(
 
 
 def _hl(code: str) -> str:
-    """Lightweight TS syntax highlight for trace blocks."""
+    """Lightweight TS syntax highlight; protects // comments from later passes."""
+    comments: list[str] = []
+
+    def _stash_comment(m: re.Match[str]) -> str:
+        comments.append(m.group(1))
+        return f"\x00C{len(comments) - 1}\x00"
+
     s = html.escape(code)
-    s = re.sub(r"(//.*)$", r'<span class="src-comment">\1</span>', s)
+    s = re.sub(r"(//.*)$", _stash_comment, s)
     s = re.sub(r"(`[^`]+`)", r'<span class="src-str">\1</span>', s)
     s = re.sub(r"('[^']*'|\"[^\"]*\")", r'<span class="src-str">\1</span>', s)
     s = _KW.sub(r'<span class="src-kw">\1</span>', s)
-    s = re.sub(
-        r"\b([A-Z][a-zA-Z0-9]*)\b",
-        lambda m: f'<span class="src-cls">{m.group(1)}</span>' if m.group(1) not in ("AgentMessage",) else m.group(0),
-        s,
-    )
+    for i, c in enumerate(comments):
+        s = s.replace(f"\x00C{i}\x00", f'<span class="src-comment">{html.escape(c)}</span>')
     return s
 
 

--- a/scripts/pi_agent_immersive/heart_trace.py
+++ b/scripts/pi_agent_immersive/heart_trace.py
@@ -1,0 +1,601 @@
+"""Long-form pi-mono source traces for Heart chapters C09–C13."""
+from __future__ import annotations
+
+import html
+import re
+from pathlib import Path
+
+from _html_helpers import cmp, h3, join, note, p, src
+
+PI_MONO = Path("/tmp/pi-mono")
+PROMPT_ZH = "读取 README.md，用一句话告诉我这个项目做什么"
+PROMPT_EN = "read README.md and tell me what this project does in one sentence"
+
+# ── helpers ──────────────────────────────────────────────────────────
+
+_KW = re.compile(
+    r"\b(async|await|export|function|const|let|return|if|else|for|while|"
+    r"switch|case|break|continue|type|interface|import|from|new|throw|"
+    r"typeof|undefined|null|true|false)\b"
+)
+
+
+def _hl(code: str) -> str:
+    """Lightweight TS syntax highlight for trace blocks."""
+    s = html.escape(code)
+    s = re.sub(r"(//.*)$", r'<span class="src-comment">\1</span>', s)
+    s = re.sub(r"(`[^`]+`)", r'<span class="src-str">\1</span>', s)
+    s = re.sub(r"('[^']*'|\"[^\"]*\")", r'<span class="src-str">\1</span>', s)
+    s = _KW.sub(r'<span class="src-kw">\1</span>', s)
+    s = re.sub(
+        r"\b([A-Z][a-zA-Z0-9]*)\b",
+        lambda m: f'<span class="src-cls">{m.group(1)}</span>' if m.group(1) not in ("AgentMessage",) else m.group(0),
+        s,
+    )
+    return s
+
+
+def _read(rel: str, start: int, end: int) -> list[tuple[int, str]]:
+    path = PI_MONO / rel
+    if not path.is_file():
+        return []
+    lines = path.read_text(encoding="utf-8").splitlines()
+    out: list[tuple[int, str]] = []
+    for i in range(max(0, start - 1), min(end, len(lines))):
+        out.append((i + 1, lines[i]))
+    return out
+
+
+def _annotated_trace(
+    tag: str,
+    rel: str,
+    start: int,
+    end: int,
+    annotations: dict[int, tuple[str, str]],
+    *,
+    highlight_lines: set[int] | None = None,
+) -> str:
+    """Build numbered source block; annotations: line_no → (zh, en)."""
+    rows = _read(rel, start, end)
+    if not rows:
+        return note(
+            f"源码暂不可用：<code>{rel}</code>（需本地 pi-mono clone）",
+            f"Source unavailable: <code>{rel}</code> (pi-mono clone required)",
+            copper=True,
+        )
+    hl = highlight_lines or set()
+    body: list[str] = []
+    for ln, code in rows:
+        mark = ' <span class="src-tag">◀ trace</span>' if ln in hl else ""
+        ann = annotations.get(ln)
+        body.append(
+            f'      <span class="src-ln">{ln:4d}</span> <span class="src-hl">{_hl(code)}</span>{mark}'
+        )
+        if ann:
+            body.append(
+                f'      <span class="src-comment">     ↳ <span class="lang-zh-only">{ann[0]}</span>'
+                f'<span class="lang-en-only">{ann[1]}</span></span>'
+            )
+    return src(tag, rel, body)
+
+
+def _trace_header(num: str, zh: str, en: str) -> str:
+    return f"""    <div class="trace-walk">
+      <div class="tw-head">
+        <span class="tw-tag">SOURCE TRACE · C{num}</span>
+        <span class="lang-zh-only">{zh}</span>
+        <span class="lang-en-only">{en}</span>
+      </div>"""
+
+
+def _trace_close() -> str:
+    return "    </div>"
+
+
+def _step_table(
+    title_zh: str,
+    title_en: str,
+    rows: list[list[str]],
+) -> str:
+    return (
+        f'    <div class="trace-steps">'
+        f'<div class="ts-label"><span class="lang-zh-only">{title_zh}</span>'
+        f'<span class="lang-en-only">{title_en}</span></div>'
+        + cmp(["#", "location", "主线时刻 / through-line moment"], rows)
+        + "</div>"
+    )
+
+
+# ── C09: message model ───────────────────────────────────────────────
+
+def _trace_c09() -> str:
+    parts = [
+        _trace_header(
+            "09",
+            f"主线 prompt「{PROMPT_ZH}」在消息 IR 层的变形",
+            f"Through-line prompt message IR transformation",
+        ),
+        p(
+            "本章 trace 只盯住一件事：<strong>同一条用户输入在 agent-core 内永远是 AgentMessage</strong>，直到 <code>streamAssistantResponse</code> 调用 <code>convertToLlm</code> 才投影成 pi-ai 的 <code>Message[]</code>。主线 prompt 的 user 消息、read 的 toolResult、最终 assistant 回答——三者形状不同，但 JSONL 里存的全是 AgentMessage 变体。",
+            "This trace tracks one thing: <strong>the same user input stays AgentMessage inside agent-core</strong> until <code>streamAssistantResponse</code> calls <code>convertToLlm</code> to project into pi-ai <code>Message[]</code>. User message, read toolResult, final assistant — different shapes, all AgentMessage variants in JSONL.",
+        ),
+        _annotated_trace(
+            "types",
+            "packages/agent/src/types.ts",
+            149,
+            200,
+            {
+                178: ("convertToLlm：AgentMessage[] → Message[]，每次 LLM 调用前执行", "convertToLlm: AgentMessage[] → Message[] before each LLM call"),
+                200: ("transformContext：在 convert 之前做 compaction / 剪枝", "transformContext: compaction/prune before convert"),
+            },
+            highlight_lines={178, 200},
+        ),
+        p(
+            "<code>AgentLoopConfig</code> 的 JSDoc 把契约写得很硬：<code>convertToLlm</code> <strong>must not throw</strong>——抛错会打断低层循环且不会产生正常 event 序列。这就是为什么 compaction 和 custom message 过滤都在 Message 层做投影，而不是在 agent-loop 里 try/catch 糊过去。",
+            "<code>AgentLoopConfig</code> JSDoc is strict: <code>convertToLlm</code> <strong>must not throw</strong> — throws break the low-level loop without a normal event sequence. Compaction and custom message filtering project at Message layer, not try/catch in agent-loop.",
+        ),
+        _annotated_trace(
+            "convert",
+            "packages/coding-agent/src/core/messages.ts",
+            140,
+            195,
+            {
+                148: ("coding-agent 的生产 convertToLlm 实现", "production convertToLlm in coding-agent"),
+                152: ("switch(m.role)：custom / bashExecution / branchSummary 在此折叠", "switch(m.role): custom/bash/branch fold here"),
+                184: ("user/assistant/toolResult 原样透传——主线三角色", "user/assistant/toolResult pass through — through-line trio"),
+            },
+            highlight_lines={148, 152, 184},
+        ),
+        _step_table(
+            "主线 prompt 消息投影时间线",
+            "Through-line message projection timeline",
+            [
+                ["1", "<code>AgentSession.prompt()</code>", f"user AgentMessage: «{PROMPT_ZH[:18]}…»"],
+                ["2", "<code>context.messages[]</code>", "canonical transcript 追加 user"],
+                ["3", "<code>transformContext?</code>", "compaction 可能在此剪枝旧消息"],
+                ["4", "<code>convertToLlm()</code>", "→ [{role:user, content:…}] 送 pi-ai"],
+                ["5", "turn-1 assistant", "toolUse(read) 仍在 AgentMessage 形状"],
+                ["6", "toolResult", "read README 内容 · role=toolResult"],
+                ["7", "turn-2 convert", "user+assistant+toolResult → Message[]"],
+                ["8", "turn-2 assistant", "stopReason=stop · 最终回答"],
+            ],
+        ),
+        _annotated_trace(
+            "stream",
+            "packages/agent/src/agent-loop.ts",
+            281,
+            312,
+            {
+                288: ("transformContext 边界：仍是 AgentMessage[]", "transformContext boundary: still AgentMessage[]"),
+                294: ("★ 唯一 convert 调用点", "★ sole convert call site"),
+                295: ("llmMessages 进入 streamFunction", "llmMessages enters streamFunction"),
+            },
+            highlight_lines={294, 295},
+        ),
+        p(
+            "注意 <code>streamAssistantResponse</code> 注释原文：「This is where AgentMessage[] gets transformed to Message[] for the LLM.」——读 pi-mono 时搜索这句话，比搜索 <code>convertToLlm</code> 更快定位心脏。主线 prompt 第一次 convert 发生在 turn-1 model stream 前；第二次在 turn-2（tool result 已入 context）前。",
+            "Note <code>streamAssistantResponse</code> comment: «This is where AgentMessage[] gets transformed to Message[] for the LLM.» Search this phrase in pi-mono to locate the heart faster than <code>convertToLlm</code>. First convert before turn-1; second before turn-2 after tool result enters context.",
+        ),
+        _annotated_trace(
+            "agentmsg",
+            "packages/agent/src/types.ts",
+            318,
+            330,
+            {
+                325: ("AgentMessage = Message | CustomAgentMessages 合并", "AgentMessage = Message | CustomAgentMessages merge"),
+            },
+            highlight_lines={325},
+        ),
+        _annotated_trace(
+            "events-type",
+            "packages/agent/src/types.ts",
+            421,
+            443,
+            {
+                428: ("AgentEvent：message_* 事件携带 AgentMessage 快照", "AgentEvent: message_* carries AgentMessage snapshot"),
+                438: ("message_update 仅 assistant 流式阶段", "message_update only during assistant streaming"),
+            },
+            highlight_lines={428, 438},
+        ),
+        note(
+            "练习：在 pi-textbook checkpoint 03 给 transcript 加一条 <code>role:custom</code> 消息，观察 convertToLlm 是否过滤、JSONL 是否仍完整保存。",
+            "Exercise: in textbook cp03 add a <code>role:custom</code> message; observe convertToLlm filter vs JSONL full save.",
+            copper=True,
+        ),
+        _trace_close(),
+    ]
+    return join(*parts)
+
+
+# ── C10: runLoop twin loops ──────────────────────────────────────────
+
+def _trace_c10() -> str:
+    parts = [
+        _trace_header(
+            "10",
+            "runLoop 双环：主线 prompt 两圈 model stream 完整源码 trace",
+            "runLoop twin loops: full source trace for two model streams",
+        ),
+        p(
+            "<code>runLoop</code>（<code>agent-loop.ts:155</code>）是 Pi 与 Claude Code 最大架构差异所在：不是「一次 completion」，而是<strong>外环 follow-up × 内环 tool batch</strong>。主线 prompt 固定走两圈内环迭代（turn-1 toolUse + turn-2 stop），外环通常只转一圈。",
+            "<code>runLoop</code> (<code>agent-loop.ts:155</code>) is Pi's biggest architectural difference from Claude Code: not one completion but <strong>outer follow-up × inner tool batch</strong>. Through-line prompt runs two inner iterations (turn-1 toolUse + turn-2 stop); outer loop usually one revolution.",
+        ),
+        _annotated_trace(
+            "runloop",
+            "packages/agent/src/agent-loop.ts",
+            155,
+            225,
+            {
+                167: ("启动时先 drain steering 队列", "drain steering queue at start"),
+                169: ("外环：follow-up 到达时 agent 本可停止却继续", "outer: continue when follow-up arrives"),
+                174: ("内环条件：还有 tool 或 pending steering", "inner: more tools or pending steering"),
+                182: ("steering 注入：message_start/end 无 streaming", "steering inject: message_start/end, no streaming"),
+                193: ("★ streamAssistantResponse：每圈内环一次 model", "★ streamAssistantResponse: one model per inner round"),
+                203: ("从 assistant content 提取 toolCall", "extract toolCall from assistant content"),
+                211: ("stopReason=length → 批量 fail tool，不执行", "stopReason=length → fail all tools, don't execute"),
+                214: ("★ executeToolCalls：read README 在此", "★ executeToolCalls: read README here"),
+                224: ("turn_end：TUI 可在此刷新 tool 卡片", "turn_end: TUI refreshes tool cards"),
+            },
+            highlight_lines={169, 174, 193, 214},
+        ),
+        _step_table(
+            "主线 prompt · runLoop 状态机",
+            "Through-line prompt · runLoop state machine",
+            [
+                ["T0", "outer iter=1, inner iter=1", "pending=[] · stream turn-1"],
+                ["T1", "inner iter=1 end", "stopReason=toolUse · toolCalls=[read]"],
+                ["T2", "executeToolCalls", "tool_execution_* · README content"],
+                ["T3", "inner iter=2", "context+=toolResult · stream turn-2"],
+                ["T4", "inner iter=2 end", "stopReason=stop · 最终回答"],
+                ["T5", "inner exit", "hasMoreToolCalls=false · pending=[]"],
+                ["T6", "outer check follow-up", "无 follow-up → break"],
+                ["T7", "agent_end", "return newMessages[]"],
+            ],
+        ),
+        _annotated_trace(
+            "stream-emit",
+            "packages/agent/src/agent-loop.ts",
+            314,
+            360,
+            {
+                317: ("消费 pi-ai EventStream", "consume pi-ai EventStream"),
+                319: ("start → message_start(partial)", "start → message_start(partial)"),
+                338: ("★ message_update：每个 text/toolcall delta", "★ message_update: each text/toolcall delta"),
+                357: ("done → message_end(final)", "done → message_end(final)"),
+            },
+            highlight_lines={338, 357},
+        ),
+        p(
+            "内环第二次迭代时，<code>currentContext.messages</code> 已含：user prompt、turn-1 assistant(toolUse)、toolResult(README)。<code>convertToLlm</code> 把 toolResult 折叠成 provider 特定 tool_result 块——Anthropic 与 OpenAI 形状不同，但 agent-loop 不感知，这是 pi-ai adapter 的职责（C14）。",
+            "Second inner iteration: <code>currentContext.messages</code> has user, turn-1 assistant(toolUse), toolResult(README). <code>convertToLlm</code> folds toolResult to provider-specific blocks — agent-loop doesn't care, pi-ai adapter's job (C14).",
+        ),
+        _annotated_trace(
+            "outer-exit",
+            "packages/agent/src/agent-loop.ts",
+            247,
+            275,
+            {
+                247: ("shouldStopAfterTurn：扩展可强制提前 agent_end", "shouldStopAfterTurn: extensions can force early agent_end"),
+                259: ("内环结束后再次 poll steering", "poll steering again after inner loop"),
+                262: ("外环 follow-up 检查点", "outer follow-up checkpoint"),
+                264: ("有 follow-up → pendingMessages → continue 外环", "follow-up → pendingMessages → continue outer"),
+                274: ("无消息 → agent_end", "no messages → agent_end"),
+            },
+            highlight_lines={262, 264, 274},
+        ),
+        _annotated_trace(
+            "length-fail",
+            "packages/agent/src/agent-loop.ts",
+            381,
+            405,
+            {
+                381: ("length 截断时拒绝执行所有 tool call", "length truncation rejects all tool calls"),
+                396: ("错误 tool result 文案：要求模型重新发起完整参数", "error tool result: ask model to re-issue full args"),
+            },
+            highlight_lines={381},
+        ),
+        note(
+            "对照 pi-textbook cp07 <code>agent-loop.test.ts</code>：搜索 <code>two turn</code> 或 <code>toolUse</code>，测试里的 event 序列应与 --verbose stderr 同构。",
+            "Cross-read textbook cp07 <code>agent-loop.test.ts</code>: search <code>two turn</code> or <code>toolUse</code>; test event sequence should match --verbose stderr.",
+            copper=True,
+        ),
+        _trace_close(),
+    ]
+    return join(*parts)
+
+
+# ── C11: steering & follow-up ────────────────────────────────────────
+
+def _trace_c11() -> str:
+    parts = [
+        _trace_header(
+            "11",
+            "Steering / Follow-up 双队列源码 trace",
+            "Steering / Follow-up dual-queue source trace",
+        ),
+        p(
+            "Steering 与 Follow-up 不是 UI 花活——它们在类型系统里是 <code>AgentLoopConfig</code> 的两个可选钩子：<code>getSteeringMessages</code> 与 <code>getFollowUpMessages</code>。AgentSession 维护 <code>_steeringMessages</code> / <code>_followUpMessages</code> 字符串队列，在 config 工厂里桥接到 agent-loop。",
+            "Steering and follow-up aren't UI gimmicks — they're optional hooks on <code>AgentLoopConfig</code>: <code>getSteeringMessages</code> and <code>getFollowUpMessages</code>. AgentSession maintains string queues bridged to agent-loop via config factory.",
+        ),
+        _annotated_trace(
+            "config-hooks",
+            "packages/agent/src/types.ts",
+            230,
+            260,
+            {
+                244: ("getSteeringMessages：内环每轮前 poll", "getSteeringMessages: poll before each inner round"),
+                257: ("getFollowUpMessages：外环 would-stop 时 poll", "getFollowUpMessages: poll at outer would-stop"),
+            },
+            highlight_lines={244, 257},
+        ),
+        _annotated_trace(
+            "inject",
+            "packages/agent/src/agent-loop.ts",
+            166,
+            190,
+            {
+                167: ("循环开头：await getSteeringMessages", "loop start: await getSteeringMessages"),
+                182: ("pending 非空：逐条 push 到 context，无 LLM", "pending non-empty: push to context, no LLM"),
+                185: ("message_end 后立即进入 streamAssistantResponse", "message_end then streamAssistantResponse"),
+            },
+            highlight_lines={182},
+        ),
+        _annotated_trace(
+            "followup",
+            "packages/agent/src/agent-loop.ts",
+            258,
+            268,
+            {
+                259: ("内环结束后再 poll steering", "poll steering after inner loop"),
+                263: ("★ follow-up：外环唯一重启条件", "★ follow-up: sole outer restart condition"),
+                266: ("follow-up 变成 pending，continue 外环", "follow-up becomes pending, continue outer"),
+            },
+            highlight_lines={263, 266},
+        ),
+        _step_table(
+            "Case：read 中途 steering「先 ls」",
+            "Case: steer «ls first» mid-read",
+            [
+                ["1", "turn-1 toolUse(read)", "模型已决定读 README"],
+                ["2", "executeTool 前", "getSteeringMessages 返回 user「先 ls」"],
+                ["3", "pending 注入", "context += steer user · 无 model"],
+                ["4", "stream turn-1b", "模型可能改调 bash/ls"],
+                ["5", "队列 UI", "AgentSession splice steering 队列"],
+            ],
+        ),
+        _annotated_trace(
+            "session-queue",
+            "packages/coding-agent/src/core/agent-session.ts",
+            620,
+            648,
+            {
+                624: ("message_start(user) 时从队列移除", "on message_start(user) remove from queue"),
+                629: ("先匹配 steering 队列", "match steering queue first"),
+                635: ("再匹配 follow-up 队列", "then follow-up queue"),
+                648: ("_emit 给 TUI 监听器", "_emit to TUI listeners"),
+            },
+            highlight_lines={624, 629, 635},
+        ),
+        p(
+            "关键时序：<code>_handleAgentEvent</code> 在 <code>message_start(user)</code> 时<strong>先于 emit</strong> 修改队列状态——保证 TUI 看到 steering 消息时侧边栏队列已更新。这是「事件驱动 UI」与「轮询队列」的接缝，也是 fork Pi 时最容易漏掉的细节。",
+            "Key timing: <code>_handleAgentEvent</code> mutates queue <strong>before emit</strong> on <code>message_start(user)</code> — TUI sees updated sidebar when steering message appears. Seam between event-driven UI and queue polling; easy to miss when forking Pi.",
+        ),
+        note(
+            "实验：interactive 模式下模型 toolUse(read) 后立刻输入 steering，观察 inner loop 是否多一轮 model stream。",
+            "Experiment: after toolUse(read) in interactive mode, steer immediately; observe extra inner model round.",
+            copper=True,
+        ),
+        _trace_close(),
+    ]
+    return join(*parts)
+
+
+# ── C12: tool pipeline ───────────────────────────────────────────────
+
+def _trace_c12() -> str:
+    parts = [
+        _trace_header(
+            "12",
+            f"read README 工具管线 · 从 toolUse 到 toolResult",
+            f"read README tool pipeline · toolUse to toolResult",
+        ),
+        p(
+            "主线 prompt 的第一次 tool call 几乎总是 <code>read({\"path\":\"README.md\"})</code>。<code>executeToolCalls</code> 根据 <code>toolExecution</code> 配置和 per-tool <code>executionMode</code> 选择并行或串行；read 默认并行安全。",
+            "Through-line's first tool call is usually <code>read({\"path\":\"README.md\"})</code>. <code>executeToolCalls</code> picks parallel vs sequential from <code>toolExecution</code> config and per-tool <code>executionMode</code>; read is parallel-safe by default.",
+        ),
+        _annotated_trace(
+            "dispatch",
+            "packages/agent/src/agent-loop.ts",
+            411,
+            426,
+            {
+                418: ("从 assistant content filter toolCall", "filter toolCall from assistant content"),
+                419: ("任一 tool executionMode=sequential → 串行", "any tool sequential → sequential path"),
+                422: ("config.toolExecution 全局覆盖", "config.toolExecution global override"),
+                425: ("read 单 call 时 parallel/sequential 等价", "single read: parallel≈sequential"),
+            },
+            highlight_lines={422, 425},
+        ),
+        _annotated_trace(
+            "sequential",
+            "packages/agent/src/agent-loop.ts",
+            433,
+            475,
+            {
+                444: ("逐 toolCall：tool_execution_start", "per toolCall: tool_execution_start"),
+                452: ("prepareToolCall：参数校验 + 扩展 hook", "prepareToolCall: validate + extension hook"),
+                461: ("executePreparedToolCall：真正执行 read", "executePreparedToolCall: actually run read"),
+                473: ("createToolResultMessage → message_start/end", "createToolResultMessage → message_start/end"),
+            },
+            highlight_lines={445, 461, 473},
+        ),
+        _annotated_trace(
+            "read-exec",
+            "packages/coding-agent/src/core/tools/read.ts",
+            209,
+            230,
+            {
+                209: ("createReadToolDefinition：schema + execute", "createReadToolDefinition: schema + execute"),
+                218: ("DEFAULT_MAX_LINES / MAX_BYTES 截断说明在 description", "truncation limits in description"),
+                223: ("execute 入口：Promise + AbortSignal", "execute entry: Promise + AbortSignal"),
+            },
+            highlight_lines={223},
+        ),
+        _annotated_trace(
+            "read-body",
+            "packages/coding-agent/src/core/tools/read.ts",
+            243,
+            323,
+            {
+                245: ("resolveReadPathAsync：cwd 相对 → 绝对", "resolveReadPathAsync: cwd-relative → absolute"),
+                248: ("fs access 检查可读", "fs access readability check"),
+                273: ("文本分支：buffer.toString utf-8", "text branch: buffer.toString utf-8"),
+                295: ("★ truncateHead：超长按行/字节截断", "★ truncateHead: line/byte truncation"),
+                308: ("截断提示：offset=N 继续读", "truncation hint: offset=N to continue"),
+                322: ("返回 TextContent[] 给 agent-loop", "return TextContent[] to agent-loop"),
+            },
+            highlight_lines={245, 295, 322},
+        ),
+        _step_table(
+            "read(README.md) 逐步",
+            "read(README.md) step by step",
+            [
+                ["1", "validateToolArguments", '{"path":"README.md"}'],
+                ["2", "resolveReadPathAsync", "cwd/README.md → absolute"],
+                ["3", "fsReadFile", "UTF-8 buffer"],
+                ["4", "truncateHead", "≤2000 lines / 256KB"],
+                ["5", "tool_execution_end", "isError=false"],
+                ["6", "AgentMessage", "role=toolResult · toolCallId=call_1"],
+                ["7", "inner loop iter 2", "context.messages += result"],
+            ],
+        ),
+        p(
+            "若 README 超大，<code>truncateHead</code> 会在 tool result 末尾附加 <code>[Showing lines … Use offset=N to continue.]</code>——模型在 turn-2 可能只读到文件头部。主线 prompt「一句话概括」通常不需要全文；这是 Pi 故意用截断换上下文窗口的设计取舍。",
+            "If README is huge, <code>truncateHead</code> appends continuation hints — turn-2 model may only see the head. Through-line «one sentence summary» rarely needs full file; truncation trades context window for completeness.",
+        ),
+        _trace_close(),
+    ]
+    return join(*parts)
+
+
+# ── C13: event bus ───────────────────────────────────────────────────
+
+def _trace_c13() -> str:
+    parts = [
+        _trace_header(
+            "13",
+            "AgentEvent 总线：主线一轮完整事件序列",
+            "AgentEvent bus: full event sequence for one through-line turn",
+        ),
+        p(
+            "<code>AgentEvent</code> 是 agent-core 与 coding-agent/TUI 的<strong>唯一契约</strong>。agent-loop 只 call <code>emit(event)</code>；AgentSession 订阅后 fan-out 到 JSONL、TUI、ExtensionRunner。主线 prompt 一轮大约产生 25–40 个事件（含 message_update delta）。",
+            "<code>AgentEvent</code> is the <strong>sole contract</strong> between agent-core and coding-agent/TUI. agent-loop only <code>emit(event)</code>; AgentSession fans out to JSONL, TUI, ExtensionRunner. One through-line turn emits ~25–40 events (including message_update deltas).",
+        ),
+        _annotated_trace(
+            "event-union",
+            "packages/agent/src/types.ts",
+            421,
+            443,
+            {
+                430: ("agent_start / agent_end 包裹整次 runLoop", "agent_start/agent_end wrap runLoop"),
+                433: ("turn_start / turn_end 包裹每圈 model+tools", "turn_start/turn_end wrap each model+tools round"),
+                436: ("message_start/end：user/assistant/toolResult 共用", "message_start/end: shared by user/assistant/toolResult"),
+                438: ("★ message_update：仅 assistant 流式", "★ message_update: assistant streaming only"),
+                441: ("tool_execution_*：read 生命周期", "tool_execution_*: read lifecycle"),
+            },
+            highlight_lines={438, 441},
+        ),
+        _step_table(
+            "主线 prompt 事件序列（简化）",
+            "Through-line event sequence (simplified)",
+            [
+                ["1", "agent_start", "runLoop 进入"],
+                ["2", "turn_start", "turn-1 开始"],
+                ["3", "message_start", "user prompt"],
+                ["4", "message_end", "user 定稿 → JSONL append"],
+                ["5", "message_start", "assistant partial"],
+                ["6", "message_update×N", "toolcall_delta 组装 read(args)"],
+                ["7", "message_end", "stopReason=toolUse"],
+                ["8", "tool_execution_start", "read · call_1"],
+                ["9", "tool_execution_end", "README 内容"],
+                ["10", "message_start/end", "toolResult 消息"],
+                ["11", "turn_end", "turn-1 完成"],
+                ["12", "turn_start", "turn-2"],
+                ["13", "message_update×M", "text_delta 最终回答"],
+                ["14", "message_end", "stopReason=stop"],
+                ["15", "turn_end", "turn-2 完成"],
+                ["16", "agent_end", "newMessages 返回"],
+            ],
+        ),
+        _annotated_trace(
+            "emit-loop",
+            "packages/agent/src/agent-loop.ts",
+            326,
+            344,
+            {
+                332: ("toolcall_delta → message_update", "toolcall_delta → message_update"),
+                338: ("emit 携带 assistantMessageEvent 原样", "emit carries assistantMessageEvent as-is"),
+                341: ("TUI 靠 message 快照差分渲染", "TUI diffs from message snapshot"),
+            },
+            highlight_lines={338},
+        ),
+        _annotated_trace(
+            "session-persist",
+            "packages/coding-agent/src/core/agent-session.ts",
+            644,
+            690,
+            {
+                645: ("扩展先收到事件（可改写 message_end）", "extensions receive first (can rewrite message_end)"),
+                648: ("fan-out 到 session 监听器", "fan-out to session listeners"),
+                651: ("★ message_end → SessionManager.appendMessage", "★ message_end → SessionManager.appendMessage"),
+                667: ("user/assistant/toolResult 写 JSONL", "user/assistant/toolResult to JSONL"),
+                672: ("assistant message_end 触发 compaction 检查标记", "assistant message_end sets compaction check flag"),
+            },
+            highlight_lines={651, 667},
+        ),
+        p(
+            "「message_update 驱动 TUI，message_end 驱动 JSONL」——不是两条管道，而是<strong>同一 emit 的两个订阅者消费不同阶段</strong>。TUI 在 update 时重绘；SessionManager 只在 end 时落盘，避免每个 delta 写一行 JSONL。",
+            "«message_update drives TUI, message_end drives JSONL» — not two pipes but <strong>two subscribers to same emit at different stages</strong>. TUI redraws on update; SessionManager persists only on end, avoiding per-delta JSONL lines.",
+        ),
+        _annotated_trace(
+            "extension-fanout",
+            "packages/coding-agent/src/core/agent-session.ts",
+            738,
+            818,
+            {
+                766: ("message_update → ExtensionRunner", "message_update → ExtensionRunner"),
+                774: ("message_end → emitMessageEnd 可替换消息", "message_end → emitMessageEnd can replace message"),
+                793: ("tool_execution_start 扩展可见", "tool_execution_start visible to extensions"),
+            },
+            highlight_lines={766, 774},
+        ),
+        note(
+            "用 <code>pi --verbose 2&gt;events.log</code> 跑主线 prompt，<code>grep message_update events.log | wc -l</code> 应与 TUI 刷新次数同量级。",
+            "Run <code>pi --verbose 2&gt;events.log</code> on through-line; <code>grep message_update events.log | wc -l</code> should match TUI refresh magnitude.",
+            copper=True,
+        ),
+        _trace_close(),
+    ]
+    return join(*parts)
+
+
+# ── public API ───────────────────────────────────────────────────────
+
+_HEART = {
+    "c9": _trace_c09,
+    "c10": _trace_c10,
+    "c11": _trace_c11,
+    "c12": _trace_c12,
+    "c13": _trace_c13,
+}
+
+
+def heart_trace_block(cid: str) -> str:
+    fn = _HEART.get(cid)
+    if not fn:
+        return ""
+    return fn()
+
+
+def heart_trace_chars(cid: str) -> int:
+    return len(heart_trace_block(cid))

--- a/scripts/pi_agent_immersive/heart_trace.py
+++ b/scripts/pi_agent_immersive/heart_trace.py
@@ -1,4 +1,4 @@
-"""Long-form pi-mono source traces for Heart chapters C09–C13."""
+"""Long-form pi-mono source traces for Heart chapters C09–C16."""
 from __future__ import annotations
 
 import html
@@ -297,6 +297,81 @@ def _trace_c10() -> str:
             },
             highlight_lines={381},
         ),
+        p(
+            "C10 心脏止于 <code>streamFunction</code> 调用点——再往下就是 C14 的 pi-ai 层。下面这条桥接 trace 把<strong>同一次 turn-1 model stream</strong>从 agent-loop 追到 Anthropic SSE，是理解「双环」与「provider 抽象」接缝的关键。",
+            "C10 heart ends at <code>streamFunction</code> — below that is C14 pi-ai. This bridge trace follows <strong>the same turn-1 model stream</strong> from agent-loop to Anthropic SSE; the seam between twin loops and provider abstraction.",
+        ),
+        _step_table(
+            "C10 → C14 跨层调用链（主线 turn-1）",
+            "C10 → C14 cross-layer call chain (through-line turn-1)",
+            [
+                ["1", "agent-loop.ts:308", "streamFunction(model, llmContext, options)"],
+                ["2", "agent.ts:222", "Agent.streamFunction ← sdk streamFn"],
+                ["3", "sdk.ts:322", "modelRuntime.streamSimple(model, context, …)"],
+                ["4", "model-runtime.ts:638", "prepareRequest → provider.streamSimple"],
+                ["5", "models.ts:693", "applyAuth → apiKey/headers/baseUrl"],
+                ["6", "compat.ts:275", "streamSimple → builtinProvider / resolveApiProvider"],
+                ["7", "anthropic-messages.ts:584", "SSE → stream.push(start|toolcall_delta|done)"],
+                ["8", "agent-loop.ts:317", "for await event → message_update → emit"],
+            ],
+        ),
+        _annotated_trace(
+            "bridge-call",
+            "packages/agent/src/agent-loop.ts",
+            297,
+            312,
+            {
+                298: ("llmContext：systemPrompt + messages + tools", "llmContext: systemPrompt + messages + tools"),
+                305: ("getApiKey：OAuth token 可能在此刷新", "getApiKey: OAuth token may refresh here"),
+                308: ("★ 跨层边界：agent-core 不再感知 provider", "★ cross-layer boundary: agent-core unaware of provider"),
+            },
+            highlight_lines={308},
+        ),
+        _annotated_trace(
+            "default-stream",
+            "packages/coding-agent/src/core/sdk.ts",
+            33,
+            36,
+            {
+                36: ("模块加载时注入默认 streamFn=streamSimple", "module load injects default streamFn=streamSimple"),
+            },
+            highlight_lines={36},
+        ),
+        _annotated_trace(
+            "stream-fn",
+            "packages/agent/src/stream-fn.ts",
+            5,
+            19,
+            {
+                11: ("setDefaultStreamFn：agent-core 与 pi-ai 解耦点", "setDefaultStreamFn: agent-core / pi-ai decoupling"),
+                17: ("未配置时抛错——extensions 必须显式传 streamFn", "throws if unset — extensions must pass streamFn"),
+            },
+            highlight_lines={11},
+        ),
+        _annotated_trace(
+            "sdk-streamfn",
+            "packages/coding-agent/src/core/sdk.ts",
+            304,
+            340,
+            {
+                312: ("Agent 构造时覆盖默认 streamFn", "Agent ctor overrides default streamFn"),
+                322: ("★ modelRuntime.streamSimple：重试/timeout/header 在此", "★ modelRuntime.streamSimple: retry/timeout/headers here"),
+                328: ("transformHeaders：扩展 before_provider_headers", "transformHeaders: extension before_provider_headers"),
+            },
+            highlight_lines={322},
+        ),
+        _annotated_trace(
+            "runtime-simple",
+            "packages/coding-agent/src/core/model-runtime.ts",
+            573,
+            640,
+            {
+                583: ("prepareRequest：getAuth + merge headers", "prepareRequest: getAuth + merge headers"),
+                636: ("ModelRuntime.streamSimple 入口", "ModelRuntime.streamSimple entry"),
+                639: ("委托 provider.streamSimple", "delegate to provider.streamSimple"),
+            },
+            highlight_lines={636, 639},
+        ),
         note(
             "对照 pi-textbook cp07 <code>agent-loop.test.ts</code>：搜索 <code>two turn</code> 或 <code>toolUse</code>，测试里的 event 序列应与 --verbose stderr 同构。",
             "Cross-read textbook cp07 <code>agent-loop.test.ts</code>: search <code>two turn</code> or <code>toolUse</code>; test event sequence should match --verbose stderr.",
@@ -582,6 +657,401 @@ def _trace_c13() -> str:
     return join(*parts)
 
 
+# ── C14: pi-ai provider abstraction ──────────────────────────────────
+
+def _trace_c14() -> str:
+    parts = [
+        _trace_header(
+            "14",
+            "pi-ai 提供商抽象：streamSimple 如何接到 agent-loop",
+            "pi-ai provider abstraction: how streamSimple connects to agent-loop",
+        ),
+        p(
+            "pi-ai（<code>packages/ai</code>）是 Pi 的 LLM 适配层。<code>streamSimple</code> 是 agent-core 与 40+ provider 之间的<strong>唯一窄接口</strong>：输入 <code>Model + Context + options</code>，输出 <code>AssistantMessageEventStream</code>。主线 prompt turn-1 的 <code>toolcall_delta</code> 组装 <code>read({\"path\":\"README.md\"})</code> 就发生在此层。",
+            "pi-ai (<code>packages/ai</code>) is Pi's LLM adapter layer. <code>streamSimple</code> is the <strong>sole narrow interface</strong> between agent-core and 40+ providers: <code>Model + Context + options</code> in, <code>AssistantMessageEventStream</code> out. Through-line turn-1 <code>toolcall_delta</code> assembling <code>read({\"path\":\"README.md\"})</code> happens here.",
+        ),
+        _annotated_trace(
+            "stream-simple",
+            "packages/ai/src/compat.ts",
+            275,
+            289,
+            {
+                275: ("compat 层 streamSimple 入口", "compat layer streamSimple entry"),
+                280: ("builtin provider 优先（anthropic/openai/…）", "builtin provider first (anthropic/openai/…)"),
+                287: ("自定义 provider 走 resolveApiProvider", "custom providers via resolveApiProvider"),
+            },
+            highlight_lines={275, 287},
+        ),
+        _annotated_trace(
+            "provider-if",
+            "packages/ai/src/models.ts",
+            97,
+            140,
+            {
+                111: ("Provider.auth：每个 provider 必有认证语义", "Provider.auth: every provider has auth semantics"),
+                119: ("getModels()：静态目录或 refresh 后动态列表", "getModels(): static catalog or post-refresh dynamic list"),
+            },
+            highlight_lines={111, 119},
+        ),
+        _annotated_trace(
+            "apply-auth",
+            "packages/ai/src/models.ts",
+            636,
+            665,
+            {
+                643: ("requireProvider：model.provider → Provider 实例", "requireProvider: model.provider → Provider instance"),
+                644: ("getAuth：credential / env / OAuth 解析", "getAuth: credential / env / OAuth resolution"),
+                655: ("apiKey = options.apiKey ?? auth.apiKey", "apiKey = options.apiKey ?? auth.apiKey"),
+                659: ("baseUrl overlay：代理/自定义 endpoint", "baseUrl overlay: proxy/custom endpoint"),
+            },
+            highlight_lines={644, 655},
+        ),
+        _annotated_trace(
+            "models-stream",
+            "packages/ai/src/models.ts",
+            690,
+            704,
+            {
+                690: ("Models.streamSimple：lazyStream + applyAuth", "Models.streamSimple: lazyStream + applyAuth"),
+                694: ("provider.streamSimple 真正发 HTTP", "provider.streamSimple actually sends HTTP"),
+            },
+            highlight_lines={690, 694},
+        ),
+        _step_table(
+            "主线 turn-1 · streamSimple 数据流",
+            "Through-line turn-1 · streamSimple data flow",
+            [
+                ["in", "Context.messages", "user + system + tools schema"],
+                ["auth", "applyAuth", "ANTHROPIC_API_KEY / OAuth bearer"],
+                ["http", "anthropic-messages", "POST /v1/messages stream:true"],
+                ["out", "EventStream", "start → toolcall_delta×N → done(toolUse)"],
+                ["up", "agent-loop:317", "message_update → TUI tool 卡片"],
+            ],
+        ),
+        _annotated_trace(
+            "create-provider",
+            "packages/ai/src/models.ts",
+            739,
+            792,
+            {
+                746: ("auth 必填——即使 ambient/keyless provider", "auth required — even ambient/keyless providers"),
+                757: ("api 字段：单实现或按 model.api 分派", "api field: single impl or dispatch by model.api"),
+                762: ("createProvider：内置与 models.json 自定义共用", "createProvider: built-in and models.json custom share this"),
+                779: ("apiFor(model)：按 model.api 选 stream 实现", "apiFor(model): pick stream impl by model.api"),
+            },
+            highlight_lines={762, 779},
+        ),
+        _annotated_trace(
+            "anthropic-prov",
+            "packages/ai/src/providers/anthropic.ts",
+            9,
+            58,
+            {
+                18: ("resolve：credential → env ANTHROPIC_* 回退", "resolve: credential → env ANTHROPIC_* fallback"),
+                44: ("anthropicProvider() 工厂", "anthropicProvider() factory"),
+                57: ("api: anthropicMessagesApi()", "api: anthropicMessagesApi()"),
+            },
+            highlight_lines={44, 57},
+        ),
+        p(
+            "<code>createProvider</code> 把 auth、models、api 三块粘成不可再分的 Provider 对象。<code>Models</code> 类持有 provider map，<code>ModelRuntime</code>（coding-agent）在其上叠加 credential store、extension provider、availability snapshot——但<strong>HTTP/SSE 协议细节永远不下沉到 agent-loop</strong>。",
+            "<code>createProvider</code> glues auth, models, api into one Provider. <code>Models</code> holds the provider map; <code>ModelRuntime</code> adds credential store, extension providers, availability — but <strong>HTTP/SSE protocol never sinks into agent-loop</strong>.",
+        ),
+        _annotated_trace(
+            "provider-dispatch",
+            "packages/ai/src/models.ts",
+            794,
+            830,
+            {
+                794: ("Provider 对象：stream/streamSimple 分派", "Provider object: stream/streamSimple dispatch"),
+                801: ("refreshModels：动态 provider 拉取模型列表", "refreshModels: dynamic provider fetches model list"),
+            },
+            highlight_lines={794},
+        ),
+        note(
+            "练习：在 pi-textbook 用 <code>registerFauxProvider</code> 替换 streamSimple，观察 agent-loop 是否仍收到相同形状的 toolcall_delta。",
+            "Exercise: in pi-textbook replace streamSimple with <code>registerFauxProvider</code>; observe agent-loop still gets same-shaped toolcall_delta.",
+            copper=True,
+        ),
+        _trace_close(),
+    ]
+    return join(*parts)
+
+
+# ── C15: EventStream protocol ──────────────────────────────────────
+
+def _trace_c15() -> str:
+    parts = [
+        _trace_header(
+            "15",
+            "流式 EventStream：text_delta / toolcall_delta 协议全 trace",
+            "Streaming EventStream: full text_delta / toolcall_delta protocol trace",
+        ),
+        p(
+            "pi-ai 与 agent-core 之间的流式契约是 <code>AssistantMessageEvent</code> 联合类型 + <code>AssistantMessageEventStream</code> 队列。<code>agent-loop</code> 的 <code>for await (event of response)</code> 消费的正是这个协议——<strong>不是</strong> provider 原始 SSE。主线 turn-1 的 read toolUse 由一串 <code>toolcall_start → toolcall_delta×N → toolcall_end</code> 组装。",
+            "The streaming contract between pi-ai and agent-core is <code>AssistantMessageEvent</code> union + <code>AssistantMessageEventStream</code> queue. <code>agent-loop</code>'s <code>for await (event of response)</code> consumes this protocol — <strong>not</strong> raw provider SSE. Through-line turn-1 read toolUse is assembled from <code>toolcall_start → toolcall_delta×N → toolcall_end</code>.",
+        ),
+        _annotated_trace(
+            "event-protocol",
+            "packages/ai/src/types.ts",
+            527,
+            551,
+            {
+                535: ("AssistantMessageEvent 联合类型定义", "AssistantMessageEvent union definition"),
+                536: ("start：携带 partial AssistantMessage", "start: carries partial AssistantMessage"),
+                538: ("text_delta：turn-2 最终回答的增量", "text_delta: turn-2 final answer increments"),
+                544: ("★ toolcall_delta：turn-1 read args 增量 JSON", "★ toolcall_delta: turn-1 read args incremental JSON"),
+                547: ("done：stopReason=stop|toolUse|length|deferred", "done: stopReason=stop|toolUse|length|deferred"),
+                551: ("error：aborted|error + errorMessage", "error: aborted|error + errorMessage"),
+            },
+            highlight_lines={544, 547},
+        ),
+        _annotated_trace(
+            "event-stream",
+            "packages/ai/src/utils/event-stream.ts",
+            1,
+            67,
+            {
+                4: ("EventStream 泛型：AsyncIterable + result()", "EventStream generic: AsyncIterable + result()"),
+                21: ("push：完成事件 resolve finalResult", "push: complete event resolves finalResult"),
+                29: ("等待消费者或入队", "wait for consumer or enqueue"),
+                38: ("end()：强制结束迭代器", "end(): force iterator completion"),
+                50: ("async iterator：背压友好", "async iterator: backpressure-friendly"),
+                64: ("result()：await 最终 AssistantMessage", "result(): await final AssistantMessage"),
+            },
+            highlight_lines={21, 64},
+        ),
+        _annotated_trace(
+            "assistant-stream",
+            "packages/ai/src/utils/event-stream.ts",
+            69,
+            88,
+            {
+                69: ("AssistantMessageEventStream 子类", "AssistantMessageEventStream subclass"),
+                72: ("isComplete：done 或 error", "isComplete: done or error"),
+                74: ("extractResult：done→message, error→error", "extractResult: done→message, error→error"),
+                86: ("工厂：extensions 可构造假流", "factory: extensions can build fake streams"),
+            },
+            highlight_lines={69, 72},
+        ),
+        _step_table(
+            "主线 turn-1 · toolcall_delta 时间线",
+            "Through-line turn-1 · toolcall_delta timeline",
+            [
+                ["1", "toolcall_start", "content block tool_use 开始"],
+                ["2", "toolcall_delta", "{\"path\""],
+                ["3", "toolcall_delta", ":\"README.md\"}"],
+                ["4", "toolcall_delta", "} 片段…"],
+                ["5", "toolcall_end", "arguments 解析完成 · id=toolu_…"],
+                ["6", "done", "stopReason=toolUse"],
+                ["7", "agent-loop", "message_update×N → executeToolCalls"],
+            ],
+        ),
+        _annotated_trace(
+            "sse-start",
+            "packages/ai/src/api/anthropic-messages.ts",
+            575,
+            652,
+            {
+                576: ("client.messages.create stream:true", "client.messages.create stream:true"),
+                584: ("stream.push start", "stream.push start"),
+                611: ("content_block_start：text/thinking/tool_use", "content_block_start: text/thinking/tool_use"),
+                639: ("tool_use block → toolcall_start", "tool_use block → toolcall_start"),
+                651: ("★ toolcall_start push", "★ toolcall_start push"),
+            },
+            highlight_lines={584, 651},
+        ),
+        _annotated_trace(
+            "sse-delta",
+            "packages/ai/src/api/anthropic-messages.ts",
+            653,
+            729,
+            {
+                678: ("input_json_delta → toolcall_delta", "input_json_delta → toolcall_delta"),
+                682: ("partialJson 累加 + parseStreamingJson", "partialJson accumulate + parseStreamingJson"),
+                684: ("★ 每个 JSON 片段 push toolcall_delta", "★ each JSON fragment pushes toolcall_delta"),
+                718: ("content_block_stop → toolcall_end", "content_block_stop → toolcall_end"),
+                723: ("delete partialJson，只保留 arguments", "delete partialJson, keep arguments only"),
+            },
+            highlight_lines={684, 723},
+        ),
+        _annotated_trace(
+            "sse-done",
+            "packages/ai/src/api/anthropic-messages.ts",
+            731,
+            797,
+            {
+                732: ("message_delta：stop_reason → stopReason", "message_delta: stop_reason → stopReason"),
+                782: ("stream.push done", "stream.push done"),
+                792: ("catch → error event + end", "catch → error event + end"),
+            },
+            highlight_lines={782},
+        ),
+        _annotated_trace(
+            "agent-consume",
+            "packages/agent/src/agent-loop.ts",
+            314,
+            360,
+            {
+                317: ("for await response：消费 pi-ai EventStream", "for await response: consume pi-ai EventStream"),
+                319: ("start → message_start", "start → message_start"),
+                332: ("toolcall_delta → message_update", "toolcall_delta → message_update"),
+                357: ("done → message_end(final)", "done → message_end(final)"),
+            },
+            highlight_lines={332, 357},
+        ),
+        p(
+            "设计要点：<code>partial</code> 字段在每个 event 里携带<strong>当前累积状态</strong>的 AssistantMessage 快照——TUI 不需要自己拼 delta；agent-loop 把 event 原样 emit 给 AgentSession，由订阅者决定是差分渲染还是等 message_end 落盘。",
+            "Design note: <code>partial</code> in each event carries a <strong>cumulative</strong> AssistantMessage snapshot — TUI need not assemble deltas; agent-loop emits events as-is to AgentSession; subscribers diff-render or persist on message_end.",
+        ),
+        note(
+            "用 <code>--verbose</code> 跑主线 prompt，stderr 里 <code>toolcall_delta</code> 行数应与 Anthropic SSE <code>input_json_delta</code> 包数同量级。",
+            "Run through-line with <code>--verbose</code>; stderr <code>toolcall_delta</code> count should match Anthropic SSE <code>input_json_delta</code> packets.",
+            copper=True,
+        ),
+        _trace_close(),
+    ]
+    return join(*parts)
+
+
+# ── C16: auth & model catalog ────────────────────────────────────────
+
+def _trace_c16() -> str:
+    parts = [
+        _trace_header(
+            "16",
+            "认证与模型目录：从 models.generated 到 findInitialModel",
+            "Auth and model catalog: models.generated to findInitialModel",
+        ),
+        p(
+            "Pi 启动时必须先回答两个问题：<strong>用哪个 model？</strong> 和 <strong>凭据从哪来？</strong> <code>models.generated.ts</code> 聚合 40+ provider 的静态目录；<code>ModelRuntime</code> 叠加 credential store 与 availability；<code>findInitialModel</code> 按 CLI → scoped → settings → first-available 优先级选型。没有 key 时 <code>auth-guidance.ts</code> 给出 /login 指引。",
+            "Pi boot must answer: <strong>which model?</strong> and <strong>where credentials come from?</strong> <code>models.generated.ts</code> aggregates 40+ provider static catalogs; <code>ModelRuntime</code> adds credential store and availability; <code>findInitialModel</code> picks CLI → scoped → settings → first-available. No key → <code>auth-guidance.ts</code> points to /login.",
+        ),
+        _annotated_trace(
+            "models-gen",
+            "packages/ai/src/models.generated.ts",
+            1,
+            45,
+            {
+                1: ("自动生成：npm run generate-models", "auto-generated: npm run generate-models"),
+                4: ("每 provider 一个 *.models.ts", "one *.models.ts per provider"),
+                44: ("MODELS 聚合对象类型", "MODELS aggregate object type"),
+            },
+            highlight_lines={1, 44},
+        ),
+        _annotated_trace(
+            "models-map",
+            "packages/ai/src/models.generated.ts",
+            84,
+            124,
+            {
+                87: ("anthropic: ANTHROPIC_MODELS", "anthropic: ANTHROPIC_MODELS"),
+                106: ("openai / openai-codex", "openai / openai-codex"),
+                111: ("openrouter / moonshotai / …", "openrouter / moonshotai / …"),
+            },
+            highlight_lines={87},
+        ),
+        _annotated_trace(
+            "anthropic-models",
+            "packages/ai/src/providers/anthropic.models.ts",
+            1,
+            8,
+            {
+                4: ("从 anthropic.json flatten", "flatten from anthropic.json"),
+                7: ("ANTHROPIC_MODELS 目录常量", "ANTHROPIC_MODELS catalog constant"),
+            },
+            highlight_lines={7},
+        ),
+        _annotated_trace(
+            "auth-resolve",
+            "packages/ai/src/providers/anthropic.ts",
+            18,
+            40,
+            {
+                20: ("stored credential 优先", "stored credential first"),
+                24: ("ANTHROPIC_AUTH_TOKEN env", "ANTHROPIC_AUTH_TOKEN env"),
+                33: ("OAuth token / API key env 回退链", "OAuth token / API key env fallback chain"),
+            },
+            highlight_lines={20, 33},
+        ),
+        _annotated_trace(
+            "auth-guidance",
+            "packages/coding-agent/src/core/auth-guidance.ts",
+            6,
+            25,
+            {
+                7: ("getProviderLoginHelp：/login + docs 链接", "getProviderLoginHelp: /login + docs links"),
+                14: ("formatNoModelsAvailableMessage", "formatNoModelsAvailableMessage"),
+                22: ("formatNoApiKeyFoundMessage(provider)", "formatNoApiKeyFoundMessage(provider)"),
+            },
+            highlight_lines={14, 22},
+        ),
+        _step_table(
+            "findInitialModel 优先级",
+            "findInitialModel priority",
+            [
+                ["1", "CLI --provider/--model", "最高优先级"],
+                ["2", "scopedModels[0]", "非 resume 时"],
+                ["3", "settings default", "hasConfiguredAuth"],
+                ["4", "defaultModelPerProvider", "anthropic/claude-sonnet-…"],
+                ["5", "availableModels[0]", "任意有 key 的模型"],
+                ["fail", "formatNoModelsAvailableMessage", "/login 指引"],
+            ],
+        ),
+        _annotated_trace(
+            "find-model",
+            "packages/coding-agent/src/core/model-resolver.ts",
+            621,
+            708,
+            {
+                647: ("CLI args 优先", "CLI args first"),
+                664: ("scoped models 第二", "scoped models second"),
+                675: ("settings default + hasConfiguredAuth", "settings default + hasConfiguredAuth"),
+                690: ("getAvailableSnapshot 过滤无 key provider", "getAvailableSnapshot filters unconfigured providers"),
+                694: ("defaultModelPerProvider 偏好", "defaultModelPerProvider preference"),
+                703: ("兜底：第一个 available", "fallback: first available"),
+                707: ("无模型 → undefined", "no model → undefined"),
+            },
+            highlight_lines={690, 703},
+        ),
+        _annotated_trace(
+            "sdk-boot",
+            "packages/coding-agent/src/core/sdk.ts",
+            208,
+            225,
+            {
+                210: ("findInitialModel 调用点", "findInitialModel call site"),
+                220: ("无 model → formatNoModelsAvailableMessage", "no model → formatNoModelsAvailableMessage"),
+                223: ("fallback 文案拼接 provider/id", "fallback message appends provider/id"),
+            },
+            highlight_lines={220},
+        ),
+        _annotated_trace(
+            "runtime-auth",
+            "packages/coding-agent/src/core/model-runtime.ts",
+            561,
+            588,
+            {
+                561: ("getProviderAuthStatus：runtime/stored/env", "getProviderAuthStatus: runtime/stored/env"),
+                583: ("prepareRequest getAuth", "prepareRequest getAuth"),
+                588: ("无 resolution → Provider is not configured", "no resolution → Provider is not configured"),
+            },
+            highlight_lines={561, 588},
+        ),
+        p(
+            "主线 prompt 能跑通的前提：<code>findInitialModel</code> 返回的 model 在 <code>getAvailableSnapshot()</code> 里，且 <code>streamSimple</code> 时 <code>applyAuth</code> 能解析出 apiKey。OAuth provider（如 Anthropic Claude Pro）走 credential store + refresh；纯 API key 走 env 或 <code>/login</code> 写入的 auth.json。",
+            "Through-line prompt requires: <code>findInitialModel</code> model is in <code>getAvailableSnapshot()</code>, and <code>applyAuth</code> resolves apiKey at <code>streamSimple</code>. OAuth providers use credential store + refresh; API key uses env or auth.json from <code>/login</code>.",
+        ),
+        note(
+            "实验：删掉 <code>~/.pi/agent/auth.json</code> 中 anthropic 条目再启动 pi，应看到 formatNoModelsAvailableMessage 或 formatNoApiKeyFoundMessage。",
+            "Experiment: remove anthropic from <code>~/.pi/agent/auth.json</code> and start pi; expect formatNoModelsAvailableMessage or formatNoApiKeyFoundMessage.",
+            copper=True,
+        ),
+        _trace_close(),
+    ]
+    return join(*parts)
+
+
 # ── public API ───────────────────────────────────────────────────────
 
 _HEART = {
@@ -590,6 +1060,9 @@ _HEART = {
     "c11": _trace_c11,
     "c12": _trace_c12,
     "c13": _trace_c13,
+    "c14": _trace_c14,
+    "c15": _trace_c15,
+    "c16": _trace_c16,
 }
 
 

--- a/scripts/pi_agent_immersive/meta.py
+++ b/scripts/pi_agent_immersive/meta.py
@@ -1,0 +1,96 @@
+"""Metadata and TOC structure for Pi Agent immersive article."""
+
+SLUG = "pi-agent"
+TITLE_ZH = "一条用户消息在 Pi Agent 里的一生"
+TITLE_EN = "The Life of a User Message Inside Pi Agent"
+SUBTITLE_ZH = "CLI → AgentSession → agentLoop → pi-ai → tools → JSONL → TUI diff"
+SUBTITLE_EN = "CLI → AgentSession → agentLoop → pi-ai → tools → JSONL → TUI diff"
+DECK_ZH = (
+    "你在终端里敲下一行「读取 README.md，用一句话告诉我这个项目做什么」之后，这串文字要穿过 26 道工序、"
+    "跨 6 个 npm 包、在 3 层消息模型里变形，最后才变成屏幕上滚动的 token 和磁盘上的一行 JSONL。"
+    "对照 earendil-works/pi 生产源码与 hahhforest/pi-textbook 的 15 个 checkpoint，把每一步的类层级、"
+    "事件流、owner 分工、可视化全摊开。"
+)
+DECK_EN = (
+    "After you type «read README.md and tell me what this project does in one sentence», that string "
+    "passes through 26 stations, crosses six npm packages, morphs across three message layers, and "
+    "only then becomes scrolling tokens on screen and one JSONL line on disk. Cross-reading "
+    "earendil-works/pi production source with hahhforest/pi-textbook's 15 checkpoints — every step: "
+    "class hierarchy, event flow, owner roles, and diagrams."
+)
+FIELD_NOTE = "10"
+DATE = "2026-08-22"
+OG_IMAGE = "https://ursb.me/og/pi-agent.png"
+
+CHAPTERS = [
+    # (id, num, phase_zh, phase_en, title_zh, title_en, subtitle_zh, subtitle_en, special)
+    ("c1", "01", "引子", "Prologue", "Harness 不是 Product", "Harness is not a product",
+     "agent 产品战争里的第三条路", "a third path in the agent product war", False),
+    ("c2", "02", "引子", "Prologue", "一条消息的 22 站", "22 stations for one message",
+     "从回车到 JSONL 的全景图", "from Enter to JSONL, the full map", False),
+    ("c3", "03", "背景", "Background", "pi-mono 家谱", "The pi-mono family tree",
+     "Mario Zechner 与 earendil-works", "Mario Zechner and earendil-works", False),
+    ("c4", "04", "背景", "Background", "六层蛋糕", "The six-layer cake",
+     "agent-core · ai · tui · coding-agent", "agent-core · ai · tui · coding-agent", False),
+    ("c5", "05", "背景", "Background", "故意不做的功能", "Intentionally missing features",
+     "No MCP · No sub-agents · No plan mode", "No MCP · No sub-agents · No plan mode", True),
+    ("c6", "06", "入口", "Intake", "CLI 启动链", "CLI boot chain",
+     "cli.ts → main.ts → createAgentSession", "cli.ts → main.ts → createAgentSession", False),
+    ("c7", "07", "入口", "Intake", "AgentSession 编排", "AgentSession orchestration",
+     "唯一的中枢调度器", "the single orchestration hub", False),
+    ("c8", "08", "入口", "Intake", "AGENTS.md 上下文栈", "The AGENTS.md context stack",
+     "从 ~/.pi 到项目根的指令叠加", "instructions stacked from ~/.pi to project root", False),
+    ("c9", "09", "心脏", "Heart", "两层消息模型", "Two-layer message model",
+     "AgentMessage ≠ Message", "AgentMessage ≠ Message", True),
+    ("c10", "10", "心脏", "Heart", "runLoop 双环", "The runLoop twin loops",
+     "outer follow-up · inner tool batch", "outer follow-up · inner tool batch", True),
+    ("c11", "11", "心脏", "Heart", "Steering 与 Follow-up", "Steering and follow-up",
+     "运行中插队与结束后续", "mid-run injection and post-stop follow-up", False),
+    ("c12", "12", "心脏", "Heart", "Tool 执行管线", "Tool execution pipeline",
+     "parallel vs sequential · length 截断", "parallel vs sequential · length truncation", False),
+    ("c13", "13", "心脏", "Heart", "事件总线", "The event bus",
+     "message_update 如何驱动 TUI", "how message_update drives the TUI", False),
+    ("c14", "14", "LLM", "LLM", "pi-ai 提供商抽象", "pi-ai provider abstraction",
+     "Models · createProvider · streamSimple", "Models · createProvider · streamSimple", False),
+    ("c15", "15", "LLM", "LLM", "流式 EventStream", "Streaming EventStream",
+     "text_delta · toolcall_delta · done", "text_delta · toolcall_delta · done", False),
+    ("c16", "16", "LLM", "LLM", "认证与模型目录", "Auth and model catalog",
+     "40+ providers · OAuth · models.generated.ts", "40+ providers · OAuth · models.generated.ts", False),
+    ("c17", "17", "终端", "Terminal", "差分渲染 TUI", "Differential-render TUI",
+     "CSI 2026 · firstChanged → lastChanged", "CSI 2026 · firstChanged → lastChanged", True),
+    ("c18", "18", "终端", "Terminal", "Interactive Mode", "Interactive mode",
+     "Editor · Markdown · tool renderers", "Editor · Markdown · tool renderers", False),
+    ("c19", "19", "扩展", "Extensions", "Extension API 面", "Extension API surface",
+     "registerTool · registerCommand · events", "registerTool · registerCommand · events", False),
+    ("c20", "20", "扩展", "Extensions", "ExtensionRunner", "ExtensionRunner",
+     "jiti 加载 · 事件合并 · hook 注入", "jiti load · event merge · hook injection", False),
+    ("c21", "21", "扩展", "Extensions", "Pi Packages", "Pi packages",
+     "npm · git · 可分享的 harness 能力", "npm · git · shareable harness capabilities", False),
+    ("c22", "22", "持久化", "Persistence", "JSONL 会话树", "JSONL session tree",
+     "parentId · leafId · fork", "parentId · leafId · fork", True),
+    ("c23", "23", "持久化", "Persistence", "Compaction 与 Harness", "Compaction and harness",
+     "上下文压缩 · SQLite lanes", "context compression · SQLite lanes", False),
+    ("c24", "24", "全景", "Landscape", "对比 Claude Code / Cursor", "vs Claude Code / Cursor",
+     "minimal harness 的设计取舍", "design trade-offs of a minimal harness", False),
+    ("c25", "25", "全景", "Landscape", "RPC 与 pi-server", "RPC and pi-server",
+     "JSONL 进程协议 · CBOR 远程会话", "JSONL process protocol · CBOR remote sessions", False),
+    ("c26", "26", "Coda", "Coda", "怎么自己 trace 一轮", "How to trace a turn yourself",
+     "--verbose · event log · session file", "--verbose · event log · session file", False),
+]
+
+TOC_GROUPS = [
+    ("bg", "0", "引子", "Prologue", "2 chapters · framing", 2, ["c1", "c2"]),
+    ("in", "I", "入口", "Intake", "3 chapters · CLI to context", 3, ["c6", "c7", "c8"]),
+    ("heart", "II", "心脏", "Heart", "5 chapters · agent loop", 5, ["c9", "c10", "c11", "c12", "c13"]),
+    ("llm", "III", "LLM", "LLM", "3 chapters · pi-ai", 3, ["c14", "c15", "c16"]),
+    ("tui", "IV", "终端", "Terminal", "2 chapters · differential TUI", 2, ["c17", "c18"]),
+    ("ext", "V", "扩展", "Extensions", "3 chapters · TypeScript hooks", 3, ["c19", "c20", "c21"]),
+    ("persist", "VI", "持久化", "Persistence", "2 chapters · JSONL + harness", 2, ["c22", "c23"]),
+    ("land", "VII", "全景", "Landscape", "2 chapters · ecosystem", 2, ["c24", "c25"]),
+    ("coda", "∎", "Coda", "Coda", "trace it yourself", 1, ["c26"]),
+]
+
+# Background chapters between prologue and intake
+TOC_GROUPS_BG = [
+    ("card", "·", "背景", "Background", "3 chapters · monorepo", 3, ["c3", "c4", "c5"]),
+]

--- a/scripts/pi_agent_immersive/overview.py
+++ b/scripts/pi_agent_immersive/overview.py
@@ -1,0 +1,126 @@
+"""Article-level forest overview — see the trees and the forest."""
+from __future__ import annotations
+
+from _html_helpers import fig, join, p
+from visuals import svg_wrap
+
+
+def viz_forest_map() -> str:
+    """8-phase × 26-chapter master map (React C05 style)."""
+    inner = """
+  <text x="360" y="22" text-anchor="middle" class="svg-label">一条用户消息 · 8 PHASES · 26 CHAPTERS</text>
+
+  <!-- phase columns -->
+  <rect x="16" y="36" width="88" height="200" rx="3" class="svg-box muted"/>
+  <text x="60" y="54" text-anchor="middle" class="svg-micro" font-weight="700">0 引子</text>
+  <text x="60" y="72" text-anchor="middle" class="svg-tiny">C01–02</text>
+  <text x="60" y="100" text-anchor="middle" class="svg-body">心智</text>
+  <text x="60" y="118" text-anchor="middle" class="svg-body">22 站图</text>
+
+  <rect x="108" y="36" width="72" height="200" rx="3" class="svg-box paper"/>
+  <text x="144" y="54" text-anchor="middle" class="svg-micro" font-weight="700">· 背景</text>
+  <text x="144" y="72" text-anchor="middle" class="svg-tiny">C03–05</text>
+
+  <rect x="184" y="36" width="72" height="200" rx="3" class="svg-box accent"/>
+  <text x="220" y="54" text-anchor="middle" class="svg-micro" font-weight="700">I 入口</text>
+  <text x="220" y="72" text-anchor="middle" class="svg-tiny">C06–08</text>
+  <text x="220" y="100" text-anchor="middle" class="svg-body">CLI</text>
+  <text x="220" y="118" text-anchor="middle" class="svg-body">Session</text>
+
+  <rect x="260" y="36" width="88" height="200" rx="3" fill="#fde8e4" stroke="#c3573a" stroke-width="1.5"/>
+  <text x="304" y="54" text-anchor="middle" class="svg-micro" font-weight="700" fill="#c3573a">II 心脏</text>
+  <text x="304" y="72" text-anchor="middle" class="svg-tiny">C09–13</text>
+  <text x="304" y="100" text-anchor="middle" class="svg-body">runLoop</text>
+  <text x="304" y="118" text-anchor="middle" class="svg-body">tools</text>
+  <text x="304" y="136" text-anchor="middle" class="svg-body">events</text>
+
+  <rect x="352" y="36" width="72" height="200" rx="3" class="svg-box gpu"/>
+  <text x="388" y="54" text-anchor="middle" class="svg-micro" font-weight="700">III LLM</text>
+  <text x="388" y="72" text-anchor="middle" class="svg-tiny">C14–16</text>
+
+  <rect x="428" y="36" width="72" height="200" rx="3" class="svg-box asm"/>
+  <text x="464" y="54" text-anchor="middle" class="svg-micro" font-weight="700">IV 终端</text>
+  <text x="464" y="72" text-anchor="middle" class="svg-tiny">C17–18</text>
+
+  <rect x="504" y="36" width="72" height="200" rx="3" class="svg-box copper"/>
+  <text x="540" y="54" text-anchor="middle" class="svg-micro" font-weight="700">V 扩展</text>
+  <text x="540" y="72" text-anchor="middle" class="svg-tiny">C19–21</text>
+
+  <rect x="580" y="36" width="60" height="200" rx="3" class="svg-box muted"/>
+  <text x="610" y="54" text-anchor="middle" class="svg-micro" font-weight="700">VI</text>
+  <text x="610" y="72" text-anchor="middle" class="svg-tiny">C22–23</text>
+
+  <rect x="644" y="36" width="60" height="200" rx="3" class="svg-box paper"/>
+  <text x="674" y="54" text-anchor="middle" class="svg-micro" font-weight="700">VII</text>
+  <text x="674" y="72" text-anchor="middle" class="svg-tiny">C24–25</text>
+
+  <!-- through-line arrow -->
+  <path d="M40 250 L680 250" stroke="#1f5c8c" stroke-width="2" marker-end="url(#pi-arr)"/>
+  <text x="360" y="272" text-anchor="middle" class="svg-mute">Enter → agentLoop ×2 → read → stop → JSONL → TUI diff</text>
+
+  <!-- highlight heart -->
+  <rect x="268" y="148" width="72" height="28" rx="2" fill="none" stroke="#c3573a" stroke-width="2" stroke-dasharray="4 2"/>
+  <text x="304" y="166" text-anchor="middle" class="svg-micro" fill="#c3573a">主线最密区</text>
+"""
+    return fig(
+        "森林图：8 个 Phase 把 26 章串成一条线；Phase II（心脏）是 runLoop 与工具执行最密集的区域。",
+        "Forest map: 8 phases string 26 chapters; Phase II (Heart) is the densest runLoop + tool region.",
+        f'<div class="pi-fig wide panorama">{svg_wrap(inner, "0 0 720 290")}</div>',
+    )
+
+
+def reading_paths() -> str:
+    return """    <div class="forest-paths">
+      <div class="fp-head">
+        <span class="lang-zh-only">三条阅读路径</span>
+        <span class="lang-en-only">Three reading paths</span>
+      </div>
+      <div class="fp-grid">
+        <a href="#c2" class="fp-card">
+          <div class="fp-tag lang-zh-only">路径 A · 先看森林</div>
+          <div class="fp-tag lang-en-only">Path A · Forest first</div>
+          <div class="fp-title lang-zh-only">C02 22 站全景 → 按需跳章</div>
+          <div class="fp-title lang-en-only">C02 22-station map → jump as needed</div>
+          <div class="fp-desc lang-zh-only">适合已懂 agent 基础、想先建立全局心智模型的读者。</div>
+          <div class="fp-desc lang-en-only">For readers who know agent basics and want the global map first.</div>
+        </a>
+        <a href="#c7" class="fp-card fp-highlight">
+          <div class="fp-tag lang-zh-only">路径 B · 直奔心脏</div>
+          <div class="fp-tag lang-en-only">Path B · Straight to heart</div>
+          <div class="fp-title lang-zh-only">C07 AgentSession → C10 runLoop → C14 pi-ai</div>
+          <div class="fp-title lang-en-only">C07 AgentSession → C10 runLoop → C14 pi-ai</div>
+          <div class="fp-desc lang-zh-only">最短源码路径：从 prompt() 追到 streamSimple()。</div>
+          <div class="fp-desc lang-en-only">Shortest source path: prompt() to streamSimple().</div>
+        </a>
+        <a href="#c26" class="fp-card">
+          <div class="fp-tag lang-zh-only">路径 C · 动手 trace</div>
+          <div class="fp-tag lang-en-only">Path C · Hands-on trace</div>
+          <div class="fp-title lang-zh-only">pi-textbook cp00 → --verbose → JSONL</div>
+          <div class="fp-title lang-en-only">pi-textbook cp00 → --verbose → JSONL</div>
+          <div class="fp-desc lang-zh-only">边跑 checkpoint 边对照本文章节，最后读 C26 自查清单。</div>
+          <div class="fp-desc lang-en-only">Run checkpoints alongside chapters; finish with C26 checklist.</div>
+        </a>
+      </div>
+    </div>"""
+
+
+def forest_overview_section() -> str:
+    """Standalone overview block inserted after TOC, before C01."""
+    return f"""  <section class="forest-overview" id="forest-overview">
+    <div class="fo-label">
+      <span class="lang-zh-only">OVERVIEW · 森林图</span>
+      <span class="lang-en-only">OVERVIEW · Forest map</span>
+    </div>
+    <h2 class="fo-title lang-zh-only">先见森林，再见树木</h2>
+    <h2 class="fo-title lang-en-only">See the forest before the trees</h2>
+{p(
+    "全文 26 章不是平铺的百科条目，而是一条<strong>固定主线 prompt</strong>从终端回车追到 JSONL 落盘的流水线。下面这张图是望远镜：告诉你 Phase 在哪、章节密度在哪、心脏区（runLoop + tools）在哪。读任何一章前，先看这里的 compass 条（每章顶部）确认自己在全局中的位置。",
+    "All 26 chapters are not a flat encyclopedia — they are a pipeline tracing one <strong>fixed through-line prompt</strong> from Enter to JSONL on disk. The diagram below is the telescope: where phases sit, where chapter density peaks, where the heart (runLoop + tools) lives. Before any chapter, check the compass bar at the top to locate yourself in the whole.",
+)}
+{viz_forest_map()}
+{reading_paths()}
+    <div class="fo-legend">
+      <span class="lang-zh-only"><strong>标题层级约定：</strong>每章仅一个 <code>h2</code> 章标题；正文小节为 <code>C07.1</code> 式编号；「深度细读」块内为 <code>C07.4+</code>，FAQ / Case Study 不再占用标题层级。</span>
+      <span class="lang-en-only"><strong>Heading convention:</strong> one <code>h2</code> chapter title; body sections numbered <code>C07.1</code>; deep-dive block uses <code>C07.4+</code>; FAQ / Case Study use labels, not headings.</span>
+    </div>
+  </section>"""

--- a/scripts/pi_agent_immersive/section_num.py
+++ b/scripts/pi_agent_immersive/section_num.py
@@ -1,0 +1,18 @@
+"""Auto-number h3 body sections as C{chap}.{n}."""
+from __future__ import annotations
+
+import re
+
+_H3_OPEN = re.compile(r"<h3 class=\"sub\">")
+
+
+def number_body_sections(ch_num: str, body: str) -> str:
+    n = 1
+
+    def repl(_: re.Match[str]) -> str:
+        nonlocal n
+        label = f'<span class="sec-num">C{ch_num}.{n}</span> '
+        n += 1
+        return f'<h3 class="sub">{label}'
+
+    return _H3_OPEN.sub(repl, body)

--- a/scripts/pi_agent_immersive/shell.py
+++ b/scripts/pi_agent_immersive/shell.py
@@ -1,0 +1,451 @@
+"""HTML shell assembly for Pi Agent immersive article."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from meta import (
+    CHAPTERS,
+    DATE,
+    DECK_EN,
+    DECK_ZH,
+    FIELD_NOTE,
+    OG_IMAGE,
+    SLUG,
+    SUBTITLE_EN,
+    SUBTITLE_ZH,
+    TITLE_EN,
+    TITLE_ZH,
+    TOC_GROUPS,
+    TOC_GROUPS_BG,
+)
+from textbook_map import TEXTBOOK_CHECKPOINTS
+
+TEMPLATE = Path(__file__).resolve().parents[2] / "public/immersive/llm-inference-life/index.html"
+
+# Pipeline cell color by chapter phase
+PIPELINE_COLORS = {
+    "c1": "p0", "c2": "p0",
+    "c3": "p1", "c4": "p1", "c5": "p1",
+    "c6": "p2", "c7": "p2", "c8": "p2",
+    "c9": "p3", "c10": "p3", "c11": "p3", "c12": "p3", "c13": "p3",
+    "c14": "p4", "c15": "p4", "c16": "p4",
+    "c17": "p5", "c18": "p5",
+    "c19": "p6", "c20": "p6", "c21": "p6",
+    "c22": "p7", "c23": "p7",
+    "c24": "p8", "c25": "p8",
+    "c26": "pc",
+}
+
+EXTRA_CSS = """
+  .toc-group[data-phase="heart"] { border-left-color: var(--accent); background: linear-gradient(135deg, rgba(31,92,140,0.04) 0%, var(--paper) 60%); }
+  .toc-group[data-phase="llm"] { border-left-color: var(--gpu); background: linear-gradient(135deg, rgba(107,58,163,0.05) 0%, var(--paper) 60%); }
+  .toc-group[data-phase="tui"] { border-left-color: var(--asm); background: linear-gradient(135deg, rgba(45,106,79,0.04) 0%, var(--paper) 60%); }
+  .toc-group[data-phase="ext"] { border-left-color: var(--heat); background: linear-gradient(135deg, rgba(195,87,58,0.05) 0%, var(--paper) 60%); }
+  .toc-group[data-phase="persist"] { border-left-color: var(--copper); background: linear-gradient(135deg, rgba(179,90,31,0.05) 0%, var(--paper) 60%); }
+  .toc-group[data-phase="land"] { border-left-color: var(--gpu-soft); }
+  .toc-group[data-phase="card"] { border-left-color: var(--ink-mute); }
+  .perf-bar .pb-track { grid-template-columns: repeat(26, 1fr); }
+  .perf-bar .pb-cell.lit { transform: translateY(-2px); box-shadow: 0 0 0 2px rgba(31,92,140,0.45); }
+  #readProgress {
+    position: fixed; top: 0; left: 0; height: 2px; width: 0%;
+    background: linear-gradient(90deg, var(--copper), var(--accent));
+    z-index: 200; transition: width 0.08s linear;
+  }
+  .session-tree {
+    font-family: var(--mono); font-size: 11px; line-height: 1.7;
+    padding: 16px; background: var(--paper-2);
+  }
+  .session-tree .st-node { padding: 4px 0 4px 20px; border-left: 2px solid var(--rule); margin-left: 8px; }
+  .session-tree .st-leaf { color: var(--accent); font-weight: 700; }
+  .event-flow { font-family: var(--mono); font-size: 11px; }
+  .event-flow .ef-row { display: grid; grid-template-columns: 100px 1fr; gap: 12px; padding: 6px 0; border-bottom: 1px dashed var(--rule-soft); }
+  .event-flow .ef-type { color: var(--accent); font-weight: 600; }
+  .milestone-table td.owner-user { color: var(--copper); }
+  .milestone-table td.owner-model { color: var(--accent); }
+  .milestone-table td.owner-loop { color: var(--gpu); }
+  .milestone-table td.owner-tool { color: var(--asm); }
+  .case-study {
+    margin: 22px 0; padding: 18px 20px;
+    background: var(--paper-2); border: 1px solid var(--rule);
+    border-left: 3px solid var(--accent); border-radius: 0 4px 4px 0;
+  }
+  .case-study .cs-tag {
+    font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.18em;
+    text-transform: uppercase; color: var(--accent); font-weight: 700; margin-bottom: 8px;
+  }
+"""
+
+
+def extract_css() -> str:
+    text = TEMPLATE.read_text(encoding="utf-8")
+    start = text.index("<style>") + len("<style>")
+    end = text.index("</style>", start)
+    css = text[start:end]
+    # Patch grid for 26 stations
+    css = css.replace("grid-template-columns: repeat(28, 1fr)", "grid-template-columns: repeat(26, 1fr)")
+    return css + EXTRA_CSS
+
+
+def extract_interactive_css() -> str:
+    text = TEMPLATE.read_text(encoding="utf-8")
+    marker = '<style>\n.ursb-interactive'
+    start = text.index(marker) + len("<style>")
+    end = text.index("</style>", start)
+    return text[start:end]
+
+
+def head() -> str:
+    desc_zh = (
+        "你在终端敲下「读取 README.md，用一句话告诉我这个项目做什么」之后，"
+        "这串文字穿过 26 道工序、跨 6 个 npm 包、在 3 层消息模型里变形——"
+        "对照 earendil-works/pi 生产源码与 pi-textbook 的 15 个 checkpoint 逐行读。"
+    )
+    desc_en = (
+        "After you type read README.md and tell me what this project does in one sentence, "
+        "that string passes through 26 stations across six npm packages — "
+        "cross-reading earendil-works/pi production source with pi-textbook checkpoints."
+    )
+    return f"""<!DOCTYPE html>
+<html lang="zh-CN" translate="no">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="google" content="notranslate">
+<meta name="referrer" content="strict-origin-when-cross-origin">
+<link rel="shortcut icon" href="https://airing.ursb.me/image/favicon.ico">
+<link rel="apple-touch-icon" href="https://airing.ursb.me/image/favicon.ico">
+<link rel="icon" href="https://airing.ursb.me/image/favicon.ico">
+<meta name="description" content="{desc_zh}">
+<meta name="author" content="Airing">
+<meta property="og:title" content="{TITLE_ZH} — Pi Agent 源码全景">
+<meta property="og:description" content="CLI → AgentSession → agentLoop → pi-ai → tools → JSONL → TUI diff · 真源码逐行。">
+<meta property="og:image" content="{OG_IMAGE}">
+<meta property="og:url" content="https://ursb.me/immersive/{SLUG}/">
+<meta property="og:type" content="article">
+<meta property="og:site_name" content="ursb.me · Airing">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="{TITLE_ZH}">
+<meta name="twitter:description" content="{desc_en}">
+<meta name="twitter:image" content="{OG_IMAGE}">
+<meta name="twitter:creator" content="@airingursb">
+<title>{TITLE_ZH} — Pi Agent 源码全景</title>
+<style>
+{extract_css()}
+</style>
+<script async defer src="https://analytics.ursb.me/script.js" data-website-id="aa8d5a16-df21-4058-a0a8-0191cdd3798d"></script>
+<style>
+{extract_interactive_css()}
+</style>
+</head>
+<body>
+<div id="readProgress" aria-hidden="true"></div>"""
+
+
+def lang_toggle_and_back() -> str:
+    return """
+<a class="ursb-backlink" href="https://ursb.me/notes/pi-agent/">← ursb.me</a>
+<div class="lang-toggle" role="navigation" aria-label="language">
+  <button id="lang-zh" class="active" aria-pressed="true">中</button>
+  <span class="sep">/</span>
+  <button id="lang-en" aria-pressed="false">EN</button>
+</div>"""
+
+
+def side_toc() -> str:
+    items: list[str] = []
+    chapter_map = {c[0]: c for c in CHAPTERS}
+    prev_phase = None
+    for gid, num, pzh, pen, _sub, _cnt, cids in TOC_GROUPS_BG + TOC_GROUPS:
+        phase_label = f"{num} · {pzh}" if num not in ("0", "∎", "·") else pzh
+        if phase_label != prev_phase and num not in ("0",):
+            items.append(
+                f'    <li class="ts-divider"><span class="lang-zh-only">{phase_label}</span>'
+                f'<span class="lang-en-only">{num} · {pen}</span></li>'
+            )
+            prev_phase = phase_label
+        for cid in cids:
+            ch = chapter_map[cid]
+            items.append(
+                f'    <li data-section="{cid}"><a href="#{cid}">'
+                f'<span class="toc-num">{ch[1]}</span>'
+                f'<span class="lang-zh-only">{ch[4]}</span>'
+                f'<span class="lang-en-only">{ch[5]}</span></a></li>'
+            )
+    return f"""<nav class="toc-side" aria-label="Side contents">
+  <div class="toc-label">CONTENTS</div>
+  <ol>
+{chr(10).join(items)}
+  </ol>
+</nav>"""
+
+
+def pipeline_bar() -> str:
+    cells = []
+    chapter_map = {c[0]: c for c in CHAPTERS}
+    for cid, *_ in CHAPTERS:
+        ch = chapter_map[cid]
+        cls = PIPELINE_COLORS.get(cid, "p2")
+        title = f"C{ch[1]} {ch[4]}"
+        cells.append(
+            f'        <div class="pb-cell {cls}" data-n="{ch[1]}" data-jump="#{cid}" title="{title}"></div>'
+        )
+    cells_html = "\n".join(cells)
+    return f"""    <div class="perf-bar">
+      <div class="pb-title">
+        <span class="lang-zh-only">一条用户消息 · 26 个站</span>
+        <span class="lang-en-only">One user message · 26 stations</span>
+        <span class="pb-pulse">▸ live trace</span>
+      </div>
+      <div class="pb-track" id="pbTrack">
+{cells_html}
+      </div>
+      <div class="pb-axis">
+        <span class="lang-zh-only">回车</span><span class="lang-en-only">Enter</span>
+        <span></span><span></span><span></span><span></span><span></span>
+        <span class="lang-zh-only">JSONL</span><span class="lang-en-only">JSONL</span>
+      </div>
+    </div>"""
+
+
+def hero() -> str:
+    return f"""  <header class="hero">
+    <div class="meta">
+      <span>FIELD&nbsp;NOTE&nbsp;/&nbsp;{FIELD_NOTE}</span>
+      <span class="lang-zh-only">Pi Agent · Harness 工程</span>
+      <span class="lang-en-only">Pi Agent · Harness Engineering</span>
+      <span>{DATE[:4]}</span>
+    </div>
+    <h1 class="lang-zh-only">一条用户消息在<br><span class="copper">Pi Agent</span>里的<span class="accent">一生</span>。</h1>
+    <h1 class="lang-en-only">The <span class="copper">life</span> of one user message<br>inside <span class="accent">Pi Agent</span>.</h1>
+    <p class="subtitle lang-zh-only">{SUBTITLE_ZH.replace(" · ", ' <span class="arr">→</span> ')}</p>
+    <p class="subtitle lang-en-only">{SUBTITLE_EN.replace(" · ", ' <span class="arr">→</span> ')}</p>
+    <p class="deck lang-zh-only">{DECK_ZH}</p>
+    <p class="deck lang-en-only">{DECK_EN}</p>
+    <div class="byline">
+      <span><span class="label">AUTHOR</span><a class="value" href="https://ursb.me" target="_blank" rel="noopener">Airing</a></span>
+      <span><span class="label">SOURCE</span><span class="value">earendil-works/pi · hahhforest/pi-textbook</span></span>
+      <span><span class="label">FORMAT</span><span class="value">Long Read</span></span>
+    </div>
+
+    <aside class="hero-notice">
+      <div class="hn-tag">
+        <span class="lang-zh-only">这篇要解决什么</span>
+        <span class="lang-en-only">What this is for</span>
+      </div>
+      <p class="hn-body lang-zh-only">主线 prompt 固定为：<strong>「读取 README.md，用一句话告诉我这个项目做什么」</strong>——与 pi-textbook 序章相同。这不是 Pi 的使用教程，而是<strong>把一条用户消息从终端回车追到 JSONL 落盘</strong>的源码级 walkthrough。对照生产仓库 <code>earendil-works/pi</code> 与教学仓库 <code>hahhforest/pi-textbook</code> 的 15 个 checkpoint，每一章对应一层真实抽象。</p>
+      <p class="hn-body lang-en-only">The through-line prompt is fixed: <strong>«read README.md and tell me what this project does in one sentence»</strong> — same as the pi-textbook prologue. This is not a Pi user guide but a <strong>source-level walkthrough from Enter to JSONL on disk</strong>. Cross-reading production <code>earendil-works/pi</code> with <code>hahhforest/pi-textbook</code>'s 15 checkpoints — each chapter maps to one real abstraction layer.</p>
+    </aside>
+
+    <aside class="tldr">
+      <div class="tldr-tag">
+        <span class="lang-zh-only">主线 · 七个里程碑</span>
+        <span class="lang-en-only">Through-line · seven milestones</span>
+      </div>
+      <div class="tldr-steps">
+        <div class="tldr-step">
+          <div class="tldr-step-n">01</div>
+          <div class="tldr-step-name lang-zh-only">用户消息</div>
+          <div class="tldr-step-name lang-en-only">user_message</div>
+          <div class="tldr-step-hint">owner=user</div>
+        </div>
+        <div class="tldr-step">
+          <div class="tldr-step-n">02</div>
+          <div class="tldr-step-name lang-zh-only">第一次 model</div>
+          <div class="tldr-step-name lang-en-only">model_start</div>
+          <div class="tldr-step-hint">turn=1 · toolUse</div>
+        </div>
+        <div class="tldr-step">
+          <div class="tldr-step-n">03</div>
+          <div class="tldr-step-name lang-zh-only">read 工具调用</div>
+          <div class="tldr-step-name lang-en-only">tool_start</div>
+          <div class="tldr-step-hint">call_1 · README</div>
+        </div>
+        <div class="tldr-step">
+          <div class="tldr-step-n">04</div>
+          <div class="tldr-step-name lang-zh-only">最终回答</div>
+          <div class="tldr-step-name lang-en-only">assistant stop</div>
+          <div class="tldr-step-hint">turn=2 · stopReason=stop</div>
+        </div>
+      </div>
+      <div class="tldr-skip">
+        <span class="lang-zh-only">已经懂 agent 基础? 直接跳到 → <a href="#c7">AgentSession</a> · <a href="#c10">runLoop 双环</a> · <a href="#c14">pi-ai</a> · <a href="#c17">TUI diff</a> · <a href="#c22">JSONL 会话树</a> · <a href="#c24">vs Claude Code</a></span>
+        <span class="lang-en-only">Know agent basics? Skip to → <a href="#c7">AgentSession</a> · <a href="#c10">runLoop twin loops</a> · <a href="#c14">pi-ai</a> · <a href="#c17">TUI diff</a> · <a href="#c22">JSONL session tree</a> · <a href="#c24">vs Claude Code</a></span>
+      </div>
+    </aside>
+
+{pipeline_bar()}
+  </header>"""
+
+
+def toc_v2() -> str:
+    chapter_map = {c[0]: c for c in CHAPTERS}
+    groups_html: list[str] = []
+    all_groups = TOC_GROUPS_BG + TOC_GROUPS
+    for gid, num, pzh, pen, sub, cnt, cids in all_groups:
+        chips = []
+        for cid in cids:
+            ch = chapter_map[cid]
+            special = " tc-special" if ch[8] else ""
+            chips.append(
+                f'        <a href="#{cid}" class="toc-chip{special}"><span class="tc-num">{ch[1]}</span>'
+                f'<div class="tc-name"><span class="lang-zh-only">{ch[4]}</span>'
+                f'<span class="lang-en-only">{ch[5]}</span>'
+                f'<span class="tc-en">{ch[7]}</span></div></a>'
+            )
+        groups_html.append(
+            f"""    <div class="toc-group" data-phase="{gid}">
+      <div class="toc-group-head">
+        <div class="tg-num">{num}</div>
+        <div class="tg-name lang-zh-only">{pzh}</div>
+        <div class="tg-name lang-en-only">{pen}</div>
+        <div class="tg-count">{cnt}</div>
+      </div>
+      <div class="tg-en">{sub}</div>
+      <div class="toc-chips">
+{chr(10).join(chips)}
+      </div>
+    </div>"""
+        )
+    return f"""  <nav class="toc-v2" aria-label="Contents">
+    <div class="tv-head">
+      <div class="tv-label lang-zh-only">CONTENTS · 目录</div>
+      <div class="tv-label lang-en-only">CONTENTS</div>
+      <div class="tv-meta"><span class="tv-now">26</span> <span class="lang-zh-only">章 · 8 个 Phase + Coda</span><span class="lang-en-only">chapters · 8 phases + coda</span></div>
+    </div>
+    <div class="tv-sub lang-zh-only">「<em>读取 README.md，用一句话告诉我这个项目做什么</em>」· 26 个站。点任意一格跳转。</div>
+    <div class="tv-sub lang-en-only">«<em>read README.md and tell me what this project does in one sentence</em>» · 26 stations. Click any chip.</div>
+
+{chr(10).join(groups_html)}
+  </nav>"""
+
+
+def chapter_section(cid: str, body: str) -> str:
+    ch = next(c for c in CHAPTERS if c[0] == cid)
+    phase = ch[2].upper()
+    if phase == "CODA":
+        phase = "CODA"
+    elif ch[2] in ("引子", "背景"):
+        phase = ch[2].upper() if ch[2] == "引子" else "BACKGROUND"
+    else:
+        phase = ch[3].upper()
+    return f"""  <section class="chap" id="{cid}">
+    <div class="chap-num">CHAPTER&nbsp;{ch[1]}&nbsp;·&nbsp;{phase}</div>
+    <h2 class="chap-title lang-zh-only">{ch[4]}</h2>
+    <h2 class="chap-title lang-en-only">{ch[5]}</h2>
+    <p class="chap-en lang-zh-only">{ch[6]}</p>
+    <p class="chap-en lang-en-only">{ch[7]}</p>
+{body}
+  </section>"""
+
+
+def footer() -> str:
+    return f"""  <footer class="footer">
+    <div class="ft-rule"><span class="ft-mark">END · FIELD NOTE {FIELD_NOTE}</span></div>
+    <p class="lang-zh-only">这是 Field Note 系列的第十篇。<strong>姐妹篇</strong>:</p>
+    <p class="lang-en-only">Tenth in the Field Note series. <strong>Sister pieces</strong>:</p>
+    <div class="ft-links">
+      <a href="https://ursb.me/immersive/llm-inference-life/">LLM 推理 · 28 站</a>
+      <a href="https://ursb.me/immersive/chromium-renderer/">Chromium · 渲染管线</a>
+      <a href="https://ursb.me/immersive/react-internals/">React · setState 一生</a>
+      <a href="https://ursb.me/immersive/quickjs/">QuickJS · 一行 JS</a>
+    </div>
+    <p class="lang-zh-only" style="margin-top:24px;font-style:italic;color:var(--ink-mute);">"一条用户消息看起来只是终端里的一行字——它真正做的事情，是在六个 npm 包里穿过 26 道工序，在 JSONL 会话树上留下一个可 fork 的节点，然后被 TUI 用 CSI 2026 差分渲染成你看到的 token 流。"</p>
+    <p class="lang-en-only" style="margin-top:24px;font-style:italic;color:var(--ink-mute);">"A user message looks like one line in the terminal. What it really does: pass through 26 stations across six npm packages, leave a forkable node on the JSONL session tree, then get differential-rendered into the token stream you see via CSI 2026."</p>
+    <p style="margin-top:28px;">© 2026 <a href="https://ursb.me">Airing</a> · <span class="lang-zh-only">本文为 Field Note 长文,欢迎转载注明出处</span><span class="lang-en-only">long-form Field Note, attribution appreciated</span></p>
+  </footer>"""
+
+
+def interactive_footer() -> str:
+    text = TEMPLATE.read_text(encoding="utf-8")
+    start = text.index('<section class="ursb-interactive">')
+    end = text.index("</html>")
+    chunk = text[start:end]
+    chunk = chunk.replace("note/llm-inference-life", "note/pi-agent")
+    chunk = chunk.replace("llm-lang", "pi-agent-lang")
+    return chunk
+
+
+def scripts() -> str:
+    cp_rows = []
+    for num, phase, title, artifact, goal in TEXTBOOK_CHECKPOINTS:
+        cp_rows.append(f"      <tr><td>{num}</td><td>{phase}</td><td>{title}</td><td><code>{artifact}</code></td><td>{goal}</td></tr>")
+    return """
+<script>
+(function() {
+  var zh = document.getElementById('lang-zh');
+  var en = document.getElementById('lang-en');
+  function setLang(lang) {
+    if (lang === 'en') {
+      document.body.classList.add('lang-en');
+      document.documentElement.lang = 'en';
+      en.classList.add('active'); en.setAttribute('aria-pressed', 'true');
+      zh.classList.remove('active'); zh.setAttribute('aria-pressed', 'false');
+    } else {
+      document.body.classList.remove('lang-en');
+      document.documentElement.lang = 'zh-CN';
+      zh.classList.add('active'); zh.setAttribute('aria-pressed', 'true');
+      en.classList.remove('active'); en.setAttribute('aria-pressed', 'false');
+    }
+    try { localStorage.setItem('pi-agent-lang', lang); } catch (e) {}
+  }
+  zh.addEventListener('click', function() { setLang('zh'); });
+  en.addEventListener('click', function() { setLang('en'); });
+  try {
+    var saved = localStorage.getItem('pi-agent-lang');
+    if (saved === 'en') setLang('en');
+  } catch (e) {}
+})();
+
+(function() {
+  var bar = document.getElementById('readProgress');
+  if (!bar) return;
+  function update() {
+    var h = document.documentElement.scrollHeight - window.innerHeight;
+    bar.style.width = (h > 0 ? (window.scrollY / h) * 100 : 0) + '%';
+  }
+  window.addEventListener('scroll', update, { passive: true });
+  update();
+})();
+
+(function() {
+  var cells = document.querySelectorAll('#pbTrack .pb-cell');
+  if (!cells.length) return;
+  var i = -1;
+  function tick() {
+    cells.forEach(function(c, idx) { c.classList.toggle('lit', idx <= i); });
+    i++;
+    if (i >= cells.length + 3) i = -1;
+    setTimeout(tick, 380);
+  }
+  tick();
+  cells.forEach(function(c) {
+    c.addEventListener('click', function() {
+      var target = document.querySelector(c.dataset.jump || '');
+      if (target) target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    });
+  });
+})();
+
+(function () {
+  var sideItems = Array.prototype.map.call(
+    document.querySelectorAll('.toc-side li[data-section]'),
+    function (li) { return { node: li, el: document.getElementById(li.dataset.section) }; }
+  ).filter(function (o) { return o.el; });
+  if (!sideItems.length) return;
+  function update() {
+    var offset = window.innerHeight * 0.32;
+    var activeIdx = 0;
+    for (var i = 0; i < sideItems.length; i++) {
+      if (sideItems[i].el.getBoundingClientRect().top - offset < 0) activeIdx = i;
+    }
+    var activeId = sideItems[activeIdx].el.id;
+    sideItems.forEach(function (o) {
+      o.node.classList.toggle('active', o.el.id === activeId);
+    });
+  }
+  window.addEventListener('scroll', update, { passive: true });
+  window.addEventListener('resize', update);
+  update();
+})();
+</script>
+"""

--- a/scripts/pi_agent_immersive/shell.py
+++ b/scripts/pi_agent_immersive/shell.py
@@ -141,6 +141,57 @@ EXTRA_CSS = """
     font-family: var(--mono); font-size: 8px; letter-spacing: 0.1em;
     text-transform: uppercase; color: var(--ink-mute); margin-top: 4px;
   }
+  .stage-why-care {
+    background: linear-gradient(180deg, #fdfbf3, #faf6ed);
+    border: 1px solid var(--rule); border-top: 3px solid var(--accent);
+    border-radius: 4px; padding: 18px 22px 16px; margin: 18px 0 22px;
+  }
+  .stage-why-care .swc-label {
+    font-family: var(--mono); font-size: 9px; color: var(--accent);
+    letter-spacing: 0.12em; text-transform: uppercase; margin-bottom: 10px;
+  }
+  .stage-why-care p {
+    font-family: var(--serif); font-size: 14px; color: var(--ink-soft);
+    line-height: 1.65; margin: 6px 0; display: flex; align-items: baseline; gap: 10px;
+  }
+  body.lang-en .stage-why-care p { font-family: var(--serif-en); }
+  .stage-why-care .swc-pill {
+    flex: 0 0 auto; font-family: var(--mono); font-size: 8px; font-weight: 700;
+    letter-spacing: 0.1em; text-transform: uppercase; color: #fff;
+    background: var(--ink-mute); padding: 2px 7px; border-radius: 2px;
+  }
+  .stage-why-care .swc-pill.rev { background: var(--accent); }
+  .stage-why-care .swc-pill.act { background: var(--copper); }
+  .stage-why-care em { color: var(--ink); font-style: normal; font-weight: 600; }
+  .stage-banner {
+    display: grid; grid-template-columns: repeat(4, 1fr); gap: 0;
+    background: var(--paper); border: 1px solid var(--rule);
+    border-radius: 4px; overflow: hidden; margin: 28px 0 36px;
+  }
+  .stage-banner .sb-cell {
+    padding: 14px 18px; border-right: 1px solid var(--rule-soft);
+  }
+  .stage-banner .sb-cell:last-child { border-right: none; }
+  .stage-banner .sb-key {
+    font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.18em;
+    text-transform: uppercase; color: var(--ink-mute); margin-bottom: 4px;
+  }
+  .stage-banner .sb-val {
+    font-family: var(--sans); font-size: 13.5px; font-weight: 600; color: var(--ink);
+  }
+  .trace-box {
+    margin: 24px 0; padding: 16px 20px;
+    background: var(--paper-2); border: 1px dashed var(--accent);
+    border-radius: 4px;
+  }
+  .trace-box .tb-tag {
+    font-family: var(--mono); font-size: 9px; letter-spacing: 0.16em;
+    color: var(--accent); font-weight: 700; margin-bottom: 8px;
+  }
+  @media (max-width: 760px) {
+    .stage-banner { grid-template-columns: 1fr 1fr; }
+    .stage-why-care p { flex-direction: column; gap: 4px; }
+  }
   .event-flow {
     border: 1px solid var(--rule); border-radius: 4px;
     background: var(--paper-2); padding: 4px 0;

--- a/scripts/pi_agent_immersive/shell.py
+++ b/scripts/pi_agent_immersive/shell.py
@@ -37,6 +37,70 @@ PIPELINE_COLORS = {
 }
 
 EXTRA_CSS = """
+  .formula {
+    background: var(--ink); color: var(--bg);
+    padding: 32px; margin: 32px 0;
+    font-family: var(--mono); font-size: 14px; line-height: 1.9;
+    border-radius: 4px; position: relative;
+  }
+  .formula .ftitle {
+    font-family: var(--sans); font-size: 11px;
+    letter-spacing: 0.22em; text-transform: uppercase;
+    margin-bottom: 16px; color: var(--rule);
+  }
+  .formula .cond { display: block; margin: 4px 0; }
+  .formula .cond::before { content: "▸"; color: var(--accent-soft); margin-right: 12px; }
+  .formula .out {
+    margin-top: 16px; padding-top: 16px;
+    border-top: 1px solid #2c2f36; color: var(--accent-soft);
+  }
+  .formula .term { color: #fcd34d; font-weight: 700; }
+  .formula .term-cu { color: #d1855a; font-weight: 700; }
+  .ladder {
+    background: var(--paper); border: 1px solid var(--rule);
+    border-radius: 4px; padding: 22px 24px; margin: 8px 0 24px;
+  }
+  .ladder .ld-row {
+    display: grid; grid-template-columns: 36px 1fr;
+    align-items: center; gap: 14px;
+    padding: 10px 0; border-bottom: 1px dashed var(--rule);
+  }
+  .ladder .ld-row:last-child { border-bottom: none; }
+  .ladder .ld-num {
+    font-family: var(--mono); font-size: 22px; color: var(--accent);
+    font-weight: 700; line-height: 1;
+  }
+  .ladder .ld-row:nth-child(2) .ld-num { color: #3873a3; }
+  .ladder .ld-row:nth-child(3) .ld-num { color: #6285a8; }
+  .ladder .ld-row:nth-child(4) .ld-num { color: #8090a8; }
+  .ladder .ld-name {
+    font-family: var(--serif); font-size: 15px; font-weight: 700; color: var(--ink);
+  }
+  body.lang-en .ladder .ld-name { font-family: var(--serif-en); }
+  .ladder .ld-desc {
+    font-family: var(--sans); font-size: 12px; color: var(--ink-mute);
+    margin-top: 2px;
+  }
+  .pi-fig { width: 100%; overflow-x: auto; }
+  .pi-fig.wide svg { min-width: 720px; }
+  .pi-svg { width: 100%; height: auto; display: block; }
+  .pi-svg .svg-label {
+    font-family: var(--mono); font-size: 10px; letter-spacing: 0.14em;
+    text-transform: uppercase; fill: var(--ink-mute);
+  }
+  .pi-svg .svg-body { font-family: var(--sans); font-size: 12px; fill: var(--ink); }
+  .pi-svg .svg-mute { font-family: var(--sans); font-size: 10.5px; fill: #767c87; }
+  .pi-svg .svg-micro { font-family: var(--mono); font-size: 9px; fill: var(--ink-soft); }
+  .pi-svg .svg-tiny { font-family: var(--mono); font-size: 10px; fill: var(--ink); }
+  .pi-svg .svg-mono { font-family: var(--mono); font-size: 11px; fill: var(--ink-soft); }
+  .pi-svg .svg-box { fill: #faf6ed; stroke: #c7c4ba; stroke-width: 1.5; }
+  .pi-svg .svg-box.accent { fill: #e8f0f8; stroke: #1f5c8c; }
+  .pi-svg .svg-box.copper { fill: #f5ebe0; stroke: #b35a1f; }
+  .pi-svg .svg-box.gpu { fill: #efe8f5; stroke: #6b3aa3; }
+  .pi-svg .svg-box.asm { fill: #e8f2ec; stroke: #2d6a4f; }
+  .pi-svg .svg-box.paper { fill: #f3efe6; stroke: #c7c4ba; }
+  .pi-svg .svg-box.muted { fill: #ebe5d8; stroke: #c7c4ba; }
+  .pi-svg .svg-arrow { stroke: #1f5c8c; stroke-width: 1.5; marker-end: url(#pi-arr); }
   .toc-group[data-phase="heart"] { border-left-color: var(--accent); background: linear-gradient(135deg, rgba(31,92,140,0.04) 0%, var(--paper) 60%); }
   .toc-group[data-phase="llm"] { border-left-color: var(--gpu); background: linear-gradient(135deg, rgba(107,58,163,0.05) 0%, var(--paper) 60%); }
   .toc-group[data-phase="tui"] { border-left-color: var(--asm); background: linear-gradient(135deg, rgba(45,106,79,0.04) 0%, var(--paper) 60%); }
@@ -64,6 +128,10 @@ EXTRA_CSS = """
   .milestone-table td.owner-model { color: var(--accent); }
   .milestone-table td.owner-loop { color: var(--gpu); }
   .milestone-table td.owner-tool { color: var(--asm); }
+  .milestone-table .owner-user { color: var(--copper); }
+  .milestone-table .owner-model { color: var(--accent); }
+  .milestone-table .owner-loop { color: var(--gpu); }
+  .milestone-table .owner-tool { color: var(--asm); }
   .case-study {
     margin: 22px 0; padding: 18px 20px;
     background: var(--paper-2); border: 1px solid var(--rule);

--- a/scripts/pi_agent_immersive/shell.py
+++ b/scripts/pi_agent_immersive/shell.py
@@ -383,6 +383,30 @@ EXTRA_CSS = """
   }
   body.has-filmstrip { padding-top: 52px; }
   body.has-filmstrip .ursb-backlink { top: 58px; }
+  .trace-walk {
+    margin: 36px 0; padding: 22px 24px 8px;
+    border: 2px solid var(--accent); border-radius: 4px;
+    background: linear-gradient(135deg, rgba(31,92,140,0.03) 0%, var(--paper) 50%);
+  }
+  .trace-walk .tw-head {
+    font-family: var(--mono); font-size: 11px; letter-spacing: 0.12em;
+    text-transform: uppercase; margin-bottom: 18px; line-height: 1.6;
+  }
+  .trace-walk .tw-tag {
+    display: block; color: var(--accent); font-weight: 700;
+    margin-bottom: 6px; letter-spacing: 0.18em;
+  }
+  .trace-walk .src-stack { margin: 16px 0 20px; }
+  .trace-walk .src-ln {
+    display: inline-block; width: 44px; text-align: right;
+    color: var(--ink-mute); user-select: none; margin-right: 8px;
+  }
+  .trace-walk .src-hl { font-family: var(--mono); font-size: 12px; }
+  .trace-steps { margin: 24px 0; }
+  .trace-steps .ts-label {
+    font-family: var(--mono); font-size: 10px; letter-spacing: 0.16em;
+    text-transform: uppercase; color: var(--copper); margin-bottom: 10px;
+  }
 """
 
 

--- a/scripts/pi_agent_immersive/shell.py
+++ b/scripts/pi_agent_immersive/shell.py
@@ -20,6 +20,8 @@ from meta import (
 )
 from textbook_map import TEXTBOOK_CHECKPOINTS
 
+from compass import chapter_compass
+
 TEMPLATE = Path(__file__).resolve().parents[2] / "public/immersive/llm-inference-life/index.html"
 
 # Pipeline cell color by chapter phase
@@ -244,6 +246,143 @@ EXTRA_CSS = """
     font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.18em;
     text-transform: uppercase; color: var(--accent); font-weight: 700; margin-bottom: 8px;
   }
+  .case-study .cs-title {
+    font-family: var(--serif); font-size: 15px; font-weight: 700;
+    margin-bottom: 8px; color: var(--ink);
+  }
+  body.lang-en .case-study .cs-title { font-family: var(--serif-en); }
+  .sec-num {
+    font-family: var(--mono); font-size: 11px; letter-spacing: 0.06em;
+    color: var(--accent); font-weight: 700; margin-right: 6px;
+  }
+  .chap-compass {
+    margin: 0 0 28px; padding: 14px 18px;
+    background: var(--paper-2); border: 1px solid var(--rule);
+    border-left: 3px solid var(--accent); border-radius: 0 4px 4px 0;
+  }
+  .chap-compass .cc-row { display: flex; flex-wrap: wrap; align-items: center; gap: 8px 12px; }
+  .chap-compass .cc-row + .cc-row { margin-top: 10px; padding-top: 10px; border-top: 1px dashed var(--rule-soft); }
+  .chap-compass .cc-phase, .chap-compass .cc-chap, .chap-compass .cc-station {
+    font-family: var(--mono); font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase;
+  }
+  .chap-compass .cc-chap { color: var(--accent); font-weight: 700; }
+  .chap-compass .cc-sep { color: var(--ink-mute); }
+  .chap-compass .cc-forest-label {
+    font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.16em;
+    text-transform: uppercase; color: var(--ink-mute); margin-right: 8px;
+  }
+  .chap-compass .cc-forest-text { font-size: 13px; color: var(--ink-soft); }
+  .chap-compass .cc-links { justify-content: space-between; width: 100%; }
+  .chap-compass .cc-nav {
+    font-size: 12px; color: var(--ink-soft); text-decoration: none;
+    display: inline-flex; align-items: center; gap: 4px; max-width: 42%;
+  }
+  .chap-compass .cc-nav:hover { color: var(--accent); }
+  .chap-compass .cc-nav-num { font-family: var(--mono); font-weight: 700; }
+  .chap-compass .cc-back-map {
+    font-family: var(--mono); font-size: 10px; letter-spacing: 0.12em;
+    text-transform: uppercase; color: var(--copper); text-decoration: none;
+  }
+  .chap-compass .cc-back-map:hover { text-decoration: underline; }
+  .depth-zone {
+    margin: 32px 0 0; padding: 20px 0 0;
+    border-top: 2px solid var(--rule);
+  }
+  .depth-zone-label {
+    font-family: var(--mono); font-size: 10px; letter-spacing: 0.2em;
+    text-transform: uppercase; color: var(--ink-mute); margin-bottom: 20px;
+  }
+  .depth-zone-label .dz-tag {
+    color: var(--copper); font-weight: 700; margin-right: 8px;
+  }
+  .depth-zone h4.depth-sec {
+    font-size: 15px; margin-top: 24px;
+  }
+  .depth-aside-head {
+    margin: 28px 0 12px; padding: 10px 14px;
+    background: var(--paper-2); border: 1px solid var(--rule); border-radius: 4px;
+  }
+  .depth-aside-head .da-tag {
+    font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.16em;
+    text-transform: uppercase; color: var(--copper); font-weight: 700;
+  }
+  .depth-aside-head .da-title { font-size: 14px; font-weight: 600; color: var(--ink); }
+  .forest-overview {
+    margin: 48px 0 56px; padding: 32px 0 40px;
+    border-top: 2px solid var(--ink); border-bottom: 1px solid var(--rule);
+  }
+  .forest-overview .fo-label {
+    font-family: var(--mono); font-size: 10px; letter-spacing: 0.22em;
+    text-transform: uppercase; color: var(--ink-mute); margin-bottom: 12px;
+  }
+  .forest-overview .fo-title {
+    font-family: var(--serif); font-size: 28px; font-weight: 700;
+    margin-bottom: 16px; line-height: 1.2;
+  }
+  body.lang-en .forest-overview .fo-title { font-family: var(--serif-en); }
+  .forest-paths { margin: 28px 0; }
+  .forest-paths .fp-head {
+    font-family: var(--mono); font-size: 10px; letter-spacing: 0.18em;
+    text-transform: uppercase; color: var(--ink-mute); margin-bottom: 14px;
+  }
+  .forest-paths .fp-grid {
+    display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px;
+  }
+  @media (max-width: 800px) {
+    .forest-paths .fp-grid { grid-template-columns: 1fr; }
+  }
+  .forest-paths .fp-card {
+    display: block; padding: 16px 18px;
+    background: var(--paper); border: 1px solid var(--rule);
+    border-radius: 4px; text-decoration: none; color: inherit;
+    transition: border-color 0.15s, box-shadow 0.15s;
+  }
+  .forest-paths .fp-card:hover {
+    border-color: var(--accent); box-shadow: 0 2px 8px rgba(31,92,140,0.08);
+  }
+  .forest-paths .fp-card.fp-highlight { border-left: 3px solid var(--accent); }
+  .forest-paths .fp-tag {
+    font-family: var(--mono); font-size: 9px; letter-spacing: 0.14em;
+    text-transform: uppercase; color: var(--copper); margin-bottom: 6px;
+  }
+  .forest-paths .fp-title { font-size: 14px; font-weight: 700; margin-bottom: 6px; }
+  .forest-paths .fp-desc { font-size: 12px; color: var(--ink-mute); line-height: 1.5; }
+  .forest-overview .fo-legend {
+    margin-top: 24px; padding: 14px 16px;
+    background: var(--paper-2); border-radius: 4px;
+    font-size: 12.5px; color: var(--ink-soft); line-height: 1.6;
+  }
+  .card-filmstrip {
+    position: fixed; top: 0; left: 0; right: 0; z-index: 150;
+    background: rgba(253,251,243,0.96); border-bottom: 1px solid var(--rule);
+    backdrop-filter: blur(8px); transform: translateY(-100%);
+    transition: transform 0.25s ease; pointer-events: none;
+  }
+  .card-filmstrip.is-visible { transform: translateY(0); pointer-events: auto; }
+  .card-filmstrip .cf-inner { max-width: var(--max-w, 720px); margin: 0 auto; padding: 6px 16px 8px; }
+  .card-filmstrip .cf-header {
+    display: flex; justify-content: space-between; align-items: center;
+    font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.14em;
+    text-transform: uppercase; color: var(--ink-mute); margin-bottom: 4px;
+  }
+  .card-filmstrip .cf-header em { color: var(--accent); font-style: normal; font-weight: 700; }
+  .card-filmstrip .cf-track {
+    display: flex; gap: 4px; overflow-x: auto; padding-bottom: 2px;
+    scrollbar-width: thin;
+  }
+  .card-filmstrip .cf-cell {
+    flex: 0 0 auto; min-width: 36px; padding: 4px 6px;
+    text-align: center; text-decoration: none; color: var(--ink-mute);
+    border: 1px solid transparent; border-radius: 3px;
+    font-family: var(--mono); font-size: 10px; transition: all 0.12s;
+  }
+  .card-filmstrip .cf-cell:hover { border-color: var(--rule); color: var(--ink); }
+  .card-filmstrip .cf-cell.active {
+    border-color: var(--accent); background: var(--accent-pale, #e8f0f8);
+    color: var(--accent); font-weight: 700;
+  }
+  body.has-filmstrip { padding-top: 52px; }
+  body.has-filmstrip .ursb-backlink { top: 58px; }
 """
 
 
@@ -490,6 +629,28 @@ def toc_v2() -> str:
   </nav>"""
 
 
+def filmstrip_nav() -> str:
+    cells = []
+    for ch in CHAPTERS:
+        cid, num = ch[0], ch[1]
+        cells.append(
+            f'      <a href="#{cid}" class="cf-cell" data-chap="{num}">'
+            f'<span class="cf-num">{num}</span></a>'
+        )
+    cells_html = "\n".join(cells)
+    return f"""<nav class="card-filmstrip" id="card-filmstrip" aria-label="26 chapters">
+  <div class="cf-inner">
+    <div class="cf-header">
+      <span><span class="lang-zh-only">主线 · 26 章</span><span class="lang-en-only">Through-line · 26 chapters</span></span>
+      <span><em id="cf-current">C01</em>&nbsp;/&nbsp;26</span>
+    </div>
+    <div class="cf-track" id="cf-track">
+{cells_html}
+    </div>
+  </div>
+</nav>"""
+
+
 def chapter_section(cid: str, body: str) -> str:
     ch = next(c for c in CHAPTERS if c[0] == cid)
     phase = ch[2].upper()
@@ -505,6 +666,7 @@ def chapter_section(cid: str, body: str) -> str:
     <h2 class="chap-title lang-en-only">{ch[5]}</h2>
     <p class="chap-en lang-zh-only">{ch[6]}</p>
     <p class="chap-en lang-en-only">{ch[7]}</p>
+{chapter_compass(cid)}
 {body}
   </section>"""
 
@@ -617,6 +779,36 @@ def scripts() -> str:
   window.addEventListener('scroll', update, { passive: true });
   window.addEventListener('resize', update);
   update();
+})();
+
+(function() {
+  var filmstrip = document.getElementById('card-filmstrip');
+  var cfTrack = document.getElementById('cf-track');
+  var cfCurrent = document.getElementById('cf-current');
+  if (!filmstrip || !cfTrack) return;
+  document.body.classList.add('has-filmstrip');
+  var cells = Array.prototype.slice.call(cfTrack.querySelectorAll('.cf-cell'));
+  var sections = cells.map(function(c) {
+    return { cell: c, el: document.querySelector(c.getAttribute('href')) };
+  }).filter(function(o) { return o.el; });
+
+  function updateFilmstrip() {
+    var offset = window.innerHeight * 0.25;
+    var activeIdx = 0;
+    for (var i = 0; i < sections.length; i++) {
+      if (sections[i].el.getBoundingClientRect().top - offset < 0) activeIdx = i;
+    }
+    var active = sections[activeIdx];
+    cells.forEach(function(c) { c.classList.remove('active'); });
+    if (active) {
+      active.cell.classList.add('active');
+      if (cfCurrent) cfCurrent.textContent = 'C' + (active.cell.dataset.chap || '');
+      active.cell.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'center' });
+    }
+    filmstrip.classList.toggle('is-visible', window.scrollY > 400);
+  }
+  window.addEventListener('scroll', updateFilmstrip, { passive: true });
+  updateFilmstrip();
 })();
 </script>
 """

--- a/scripts/pi_agent_immersive/shell.py
+++ b/scripts/pi_agent_immersive/shell.py
@@ -101,6 +101,61 @@ EXTRA_CSS = """
   .pi-svg .svg-box.paper { fill: #f3efe6; stroke: #c7c4ba; }
   .pi-svg .svg-box.muted { fill: #ebe5d8; stroke: #c7c4ba; }
   .pi-svg .svg-arrow { stroke: #1f5c8c; stroke-width: 1.5; marker-end: url(#pi-arr); }
+  .pi-fig.panorama svg { min-width: 100%; }
+  .station-track {
+    margin: 20px 0 28px;
+    border: 1px solid var(--rule);
+    border-radius: 4px;
+    background: var(--paper);
+    overflow: hidden;
+  }
+  .station-track .st-rail {
+    display: grid;
+    grid-template-columns: repeat(11, minmax(72px, 1fr));
+    gap: 0;
+    overflow-x: auto;
+    padding: 0;
+    scrollbar-width: thin;
+  }
+  @media (max-width: 900px) {
+    .station-track .st-rail { grid-template-columns: repeat(11, 88px); }
+  }
+  .station-track .st-cell {
+    border-right: 1px solid var(--rule-soft);
+    border-bottom: 1px solid var(--rule-soft);
+    padding: 12px 8px 10px;
+    text-align: center;
+    background: linear-gradient(180deg, var(--paper) 0%, color-mix(in srgb, var(--st-color) 6%, var(--paper)) 100%);
+    min-height: 88px;
+  }
+  .station-track .st-cell:nth-child(n+12) { border-bottom: none; }
+  .station-track .st-num {
+    font-family: var(--mono); font-size: 18px; font-weight: 700;
+    color: var(--st-color); line-height: 1;
+  }
+  .station-track .st-name {
+    font-family: var(--sans); font-size: 11px; font-weight: 600;
+    color: var(--ink); margin-top: 6px; line-height: 1.25;
+  }
+  .station-track .st-phase {
+    font-family: var(--mono); font-size: 8px; letter-spacing: 0.1em;
+    text-transform: uppercase; color: var(--ink-mute); margin-top: 4px;
+  }
+  .event-flow {
+    border: 1px solid var(--rule); border-radius: 4px;
+    background: var(--paper-2); padding: 4px 0;
+  }
+  .event-flow .ef-row {
+    display: grid; grid-template-columns: 140px 1fr; gap: 16px;
+    padding: 10px 18px; border-bottom: 1px dashed var(--rule-soft);
+    align-items: baseline;
+  }
+  .event-flow .ef-row:last-child { border-bottom: none; }
+  .event-flow .ef-type {
+    font-family: var(--mono); font-size: 11px; font-weight: 600;
+    color: var(--accent); background: var(--accent-pale, #e8f0f8);
+    padding: 3px 8px; border-radius: 3px; display: inline-block;
+  }
   .toc-group[data-phase="heart"] { border-left-color: var(--accent); background: linear-gradient(135deg, rgba(31,92,140,0.04) 0%, var(--paper) 60%); }
   .toc-group[data-phase="llm"] { border-left-color: var(--gpu); background: linear-gradient(135deg, rgba(107,58,163,0.05) 0%, var(--paper) 60%); }
   .toc-group[data-phase="tui"] { border-left-color: var(--asm); background: linear-gradient(135deg, rgba(45,106,79,0.04) 0%, var(--paper) 60%); }
@@ -121,9 +176,6 @@ EXTRA_CSS = """
   }
   .session-tree .st-node { padding: 4px 0 4px 20px; border-left: 2px solid var(--rule); margin-left: 8px; }
   .session-tree .st-leaf { color: var(--accent); font-weight: 700; }
-  .event-flow { font-family: var(--mono); font-size: 11px; }
-  .event-flow .ef-row { display: grid; grid-template-columns: 100px 1fr; gap: 12px; padding: 6px 0; border-bottom: 1px dashed var(--rule-soft); }
-  .event-flow .ef-type { color: var(--accent); font-weight: 600; }
   .milestone-table td.owner-user { color: var(--copper); }
   .milestone-table td.owner-model { color: var(--accent); }
   .milestone-table td.owner-loop { color: var(--gpu); }

--- a/scripts/pi_agent_immersive/textbook_map.py
+++ b/scripts/pi_agent_immersive/textbook_map.py
@@ -1,0 +1,45 @@
+"""Cross-reference map between pi-textbook checkpoints and production pi-mono."""
+
+TEXTBOOK_CHECKPOINTS = [
+    ("00", "序章", "一次 README 读取的七个里程碑", "prologue.ts", "观察完整闭环"),
+    ("01", "协议", "TypeScript 生存集", "events.ts", "tagged union + 运行时校验"),
+    ("02", "协议", "EventStream", "event-stream.ts", "过程项与终态同时交付"),
+    ("03", "协议", "Message IR", "types.ts", "canonical transcript 三层消息"),
+    ("04", "协议", "ScriptedModel", "scripted-model.ts", "离线可复现的模型回合"),
+    ("05", "协议", "Provider Adapter", "provider-adapter.ts", "SSE → 统一事件"),
+    ("06", "循环", "Tool Contract", "tool-contract", "schema + Registry + executor"),
+    ("07", "循环", "Agent Loop", "agent-loop.ts", "两次 model.stream()"),
+    ("08", "循环", "Coding Tools", "coding-tools", "read/write/edit/bash"),
+    ("09", "状态", "Stateful Agent", "stateful-agent", "steer/follow-up/abort"),
+    ("10", "状态", "Session Tree", "session.ts", "JSONL parentId 分支"),
+    ("11", "状态", "Context Compaction", "context.ts", "历史不动·上下文重建"),
+    ("12", "扩展", "Resources + Extensions", "resources-extensions", "AGENTS.md + hooks"),
+    ("13", "扩展", "Composition Root", "composition-root", "Runtime 组装"),
+    ("14", "验证", "Eval Capstone", "eval-capstone", "独立评测验收"),
+]
+
+PRODUCTION_MAP = {
+    "00": "packages/coding-agent/src/main.ts · packages/agent/src/agent-loop.ts",
+    "02": "packages/ai/src/utils/event-stream.ts",
+    "03": "packages/agent/src/types.ts · packages/coding-agent/src/core/messages.ts",
+    "05": "packages/ai/src/api/*.ts · packages/ai/src/models.ts",
+    "06": "packages/agent/src/agent-loop.ts · packages/coding-agent/src/core/tools/",
+    "07": "packages/agent/src/agent-loop.ts",
+    "08": "packages/coding-agent/src/core/tools/index.ts",
+    "09": "packages/agent/src/agent.ts",
+    "10": "packages/coding-agent/src/core/session-manager.ts",
+    "11": "packages/coding-agent/src/core/compaction/",
+    "12": "packages/coding-agent/src/core/extensions/ · resource-loader.ts",
+    "13": "packages/coding-agent/src/core/agent-session.ts · sdk.ts",
+    "14": "packages/evals/",
+}
+
+SEVEN_MILESTONES = [
+    ("01", "user_message", "user", "读取 README.md，并概括项目"),
+    ("02", "model_start", "model", "turn=1"),
+    ("03", "assistant_message", "model", "stopReason=toolUse · toolCallId=call_1"),
+    ("04", "tool_start", "loop", "调度 read(call_1)"),
+    ("05", "tool_result", "tool", "README fixture · toolCallId=call_1"),
+    ("06", "model_start", "model", "turn=2"),
+    ("07", "assistant_message", "model", "stopReason=stop · 最终回答"),
+]

--- a/scripts/pi_agent_immersive/ultra_dive.py
+++ b/scripts/pi_agent_immersive/ultra_dive.py
@@ -1,0 +1,164 @@
+"""Ultra-deep walkthrough blocks — one extra numbered section per chapter."""
+from __future__ import annotations
+
+from _html_helpers import join, p, section_block, src
+
+# Per-chapter: (title_zh, title_en, paragraphs, optional source block)
+ULTRA: dict[str, tuple[str, str, list[tuple[str, str]], tuple[str, str, list[str]] | None]] = {
+    "c7": (
+        "prompt() 到 agentLoop 的逐步 trace",
+        "Step-by-step trace from prompt() to agentLoop",
+        [
+            (
+                "<code>AgentSession.prompt(text)</code> 首先构造 <code>createUserMessage(text)</code>，类型为 <code>AgentMessage</code> 而非 pi-ai 的 <code>Message</code>。这是 checkpoint 03 与 09 的分水岭：在 agent-core 内永远操作 AgentMessage，只在 <code>streamAssistantResponse</code> 边界调用 <code>convertToLlm</code>。",
+                "<code>AgentSession.prompt(text)</code> first builds <code>createUserMessage(text)</code> as <code>AgentMessage</code>, not pi-ai <code>Message</code>. Checkpoint 03/09 watershed: AgentMessage inside agent-core; <code>convertToLlm</code> only at <code>streamAssistantResponse</code>.",
+            ),
+            (
+                "随后 <code>runLoop</code> 把 userMsg 推入 pending queue，emit <code>turn_start</code> → <code>message_start</code>。若 SessionManager 已绑定，同一事件流会触发 JSONL append——因此 TUI 与磁盘是<strong>同一事件的两个订阅者</strong>，不是两条路径。",
+                "Then <code>runLoop</code> pushes userMsg to pending queue, emits <code>turn_start</code> → <code>message_start</code>. With SessionManager bound, the same stream triggers JSONL append — TUI and disk are <strong>two subscribers to one event bus</strong>, not two paths.",
+            ),
+            (
+                "主线 prompt 的第一圈 model stream 在 <code>agent-loop.ts</code> 的 inner loop 启动；当 <code>stopReason=toolUse</code> 时，outer loop 不退出，而是进入 tool batch。读 README 的 <code>read</code> 在此执行——cwd 相对路径由 coding-agent 的 tool registry 解析。",
+                "First model stream for the through-line starts in agent-loop's inner loop; when <code>stopReason=toolUse</code>, outer loop continues into tool batch. <code>read</code> for README runs here — cwd-relative paths resolved by coding-agent tool registry.",
+            ),
+        ],
+        (
+            "walkthrough",
+            "packages/coding-agent/src/core/agent-session.ts",
+            [
+                '<span class="src-kw">async</span> <span class="src-fn">prompt</span>(<span class="src-arg">text</span>: <span class="src-cls">string</span>) {',
+                '  <span class="src-kw">const</span> userMsg = <span class="src-fn">createUserMessage</span>(text);',
+                '  <span class="src-kw">await</span> <span class="src-fn">this.runLoop</span>([userMsg]);',
+                '}',
+            ],
+        ),
+    ),
+    "c10": (
+        "双环状态机：用主线 prompt 走一遍",
+        "Twin-loop state machine walked with through-line prompt",
+        [
+            (
+                "外环条件：<code>while (true)</code> 检查 follow-up 队列与 steering 注入。主线 prompt 首次进入时 follow-up 为空，但 steering 可能在 tool 执行中被用户插入——这是 Pi 与「一次性 completion API」的本质差异。",
+                "Outer loop: <code>while (true)</code> checks follow-up queue and steering. First through-line entry has empty follow-up, but steering may inject during tool execution — Pi's essential difference from one-shot completion APIs.",
+            ),
+            (
+                "内环条件：<code>while (hasMoreToolCalls || pendingMessages.length)</code>。第一圈 model 返回 toolUse(read) 后，<code>hasMoreToolCalls</code> 为真，内环继续而不回到用户。第二圈 model 收到 tool result 后 <code>stopReason=stop</code>，内环退出，外环检查无 follow-up 后 agent_end。",
+                "Inner loop: <code>while (hasMoreToolCalls || pendingMessages.length)</code>. After turn-1 toolUse(read), inner loop continues. Turn-2 stop ends inner loop; outer loop exits with agent_end when no follow-up.",
+            ),
+            (
+                "理解双环的最快方法：在 pi-textbook checkpoint 07 的测试里给 <code>ScriptedModel</code> 固定两轮响应，对照 <code>--verbose</code> stderr 的 event 顺序——应看到两次 <code>model_start</code> 夹一次 <code>tool_execution_*</code>。",
+                "Fastest way to grok twin loops: fix two-turn responses in textbook cp07's <code>ScriptedModel</code>, compare with <code>--verbose</code> stderr — expect two <code>model_start</code> bracketing one <code>tool_execution_*</code>.",
+            ),
+        ],
+        (
+            "loop",
+            "packages/agent/src/agent-loop.ts",
+            [
+                '<span class="src-kw">while</span> (<span class="src-lit">true</span>) { <span class="src-comment">// outer: follow-up</span>',
+                '  <span class="src-kw">while</span> (hasMoreToolCalls || pendingMessages.length) { <span class="src-comment">// inner</span>',
+                '    <span class="src-kw">await</span> <span class="src-fn">streamAssistantResponse</span>(...);',
+                '    <span class="src-kw">await</span> <span class="src-fn">executeToolCalls</span>(...);',
+                '  }',
+                '}',
+            ],
+        ),
+    ),
+    "c14": (
+        "streamSimple 如何吃掉 convertToLlm 的输出",
+        "How streamSimple consumes convertToLlm output",
+        [
+            (
+                "<code>convertToLlm(messages: AgentMessage[])</code> 产出 pi-ai 的 <code>Message[]</code>，其中 tool result 已折叠为 provider 特定格式。Anthropic 与 OpenAI 的 tool 块形状不同——pi-ai 的 adapter 层负责这一转换，agent-core 不应 import provider 细节。",
+                "<code>convertToLlm(messages: AgentMessage[])</code> yields pi-ai <code>Message[]</code> with tool results folded to provider format. Anthropic vs OpenAI tool blocks differ — pi-ai adapters handle this; agent-core must not import provider details.",
+            ),
+            (
+                "<code>streamSimple(model, messages, tools)</code> 返回 <code>EventStream</code>：先过程项（text_delta、toolcall_delta），后终态（done + usage）。TUI 只订阅 message_update；SessionManager 在 message_end 落盘——两者消费同一 stream 的不同阶段。",
+                "<code>streamSimple(model, messages, tools)</code> returns <code>EventStream</code>: process items first (text_delta, toolcall_delta), terminal state last (done + usage). TUI subscribes to message_update; SessionManager persists at message_end.",
+            ),
+        ],
+        None,
+    ),
+    "c22": (
+        "JSONL 一行究竟长什么样",
+        "What one JSONL line actually looks like",
+        [
+            (
+                "每条 entry 含 <code>id</code>、<code>parentId</code>、<code>type</code>、<code>message</code> 或 <code>event</code> 载荷。主线 prompt 的第一行 user entry 的 <code>parentId</code> 指向 session 根或上一 leaf；assistant toolUse 行的 <code>parentId</code> 指向 user entry——形成树而非链表。",
+                "Each entry has <code>id</code>, <code>parentId</code>, <code>type</code>, and <code>message</code> or <code>event</code> payload. First user entry's <code>parentId</code> points to session root or prior leaf; assistant toolUse points to user entry — a tree, not a linked list.",
+            ),
+            (
+                "<code>fork(fromEntryId)</code> 创建新 session 文件，复制祖先链到切点，后续 append 挂在新分支上。这是 Pi 替代 sub-agent 的方式：不是进程内 spawn，而是<strong>会话树分支</strong>。",
+                "<code>fork(fromEntryId)</code> creates a new session file, copies ancestor chain to cut point; subsequent appends hang on the new branch. Pi's sub-agent alternative: <strong>session tree branch</strong>, not in-process spawn.",
+            ),
+        ],
+        None,
+    ),
+}
+
+# Default ultra block for chapters without custom content
+_DEFAULT_PATHS: dict[str, str] = {
+    "c1": "packages/agent/src/agent-loop.ts",
+    "c2": "packages/coding-agent/src/main.ts",
+    "c3": "package.json",
+    "c4": "packages/agent/package.json",
+    "c5": "packages/coding-agent/README.md",
+    "c6": "packages/coding-agent/src/cli.ts",
+    "c8": "packages/coding-agent/src/core/resource-loader.ts",
+    "c9": "packages/agent/src/types.ts",
+    "c11": "packages/agent/src/agent-loop.ts",
+    "c12": "packages/coding-agent/src/core/tools/read.ts",
+    "c13": "packages/agent/src/types.ts",
+    "c15": "packages/ai/src/utils/event-stream.ts",
+    "c16": "packages/ai/src/models.generated.ts",
+    "c17": "packages/tui/src/terminal.ts",
+    "c18": "packages/tui/src/components/editor.ts",
+    "c19": "packages/coding-agent/src/core/extensions/types.ts",
+    "c20": "packages/coding-agent/src/core/extensions/runner.ts",
+    "c21": "packages/coding-agent/src/core/extensions/loader.ts",
+    "c23": "packages/coding-agent/src/core/compaction/",
+    "c24": "packages/coding-agent/src/core/sdk.ts",
+    "c25": "packages/protocol/src/",
+    "c26": "packages/coding-agent/src/cli.ts",
+}
+
+
+def ultra_for(cid: str, ch_num: str, sec_offset: int) -> str | None:
+    custom = ULTRA.get(cid)
+    sec = f"C{ch_num}.{sec_offset}"
+
+    if custom:
+        tz, te, paragraphs, src_block = custom
+        parts = [section_block(tz, te, paragraphs, sec=sec)]
+        if src_block:
+            tag, path, lines = src_block
+            parts.append(src(tag, path, [f'      <span class="src-line">{ln}</span>' for ln in lines]))
+        return join(*parts)
+
+    path = _DEFAULT_PATHS.get(cid)
+    if not path:
+        return None
+
+    return section_block(
+        f"打开源码：{path}",
+        f"Open source: {path}",
+        [
+            (
+                f"本章主线 prompt 经过此模块时，请在 pi-mono 打开 <code>{path}</code>，搜索 <code>export</code> 与测试文件中的同名场景。对照 pi-textbook 对应 checkpoint 的 workshop 测试——先让测试绿，再读生产实现。",
+                f"When the through-line prompt crosses this module, open <code>{path}</code> in pi-mono, search <code>export</code> and matching test scenarios. Cross-read the pi-textbook checkpoint workshop test — green test first, then production.",
+            ),
+            (
+                "建议命令：<code>cd packages/agent && npm test -- agent-loop</code>（路径因章而异）。测试文件是行为契约的executable spec，比注释更可靠。",
+                "Suggested: <code>cd packages/agent && npm test -- agent-loop</code> (path varies). Tests are executable specs of behavior contracts — more reliable than comments.",
+            ),
+            (
+                "用 <code>--verbose</code> 跑一轮主线 prompt，把 stderr event 类型与源码中的 <code>emit</code> 调用逐行对齐——这是本文 C26 推荐的 trace 方法。",
+                "Run the through-line with <code>--verbose</code>, align stderr event types with <code>emit</code> calls in source — the trace method recommended in C26.",
+            ),
+        ],
+        sec=sec,
+    )
+
+
+def attach_ultra_to_depth(depth: dict) -> dict:
+    """Mutate DEPTH entry to include ultra block (called at import time)."""
+    return depth

--- a/scripts/pi_agent_immersive/visuals.py
+++ b/scripts/pi_agent_immersive/visuals.py
@@ -1,0 +1,358 @@
+"""SVG and HTML visualization blocks for Pi Agent immersive article."""
+from __future__ import annotations
+
+from _html_helpers import fig
+
+
+def svg_wrap(inner: str, viewbox: str = "0 0 720 280") -> str:
+    defs = """
+  <defs>
+    <marker id="pi-arr" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 Z" fill="#1f5c8c"/>
+    </marker>
+  </defs>"""
+    return f'<svg viewBox="{viewbox}" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true" class="pi-svg">{defs}{inner}</svg>'
+
+
+def viz_harness_spectrum() -> str:
+    inner = """
+  <defs>
+    <linearGradient id="g-spec" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#767c87"/>
+      <stop offset="50%" stop-color="#1f5c8c"/>
+      <stop offset="100%" stop-color="#2d6a4f"/>
+    </linearGradient>
+  </defs>
+  <text x="24" y="28" class="svg-label">SEALED PRODUCT</text>
+  <text x="620" y="28" text-anchor="end" class="svg-label">OPEN HARNESS</text>
+  <rect x="24" y="40" width="672" height="10" rx="5" fill="url(#g-spec)" opacity="0.85"/>
+  <circle cx="120" cy="45" r="14" fill="#faf6ed" stroke="#767c87" stroke-width="2"/>
+  <text x="120" y="49" text-anchor="middle" class="svg-tiny">CC</text>
+  <circle cx="280" cy="45" r="14" fill="#faf6ed" stroke="#767c87" stroke-width="2"/>
+  <text x="280" y="49" text-anchor="middle" class="svg-tiny">Cur</text>
+  <circle cx="560" cy="45" r="18" fill="#1f5c8c" stroke="#15171c" stroke-width="2"/>
+  <text x="560" y="50" text-anchor="middle" fill="#faf6ed" class="svg-tiny" font-weight="700">Pi</text>
+  <rect x="40" y="80" width="200" height="56" rx="4" class="svg-box muted"/>
+  <text x="140" y="104" text-anchor="middle" class="svg-body">MCP · Sub-agents</text>
+  <text x="140" y="122" text-anchor="middle" class="svg-mute">baked in</text>
+  <rect x="260" y="80" width="200" height="56" rx="4" class="svg-box muted"/>
+  <text x="360" y="104" text-anchor="middle" class="svg-body">IDE · Cloud sync</text>
+  <text x="360" y="122" text-anchor="middle" class="svg-mute">editor lock-in</text>
+  <rect x="480" y="72" width="200" height="72" rx="4" class="svg-box accent"/>
+  <text x="580" y="100" text-anchor="middle" class="svg-body">JSONL tree</text>
+  <text x="580" y="118" text-anchor="middle" class="svg-body">TS extensions</text>
+  <text x="580" y="136" text-anchor="middle" class="svg-mute">agent-loop.ts readable</text>
+  <path d="M140 136 L140 168 L580 168 L580 144" fill="none" class="svg-arrow"/>
+  <text x="360" y="190" text-anchor="middle" class="svg-mute">Pi trades features for observability</text>
+"""
+    return fig(
+        "Harness vs Product 光谱：密封产品在左，可组合 harness 在右；Pi 落在终端原生、JSONL 可读的一侧。",
+        "Harness vs product spectrum: sealed products left, composable harness right; Pi sits on the terminal-native, JSONL-readable side.",
+        f'<div class="pi-fig">{svg_wrap(inner)}</div>',
+    )
+
+
+def viz_seven_milestones() -> str:
+    steps = [
+        ("01", "user_message", "user", 48),
+        ("02", "model_start", "model", 148),
+        ("03", "assistant", "model", 248),
+        ("04", "tool_start", "loop", 348),
+        ("05", "tool_result", "tool", 448),
+        ("06", "model_start", "model", 548),
+        ("07", "assistant", "model", 648),
+    ]
+    colors = {"user": "#b35a1f", "model": "#1f5c8c", "loop": "#6b3aa3", "tool": "#2d6a4f"}
+    nodes = ""
+    for num, typ, owner, x in steps:
+        c = colors[owner]
+        nodes += f'''
+  <circle cx="{x}" cy="120" r="22" fill="{c}" opacity="0.15" stroke="{c}" stroke-width="2"/>
+  <text x="{x}" y="116" text-anchor="middle" class="svg-tiny" fill="{c}" font-weight="700">{num}</text>
+  <text x="{x}" y="130" text-anchor="middle" class="svg-micro">{typ[:8]}</text>
+  <text x="{x}" y="158" text-anchor="middle" class="svg-mute">{owner}</text>'''
+    inner = f"""
+  <line x1="70" y1="120" x2="650" y2="120" stroke="#c7c4ba" stroke-width="2"/>
+  {nodes}
+  <text x="48" y="52" class="svg-label">pi-textbook checkpoint 00 · README read trace</text>
+  <rect x="230" y="190" width="260" height="58" rx="4" class="svg-box paper"/>
+  <text x="360" y="212" text-anchor="middle" class="svg-body">toolCallId = call_1</text>
+  <text x="360" y="232" text-anchor="middle" class="svg-mute">request (03) ↔ result (05) must pair</text>
+"""
+    return fig(
+        "七个里程碑：owner 分工——user 定目标，model 推理，loop 调度，tool 返回环境事实。",
+        "Seven milestones: owner roles — user sets goal, model reasons, loop dispatches, tool returns environment facts.",
+        f'<div class="pi-fig">{svg_wrap(inner, "0 0 720 260")}</div>',
+    )
+
+
+def viz_stations_flow() -> str:
+    """Compact 22-station flow grouped by phase."""
+    groups = [
+        ("入口", "#767c87", ["CLI", "main", "Session", "AGENTS"]),
+        ("心脏", "#1f5c8c", ["loop", "stream", "tool", "event"]),
+        ("LLM", "#6b3aa3", ["provider", "delta", "auth"]),
+        ("终端", "#2d6a4f", ["TUI", "Editor"]),
+        ("持久化", "#b35a1f", ["JSONL", "compact"]),
+    ]
+    x = 24
+    rects = ""
+    for label, color, items in groups:
+        w = 28 * len(items) + 36
+        rects += f'<rect x="{x}" y="70" width="{w}" height="88" rx="4" fill="{color}" opacity="0.08" stroke="{color}" stroke-width="1.5"/>'
+        rects += f'<text x="{x + w/2}" y="58" text-anchor="middle" class="svg-label" fill="{color}">{label}</text>'
+        for i, it in enumerate(items):
+            rects += f'<rect x="{x + 18 + i*28}" y="98" width="22" height="44" rx="2" fill="#faf6ed" stroke="{color}" stroke-width="1"/>'
+            rects += f'<text x="{x + 29 + i*28}" y="126" text-anchor="middle" class="svg-micro">{it}</text>'
+        x += w + 16
+    inner = f"""
+  <text x="24" y="28" class="svg-label">22 stations · grouped by phase (C02 map)</text>
+  {rects}
+  <path d="M 60 200 L 660 200" stroke="#c7c4ba" stroke-dasharray="4 3"/>
+  <text x="360" y="230" text-anchor="middle" class="svg-mute">Enter → JSONL on disk · one user message</text>
+"""
+    return fig(
+        "22 站按 Phase 分组：入口四站、心脏四站、LLM 三站、终端两站、持久化两站——持住这张地图读完全文。",
+        "22 stations by phase: intake 4, heart 4, LLM 3, terminal 2, persistence 2 — hold this map through the article.",
+        f'<div class="pi-fig wide">{svg_wrap(inner, "0 0 720 250")}</div>',
+    )
+
+
+def viz_monorepo_layers() -> str:
+    layers = [
+        ("L6", "coding-agent", "CLI · AgentSession · tools", "#1f5c8c"),
+        ("L5", "agent-core", "agentLoop · AgentMessage", "#3873a3"),
+        ("L4", "pi-ai", "Models · streamSimple", "#6b3aa3"),
+        ("L3", "pi-tui", "diff render · Editor", "#2d6a4f"),
+        ("L2", "protocol", "JSONL RPC frames", "#b35a1f"),
+        ("L1", "server", "CBOR remote", "#767c87"),
+    ]
+    blocks = ""
+    y = 28
+    for tag, name, desc, color in layers:
+        blocks += f'''
+  <rect x="120" y="{y}" width="480" height="36" rx="3" fill="{color}" opacity="0.12" stroke="{color}" stroke-width="1.5"/>
+  <text x="140" y="{y+16}" class="svg-tiny" fill="{color}" font-weight="700">{tag}</text>
+  <text x="180" y="{y+16}" class="svg-body">{name}</text>
+  <text x="180" y="{y+30}" class="svg-mute">{desc}</text>'''
+        y += 42
+    inner = f"""
+  <text x="24" y="18" class="svg-label">pi-mono six-layer cake · dependency flows downward</text>
+  {blocks}
+  <path d="M360 250 L360 268" stroke="#1f5c8c" marker-end="url(#arr)"/>
+  <text x="360" y="285" text-anchor="middle" class="svg-mute">through-line prompt enters at L6</text>
+"""
+    return fig(
+        "六层蛋糕：coding-agent 组装下层；agent-core 不 import pi-ai/compat，由宿主注入 StreamFn。",
+        "Six-layer cake: coding-agent composes below; agent-core does not import pi-ai/compat — host injects StreamFn.",
+        f'<div class="pi-fig">{svg_wrap(inner, "0 0 720 300")}</div>',
+    )
+
+
+def viz_message_layers() -> str:
+    inner = """
+  <rect x="40" y="50" width="180" height="160" rx="4" class="svg-box accent"/>
+  <text x="130" y="78" text-anchor="middle" class="svg-label">CANONICAL</text>
+  <text x="130" y="110" text-anchor="middle" class="svg-body">AgentMessage[]</text>
+  <text x="130" y="130" text-anchor="middle" class="svg-mute">JSONL transcript</text>
+  <text x="130" y="150" text-anchor="middle" class="svg-mute">user · assistant</text>
+  <text x="130" y="168" text-anchor="middle" class="svg-mute">toolResult · custom</text>
+  <rect x="270" y="50" width="180" height="160" rx="4" class="svg-box copper"/>
+  <text x="360" y="78" text-anchor="middle" class="svg-label">LLM PROJECTION</text>
+  <text x="360" y="110" text-anchor="middle" class="svg-body">Message[]</text>
+  <text x="360" y="130" text-anchor="middle" class="svg-mute">convertToLlm()</text>
+  <text x="360" y="150" text-anchor="middle" class="svg-mute">streamSimple boundary</text>
+  <rect x="500" y="50" width="180" height="160" rx="4" class="svg-box gpu"/>
+  <text x="590" y="78" text-anchor="middle" class="svg-label">TUI PROJECTION</text>
+  <text x="590" y="110" text-anchor="middle" class="svg-body">Rendered cells</text>
+  <text x="590" y="130" text-anchor="middle" class="svg-mute">Markdown · tool cards</text>
+  <path d="M220 130 L270 130" class="svg-arrow"/>
+  <path d="M450 130 L500 130" class="svg-arrow"/>
+  <text x="245" y="122" class="svg-micro">convert</text>
+  <text x="475" y="122" class="svg-micro">render</text>
+"""
+    return fig(
+        "三层投影：transcript 是唯一真相源；LLM 与 TUI 各取所需字段。",
+        "Three projections: transcript is single source of truth; LLM and TUI each take needed fields.",
+        f'<div class="pi-fig">{svg_wrap(inner, "0 0 720 230")}</div>',
+    )
+
+
+def viz_runloop_twin() -> str:
+    inner = """
+  <rect x="30" y="40" width="660" height="200" rx="6" fill="none" stroke="#1f5c8c" stroke-width="2" stroke-dasharray="8 4"/>
+  <text x="50" y="64" class="svg-label" fill="#1f5c8c">OUTER LOOP · follow-up queue</text>
+  <rect x="60" y="80" width="600" height="140" rx="4" fill="none" stroke="#b35a1f" stroke-width="2"/>
+  <text x="80" y="104" class="svg-label" fill="#b35a1f">INNER LOOP · tools + steering</text>
+  <rect x="100" y="120" width="120" height="44" rx="3" class="svg-box accent"/>
+  <text x="160" y="148" text-anchor="middle" class="svg-body">stream</text>
+  <path d="M220 142 L250 142" class="svg-arrow"/>
+  <rect x="250" y="120" width="100" height="44" rx="3" class="svg-box copper"/>
+  <text x="300" y="148" text-anchor="middle" class="svg-body">toolUse?</text>
+  <path d="M350 142 L380 142" class="svg-arrow"/>
+  <rect x="380" y="120" width="100" height="44" rx="3" class="svg-box asm"/>
+  <text x="430" y="148" text-anchor="middle" class="svg-body">execute</text>
+  <path d="M480 142 L510 142" class="svg-arrow"/>
+  <rect x="510" y="120" width="120" height="44" rx="3" class="svg-box accent"/>
+  <text x="570" y="148" text-anchor="middle" class="svg-body">stream again</text>
+  <path d="M570 164 L570 188 L120 188 L120 164" fill="none" stroke="#b35a1f" stroke-dasharray="4 3"/>
+  <text x="360" y="210" text-anchor="middle" class="svg-mute">README prompt: 2× stream · 1× read tool</text>
+"""
+    return fig(
+        "runLoop 双环：外环处理 follow-up；内环处理 tool batch 与 steering 注入。",
+        "runLoop twin loops: outer handles follow-up; inner handles tool batch and steering injection.",
+        f'<div class="pi-fig">{svg_wrap(inner, "0 0 720 250")}</div>',
+    )
+
+
+def viz_session_tree() -> str:
+    inner = """
+  <circle cx="360" cy="36" r="8" fill="#b35a1f"/>
+  <text x="360" y="58" text-anchor="middle" class="svg-body">u-1 · user prompt</text>
+  <line x1="360" y1="44" x2="280" y2="88" stroke="#c7c4ba"/>
+  <line x1="360" y1="44" x2="480" y2="88" stroke="#c7c4ba"/>
+  <rect x="220" y="88" width="120" height="36" rx="3" class="svg-box accent"/>
+  <text x="280" y="110" text-anchor="middle" class="svg-micro">a-read · toolUse</text>
+  <rect x="420" y="88" width="120" height="36" rx="3" class="svg-box muted"/>
+  <text x="480" y="110" text-anchor="middle" class="svg-micro">a-alt · sibling</text>
+  <line x1="280" y1="124" x2="280" y2="148" stroke="#c7c4ba"/>
+  <rect x="220" y="148" width="120" height="36" rx="3" class="svg-box asm"/>
+  <text x="280" y="170" text-anchor="middle" class="svg-micro">r-read · toolResult</text>
+  <line x1="280" y1="184" x2="280" y2="208" stroke="#c7c4ba"/>
+  <rect x="220" y="208" width="120" height="36" rx="3" class="svg-box accent"/>
+  <text x="280" y="230" text-anchor="middle" class="svg-micro">a-final · stop</text>
+  <text x="520" y="170" class="svg-mute">pathTo(leaf) →</text>
+  <text x="520" y="188" class="svg-mute">u-1→a-read→r-read→a-final</text>
+"""
+    return fig(
+        "JSONL 会话树：parentId 构成有向树；sibling 分支不覆盖旧路径；leafId 选择 active path。",
+        "JSONL session tree: parentId forms directed tree; sibling branches don't overwrite; leafId selects active path.",
+        f'<div class="pi-fig">{svg_wrap(inner, "0 0 720 270")}</div>',
+    )
+
+
+def viz_compaction() -> str:
+    inner = """
+  <text x="24" y="24" class="svg-label">HISTORY (JSONL) — never deleted</text>
+  <rect x="24" y="36" width="672" height="48" rx="3" class="svg-box paper"/>
+  <text x="40" y="58" class="svg-mono">u1 · a1 · u2 · a2 · u3 · calls · r-read · r-test · a3 · ...</text>
+  <text x="40" y="74" class="svg-mute">full append-only log on disk</text>
+  <text x="24" y="110" class="svg-label">CONTEXT (model window) — rebuilt per request</text>
+  <rect x="24" y="122" width="200" height="48" rx="3" fill="#ebe5d8" stroke="#c7c4ba"/>
+  <text x="124" y="152" text-anchor="middle" class="svg-mute">dropped · summarized</text>
+  <rect x="240" y="122" width="456" height="48" rx="3" class="svg-box accent"/>
+  <text x="260" y="152" class="svg-body">compaction summary + recent suffix (full tool interactions)</text>
+  <path d="M360 170 L360 200" class="svg-arrow"/>
+  <rect x="200" y="200" width="320" height="40" rx="3" class="svg-box asm"/>
+  <text x="360" y="226" text-anchor="middle" class="svg-body">streamSimple(context) · token budget enforced</text>
+"""
+    return fig(
+        "Compaction：历史完整保留在 JSONL；发给模型的 context 按 token 预算重建，早期事实以摘要补回。",
+        "Compaction: history stays complete in JSONL; model context rebuilt under token budget with summary for early facts.",
+        f'<div class="pi-fig">{svg_wrap(inner, "0 0 720 260")}</div>',
+    )
+
+
+def viz_tui_diff() -> str:
+    inner = """
+  <text x="180" y="28" text-anchor="middle" class="svg-label">FULL REFRESH</text>
+  <text x="540" y="28" text-anchor="middle" class="svg-label">CSI 2026 DIFF</text>
+  <rect x="40" y="40" width="280" height="160" rx="4" class="svg-box muted"/>
+  <rect x="60" y="60" width="240" height="14" fill="#ebe5d8"/>
+  <rect x="60" y="78" width="240" height="14" fill="#ebe5d8"/>
+  <rect x="60" y="96" width="240" height="14" fill="#ebe5d8"/>
+  <rect x="60" y="114" width="240" height="14" fill="#ebe5d8"/>
+  <rect x="60" y="132" width="240" height="14" fill="#ebe5d8"/>
+  <text x="180" y="185" text-anchor="middle" class="svg-mute">O(screen) · flicker</text>
+  <rect x="400" y="40" width="280" height="160" rx="4" class="svg-box accent"/>
+  <rect x="420" y="60" width="240" height="14" fill="#faf6ed" opacity="0.4"/>
+  <rect x="420" y="78" width="240" height="14" fill="#faf6ed" opacity="0.4"/>
+  <rect x="420" y="96" width="240" height="14" fill="#c9dceb" stroke="#1f5c8c"/>
+  <rect x="420" y="114" width="240" height="14" fill="#faf6ed" opacity="0.4"/>
+  <rect x="420" y="132" width="240" height="14" fill="#faf6ed" opacity="0.4"/>
+  <text x="540" y="185" text-anchor="middle" class="svg-mute">O(changed lines) · stable stream</text>
+  <text x="540" y="220" text-anchor="middle" class="svg-body">firstChanged → lastChanged only</text>
+"""
+    return fig(
+        "TUI 差分渲染：只重绘变更行区间，流式 token 不触发全屏闪烁。",
+        "TUI differential render: redraw only changed line range; streaming tokens avoid full-screen flicker.",
+        f'<div class="pi-fig">{svg_wrap(inner, "0 0 720 240")}</div>',
+    )
+
+
+def viz_extension_hooks() -> str:
+    inner = """
+  <rect x="280" y="20" width="160" height="44" rx="4" class="svg-box accent"/>
+  <text x="360" y="48" text-anchor="middle" class="svg-body">AgentSession</text>
+  <line x1="360" y1="64" x2="360" y2="88" stroke="#c7c4ba"/>
+  <rect x="240" y="88" width="240" height="36" rx="3" class="svg-box copper"/>
+  <text x="360" y="110" text-anchor="middle" class="svg-body">ExtensionRunner</text>
+  <line x1="120" y1="124" x2="600" y2="124" stroke="#c7c4ba"/>
+  <rect x="60" y="140" width="110" height="56" rx="3" class="svg-box paper"/>
+  <text x="115" y="172" text-anchor="middle" class="svg-micro">session_start</text>
+  <rect x="190" y="140" width="110" height="56" rx="3" class="svg-box paper"/>
+  <text x="245" y="172" text-anchor="middle" class="svg-micro">tool_call</text>
+  <rect x="320" y="140" width="110" height="56" rx="3" class="svg-box paper"/>
+  <text x="375" y="172" text-anchor="middle" class="svg-micro">before_compact</text>
+  <rect x="450" y="140" width="110" height="56" rx="3" class="svg-box paper"/>
+  <text x="505" y="172" text-anchor="middle" class="svg-micro">registerTool</text>
+  <rect x="580" y="140" width="110" height="56" rx="3" class="svg-box paper"/>
+  <text x="635" y="172" text-anchor="middle" class="svg-micro">message_update</text>
+"""
+    return fig(
+        "Extension 钩子：ExtensionRunner 在 AgentSession 生命周期注入，无需 MCP 同进程协议。",
+        "Extension hooks: ExtensionRunner injects at AgentSession lifecycle — no MCP same-process protocol.",
+        f'<div class="pi-fig">{svg_wrap(inner, "0 0 720 220")}</div>',
+    )
+
+
+def viz_textbook_map() -> str:
+    rows = ""
+    y = 44
+    for cp, phase, title, _, _ in [
+        ("00", "0", "Prologue", "", ""),
+        ("03", "I", "Message IR", "", ""),
+        ("07", "II", "Agent Loop", "", ""),
+        ("10", "III", "Session Tree", "", ""),
+        ("11", "III", "Compaction", "", ""),
+        ("14", "IV", "Eval", "", ""),
+    ]:
+        rows += f'<text x="48" y="{y}" class="svg-micro" fill="#1f5c8c">cp {cp}</text>'
+        rows += f'<text x="100" y="{y}" class="svg-body">{title}</text>'
+        rows += f'<line x1="90" y1="{y-4}" x2="680" y2="{y-4}" stroke="#ebe5d8"/>'
+        y += 32
+    inner = f"""
+  <text x="24" y="24" class="svg-label">pi-textbook · 15 checkpoints → production pi-mono</text>
+  {rows}
+  <text x="360" y="250" text-anchor="middle" class="svg-mute">each checkpoint = one testable abstraction layer</text>
+"""
+    return fig(
+        "pi-textbook 15 checkpoint 与生产代码的映射关系（节选）。",
+        "pi-textbook 15 checkpoints mapped to production code (excerpt).",
+        f'<div class="pi-fig">{svg_wrap(inner, "0 0 720 270")}</div>',
+    )
+
+
+def viz_event_swimlane() -> str:
+    lanes = [("user", "#b35a1f", 40), ("model", "#1f5c8c", 140), ("loop", "#6b3aa3", 240), ("tool", "#2d6a4f", 340)]
+    inner = '<text x="24" y="22" class="svg-label">AgentEvent swimlane · README through-line</text>'
+    for name, color, y in lanes:
+        inner += f'<text x="24" y="{y+16}" class="svg-micro" fill="{color}">{name}</text>'
+        inner += f'<line x1="70" y1="{y+12}" x2="700" y2="{y+12}" stroke="#ebe5d8"/>'
+    events = [
+        (90, 40, "user_message"),
+        (160, 140, "model_start"),
+        (230, 140, "assistant toolUse"),
+        (300, 240, "tool_start"),
+        (370, 340, "tool_result"),
+        (440, 140, "model_start"),
+        (510, 140, "assistant stop"),
+    ]
+    for x, y, label in events:
+        inner += f'<rect x="{x}" y="{y}" width="56" height="24" rx="2" fill="#faf6ed" stroke="#c7c4ba"/>'
+        inner += f'<text x="{x+28}" y="{y+16}" text-anchor="middle" class="svg-micro">{label[:10]}</text>'
+    return fig(
+        "事件泳道图：同一主线在 user/model/loop/tool 四条泳道上的时序。",
+        "Event swimlane: through-line timing across user/model/loop/tool lanes.",
+        f'<div class="pi-fig wide">{svg_wrap(inner, "0 0 720 400")}</div>',
+    )

--- a/scripts/pi_agent_immersive/visuals.py
+++ b/scripts/pi_agent_immersive/visuals.py
@@ -69,7 +69,7 @@ def viz_seven_milestones() -> str:
         nodes += f'''
   <circle cx="{x}" cy="120" r="22" fill="{c}" opacity="0.15" stroke="{c}" stroke-width="2"/>
   <text x="{x}" y="116" text-anchor="middle" class="svg-tiny" fill="{c}" font-weight="700">{num}</text>
-  <text x="{x}" y="130" text-anchor="middle" class="svg-micro">{typ[:8]}</text>
+  <text x="{x}" y="130" text-anchor="middle" class="svg-micro">{typ.replace("_", " ")[:12]}</text>
   <text x="{x}" y="158" text-anchor="middle" class="svg-mute">{owner}</text>'''
     inner = f"""
   <line x1="70" y1="120" x2="650" y2="120" stroke="#c7c4ba" stroke-width="2"/>

--- a/scripts/pi_agent_immersive/visuals.py
+++ b/scripts/pi_agent_immersive/visuals.py
@@ -86,6 +86,122 @@ def viz_seven_milestones() -> str:
     )
 
 
+STATIONS_22: list[tuple[str, str, str, str]] = [
+    ("01", "CLI 解析", "cli.ts argv", "intake"),
+    ("02", "main 启动", "main.ts boot", "intake"),
+    ("03", "Session", "session factory", "intake"),
+    ("04", "AGENTS.md", "context stack", "intake"),
+    ("05", "prompt 入队", "prompt queued", "heart"),
+    ("06", "agent_start", "agent_start", "heart"),
+    ("07", "turn_start", "turn_start", "heart"),
+    ("08", "convertToLlm", "→ Message[]", "llm"),
+    ("09", "streamSimple", "pi-ai stream", "llm"),
+    ("10", "text_delta", "token stream", "llm"),
+    ("11", "toolcall_δ", "tool assembly", "llm"),
+    ("12", "toolUse", "read request", "heart"),
+    ("13", "executeTool", "tool dispatch", "heart"),
+    ("14", "read README", "filesystem I/O", "tool"),
+    ("15", "tool_result", "tool result", "tool"),
+    ("16", "stream #2", "turn 2 model", "llm"),
+    ("17", "assistant stop", "final answer", "llm"),
+    ("18", "message_end", "message_end", "heart"),
+    ("19", "JSONL append", "JSONL write", "persist"),
+    ("20", "TUI diff", "diff render", "terminal"),
+    ("21", "extensions", "extension hooks", "terminal"),
+    ("22", "compaction", "context check", "persist"),
+]
+
+PHASE_COLORS = {
+    "intake": "#767c87",
+    "heart": "#1f5c8c",
+    "llm": "#6b3aa3",
+    "tool": "#2d6a4f",
+    "terminal": "#3873a3",
+    "persist": "#b35a1f",
+}
+
+
+def station_track() -> str:
+    cells = []
+    for num, zh, en, phase in STATIONS_22:
+        color = PHASE_COLORS[phase]
+        cells.append(
+            f"""      <div class="st-cell" data-phase="{phase}" style="--st-color:{color}">
+        <div class="st-num">{num}</div>
+        <div class="st-name"><span class="lang-zh-only">{zh}</span><span class="lang-en-only">{en}</span></div>
+        <div class="st-phase">{phase}</div>
+      </div>"""
+        )
+    return f"""    <div class="station-track" role="list" aria-label="22 stations">
+      <div class="st-rail">
+{chr(10).join(cells)}
+      </div>
+    </div>"""
+
+
+def viz_22_stations_panorama() -> str:
+    """Full 22-station snake timeline SVG — the main C02 panorama."""
+    # Row 1: 01-11, Row 2: 12-22
+    row1 = STATIONS_22[:11]
+    row2 = STATIONS_22[11:]
+    nodes = ""
+    paths = ""
+    x0, y1, y2 = 48, 95, 195
+    dx = 88
+    prev = None
+    for i, (num, zh, _en, phase) in enumerate(row1):
+        x = x0 + i * dx
+        c = PHASE_COLORS[phase]
+        label = zh[:10] if len(zh) > 10 else zh
+        nodes += f'''
+  <rect x="{x-28}" y="{y1-28}" width="56" height="56" rx="4" fill="{c}" opacity="0.12" stroke="{c}" stroke-width="1.5"/>
+  <text x="{x}" y="{y1-8}" text-anchor="middle" class="svg-tiny" fill="{c}" font-weight="700">{num}</text>
+  <text x="{x}" y="{y1+10}" text-anchor="middle" class="svg-micro">{label}</text>'''
+        if prev:
+            paths += f'<line x1="{prev[0]+28}" y1="{y1}" x2="{x-28}" y2="{y1}" stroke="#c7c4ba" stroke-width="1.5"/>'
+        prev = (x, y1)
+    # connector 11 → 12
+    x11 = x0 + 10 * dx
+    x12 = x0
+    mid_y = (y1 + y2) // 2
+    paths += (
+        f'<path d="M{x11+28} {y1} L{x11+52} {y1} L{x11+52} {mid_y} '
+        f'L{x12-52} {mid_y} L{x12-52} {y2-28} L{x12-28} {y2-28}" '
+        f'fill="none" stroke="#c7c4ba" stroke-width="1.5"/>'
+    )
+    prev = None
+    for i, (num, zh, _en, phase) in enumerate(row2):
+        x = x0 + i * dx
+        c = PHASE_COLORS[phase]
+        label = zh[:10] if len(zh) > 10 else zh
+        nodes += f'''
+  <rect x="{x-28}" y="{y2-28}" width="56" height="56" rx="4" fill="{c}" opacity="0.12" stroke="{c}" stroke-width="1.5"/>
+  <text x="{x}" y="{y2-8}" text-anchor="middle" class="svg-tiny" fill="{c}" font-weight="700">{num}</text>
+  <text x="{x}" y="{y2+10}" text-anchor="middle" class="svg-micro">{label}</text>'''
+        if prev:
+            paths += f'<line x1="{prev[0]+28}" y1="{y2}" x2="{x-28}" y2="{y2}" stroke="#c7c4ba" stroke-width="1.5"/>'
+        prev = (x, y2)
+    # phase legend
+    legend = ""
+    lx = 48
+    for phase, color in PHASE_COLORS.items():
+        legend += f'<rect x="{lx}" y="248" width="10" height="10" fill="{color}" opacity="0.5"/>'
+        legend += f'<text x="{lx+14}" y="257" class="svg-micro">{phase}</text>'
+        lx += 72
+    inner = f"""
+  <text x="48" y="32" class="svg-label">22 stations · snake timeline · one user message</text>
+  <text x="48" y="52" class="svg-mute">Enter → … → JSONL on disk</text>
+  {paths}
+  {nodes}
+  {legend}
+"""
+    return fig(
+        "22 站全景：从 CLI 解析到 compaction 检查的完整蛇形时间线，颜色按 Phase 编码。",
+        "22-station panorama: snake timeline from CLI parse to compaction check, color-coded by phase.",
+        f'<div class="pi-fig panorama">{svg_wrap(inner, "0 0 1000 270")}</div>',
+    )
+
+
 def viz_stations_flow() -> str:
     """Compact 22-station flow grouped by phase."""
     groups = [

--- a/src/content/notes/en/pi-agent.mdx
+++ b/src/content/notes/en/pi-agent.mdx
@@ -1,0 +1,32 @@
+---
+title: "The Life of a User Message Inside Pi Agent — 26 Stations from Enter to JSONL"
+date: "2026-08-22"
+tags: [Pi, Agent, Harness, TypeScript, CLI, Source Reading]
+public: true
+summary: After you type «read README.md and tell me what this project does in one sentence», that string passes through 26 stations, crosses six npm packages, morphs across three message layers, and only then becomes scrolling tokens on screen and one JSONL line on disk. Cross-reading earendil-works/pi production source with hahhforest/pi-textbook's 15 checkpoints — every step's class hierarchy, event flow, owner roles, and diagrams laid bare.
+immersive:
+  url: /immersive/pi-agent/
+  label: Immersive
+---
+
+> This is a long-form immersive article — read the full version on the dedicated page → [Enter full version](/immersive/pi-agent/)
+
+Tenth in the Field Note series. Sister pieces: [The Life of One LLM Inference](/immersive/llm-inference-life/) (one prompt through 28 llama.cpp stations) and [From Bytecode to Pixel](/immersive/chromium-renderer/) (Chromium render pipeline). This one switches the «OS» to **coding agent harness** — same method: **one through-line prompt**, real source, station by station.
+
+### Through-line: read README.md and tell me what this project does in one sentence
+
+The immersive article walks 26 chapters from harness philosophy through CLI boot, AgentSession orchestration, the twin-loop agent core, pi-ai streaming, differential TUI render, TypeScript extensions, JSONL session trees, compaction, and a comparison with Claude Code / Cursor.
+
+### What this edition goes deep on
+
+- **Line-by-line real source**: all 26 chapters map to concrete files in `earendil-works/pi` — `agent-loop.ts` · `agent-session.ts` · `session-manager.ts` · `event-stream.ts` · ExtensionRunner · TUI diff render.
+- **One through-line prompt**: same as pi-textbook prologue — seven-milestone table in early chapters.
+- **Two-layer message model**: `AgentMessage` (canonical transcript) vs `Message[]` (LLM projection) vs TUI render.
+- **runLoop twin loops**: outer follow-up · inner tool batch + steering.
+- **JSONL session tree**: `parentId` · `leafId` · `fork` — diagram in C22.
+- **Compaction**: history preserved · context rebuilt — C23.
+- **vs Claude Code / Cursor**: sealed product vs composable harness trade-offs in C24.
+
+> "A user message looks like one line in the terminal. What it really does: pass through 26 stations across six npm packages, leave a forkable node on the JSONL session tree, then get differential-rendered into the token stream you see via CSI 2026."
+
+Full read: **[The Life of a User Message Inside Pi Agent — 26-station source panorama](/immersive/pi-agent/)**

--- a/src/content/notes/pi-agent.mdx
+++ b/src/content/notes/pi-agent.mdx
@@ -1,0 +1,74 @@
+---
+title: "一条用户消息在 Pi Agent 里的一生 —— 从回车到 JSONL 的 26 站"
+date: "2026-08-22"
+tags: [Pi, Agent, Harness, TypeScript, CLI, 源码阅读]
+public: true
+summary: 你在终端敲下「读取 README.md，用一句话告诉我这个项目做什么」之后，这串文字要穿过 26 道工序、跨 6 个 npm 包、在 3 层消息模型里变形，最后才变成屏幕上滚动的 token 和磁盘上的一行 JSONL。对照 earendil-works/pi 生产源码与 hahhforest/pi-textbook 的 15 个 checkpoint，把每一步的类层级、事件流、owner 分工、可视化全摊开。
+immersive:
+  url: /immersive/pi-agent/
+  label: 沉浸式
+---
+
+> 这是一篇沉浸式长文，建议在专属页面阅读 → [进入完整版](/immersive/pi-agent/)
+
+这是 Field Note 系列的第十篇。姐妹篇是 [《一次 LLM 推理的一生》](/immersive/llm-inference-life/)（一个 prompt 走完 llama.cpp 28 站）和 [《字节码到像素的一生》](/immersive/chromium-renderer/)（Chromium 渲染管线）。本篇换一种「操作系统」——**coding agent harness**——但还是同一个手法：**主线一句 prompt**，对照真源码看它一站站怎么变形。
+
+### 主线：读取 README.md，用一句话告诉我这个项目做什么
+
+```
+用户回车
+  │
+  ▼
+┌─────────── 引子 ───────────┐
+│ C01 Harness 不是 Product   │
+│ C02 22 站全景 + 七里程碑    │
+├─────────── 背景 ───────────┤
+│ C03 pi-mono 家谱           │
+│ C04 六层蛋糕               │
+│ C05 故意不做的功能          │
+├─────────── 入口 ───────────┤
+│ C06 CLI 启动链             │
+│ C07 AgentSession 编排 ⭐   │
+│ C08 AGENTS.md 上下文栈     │
+├─────────── 心脏 ───────────┤
+│ C09 两层消息模型 ⭐        │
+│ C10 runLoop 双环 ⭐        │
+│ C11 Steering / Follow-up   │
+│ C12 Tool 执行管线          │
+│ C13 事件总线               │
+├─────────── LLM ────────────┤
+│ C14 pi-ai 提供商抽象       │
+│ C15 流式 EventStream       │
+│ C16 认证与模型目录         │
+├─────────── 终端 ───────────┤
+│ C17 差分渲染 TUI ⭐        │
+│ C18 Interactive Mode       │
+├─────────── 扩展 ───────────┤
+│ C19 Extension API          │
+│ C20 ExtensionRunner        │
+│ C21 Pi Packages            │
+├─────────── 持久化 ─────────┤
+│ C22 JSONL 会话树 ⭐        │
+│ C23 Compaction             │
+├─────────── 全景 ───────────┤
+│ C24 vs Claude Code/Cursor  │
+│ C25 RPC 与 pi-server       │
+└─────────── Coda ───────────┘
+  C26 怎么自己 trace 一轮
+```
+
+### 这一版深挖了什么
+
+- **逐行真源码**：26 章全部对应 `earendil-works/pi` 仓库里具体文件——`agent-loop.ts` · `agent-session.ts` · `session-manager.ts` · `event-stream.ts` · `resource-loader.ts` · ExtensionRunner · TUI diff render。
+- **一条主线 prompt**：与 pi-textbook 序章相同——「读取 README.md，用一句话告诉我这个项目做什么」。七里程碑表格贯穿 C02。
+- **两层消息模型**：`AgentMessage`（transcript 真相源）vs `Message[]`（LLM API 投影）vs TUI 渲染——checkpoint 03 的生产映射。
+- **runLoop 双环**：外环 follow-up · 内环 tool batch + steering——对照 checkpoint 07 Agent Loop。
+- **JSONL 会话树**：`parentId` · `leafId` · `fork`——checkpoint 10 Session Tree 图解在 C22。
+- **Compaction**：历史不动、上下文重建——checkpoint 11 在 C23。
+- **对比 Claude Code / Cursor**：密封产品 vs 可组合 harness 的设计取舍表在 C24。
+
+读完你会对「终端里敲一行字之后 Pi 内部发生了什么」形成非常具体的 mental model，能看懂 `--verbose` 事件日志、能读懂 JSONL 会话文件、能解释 steering 和 follow-up 的区别、能在面试里说清楚「为什么 Pi 故意不做 MCP」。
+
+> "一条用户消息看起来只是终端里的一行字——它真正做的事情，是在六个 npm 包里穿过 26 道工序，在 JSONL 会话树上留下一个可 fork 的节点，然后被 TUI 用 CSI 2026 差分渲染成你看到的 token 流。"
+
+完整阅读：**[一条用户消息在 Pi Agent 里的一生 — 26 站源码全景](/immersive/pi-agent/)**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

为 Pi Agent 沉浸式长文补齐 **C10 跨层桥接** 与 **C14–C16 SOURCE TRACE** 块，与 C09–C13 心脏区同风格：从 `/tmp/pi-mono` 读取真实源码，带行号、`◀ trace` 标记与双语 `↳` 注释。

### C10 增强
- 新增 **C10 → C14 跨层调用链** 表格：`streamFunction` → `sdk streamFn` → `modelRuntime.streamSimple` → `applyAuth` → Anthropic SSE
- 补充 `agent-loop.ts:308`、`sdk.ts` `setDefaultStreamFn` / `streamFn`、`stream-fn.ts`、`model-runtime.ts` 桥接源码块

### C14 pi-ai 提供商抽象 (~49k trace chars)
- `compat.ts` `streamSimple` 分派
- `models.ts` `Provider` 接口、`applyAuth`、`createProvider`
- `anthropic.ts` provider 工厂与 auth resolve

### C15 流式 EventStream (~74k trace chars)
- `types.ts` `AssistantMessageEvent` 协议全文
- `event-stream.ts` `push`/`result` 机制
- `anthropic-messages.ts` SSE → `toolcall_delta` 组装 read(args)
- `agent-loop.ts` 消费侧映射

### C16 认证与模型目录 (~57k trace chars)
- `models.generated.ts` 40+ provider 聚合
- `anthropic.ts` auth resolve 链
- `auth-guidance.ts` 无 key 引导
- `findInitialModel` 优先级与 `sdk.ts` 启动选型

### 体量
- 文章总量：**~1.1 MB / 11,229 行**
- C10: 63k · C14: 49k · C15: 74k · C16: 57k trace 字符

## Testing
- `python3 scripts/generate-pi-agent-immersive.py` ✓
- `npm run build` ✓
- 浏览器验证 `#c10`、`#c14`–`#c16` SOURCE TRACE 渲染 ✓

[pi_agent_c10_c14_c16_source_trace_demo.mp4](https://cursor.com/agents/bc-01a029c8-9f11-7081-af9b-7378a9e90695/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpi_agent_c10_c14_c16_source_trace_demo.mp4)

[C14 SOURCE TRACE screenshot](https://cursor.com/agents/bc-01a029c8-9f11-7081-af9b-7378a9e90695/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_c14_source_trace.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a029c8-9f11-7081-af9b-7378a9e90695?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a029c8-9f11-7081-af9b-7378a9e90695&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

