### PR TITLE
feat(dsh): DeepSeek Harness 沉浸式技术长文（26 章 · Cordis turn/step trace）

### DIFF
--- a/public/immersive/dsh/index.html
+++ b/public/immersive/dsh/index.html
@@ -1,0 +1,6967 @@
+<!DOCTYPE html>
+<html lang="zh-CN" translate="no">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="google" content="notranslate">
+<meta name="referrer" content="strict-origin-when-cross-origin">
+<link rel="shortcut icon" href="https://airing.ursb.me/image/favicon.ico">
+<link rel="apple-touch-icon" href="https://airing.ursb.me/image/favicon.ico">
+<link rel="icon" href="https://airing.ursb.me/image/favicon.ico">
+<meta name="description" content="你在 Web UI 敲下「读取 README.md，用一句话告诉我这个项目做什么」之后，这串文字穿过 26 道工序、跨 Cordis 插件树与 core spine，在 SessionEvent 日志里变形——对照 deepseek-ai/deepseek-harness 生产源码与官方 docs 逐行读。">
+<meta name="author" content="Airing">
+<meta property="og:title" content="一条用户消息在 DeepSeek Harness 里的一生 — DSH 源码全景">
+<meta property="og:description" content="Cordis → ReactLoopAgent → turn/step → ctx.llm → tools → SessionEvent log · 真源码逐行。">
+<meta property="og:image" content="https://ursb.me/og/dsh.png">
+<meta property="og:url" content="https://ursb.me/immersive/dsh/">
+<meta property="og:type" content="article">
+<meta property="og:site_name" content="ursb.me · Airing">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="一条用户消息在 DeepSeek Harness 里的一生">
+<meta name="twitter:description" content="After you type read README.md and tell me what this project does in one sentence, that string passes through 26 stations across the Cordis plugin tree and core spine — cross-reading deepseek-ai/deepseek-harness production source with official docs.">
+<meta name="twitter:image" content="https://ursb.me/og/dsh.png">
+<meta name="twitter:creator" content="@airingursb">
+<title>一条用户消息在 DeepSeek Harness 里的一生 — DSH 源码全景</title>
+<style>
+
+  :root {
+    --bg: #f4efe6;
+    --bg-soft: #ebe5d8;
+    --paper: #faf6ed;
+    --paper-2: #fdfbf3;
+    --ink: #15171c;
+    --ink-soft: #3c4148;
+    --ink-mute: #767c87;
+    --rule: #c7c4ba;
+    --rule-soft: #ddd9cd;
+    --accent: #1f5c8c;          /* cobalt — compute / matrix */
+    --accent-soft: #4a85b3;
+    --accent-pale: #c9dceb;
+    --copper: #b35a1f;          /* warm — tokenizer / prompt */
+    --copper-soft: #d1855a;
+    --copper-pale: #ecd3bf;
+    --good: #4a6b3e;
+    --warn: #a87a1f;
+    --asm: #2d6a4f;             /* green — KV cache / memory */
+    --asm-soft: #6b8f7a;
+    --asm-pale: #cfe2d7;
+    --gpu: #6b3aa3;             /* purple — attention / parallel */
+    --gpu-soft: #9572bd;
+    --gpu-pale: #d8c8e6;
+    --heat: #c3573a;            /* orange — hot kernels / sampling */
+    --heat-soft: #d99c87;
+    --heat-pale: #f3d6c8;
+    --serif: "Source Han Serif SC", "Noto Serif CJK SC", "Songti SC", "STSong", Georgia, "Times New Roman", serif;
+    --serif-en: "Source Serif Pro", "Source Serif 4", Georgia, "Times New Roman", "Source Han Serif SC", serif;
+    --sans: "Inter", -apple-system, "PingFang SC", "Helvetica Neue", system-ui, sans-serif;
+    --mono: "JetBrains Mono", "SF Mono", Menlo, ui-monospace, monospace;
+  }
+
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; overflow-x: hidden; }
+
+  body {
+    background: var(--bg);
+    color: var(--ink);
+    font-family: var(--serif);
+    font-size: 16px;
+    line-height: 1.85;
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+  }
+  body.lang-en { font-family: var(--serif-en); }
+
+  body::before {
+    content: "";
+    position: fixed; inset: 0;
+    background-image: radial-gradient(rgba(40,60,90,0.05) 1px, transparent 1px);
+    background-size: 3px 3px;
+    pointer-events: none;
+    z-index: 1;
+  }
+
+  .container {
+    max-width: 820px; margin: 0 auto;
+    padding: 0 32px;
+    position: relative; z-index: 2;
+  }
+
+  /* lang + back */
+  .lang-toggle {
+    position: fixed; top: 28px; right: 32px; z-index: 100;
+    font-family: var(--mono); font-size: 12px; letter-spacing: 0.12em;
+    background: var(--paper); border: 1px solid var(--rule);
+    padding: 6px 12px; border-radius: 99px;
+    display: flex; align-items: center; gap: 10px;
+    backdrop-filter: blur(6px); -webkit-backdrop-filter: blur(6px);
+  }
+  .lang-toggle button {
+    background: transparent; border: 0; padding: 2px 6px;
+    font: inherit; color: var(--ink-mute); cursor: pointer;
+    letter-spacing: inherit; border-radius: 99px; transition: color .15s;
+  }
+  .lang-toggle button:hover { color: var(--ink); }
+  .lang-toggle button.active { color: var(--ink); font-weight: 600; }
+  .lang-toggle .sep { color: var(--rule); user-select: none; }
+  body:not(.lang-en) .lang-en-only { display: none !important; }
+  body.lang-en .lang-zh-only { display: none !important; }
+
+  /* ====================== Side TOC (added 2026-06) ====================== */
+  .toc-side {
+    position: fixed; top: 84px; left: 22px;
+    z-index: 100; width: 200px;
+    max-height: calc(100vh - 120px);
+    overflow-y: auto;
+    font-family: var(--mono);
+    font-size: 10.5px; line-height: 1.4;
+    scrollbar-width: thin; scrollbar-color: var(--rule) transparent;
+    padding-right: 4px;
+  }
+  .toc-side::-webkit-scrollbar { width: 3px; }
+  .toc-side::-webkit-scrollbar-thumb { background: var(--rule); border-radius: 2px; }
+  .toc-side ol { list-style: none; margin: 0; padding: 0; }
+  .toc-side a { color: var(--ink-soft); text-decoration: none; }
+  .toc-side > .toc-label {
+    font-size: 9.5px; letter-spacing: 0.2em; color: var(--ink-mute);
+    text-transform: uppercase; margin-bottom: 8px; font-weight: 600;
+  }
+  .toc-side li { margin-bottom: 0; }
+  .toc-side li > a {
+    display: flex; align-items: baseline; gap: 8px;
+    padding: 2px 0; opacity: 0.55; transition: opacity 0.18s, color 0.18s;
+    border: none;
+    line-height: 1.35;
+  }
+  .toc-side li > a:hover { opacity: 0.9; color: var(--accent); }
+  .toc-side li.active > a { opacity: 1; color: var(--accent); font-weight: 600; }
+  .toc-side .toc-num {
+    flex-shrink: 0; width: 18px; color: var(--accent);
+    font-variant-numeric: tabular-nums; font-size: 9.5px;
+    font-weight: 700; letter-spacing: 0.04em;
+  }
+  @media (max-width: 1320px) { .toc-side { display: none; } }
+  .toc-side .ts-divider {
+    font-family: var(--mono); font-size: 8.5px;
+    letter-spacing: 0.16em; text-transform: uppercase;
+    color: var(--ink-mute);
+    margin: 8px 0 2px;
+    padding-top: 5px;
+    border-top: 1px dashed var(--rule);
+    opacity: 0.7;
+    line-height: 1.2;
+  }
+  .toc-side .ts-divider:first-child {
+    margin-top: 0;
+    border-top: 0;
+    padding-top: 0;
+  }
+
+
+
+  .ursb-backlink {
+    position: fixed; top: 28px; left: 32px; z-index: 100;
+    display: inline-flex; align-items: center; gap: 6px;
+    background: var(--paper); border: 1px solid var(--rule);
+    padding: 6px 14px 6px 12px; border-radius: 99px;
+    font-family: var(--mono); font-size: 12px; letter-spacing: 0.04em;
+    color: var(--ink-soft); text-decoration: none;
+    backdrop-filter: blur(6px); -webkit-backdrop-filter: blur(6px);
+    transition: all .18s ease;
+  }
+  .ursb-backlink:hover { color: var(--accent); border-color: var(--accent-soft); transform: translateX(-1px); }
+
+  /* hero */
+  .hero { padding: 120px 0 80px; border-bottom: 1px solid var(--rule); position: relative; }
+  .hero .meta {
+    font-family: var(--sans); font-size: 12px;
+    letter-spacing: 0.18em; text-transform: uppercase;
+    color: var(--ink-mute); margin-bottom: 32px;
+  }
+  .hero .meta span + span::before { content: "·"; margin: 0 12px; color: var(--rule); }
+  .hero h1 {
+    font-family: var(--serif); font-size: 64px; line-height: 1.1;
+    margin: 0 0 24px; font-weight: 600; letter-spacing: -0.01em;
+  }
+  body.lang-en .hero h1 { font-family: var(--serif-en); font-size: 60px; line-height: 1.05; letter-spacing: -0.02em; }
+  .hero h1 .accent { color: var(--accent); }
+  .hero h1 .copper { color: var(--copper); }
+  .hero h1 .gpu { color: var(--gpu); }
+  .hero h1 .heat { color: var(--heat); }
+  .hero h1 .asm { color: var(--asm); }
+  .hero .subtitle {
+    font-family: var(--mono); font-size: 14px; line-height: 1.6;
+    color: var(--ink-soft); margin: -8px 0 28px;
+    letter-spacing: 0.02em;
+  }
+  .hero .subtitle .arr { color: var(--ink-mute); margin: 0 8px; }
+  .hero .deck {
+    font-family: var(--sans); font-size: 19px; line-height: 1.55;
+    color: var(--ink-soft); max-width: 620px;
+    margin: 0 0 48px; font-weight: 300;
+  }
+  .byline {
+    font-family: var(--sans); font-size: 13px; color: var(--ink-mute);
+    display: flex; gap: 32px; flex-wrap: wrap;
+  }
+  .byline .label { color: var(--ink-mute); }
+  .byline .value { color: var(--ink); margin-left: 6px; }
+  .byline a.value {
+    text-decoration: none; border-bottom: 1px solid var(--rule);
+    transition: color .18s, border-color .18s;
+  }
+  .byline a.value:hover { color: var(--accent); border-bottom-color: var(--accent); }
+
+  .hero-notice {
+    margin: 36px 0 0; padding: 18px 22px;
+    background: var(--paper);
+    border: 1px solid var(--rule); border-left: 3px solid var(--copper);
+    border-radius: 0 4px 4px 0; max-width: 640px;
+  }
+  .hero-notice .hn-tag {
+    font-family: var(--mono); font-size: 10px;
+    letter-spacing: 0.18em; text-transform: uppercase;
+    color: var(--copper); font-weight: 700; margin-bottom: 8px;
+  }
+  .hero-notice .hn-body {
+    margin: 0; font-family: var(--sans);
+    font-size: 13.5px; line-height: 1.7; color: var(--ink-soft);
+  }
+  .hero-notice .hn-body strong { color: var(--ink); font-weight: 600; }
+  .hero-notice .hn-body em { color: var(--copper); font-style: normal; font-weight: 600; }
+
+  /* tldr 4-step */
+  .tldr {
+    margin: 36px 0 0; padding: 22px 24px;
+    background: var(--paper-2);
+    border: 1px solid var(--rule); border-left: 3px solid var(--accent);
+    border-radius: 0 4px 4px 0; max-width: 640px;
+  }
+  .tldr-tag {
+    font-family: var(--mono); font-size: 10px;
+    letter-spacing: 0.18em; text-transform: uppercase;
+    color: var(--accent); font-weight: 700; margin-bottom: 14px;
+  }
+  .tldr-steps {
+    display: grid; grid-template-columns: repeat(4, 1fr);
+    gap: 10px; margin: 0 0 14px;
+  }
+  .tldr-step {
+    background: var(--paper);
+    border: 1px solid var(--rule-soft);
+    border-top: 2px solid var(--accent);
+    border-radius: 3px; padding: 10px 12px;
+  }
+  .tldr-step:nth-child(2) { border-top-color: var(--copper); }
+  .tldr-step:nth-child(3) { border-top-color: var(--asm); }
+  .tldr-step:nth-child(4) { border-top-color: var(--heat); }
+  .tldr-step-n {
+    font-family: var(--mono); font-size: 9.5px;
+    letter-spacing: 0.18em; color: var(--ink-mute); margin-bottom: 4px;
+  }
+  .tldr-step-name {
+    font-family: var(--sans); font-size: 13px; font-weight: 700;
+    color: var(--ink); line-height: 1.3;
+  }
+  .tldr-step-hint {
+    font-family: var(--mono); font-size: 9.5px;
+    color: var(--ink-mute); margin-top: 4px; line-height: 1.4;
+  }
+  .tldr-skip {
+    margin-top: 14px; padding-top: 12px;
+    border-top: 1px dashed var(--rule);
+    font-family: var(--sans); font-size: 12px;
+    color: var(--ink-mute); line-height: 1.55;
+  }
+  .tldr-skip a {
+    color: var(--accent); border-bottom: 1px solid currentColor;
+    font-weight: 600;
+  }
+  .tldr-skip a:hover { color: var(--ink); }
+  @media (max-width: 720px) { .tldr-steps { grid-template-columns: 1fr 1fr; } }
+
+  /* pipeline bar — 18 stations */
+  .perf-bar {
+    margin: 56px 0 0; background: var(--paper);
+    border: 1px solid var(--rule); border-radius: 4px;
+    padding: 22px 24px; position: relative;
+  }
+  .perf-bar .pb-title {
+    font-family: var(--mono); font-size: 10px; letter-spacing: 0.18em;
+    color: var(--ink-mute); text-transform: uppercase; margin-bottom: 16px;
+    display: flex; justify-content: space-between;
+  }
+  .perf-bar .pb-title .pb-pulse { color: var(--heat); }
+  .perf-bar .pb-track {
+    display: grid; grid-template-columns: repeat(26, 1fr); gap: 3px;
+    height: 36px;
+  }
+  .perf-bar .pb-cell {
+    background: var(--bg-soft); border-radius: 2px;
+    cursor: pointer; transition: transform .15s;
+    position: relative; overflow: hidden;
+  }
+  .perf-bar .pb-cell:hover { transform: translateY(-2px); }
+  .perf-bar .pb-cell.p0 { background: var(--ink-mute); opacity: .55; }
+  .perf-bar .pb-cell.p1 { background: var(--copper); }
+  .perf-bar .pb-cell.p2 { background: var(--accent); }
+  .perf-bar .pb-cell.p3 { background: var(--gpu); }
+  .perf-bar .pb-cell.p4 { background: var(--heat); }
+  .perf-bar .pb-cell.p5 { background: var(--asm); }
+  .perf-bar .pb-cell.p6 { background: var(--asm-soft); }
+  .perf-bar .pb-cell.p7 { background: var(--gpu-soft); }
+  .perf-bar .pb-cell.p8 { background: var(--copper-soft); }
+  .perf-bar .pb-cell.pc { background: var(--ink-mute); opacity: .7; }
+  .perf-bar .pb-cell::after {
+    content: attr(data-n); position: absolute; inset: 0;
+    display: flex; align-items: center; justify-content: center;
+    font-family: var(--mono); font-size: 8px; font-weight: 700;
+    color: rgba(255,255,255,.85);
+  }
+  @media (max-width: 720px) {
+    .perf-bar .pb-cell::after { font-size: 0; }
+  }
+  .perf-bar .pb-axis {
+    display: flex; justify-content: space-between;
+    font-family: var(--mono); font-size: 9px; color: var(--ink-mute);
+    margin-top: 12px; letter-spacing: 0.06em;
+  }
+
+  /* TOC */
+  .toc-v2 { padding: 56px 0; border-bottom: 1px solid var(--rule); }
+  .toc-v2 .tv-head {
+    display: flex; align-items: baseline; justify-content: space-between;
+    margin-bottom: 6px;
+  }
+  .toc-v2 .tv-label {
+    font-family: var(--sans); font-size: 11px;
+    letter-spacing: 0.22em; text-transform: uppercase; color: var(--ink-mute);
+  }
+  .toc-v2 .tv-meta {
+    font-family: var(--mono); font-size: 10.5px;
+    color: var(--ink-mute); letter-spacing: 0.08em;
+  }
+  .toc-v2 .tv-meta .tv-now { color: var(--accent); font-weight: 700; }
+  .toc-v2 .tv-sub {
+    font-family: var(--sans); font-size: 13px;
+    color: var(--ink-mute); margin: 2px 0 26px; font-style: italic;
+  }
+
+  .toc-group {
+    margin-bottom: 18px;
+    border: 1px solid var(--rule);
+    border-left: 3px solid var(--ink-mute);
+    border-radius: 0 4px 4px 0;
+    background: var(--paper);
+    padding: 14px 18px 16px;
+  }
+  .toc-group[data-phase="bg"]   { border-left-color: var(--ink-mute); }
+  .toc-group[data-phase="in"]   { border-left-color: var(--copper); background: linear-gradient(135deg, rgba(179,90,31,0.04) 0%, var(--paper) 60%); }
+  .toc-group[data-phase="att"]  { border-left-color: var(--accent); background: linear-gradient(135deg, rgba(31,92,140,0.04) 0%, var(--paper) 60%); }
+  .toc-group[data-phase="var"]  { border-left-color: var(--gpu); background: linear-gradient(135deg, rgba(107,58,163,0.05) 0%, var(--paper) 60%); }
+  .toc-group[data-phase="out"]  { border-left-color: var(--heat); background: linear-gradient(135deg, rgba(195,87,58,0.05) 0%, var(--paper) 60%); }
+  .toc-group[data-phase="big"]  { border-left-color: var(--asm); background: linear-gradient(135deg, rgba(45,106,79,0.04) 0%, var(--paper) 60%); }
+  .toc-group[data-phase="prod"] { border-left-color: var(--heat); background: linear-gradient(135deg, rgba(195,87,58,0.05) 0%, var(--paper) 60%); }
+  .toc-group[data-phase="scale"]{ border-left-color: var(--asm); background: linear-gradient(135deg, rgba(45,106,79,0.05) 0%, var(--paper) 60%); }
+  .toc-group[data-phase="mile"] { border-left-color: var(--gpu); background: linear-gradient(135deg, rgba(107,58,163,0.04) 0%, var(--paper) 60%); }
+  .toc-group[data-phase="front"] { border-left-color: var(--copper); background: linear-gradient(135deg, rgba(179,90,31,0.06) 0%, var(--paper) 60%); }
+  .toc-group[data-phase="coda"] { border-left-color: var(--ink-mute); }
+
+  .toc-group-head {
+    display: flex; align-items: baseline; gap: 14px;
+    margin-bottom: 12px;
+    border-bottom: 1px dotted var(--rule);
+    padding-bottom: 10px;
+  }
+  .toc-group-head .tg-num {
+    font-family: var(--mono); font-size: 12px; font-weight: 700;
+    letter-spacing: 0.16em; color: var(--ink-mute); width: 32px;
+  }
+  .toc-group-head .tg-name {
+    font-family: var(--serif); font-size: 16px; font-weight: 700;
+    color: var(--ink); flex: 1;
+  }
+  body.lang-en .toc-group-head .tg-name { font-family: var(--serif-en); }
+  .toc-group-head .tg-en {
+    font-family: var(--mono); font-size: 9.5px;
+    letter-spacing: 0.18em; text-transform: uppercase; color: var(--ink-mute);
+  }
+  .toc-group-head .tg-count {
+    font-family: var(--mono); font-size: 10px; color: var(--ink-mute);
+    background: var(--bg-soft); padding: 2px 8px; border-radius: 999px;
+  }
+
+  .toc-chips {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: 5px;
+  }
+  .toc-chip {
+    display: flex; align-items: baseline; gap: 8px;
+    padding: 7px 10px; border-radius: 3px;
+    background: var(--paper-2); border: 1px solid var(--rule-soft);
+    text-decoration: none; color: var(--ink); transition: all .15s;
+  }
+  .toc-chip:hover { background: var(--bg-soft); border-color: var(--ink-mute); transform: translateX(2px); }
+  .toc-chip .tc-num {
+    font-family: var(--mono); font-size: 10px; font-weight: 700;
+    color: var(--ink-mute); min-width: 22px;
+  }
+  .toc-chip .tc-name {
+    flex: 1; font-family: var(--sans); font-size: 12.5px; font-weight: 600;
+    color: var(--ink); line-height: 1.3;
+  }
+  .toc-chip .tc-name .tc-en {
+    display: block; font-family: var(--mono); font-size: 9px;
+    color: var(--ink-mute); font-weight: 400; margin-top: 2px;
+    letter-spacing: 0.04em;
+  }
+  .toc-chip.tc-special { background: linear-gradient(135deg, rgba(31,92,140,0.06), var(--paper-2)); border-color: var(--accent-soft); }
+
+  /* chapters */
+  .chap { padding: 72px 0 56px; border-bottom: 1px solid var(--rule); }
+  .chap-num {
+    font-family: var(--mono); font-size: 11px;
+    letter-spacing: 0.22em; text-transform: uppercase;
+    color: var(--ink-mute); margin-bottom: 10px;
+  }
+  .chap-title {
+    font-family: var(--serif); font-size: 36px; font-weight: 600;
+    margin: 0 0 8px; line-height: 1.18; letter-spacing: -0.005em;
+  }
+  body.lang-en .chap-title { font-family: var(--serif-en); font-size: 34px; }
+  .chap-en {
+    font-family: var(--mono); font-size: 12px;
+    color: var(--ink-mute); letter-spacing: 0.04em; margin: 0 0 28px;
+  }
+
+  .chap p {
+    margin: 0 0 16px;
+    font-size: 16px; line-height: 1.9;
+    color: var(--ink-soft);
+  }
+  .chap p strong { color: var(--ink); font-weight: 700; }
+  .chap p em { font-style: italic; color: var(--ink); }
+  .chap p code, .chap li code, .chap td code, .chap th code {
+    font-family: var(--mono); font-size: 0.88em;
+    background: var(--bg-soft); padding: 1px 5px;
+    border-radius: 3px; color: var(--copper);
+  }
+  .chap .em { color: var(--accent); font-weight: 600; }
+  .chap .em-copper { color: var(--copper); font-weight: 600; }
+  .chap .em-gpu { color: var(--gpu); font-weight: 600; }
+  .chap .em-heat { color: var(--heat); font-weight: 600; }
+  .chap .em-asm { color: var(--asm); font-weight: 600; }
+
+  .chap ul, .chap ol {
+    margin: 0 0 18px; padding-left: 24px;
+    color: var(--ink-soft);
+  }
+  .chap li { margin-bottom: 6px; line-height: 1.85; }
+  .chap li strong { color: var(--ink); }
+
+  .sub {
+    font-family: var(--serif); font-size: 22px; font-weight: 700;
+    margin: 38px 0 14px; color: var(--ink);
+    letter-spacing: -0.005em;
+  }
+  body.lang-en .sub { font-family: var(--serif-en); }
+
+  /* source-code blocks (the "逐行源码" style) */
+  .src-stack {
+    background: var(--ink); color: #d8d8d8;
+    border-radius: 4px; padding: 18px 20px; margin: 18px 0;
+    font-family: var(--mono); font-size: 11.5px; line-height: 1.85;
+    overflow-x: auto;
+  }
+  .src-stack .src-h {
+    display: flex; justify-content: space-between;
+    font-family: var(--mono); font-size: 10px;
+    letter-spacing: 0.16em; text-transform: uppercase;
+    color: #888d96; margin-bottom: 12px;
+    padding-bottom: 10px; border-bottom: 1px dashed #2a2d33;
+  }
+  .src-stack .src-h .src-tag { color: #fcd34d; }
+  .src-stack .src-h .src-path { color: #5fc18a; text-transform: none; letter-spacing: 0; font-size: 10.5px; }
+  .src-stack .src-line { display: block; }
+  .src-stack .src-comment { color: #5a6172; font-style: italic; }
+  .src-stack .src-kw { color: #b48cd6; }
+  .src-stack .src-fn { color: #fcd34d; }
+  .src-stack .src-cls { color: var(--accent-soft); }
+  .src-stack .src-arg { color: #5fc18a; }
+  .src-stack .src-str { color: #5fc18a; }
+  .src-stack .src-num { color: #d1855a; }
+  .src-stack .src-op { color: #b48cd6; }
+  .src-stack .src-type { color: #6ec3d1; }
+  .src-stack .src-hl { background: rgba(252,211,77,0.10); display: inline-block; padding: 0 2px; border-radius: 2px; }
+  .src-stack .src-ln { color: #4a4d52; display: inline-block; width: 32px; user-select: none; }
+
+  /* note boxes */
+  .note {
+    margin: 22px 0; padding: 14px 18px;
+    background: var(--paper);
+    border: 1px solid var(--rule); border-left: 3px solid var(--ink-mute);
+    border-radius: 0 4px 4px 0;
+    font-family: var(--sans); font-size: 13.5px; line-height: 1.7;
+    color: var(--ink-soft);
+  }
+  .note .ntag {
+    display: inline-block;
+    font-family: var(--mono); font-size: 9.5px;
+    letter-spacing: 0.18em; text-transform: uppercase;
+    color: var(--ink-mute); font-weight: 700;
+    margin-right: 10px;
+  }
+  .note strong { color: var(--ink); }
+  .note.asm { border-left-color: var(--asm); }
+  .note.asm .ntag { color: var(--asm); }
+  .note.gpu { border-left-color: var(--gpu); }
+  .note.gpu .ntag { color: var(--gpu); }
+  .note.heat { border-left-color: var(--heat); }
+  .note.heat .ntag { color: var(--heat); }
+  .note.copper { border-left-color: var(--copper); }
+  .note.copper .ntag { color: var(--copper); }
+  .note.accent { border-left-color: var(--accent); }
+  .note.accent .ntag { color: var(--accent); }
+
+  /* figure */
+  figure {
+    margin: 26px 0;
+    border: 1px solid var(--rule);
+    background: var(--paper);
+    border-radius: 4px;
+    overflow: hidden;
+  }
+  .figbox { padding: 20px; }
+  figcaption {
+    border-top: 1px dashed var(--rule);
+    padding: 10px 18px;
+    font-family: var(--sans); font-size: 12px;
+    color: var(--ink-mute); line-height: 1.6;
+    background: var(--paper-2);
+  }
+  figcaption .figid {
+    font-family: var(--mono); font-size: 9.5px;
+    letter-spacing: 0.18em; text-transform: uppercase;
+    color: var(--accent); font-weight: 700; margin-right: 10px;
+  }
+
+  /* tables */
+  table.cmp {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 22px 0;
+    font-family: var(--sans); font-size: 13px;
+  }
+  table.cmp th, table.cmp td {
+    padding: 10px 12px; text-align: left;
+    border-bottom: 1px solid var(--rule-soft);
+    vertical-align: top;
+  }
+  table.cmp thead th {
+    background: var(--bg-soft);
+    font-family: var(--mono); font-size: 10.5px;
+    letter-spacing: 0.16em; text-transform: uppercase;
+    color: var(--ink-mute); font-weight: 700;
+    border-bottom: 1px solid var(--rule);
+  }
+  table.cmp td.good { color: var(--good); font-weight: 600; }
+  table.cmp td.bad { color: var(--heat); font-weight: 600; }
+  table.cmp td.heat { background: var(--heat-pale); color: var(--heat); font-weight: 600; }
+  table.cmp td code { font-family: var(--mono); font-size: 11px; background: var(--bg-soft); padding: 1px 5px; border-radius: 3px; color: var(--copper); }
+  table.cmp td.num { font-family: var(--mono); }
+
+  /* details (extended) */
+  details.extended {
+    margin: 22px 0;
+    border: 1px solid var(--rule);
+    border-radius: 4px;
+    background: var(--paper-2);
+  }
+  details.extended summary {
+    padding: 12px 16px;
+    cursor: pointer;
+    font-family: var(--sans); font-size: 13.5px;
+    color: var(--ink); font-weight: 600;
+    list-style: none;
+    display: flex; align-items: center; gap: 12px;
+  }
+  details.extended summary::-webkit-details-marker { display: none; }
+  details.extended summary::before {
+    content: "▸"; color: var(--ink-mute);
+    transition: transform .2s;
+    font-size: 10px;
+  }
+  details.extended[open] summary::before { transform: rotate(90deg); }
+  details.extended summary .ext-tag {
+    font-family: var(--mono); font-size: 9.5px;
+    letter-spacing: 0.18em; text-transform: uppercase;
+    color: var(--ink-mute); background: var(--bg-soft);
+    padding: 2px 8px; border-radius: 999px; font-weight: 700;
+  }
+  details.extended .ext-body { padding: 0 18px 16px; }
+  details.extended .ext-body p { font-size: 14.5px; }
+
+  /* tokenizer-vis */
+  .tok-vis { font-family: var(--mono); font-size: 13px; }
+  .tok-vis .tv-input-row {
+    display: flex; align-items: center; gap: 12px;
+    padding: 8px 12px; background: var(--paper-2);
+    border: 1px solid var(--rule-soft); border-radius: 3px;
+    margin-bottom: 14px;
+  }
+  .tok-vis .tv-input {
+    flex: 1; padding: 6px 10px;
+    font: inherit; border: 1px solid var(--rule);
+    border-radius: 3px; background: var(--paper); color: var(--ink);
+  }
+  .tok-vis .tv-tokens {
+    display: flex; flex-wrap: wrap; gap: 3px;
+    padding: 16px; background: var(--paper); border-radius: 3px;
+    min-height: 40px;
+  }
+  .tok-vis .tv-token {
+    display: inline-flex; flex-direction: column; align-items: center;
+    padding: 6px 10px; border-radius: 3px;
+    background: var(--copper-pale);
+    border: 1px solid var(--copper-soft);
+    color: var(--ink);
+  }
+  .tok-vis .tv-token .tv-tok-str { font-size: 12px; font-weight: 700; color: var(--copper); }
+  .tok-vis .tv-token .tv-tok-id { font-size: 9.5px; color: var(--ink-mute); margin-top: 2px; }
+
+  /* kv-vis */
+  .kv-vis {
+    font-family: var(--mono);
+    background: var(--paper-2); border: 1px solid var(--rule-soft);
+    padding: 16px; border-radius: 3px;
+  }
+  .kv-grid {
+    display: grid;
+    grid-template-columns: repeat(16, 1fr);
+    gap: 2px;
+    margin: 12px 0;
+  }
+  .kv-cell {
+    aspect-ratio: 1;
+    background: var(--bg-soft);
+    border-radius: 1px;
+  }
+  .kv-cell.used { background: var(--asm); }
+  .kv-cell.cur { background: var(--heat); animation: pulse 1.4s infinite; }
+  @keyframes pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.55; }
+  }
+  .kv-axis {
+    display: flex; justify-content: space-between;
+    font-size: 9px; color: var(--ink-mute);
+    letter-spacing: 0.06em;
+    margin-top: 6px;
+  }
+  .kv-legend {
+    display: flex; gap: 16px; margin-top: 10px;
+    font-size: 11px; color: var(--ink-soft);
+  }
+  .kv-legend .kl { display: inline-flex; align-items: center; gap: 6px; }
+  .kv-legend .kl .ksw { width: 10px; height: 10px; border-radius: 2px; background: var(--asm); }
+  .kv-legend .kl.free .ksw { background: var(--bg-soft); border: 1px solid var(--rule); }
+  .kv-legend .kl.cur .ksw { background: var(--heat); }
+
+  /* moe-vis */
+  .moe-vis {
+    font-family: var(--mono);
+    background: var(--paper-2); border: 1px solid var(--rule-soft);
+    padding: 18px; border-radius: 3px;
+  }
+  .moe-experts {
+    display: grid;
+    grid-template-columns: repeat(8, 1fr);
+    gap: 6px;
+    margin: 12px 0;
+  }
+  .moe-expert {
+    aspect-ratio: 1;
+    background: var(--bg-soft);
+    border: 1px solid var(--rule);
+    border-radius: 3px;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 11px; font-weight: 700;
+    color: var(--ink-mute);
+    transition: all .25s;
+  }
+  .moe-expert.active {
+    background: var(--gpu); border-color: var(--gpu); color: #fff;
+    transform: scale(1.08);
+    box-shadow: 0 4px 12px rgba(107,58,163,0.3);
+  }
+  .moe-expert .me-w {
+    display: block; font-size: 8px; font-weight: 400;
+    color: var(--ink-mute); margin-top: 2px;
+  }
+  .moe-expert.active .me-w { color: rgba(255,255,255,0.85); }
+  .moe-router {
+    text-align: center; padding: 8px 12px;
+    background: var(--paper); border: 1px solid var(--rule);
+    border-radius: 3px; font-size: 11px;
+    color: var(--ink-soft);
+    margin-bottom: 12px;
+  }
+
+  /* sampling-vis */
+  .smp-vis {
+    font-family: var(--mono);
+    background: var(--paper-2); border: 1px solid var(--rule-soft);
+    padding: 16px; border-radius: 3px;
+  }
+  .smp-bars { display: flex; flex-direction: column; gap: 4px; }
+  .smp-row { display: flex; align-items: center; gap: 8px; font-size: 11.5px; }
+  .smp-row .smp-tok { width: 90px; color: var(--copper); font-weight: 700; }
+  .smp-row .smp-bar {
+    height: 14px; background: var(--accent);
+    border-radius: 2px; flex: 0 0 auto;
+    min-width: 4px;
+    transition: width .3s, background .3s;
+  }
+  .smp-row.cut .smp-bar { background: var(--rule); opacity: 0.5; }
+  .smp-row.pick .smp-bar { background: var(--heat); }
+  .smp-row .smp-p { color: var(--ink-mute); font-size: 10px; }
+  .smp-ctrls {
+    display: flex; gap: 14px; flex-wrap: wrap;
+    padding: 10px 12px; background: var(--paper);
+    border: 1px solid var(--rule); border-radius: 3px;
+    margin-bottom: 14px;
+    font-size: 11px;
+  }
+  .smp-ctrls label { display: inline-flex; align-items: center; gap: 6px; color: var(--ink-soft); }
+  .smp-ctrls input[type="range"] { width: 90px; }
+  .smp-ctrls .smp-val { color: var(--accent); font-weight: 700; min-width: 32px; }
+
+  /* hot-bench bar */
+  .hot-bar {
+    background: var(--paper);
+    border: 1px solid var(--rule);
+    border-left: 3px solid var(--heat);
+    border-radius: 0 4px 4px 0;
+    padding: 14px 18px; margin: 22px 0;
+  }
+  .hot-bar .hb-tag {
+    font-family: var(--mono); font-size: 9.5px;
+    letter-spacing: 0.18em; text-transform: uppercase;
+    color: var(--heat); font-weight: 700;
+    margin-bottom: 8px;
+  }
+  .hot-bar table { width: 100%; font-family: var(--mono); font-size: 12px; }
+  .hot-bar td { padding: 3px 8px 3px 0; color: var(--ink-soft); }
+  .hot-bar td:first-child { color: var(--ink); font-weight: 600; min-width: 140px; }
+  .hot-bar td.num { color: var(--accent); font-weight: 700; }
+  .hot-bar td.bad { color: var(--heat); font-weight: 700; }
+
+  /* footer */
+  .footer {
+    padding: 60px 0 100px;
+    font-family: var(--sans); font-size: 13px;
+    color: var(--ink-mute); line-height: 1.7;
+  }
+  .footer .ft-rule {
+    display: flex; align-items: center; gap: 14px;
+    margin-bottom: 20px;
+  }
+  .footer .ft-rule::before, .footer .ft-rule::after {
+    content: ""; flex: 1; height: 1px; background: var(--rule);
+  }
+  .footer .ft-rule .ft-mark {
+    font-family: var(--mono); font-size: 10px;
+    letter-spacing: 0.22em; color: var(--ink-mute);
+  }
+  .footer p { margin: 0 0 10px; }
+  .footer a { color: var(--accent); text-decoration: none; border-bottom: 1px solid var(--rule); }
+  .footer a:hover { color: var(--ink); }
+  .footer .ft-links {
+    display: flex; gap: 18px; flex-wrap: wrap;
+    margin-top: 16px;
+    font-family: var(--mono); font-size: 11.5px;
+  }
+
+  @media (max-width: 720px) {
+    .container { padding: 0 20px; }
+    .hero { padding: 90px 0 60px; }
+    .hero h1 { font-size: 44px; }
+    body.lang-en .hero h1 { font-size: 42px; }
+    .hero .subtitle { font-size: 12px; }
+    .chap-title { font-size: 28px; }
+    body.lang-en .chap-title { font-size: 26px; }
+    .perf-bar .pb-track { grid-template-columns: repeat(9, 1fr); grid-auto-rows: 28px; height: auto; }
+    .kv-grid { grid-template-columns: repeat(8, 1fr); }
+    .moe-experts { grid-template-columns: repeat(4, 1fr); }
+    .lang-toggle, .ursb-backlink { top: 16px; }
+    .ursb-backlink { left: 16px; padding: 5px 12px 5px 10px; font-size: 11px; }
+    .lang-toggle { right: 16px; font-size: 11px; }
+  }
+
+  .formula {
+    background: var(--ink); color: var(--bg);
+    padding: 32px; margin: 32px 0;
+    font-family: var(--mono); font-size: 14px; line-height: 1.9;
+    border-radius: 4px; position: relative;
+  }
+  .formula .ftitle {
+    font-family: var(--sans); font-size: 11px;
+    letter-spacing: 0.22em; text-transform: uppercase;
+    margin-bottom: 16px; color: var(--rule);
+  }
+  .formula .cond { display: block; margin: 4px 0; }
+  .formula .cond::before { content: "▸"; color: var(--accent-soft); margin-right: 12px; }
+  .formula .out {
+    margin-top: 16px; padding-top: 16px;
+    border-top: 1px solid #2c2f36; color: var(--accent-soft);
+  }
+  .formula .term { color: #fcd34d; font-weight: 700; }
+  .formula .term-cu { color: #d1855a; font-weight: 700; }
+  .ladder {
+    background: var(--paper); border: 1px solid var(--rule);
+    border-radius: 4px; padding: 22px 24px; margin: 8px 0 24px;
+  }
+  .ladder .ld-row {
+    display: grid; grid-template-columns: 36px 1fr;
+    align-items: center; gap: 14px;
+    padding: 10px 0; border-bottom: 1px dashed var(--rule);
+  }
+  .ladder .ld-row:last-child { border-bottom: none; }
+  .ladder .ld-num {
+    font-family: var(--mono); font-size: 22px; color: var(--accent);
+    font-weight: 700; line-height: 1;
+  }
+  .ladder .ld-row:nth-child(2) .ld-num { color: #3873a3; }
+  .ladder .ld-row:nth-child(3) .ld-num { color: #6285a8; }
+  .ladder .ld-row:nth-child(4) .ld-num { color: #8090a8; }
+  .ladder .ld-name {
+    font-family: var(--serif); font-size: 15px; font-weight: 700; color: var(--ink);
+  }
+  body.lang-en .ladder .ld-name { font-family: var(--serif-en); }
+  .ladder .ld-desc {
+    font-family: var(--sans); font-size: 12px; color: var(--ink-mute);
+    margin-top: 2px;
+  }
+  .pi-fig { width: 100%; overflow-x: auto; }
+  .pi-fig.wide svg { min-width: 720px; }
+  .pi-svg { width: 100%; height: auto; display: block; }
+  .pi-svg .svg-label {
+    font-family: var(--mono); font-size: 10px; letter-spacing: 0.14em;
+    text-transform: uppercase; fill: var(--ink-mute);
+  }
+  .pi-svg .svg-body { font-family: var(--sans); font-size: 12px; fill: var(--ink); }
+  .pi-svg .svg-mute { font-family: var(--sans); font-size: 10.5px; fill: #767c87; }
+  .pi-svg .svg-micro { font-family: var(--mono); font-size: 9px; fill: var(--ink-soft); }
+  .pi-svg .svg-tiny { font-family: var(--mono); font-size: 10px; fill: var(--ink); }
+  .pi-svg .svg-mono { font-family: var(--mono); font-size: 11px; fill: var(--ink-soft); }
+  .pi-svg .svg-box { fill: #faf6ed; stroke: #c7c4ba; stroke-width: 1.5; }
+  .pi-svg .svg-box.accent { fill: #e8f0f8; stroke: #1f5c8c; }
+  .pi-svg .svg-box.copper { fill: #f5ebe0; stroke: #b35a1f; }
+  .pi-svg .svg-box.gpu { fill: #efe8f5; stroke: #6b3aa3; }
+  .pi-svg .svg-box.asm { fill: #e8f2ec; stroke: #2d6a4f; }
+  .pi-svg .svg-box.paper { fill: #f3efe6; stroke: #c7c4ba; }
+  .pi-svg .svg-box.muted { fill: #ebe5d8; stroke: #c7c4ba; }
+  .pi-svg .svg-arrow { stroke: #1f5c8c; stroke-width: 1.5; marker-end: url(#pi-arr); }
+  .pi-fig.panorama svg { min-width: 100%; }
+  .station-track {
+    margin: 20px 0 28px;
+    border: 1px solid var(--rule);
+    border-radius: 4px;
+    background: var(--paper);
+    overflow: hidden;
+  }
+  .station-track .st-rail {
+    display: grid;
+    grid-template-columns: repeat(11, minmax(72px, 1fr));
+    gap: 0;
+    overflow-x: auto;
+    padding: 0;
+    scrollbar-width: thin;
+  }
+  @media (max-width: 900px) {
+    .station-track .st-rail { grid-template-columns: repeat(11, 88px); }
+  }
+  .station-track .st-cell {
+    border-right: 1px solid var(--rule-soft);
+    border-bottom: 1px solid var(--rule-soft);
+    padding: 12px 8px 10px;
+    text-align: center;
+    background: linear-gradient(180deg, var(--paper) 0%, color-mix(in srgb, var(--st-color) 6%, var(--paper)) 100%);
+    min-height: 88px;
+  }
+  .station-track .st-cell:nth-child(n+12) { border-bottom: none; }
+  .station-track .st-num {
+    font-family: var(--mono); font-size: 18px; font-weight: 700;
+    color: var(--st-color); line-height: 1;
+  }
+  .station-track .st-name {
+    font-family: var(--sans); font-size: 11px; font-weight: 600;
+    color: var(--ink); margin-top: 6px; line-height: 1.25;
+  }
+  .station-track .st-phase {
+    font-family: var(--mono); font-size: 8px; letter-spacing: 0.1em;
+    text-transform: uppercase; color: var(--ink-mute); margin-top: 4px;
+  }
+  .stage-why-care {
+    background: linear-gradient(180deg, #fdfbf3, #faf6ed);
+    border: 1px solid var(--rule); border-top: 3px solid var(--accent);
+    border-radius: 4px; padding: 18px 22px 16px; margin: 18px 0 22px;
+  }
+  .stage-why-care .swc-label {
+    font-family: var(--mono); font-size: 9px; color: var(--accent);
+    letter-spacing: 0.12em; text-transform: uppercase; margin-bottom: 10px;
+  }
+  .stage-why-care p {
+    font-family: var(--serif); font-size: 14px; color: var(--ink-soft);
+    line-height: 1.65; margin: 6px 0; display: flex; align-items: baseline; gap: 10px;
+  }
+  body.lang-en .stage-why-care p { font-family: var(--serif-en); }
+  .stage-why-care .swc-pill {
+    flex: 0 0 auto; font-family: var(--mono); font-size: 8px; font-weight: 700;
+    letter-spacing: 0.1em; text-transform: uppercase; color: #fff;
+    background: var(--ink-mute); padding: 2px 7px; border-radius: 2px;
+  }
+  .stage-why-care .swc-pill.rev { background: var(--accent); }
+  .stage-why-care .swc-pill.act { background: var(--copper); }
+  .stage-why-care em { color: var(--ink); font-style: normal; font-weight: 600; }
+  .stage-banner {
+    display: grid; grid-template-columns: repeat(4, 1fr); gap: 0;
+    background: var(--paper); border: 1px solid var(--rule);
+    border-radius: 4px; overflow: hidden; margin: 28px 0 36px;
+  }
+  .stage-banner .sb-cell {
+    padding: 14px 18px; border-right: 1px solid var(--rule-soft);
+  }
+  .stage-banner .sb-cell:last-child { border-right: none; }
+  .stage-banner .sb-key {
+    font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.18em;
+    text-transform: uppercase; color: var(--ink-mute); margin-bottom: 4px;
+  }
+  .stage-banner .sb-val {
+    font-family: var(--sans); font-size: 13.5px; font-weight: 600; color: var(--ink);
+  }
+  .trace-box {
+    margin: 24px 0; padding: 16px 20px;
+    background: var(--paper-2); border: 1px dashed var(--accent);
+    border-radius: 4px;
+  }
+  .trace-box .tb-tag {
+    font-family: var(--mono); font-size: 9px; letter-spacing: 0.16em;
+    color: var(--accent); font-weight: 700; margin-bottom: 8px;
+  }
+  @media (max-width: 760px) {
+    .stage-banner { grid-template-columns: 1fr 1fr; }
+    .stage-why-care p { flex-direction: column; gap: 4px; }
+  }
+  .event-flow {
+    border: 1px solid var(--rule); border-radius: 4px;
+    background: var(--paper-2); padding: 4px 0;
+  }
+  .event-flow .ef-row {
+    display: grid; grid-template-columns: 140px 1fr; gap: 16px;
+    padding: 10px 18px; border-bottom: 1px dashed var(--rule-soft);
+    align-items: baseline;
+  }
+  .event-flow .ef-row:last-child { border-bottom: none; }
+  .event-flow .ef-type {
+    font-family: var(--mono); font-size: 11px; font-weight: 600;
+    color: var(--accent); background: var(--accent-pale, #e8f0f8);
+    padding: 3px 8px; border-radius: 3px; display: inline-block;
+  }
+  .toc-group[data-phase="heart"] { border-left-color: var(--accent); background: linear-gradient(135deg, rgba(31,92,140,0.04) 0%, var(--paper) 60%); }
+  .toc-group[data-phase="llm"] { border-left-color: var(--gpu); background: linear-gradient(135deg, rgba(107,58,163,0.05) 0%, var(--paper) 60%); }
+  .toc-group[data-phase="tui"] { border-left-color: var(--asm); background: linear-gradient(135deg, rgba(45,106,79,0.04) 0%, var(--paper) 60%); }
+  .toc-group[data-phase="ext"] { border-left-color: var(--heat); background: linear-gradient(135deg, rgba(195,87,58,0.05) 0%, var(--paper) 60%); }
+  .toc-group[data-phase="persist"] { border-left-color: var(--copper); background: linear-gradient(135deg, rgba(179,90,31,0.05) 0%, var(--paper) 60%); }
+  .toc-group[data-phase="land"] { border-left-color: var(--gpu-soft); }
+  .toc-group[data-phase="card"] { border-left-color: var(--ink-mute); }
+  .perf-bar .pb-track { grid-template-columns: repeat(26, 1fr); }
+  .perf-bar .pb-cell.lit { transform: translateY(-2px); box-shadow: 0 0 0 2px rgba(31,92,140,0.45); }
+  #readProgress {
+    position: fixed; top: 0; left: 0; height: 2px; width: 0%;
+    background: linear-gradient(90deg, var(--copper), var(--accent));
+    z-index: 200; transition: width 0.08s linear;
+  }
+  .session-tree {
+    font-family: var(--mono); font-size: 11px; line-height: 1.7;
+    padding: 16px; background: var(--paper-2);
+  }
+  .session-tree .st-node { padding: 4px 0 4px 20px; border-left: 2px solid var(--rule); margin-left: 8px; }
+  .session-tree .st-leaf { color: var(--accent); font-weight: 700; }
+  .milestone-table td.owner-user { color: var(--copper); }
+  .milestone-table td.owner-model { color: var(--accent); }
+  .milestone-table td.owner-loop { color: var(--gpu); }
+  .milestone-table td.owner-tool { color: var(--asm); }
+  .milestone-table .owner-user { color: var(--copper); }
+  .milestone-table .owner-model { color: var(--accent); }
+  .milestone-table .owner-loop { color: var(--gpu); }
+  .milestone-table .owner-tool { color: var(--asm); }
+  .case-study {
+    margin: 22px 0; padding: 18px 20px;
+    background: var(--paper-2); border: 1px solid var(--rule);
+    border-left: 3px solid var(--accent); border-radius: 0 4px 4px 0;
+  }
+  .case-study .cs-tag {
+    font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.18em;
+    text-transform: uppercase; color: var(--accent); font-weight: 700; margin-bottom: 8px;
+  }
+  .case-study .cs-title {
+    font-family: var(--serif); font-size: 15px; font-weight: 700;
+    margin-bottom: 8px; color: var(--ink);
+  }
+  body.lang-en .case-study .cs-title { font-family: var(--serif-en); }
+  .sec-num {
+    font-family: var(--mono); font-size: 11px; letter-spacing: 0.06em;
+    color: var(--accent); font-weight: 700; margin-right: 6px;
+  }
+  .chap-compass {
+    margin: 0 0 28px; padding: 14px 18px;
+    background: var(--paper-2); border: 1px solid var(--rule);
+    border-left: 3px solid var(--accent); border-radius: 0 4px 4px 0;
+  }
+  .chap-compass .cc-row { display: flex; flex-wrap: wrap; align-items: center; gap: 8px 12px; }
+  .chap-compass .cc-row + .cc-row { margin-top: 10px; padding-top: 10px; border-top: 1px dashed var(--rule-soft); }
+  .chap-compass .cc-phase, .chap-compass .cc-chap, .chap-compass .cc-station {
+    font-family: var(--mono); font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase;
+  }
+  .chap-compass .cc-chap { color: var(--accent); font-weight: 700; }
+  .chap-compass .cc-sep { color: var(--ink-mute); }
+  .chap-compass .cc-forest-label {
+    font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.16em;
+    text-transform: uppercase; color: var(--ink-mute); margin-right: 8px;
+  }
+  .chap-compass .cc-forest-text { font-size: 13px; color: var(--ink-soft); }
+  .chap-compass .cc-links { justify-content: space-between; width: 100%; }
+  .chap-compass .cc-nav {
+    font-size: 12px; color: var(--ink-soft); text-decoration: none;
+    display: inline-flex; align-items: center; gap: 4px; max-width: 42%;
+  }
+  .chap-compass .cc-nav:hover { color: var(--accent); }
+  .chap-compass .cc-nav-num { font-family: var(--mono); font-weight: 700; }
+  .chap-compass .cc-back-map {
+    font-family: var(--mono); font-size: 10px; letter-spacing: 0.12em;
+    text-transform: uppercase; color: var(--copper); text-decoration: none;
+  }
+  .chap-compass .cc-back-map:hover { text-decoration: underline; }
+  .depth-zone {
+    margin: 32px 0 0; padding: 20px 0 0;
+    border-top: 2px solid var(--rule);
+  }
+  .depth-zone-label {
+    font-family: var(--mono); font-size: 10px; letter-spacing: 0.2em;
+    text-transform: uppercase; color: var(--ink-mute); margin-bottom: 20px;
+  }
+  .depth-zone-label .dz-tag {
+    color: var(--copper); font-weight: 700; margin-right: 8px;
+  }
+  .depth-zone h4.depth-sec {
+    font-size: 15px; margin-top: 24px;
+  }
+  .depth-aside-head {
+    margin: 28px 0 12px; padding: 10px 14px;
+    background: var(--paper-2); border: 1px solid var(--rule); border-radius: 4px;
+  }
+  .depth-aside-head .da-tag {
+    font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.16em;
+    text-transform: uppercase; color: var(--copper); font-weight: 700;
+  }
+  .depth-aside-head .da-title { font-size: 14px; font-weight: 600; color: var(--ink); }
+  .forest-overview {
+    margin: 48px 0 56px; padding: 32px 0 40px;
+    border-top: 2px solid var(--ink); border-bottom: 1px solid var(--rule);
+  }
+  .forest-overview .fo-label {
+    font-family: var(--mono); font-size: 10px; letter-spacing: 0.22em;
+    text-transform: uppercase; color: var(--ink-mute); margin-bottom: 12px;
+  }
+  .forest-overview .fo-title {
+    font-family: var(--serif); font-size: 28px; font-weight: 700;
+    margin-bottom: 16px; line-height: 1.2;
+  }
+  body.lang-en .forest-overview .fo-title { font-family: var(--serif-en); }
+  .forest-paths { margin: 28px 0; }
+  .forest-paths .fp-head {
+    font-family: var(--mono); font-size: 10px; letter-spacing: 0.18em;
+    text-transform: uppercase; color: var(--ink-mute); margin-bottom: 14px;
+  }
+  .forest-paths .fp-grid {
+    display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px;
+  }
+  @media (max-width: 800px) {
+    .forest-paths .fp-grid { grid-template-columns: 1fr; }
+  }
+  .forest-paths .fp-card {
+    display: block; padding: 16px 18px;
+    background: var(--paper); border: 1px solid var(--rule);
+    border-radius: 4px; text-decoration: none; color: inherit;
+    transition: border-color 0.15s, box-shadow 0.15s;
+  }
+  .forest-paths .fp-card:hover {
+    border-color: var(--accent); box-shadow: 0 2px 8px rgba(31,92,140,0.08);
+  }
+  .forest-paths .fp-card.fp-highlight { border-left: 3px solid var(--accent); }
+  .forest-paths .fp-tag {
+    font-family: var(--mono); font-size: 9px; letter-spacing: 0.14em;
+    text-transform: uppercase; color: var(--copper); margin-bottom: 6px;
+  }
+  .forest-paths .fp-title { font-size: 14px; font-weight: 700; margin-bottom: 6px; }
+  .forest-paths .fp-desc { font-size: 12px; color: var(--ink-mute); line-height: 1.5; }
+  .forest-overview .fo-legend {
+    margin-top: 24px; padding: 14px 16px;
+    background: var(--paper-2); border-radius: 4px;
+    font-size: 12.5px; color: var(--ink-soft); line-height: 1.6;
+  }
+  .card-filmstrip {
+    position: fixed; top: 0; left: 0; right: 0; z-index: 150;
+    background: rgba(253,251,243,0.96); border-bottom: 1px solid var(--rule);
+    backdrop-filter: blur(8px); transform: translateY(-100%);
+    transition: transform 0.25s ease; pointer-events: none;
+  }
+  .card-filmstrip.is-visible { transform: translateY(0); pointer-events: auto; }
+  .card-filmstrip .cf-inner { max-width: var(--max-w, 720px); margin: 0 auto; padding: 6px 16px 8px; }
+  .card-filmstrip .cf-header {
+    display: flex; justify-content: space-between; align-items: center;
+    font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.14em;
+    text-transform: uppercase; color: var(--ink-mute); margin-bottom: 4px;
+  }
+  .card-filmstrip .cf-header em { color: var(--accent); font-style: normal; font-weight: 700; }
+  .card-filmstrip .cf-track {
+    display: flex; gap: 4px; overflow-x: auto; padding-bottom: 2px;
+    scrollbar-width: thin;
+  }
+  .card-filmstrip .cf-cell {
+    flex: 0 0 auto; min-width: 36px; padding: 4px 6px;
+    text-align: center; text-decoration: none; color: var(--ink-mute);
+    border: 1px solid transparent; border-radius: 3px;
+    font-family: var(--mono); font-size: 10px; transition: all 0.12s;
+  }
+  .card-filmstrip .cf-cell:hover { border-color: var(--rule); color: var(--ink); }
+  .card-filmstrip .cf-cell.active {
+    border-color: var(--accent); background: var(--accent-pale, #e8f0f8);
+    color: var(--accent); font-weight: 700;
+  }
+  body.has-filmstrip { padding-top: 52px; }
+  body.has-filmstrip .ursb-backlink { top: 58px; }
+  .trace-walk {
+    margin: 36px 0; padding: 22px 24px 8px;
+    border: 2px solid var(--accent); border-radius: 4px;
+    background: linear-gradient(135deg, rgba(31,92,140,0.03) 0%, var(--paper) 50%);
+  }
+  .trace-walk .tw-head {
+    font-family: var(--mono); font-size: 11px; letter-spacing: 0.12em;
+    text-transform: uppercase; margin-bottom: 18px; line-height: 1.6;
+  }
+  .trace-walk .tw-tag {
+    display: block; color: var(--accent); font-weight: 700;
+    margin-bottom: 6px; letter-spacing: 0.18em;
+  }
+  .trace-walk .src-stack { margin: 16px 0 20px; }
+  .trace-walk .src-ln {
+    display: inline-block; width: 44px; text-align: right;
+    color: var(--ink-mute); user-select: none; margin-right: 8px;
+  }
+  .trace-walk .src-hl { font-family: var(--mono); font-size: 12px; }
+  .trace-steps { margin: 24px 0; }
+  .trace-steps .ts-label {
+    font-family: var(--mono); font-size: 10px; letter-spacing: 0.16em;
+    text-transform: uppercase; color: var(--copper); margin-bottom: 10px;
+  }
+
+</style>
+<script async defer src="https://analytics.ursb.me/script.js" data-website-id="aa8d5a16-df21-4058-a0a8-0191cdd3798d"></script>
+<style>
+
+.ursb-interactive { background: var(--bg-soft); border-top: 1px solid var(--rule); padding: 24px 24px 80px; position: relative; z-index: 2; }
+.ursb-interactive .ursb-fbody { max-width: 720px; margin: 0 auto; }
+.ui-divider { text-align: center; margin: 28px 0 28px; position: relative; }
+.ui-divider::before { content: ''; position: absolute; top: 50%; left: 0; right: 0; height: 1px; background: var(--rule); }
+.ui-divider-mark { position: relative; background: var(--bg-soft); padding: 0 18px; color: var(--accent); font-size: 14px; letter-spacing: 0.2em; }
+.ui-stats-row { display: flex; align-items: center; justify-content: center; gap: 6px; margin: 36px 0 56px; flex-wrap: wrap; }
+.ui-like, .ui-share, .ui-views {
+  display: inline-flex; align-items: center; gap: 9px;
+  padding: 9px 18px; border-radius: 999px;
+  background: transparent; border: 1px solid var(--rule);
+  font-family: var(--sans); font-size: 12.5px; font-weight: 500; color: var(--ink-mute); line-height: 1;
+  transition: all 0.18s ease;
+}
+.ui-like, .ui-share { cursor: pointer; }
+.ui-like:hover, .ui-share:hover { border-color: var(--accent-soft); color: var(--accent); background: rgba(31,92,140,0.04); }
+.ui-like:disabled, .ui-share:disabled, .ui-comment-form button:disabled { opacity: 0.55; cursor: wait; }
+.ui-like.liked { border-color: var(--accent); background: rgba(31,92,140,0.08); color: var(--accent); }
+.ui-like.liked svg { fill: var(--accent); stroke: var(--accent); }
+.ui-like.liked .ui-count { color: var(--accent); }
+.ui-views { cursor: default; color: var(--ink-mute); }
+.ui-views:hover { background: transparent; border-color: var(--rule); color: var(--ink-mute); }
+.ui-online {
+  display: inline-flex; align-items: center; gap: 9px;
+  padding: 9px 18px; border-radius: 999px;
+  background: rgba(34,197,94,0.06); border: 1px solid rgba(34,197,94,0.28);
+  font-family: var(--sans); font-size: 12.5px; font-weight: 500; color: #15803d; line-height: 1;
+  cursor: default; opacity: 0; transition: opacity 0.4s;
+}
+.ui-online.loaded { opacity: 1; }
+.ui-online .ui-count { color: #15803d; }
+.ui-online-dot {
+  display: inline-block; width: 6px; height: 6px; border-radius: 50%;
+  background: #22c55e; box-shadow: 0 0 0 0 rgba(34,197,94,0.55);
+  animation: ui-online-pulse 2s ease-in-out infinite;
+}
+@keyframes ui-online-pulse {
+  0%   { box-shadow: 0 0 0 0 rgba(34,197,94,0.55); }
+  70%  { box-shadow: 0 0 0 5px rgba(34,197,94,0); }
+  100% { box-shadow: 0 0 0 0 rgba(34,197,94,0); }
+}
+.ui-count { font-family: var(--serif); font-weight: 700; color: var(--ink); font-variant-numeric: tabular-nums; font-size: 13.5px; }
+.ui-count-small { font-family: var(--mono); font-size: 12px; color: var(--ink-mute); font-weight: 400; margin-left: 8px; }
+.ui-section-title { font-family: var(--serif); font-size: 20px; font-weight: 700; color: var(--ink); margin: 36px 0 14px; }
+.ui-comment-form { background: var(--paper); border: 1px solid var(--rule); border-radius: 6px; padding: 20px; margin-bottom: 32px; }
+.ui-form-row { display: grid; grid-template-columns: 1fr 1.5fr; gap: 10px; margin-bottom: 10px; }
+.ui-form-row input, .ui-comment-form textarea {
+  width: 100%; padding: 10px 12px; border: 1px solid var(--rule); border-radius: 4px;
+  font-size: 14px; font-family: var(--sans); color: var(--ink);
+  box-sizing: border-box; background: #fefcf6;
+}
+.ui-comment-form textarea { resize: vertical; min-height: 84px; line-height: 1.55; }
+.ui-form-row input:focus, .ui-comment-form textarea:focus { outline: none; border-color: var(--accent); box-shadow: 0 0 0 3px rgba(31,92,140,0.10); }
+.ui-form-foot { display: flex; justify-content: space-between; align-items: center; margin-top: 12px; gap: 12px; }
+.ui-form-status { font-size: 12px; color: var(--ink-mute); flex: 1; }
+.ui-form-status.error { color: var(--copper); }
+.ui-form-status.success { color: var(--good); font-weight: 600; }
+.ui-comment-form button[type="submit"] {
+  background: var(--ink); color: var(--paper); border: none; padding: 10px 22px; border-radius: 999px;
+  font-size: 13px; font-weight: 600; cursor: pointer; transition: all 0.2s; font-family: var(--sans);
+}
+.ui-comment-form button[type="submit"]:hover { background: var(--accent); }
+.ui-comment-loading, .ui-comment-empty { text-align: center; color: var(--ink-mute); padding: 36px 0; font-family: var(--serif); font-style: italic; font-size: 14px; }
+.ui-comment { padding: 18px 0; border-bottom: 1px solid var(--rule); }
+.ui-comment:last-child { border-bottom: none; }
+.ui-comment-head { display: flex; align-items: baseline; gap: 12px; margin-bottom: 6px; font-size: 13px; }
+.ui-comment-name { font-weight: 700; color: var(--ink); }
+.ui-comment-date { color: var(--ink-mute); font-family: var(--serif); font-size: 12px; }
+.ui-comment-body { color: var(--ink-soft); line-height: 1.65; font-size: 14px; white-space: pre-wrap; word-wrap: break-word; }
+@media (max-width: 768px) {
+  .ui-form-row { grid-template-columns: 1fr; }
+  .ui-stats-row { gap: 8px; }
+  .ui-like, .ui-share { padding: 8px 14px; font-size: 12px; }
+}
+  body:not(.lang-en) .ursb-fbody [lang="en"] { display: none !important; }
+  body.lang-en .ursb-fbody [lang="zh"] { display: none !important; }
+
+</style>
+</head>
+<body>
+<div id="readProgress" aria-hidden="true"></div>
+
+
+<a class="ursb-backlink" href="https://ursb.me/notes/dsh/">← ursb.me</a>
+<div class="lang-toggle" role="navigation" aria-label="language">
+  <button id="lang-zh" class="active" aria-pressed="true">中</button>
+  <span class="sep">/</span>
+  <button id="lang-en" aria-pressed="false">EN</button>
+</div>
+
+<nav class="card-filmstrip" id="card-filmstrip" aria-label="26 chapters">
+  <div class="cf-inner">
+    <div class="cf-header">
+      <span><span class="lang-zh-only">主线 · 26 章</span><span class="lang-en-only">Through-line · 26 chapters</span></span>
+      <span><em id="cf-current">C01</em>&nbsp;/&nbsp;26</span>
+    </div>
+    <div class="cf-track" id="cf-track">
+      <a href="#c1" class="cf-cell" data-chap="01"><span class="cf-num">01</span></a>
+      <a href="#c2" class="cf-cell" data-chap="02"><span class="cf-num">02</span></a>
+      <a href="#c3" class="cf-cell" data-chap="03"><span class="cf-num">03</span></a>
+      <a href="#c4" class="cf-cell" data-chap="04"><span class="cf-num">04</span></a>
+      <a href="#c5" class="cf-cell" data-chap="05"><span class="cf-num">05</span></a>
+      <a href="#c6" class="cf-cell" data-chap="06"><span class="cf-num">06</span></a>
+      <a href="#c7" class="cf-cell" data-chap="07"><span class="cf-num">07</span></a>
+      <a href="#c8" class="cf-cell" data-chap="08"><span class="cf-num">08</span></a>
+      <a href="#c9" class="cf-cell" data-chap="09"><span class="cf-num">09</span></a>
+      <a href="#c10" class="cf-cell" data-chap="10"><span class="cf-num">10</span></a>
+      <a href="#c11" class="cf-cell" data-chap="11"><span class="cf-num">11</span></a>
+      <a href="#c12" class="cf-cell" data-chap="12"><span class="cf-num">12</span></a>
+      <a href="#c13" class="cf-cell" data-chap="13"><span class="cf-num">13</span></a>
+      <a href="#c14" class="cf-cell" data-chap="14"><span class="cf-num">14</span></a>
+      <a href="#c15" class="cf-cell" data-chap="15"><span class="cf-num">15</span></a>
+      <a href="#c16" class="cf-cell" data-chap="16"><span class="cf-num">16</span></a>
+      <a href="#c17" class="cf-cell" data-chap="17"><span class="cf-num">17</span></a>
+      <a href="#c18" class="cf-cell" data-chap="18"><span class="cf-num">18</span></a>
+      <a href="#c19" class="cf-cell" data-chap="19"><span class="cf-num">19</span></a>
+      <a href="#c20" class="cf-cell" data-chap="20"><span class="cf-num">20</span></a>
+      <a href="#c21" class="cf-cell" data-chap="21"><span class="cf-num">21</span></a>
+      <a href="#c22" class="cf-cell" data-chap="22"><span class="cf-num">22</span></a>
+      <a href="#c23" class="cf-cell" data-chap="23"><span class="cf-num">23</span></a>
+      <a href="#c24" class="cf-cell" data-chap="24"><span class="cf-num">24</span></a>
+      <a href="#c25" class="cf-cell" data-chap="25"><span class="cf-num">25</span></a>
+      <a href="#c26" class="cf-cell" data-chap="26"><span class="cf-num">26</span></a>
+    </div>
+  </div>
+</nav>
+
+<nav class="toc-side" aria-label="Side contents">
+  <div class="toc-label">CONTENTS</div>
+  <ol>
+    <li class="ts-divider"><span class="lang-zh-only">背景</span><span class="lang-en-only">· · Background</span></li>
+    <li data-section="c3"><a href="#c3"><span class="toc-num">03</span><span class="lang-zh-only">deepseek-harness 家谱</span><span class="lang-en-only">The deepseek-harness family tree</span></a></li>
+    <li data-section="c4"><a href="#c4"><span class="toc-num">04</span><span class="lang-zh-only">Core spine 六层</span><span class="lang-en-only">The core-spine six layers</span></a></li>
+    <li data-section="c5"><a href="#c5"><span class="toc-num">05</span><span class="lang-zh-only">Everything is a plugin</span><span class="lang-en-only">Everything is a plugin</span></a></li>
+    <li data-section="c1"><a href="#c1"><span class="toc-num">01</span><span class="lang-zh-only">Harness 不是 Product</span><span class="lang-en-only">Harness is not a product</span></a></li>
+    <li data-section="c2"><a href="#c2"><span class="toc-num">02</span><span class="lang-zh-only">一条消息的 turn/step 全景</span><span class="lang-en-only">turn/step panorama for one message</span></a></li>
+    <li class="ts-divider"><span class="lang-zh-only">I · 入口</span><span class="lang-en-only">I · Intake</span></li>
+    <li data-section="c6"><a href="#c6"><span class="toc-num">06</span><span class="lang-zh-only">dsh 启动链</span><span class="lang-en-only">dsh boot chain</span></a></li>
+    <li data-section="c7"><a href="#c7"><span class="toc-num">07</span><span class="lang-zh-only">ctx.agents 生命周期</span><span class="lang-en-only">ctx.agents lifecycle</span></a></li>
+    <li data-section="c8"><a href="#c8"><span class="toc-num">08</span><span class="lang-zh-only">system-prompt 组装</span><span class="lang-en-only">System prompt assembly</span></a></li>
+    <li class="ts-divider"><span class="lang-zh-only">II · 心脏</span><span class="lang-en-only">II · Heart</span></li>
+    <li data-section="c9"><a href="#c9"><span class="toc-num">09</span><span class="lang-zh-only">Session log 不变量</span><span class="lang-en-only">Session log invariant</span></a></li>
+    <li data-section="c10"><a href="#c10"><span class="toc-num">10</span><span class="lang-zh-only">ReactLoopAgent 驱动</span><span class="lang-en-only">ReactLoopAgent driver</span></a></li>
+    <li data-section="c11"><a href="#c11"><span class="toc-num">11</span><span class="lang-zh-only">agent/pre-step 瀑布</span><span class="lang-en-only">agent/pre-step waterfall</span></a></li>
+    <li data-section="c12"><a href="#c12"><span class="toc-num">12</span><span class="lang-zh-only">Tool 执行管线</span><span class="lang-en-only">Tool execution pipeline</span></a></li>
+    <li data-section="c13"><a href="#c13"><span class="toc-num">13</span><span class="lang-zh-only">三域事件矩阵</span><span class="lang-en-only">Three-domain event matrix</span></a></li>
+    <li class="ts-divider"><span class="lang-zh-only">III · LLM</span><span class="lang-en-only">III · LLM</span></li>
+    <li data-section="c14"><a href="#c14"><span class="toc-num">14</span><span class="lang-zh-only">ctx.llm 适配层</span><span class="lang-en-only">ctx.llm adapter seam</span></a></li>
+    <li data-section="c15"><a href="#c15"><span class="toc-num">15</span><span class="lang-zh-only">assistant/chunk 流式</span><span class="lang-en-only">assistant/chunk streaming</span></a></li>
+    <li data-section="c16"><a href="#c16"><span class="toc-num">16</span><span class="lang-zh-only">deriveMessages 闭环</span><span class="lang-en-only">deriveMessages closed loop</span></a></li>
+    <li class="ts-divider"><span class="lang-zh-only">IV · Web</span><span class="lang-en-only">IV · Web</span></li>
+    <li data-section="c17"><a href="#c17"><span class="toc-num">17</span><span class="lang-zh-only">ctx.web 能力缝</span><span class="lang-en-only">ctx.web capability seam</span></a></li>
+    <li data-section="c18"><a href="#c18"><span class="toc-num">18</span><span class="lang-zh-only">tool-web Consumer</span><span class="lang-en-only">tool-web consumer</span></a></li>
+    <li class="ts-divider"><span class="lang-zh-only">V · 扩展</span><span class="lang-en-only">V · Extensions</span></li>
+    <li data-section="c19"><a href="#c19"><span class="toc-num">19</span><span class="lang-zh-only">Cordis 插件面</span><span class="lang-en-only">Cordis plugin surface</span></a></li>
+    <li data-section="c20"><a href="#c20"><span class="toc-num">20</span><span class="lang-zh-only">Loader 与 bundle</span><span class="lang-en-only">Loader and bundle</span></a></li>
+    <li data-section="c21"><a href="#c21"><span class="toc-num">21</span><span class="lang-zh-only">cordis.patch 组合</span><span class="lang-en-only">cordis.patch composition</span></a></li>
+    <li class="ts-divider"><span class="lang-zh-only">VI · 持久化</span><span class="lang-en-only">VI · Persistence</span></li>
+    <li data-section="c22"><a href="#c22"><span class="toc-num">22</span><span class="lang-zh-only">SessionEvent JSONL</span><span class="lang-en-only">SessionEvent JSONL</span></a></li>
+    <li data-section="c23"><a href="#c23"><span class="toc-num">23</span><span class="lang-zh-only">Compaction 与 surface</span><span class="lang-en-only">Compaction and surface replace</span></a></li>
+    <li class="ts-divider"><span class="lang-zh-only">VII · 全景</span><span class="lang-en-only">VII · Landscape</span></li>
+    <li data-section="c24"><a href="#c24"><span class="toc-num">24</span><span class="lang-zh-only">对比 Pi Harness</span><span class="lang-en-only">vs Pi harness</span></a></li>
+    <li data-section="c25"><a href="#c25"><span class="toc-num">25</span><span class="lang-zh-only">JSON-RPC 与 profiles</span><span class="lang-en-only">JSON-RPC and profiles</span></a></li>
+    <li class="ts-divider"><span class="lang-zh-only">Coda</span><span class="lang-en-only">∎ · Coda</span></li>
+    <li data-section="c26"><a href="#c26"><span class="toc-num">26</span><span class="lang-zh-only">怎么自己 trace 一轮</span><span class="lang-en-only">How to trace a turn yourself</span></a></li>
+  </ol>
+</nav>
+
+<div class="container">
+
+  <header class="hero">
+    <div class="meta">
+      <span>FIELD&nbsp;NOTE&nbsp;/&nbsp;11</span>
+      <span class="lang-zh-only">DeepSeek Harness · Cordis 插件</span>
+      <span class="lang-en-only">DeepSeek Harness · Cordis plugins</span>
+      <span>2026</span>
+    </div>
+    <h1 class="lang-zh-only">一条用户消息在<br><span class="copper">DeepSeek Harness</span>里的<span class="accent">一生</span>。</h1>
+    <h1 class="lang-en-only">The <span class="copper">life</span> of one user message<br>inside <span class="accent">DeepSeek Harness</span>.</h1>
+    <p class="subtitle lang-zh-only">Cordis plugins → ReactLoopAgent → turn/step → deriveMessages → tools → session log</p>
+    <p class="subtitle lang-en-only">Cordis plugins → ReactLoopAgent → turn/step → deriveMessages → tools → session log</p>
+    <p class="deck lang-zh-only">你在终端里敲下一行「读取 README.md，用一句话告诉我这个项目做什么」之后，这串文字要穿过 26 道工序、跨 Cordis 插件树与 core spine 六个包，在 session log 与 surface 投影里变形，最后才变成流式 chunk、tool/result 与磁盘上的 SessionEvent JSONL。对照 deepseek-harness 生产源码，用与 Pi 文章相同的主线 prompt，把 turn/step 边界、agent/pre-step 瀑布、事件三域、deriveMessages 不变量全摊开。</p>
+    <p class="deck lang-en-only">After you type «read README.md and tell me what this project does in one sentence», that string passes through 26 stations, crosses the Cordis plugin tree and six core-spine packages, morphs across session log and surface projection, and only then becomes streaming chunks, tool/result events, and SessionEvent JSONL on disk. Cross-reading deepseek-harness production source with the same through-line prompt as the Pi article — every turn/step boundary, agent/pre-step waterfall, three event domains, and deriveMessages invariant laid bare.</p>
+    <div class="byline">
+      <span><span class="label">AUTHOR</span><a class="value" href="https://ursb.me" target="_blank" rel="noopener">Airing</a></span>
+      <span><span class="label">SOURCE</span><span class="value">deepseek-ai/deepseek-harness · docs/</span></span>
+      <span><span class="label">FORMAT</span><span class="value">Long Read</span></span>
+    </div>
+
+    <aside class="hero-notice">
+      <div class="hn-tag">
+        <span class="lang-zh-only">这篇要解决什么</span>
+        <span class="lang-en-only">What this is for</span>
+      </div>
+      <p class="hn-body lang-zh-only">主线 prompt 固定为：<strong>「读取 README.md，用一句话告诉我这个项目做什么」</strong>——与 Pi 沉浸式文章相同，便于对照。这不是 DSH 的使用教程，而是<strong>把一条用户消息从 Web UI 回车追到 SessionEvent 落盘</strong>的源码级 walkthrough。对照生产仓库 <code>deepseek-ai/deepseek-harness</code> 与 <code>docs/architecture.md</code> 等官方文档，每一章对应一层 Cordis 抽象。</p>
+      <p class="hn-body lang-en-only">The through-line prompt is fixed: <strong>«read README.md and tell me what this project does in one sentence»</strong> — same as the Pi immersive article for comparison. This is not a DSH user guide but a <strong>source-level walkthrough from Enter to SessionEvent on disk</strong>. Cross-reading production <code>deepseek-ai/deepseek-harness</code> with official docs like <code>docs/architecture.md</code> — each chapter maps to one Cordis abstraction layer.</p>
+    </aside>
+
+    <aside class="tldr">
+      <div class="tldr-tag">
+        <span class="lang-zh-only">主线 · 七个里程碑</span>
+        <span class="lang-en-only">Through-line · seven milestones</span>
+      </div>
+      <div class="tldr-steps">
+        <div class="tldr-step">
+          <div class="tldr-step-n">01</div>
+          <div class="tldr-step-name lang-zh-only">用户消息</div>
+          <div class="tldr-step-name lang-en-only">user_message</div>
+          <div class="tldr-step-hint">owner=user</div>
+        </div>
+        <div class="tldr-step">
+          <div class="tldr-step-n">02</div>
+          <div class="tldr-step-name lang-zh-only">第一次 model</div>
+          <div class="tldr-step-name lang-en-only">model_start</div>
+          <div class="tldr-step-hint">turn=1 · toolUse</div>
+        </div>
+        <div class="tldr-step">
+          <div class="tldr-step-n">03</div>
+          <div class="tldr-step-name lang-zh-only">read 工具调用</div>
+          <div class="tldr-step-name lang-en-only">tool_start</div>
+          <div class="tldr-step-hint">call_1 · README</div>
+        </div>
+        <div class="tldr-step">
+          <div class="tldr-step-n">04</div>
+          <div class="tldr-step-name lang-zh-only">最终回答</div>
+          <div class="tldr-step-name lang-en-only">assistant stop</div>
+          <div class="tldr-step-hint">turn=2 · stopReason=stop</div>
+        </div>
+      </div>
+      <div class="tldr-skip">
+        <span class="lang-zh-only">已经懂 agent 基础? 直接跳到 → <a href="#c7">ctx.agents</a> · <a href="#c10">ReactLoopAgent</a> · <a href="#c14">ctx.llm</a> · <a href="#c17">Web UI</a> · <a href="#c22">SessionEvent</a> · <a href="#c24">vs Pi</a></span>
+        <span class="lang-en-only">Know agent basics? Skip to → <a href="#c7">ctx.agents</a> · <a href="#c10">ReactLoopAgent</a> · <a href="#c14">ctx.llm</a> · <a href="#c17">Web UI</a> · <a href="#c22">SessionEvent</a> · <a href="#c24">vs Pi</a></span>
+      </div>
+    </aside>
+
+    <div class="perf-bar">
+      <div class="pb-title">
+        <span class="lang-zh-only">一条用户消息 · 26 个站</span>
+        <span class="lang-en-only">One user message · 26 stations</span>
+        <span class="pb-pulse">▸ live trace</span>
+      </div>
+      <div class="pb-track" id="pbTrack">
+        <div class="pb-cell p0" data-n="01" data-jump="#c1" title="C01 Harness 不是 Product"></div>
+        <div class="pb-cell p0" data-n="02" data-jump="#c2" title="C02 一条消息的 turn/step 全景"></div>
+        <div class="pb-cell p1" data-n="03" data-jump="#c3" title="C03 deepseek-harness 家谱"></div>
+        <div class="pb-cell p1" data-n="04" data-jump="#c4" title="C04 Core spine 六层"></div>
+        <div class="pb-cell p1" data-n="05" data-jump="#c5" title="C05 Everything is a plugin"></div>
+        <div class="pb-cell p2" data-n="06" data-jump="#c6" title="C06 dsh 启动链"></div>
+        <div class="pb-cell p2" data-n="07" data-jump="#c7" title="C07 ctx.agents 生命周期"></div>
+        <div class="pb-cell p2" data-n="08" data-jump="#c8" title="C08 system-prompt 组装"></div>
+        <div class="pb-cell p3" data-n="09" data-jump="#c9" title="C09 Session log 不变量"></div>
+        <div class="pb-cell p3" data-n="10" data-jump="#c10" title="C10 ReactLoopAgent 驱动"></div>
+        <div class="pb-cell p3" data-n="11" data-jump="#c11" title="C11 agent/pre-step 瀑布"></div>
+        <div class="pb-cell p3" data-n="12" data-jump="#c12" title="C12 Tool 执行管线"></div>
+        <div class="pb-cell p3" data-n="13" data-jump="#c13" title="C13 三域事件矩阵"></div>
+        <div class="pb-cell p4" data-n="14" data-jump="#c14" title="C14 ctx.llm 适配层"></div>
+        <div class="pb-cell p4" data-n="15" data-jump="#c15" title="C15 assistant/chunk 流式"></div>
+        <div class="pb-cell p4" data-n="16" data-jump="#c16" title="C16 deriveMessages 闭环"></div>
+        <div class="pb-cell p5" data-n="17" data-jump="#c17" title="C17 ctx.web 能力缝"></div>
+        <div class="pb-cell p5" data-n="18" data-jump="#c18" title="C18 tool-web Consumer"></div>
+        <div class="pb-cell p6" data-n="19" data-jump="#c19" title="C19 Cordis 插件面"></div>
+        <div class="pb-cell p6" data-n="20" data-jump="#c20" title="C20 Loader 与 bundle"></div>
+        <div class="pb-cell p6" data-n="21" data-jump="#c21" title="C21 cordis.patch 组合"></div>
+        <div class="pb-cell p7" data-n="22" data-jump="#c22" title="C22 SessionEvent JSONL"></div>
+        <div class="pb-cell p7" data-n="23" data-jump="#c23" title="C23 Compaction 与 surface"></div>
+        <div class="pb-cell p8" data-n="24" data-jump="#c24" title="C24 对比 Pi Harness"></div>
+        <div class="pb-cell p8" data-n="25" data-jump="#c25" title="C25 JSON-RPC 与 profiles"></div>
+        <div class="pb-cell pc" data-n="26" data-jump="#c26" title="C26 怎么自己 trace 一轮"></div>
+      </div>
+      <div class="pb-axis">
+        <span class="lang-zh-only">回车</span><span class="lang-en-only">Enter</span>
+        <span></span><span></span><span></span><span></span><span></span>
+        <span class="lang-zh-only">JSONL</span><span class="lang-en-only">JSONL</span>
+      </div>
+    </div>
+  </header>
+
+  <nav class="toc-v2" aria-label="Contents">
+    <div class="tv-head">
+      <div class="tv-label lang-zh-only">CONTENTS · 目录</div>
+      <div class="tv-label lang-en-only">CONTENTS</div>
+      <div class="tv-meta"><span class="tv-now">26</span> <span class="lang-zh-only">章 · 8 个 Phase + Coda</span><span class="lang-en-only">chapters · 8 phases + coda</span></div>
+    </div>
+    <div class="tv-sub lang-zh-only">「<em>读取 README.md，用一句话告诉我这个项目做什么</em>」· 26 个站。点任意一格跳转。</div>
+    <div class="tv-sub lang-en-only">«<em>read README.md and tell me what this project does in one sentence</em>» · 26 stations. Click any chip.</div>
+
+    <div class="toc-group" data-phase="card">
+      <div class="toc-group-head">
+        <div class="tg-num">·</div>
+        <div class="tg-name lang-zh-only">背景</div>
+        <div class="tg-name lang-en-only">Background</div>
+        <div class="tg-count">3</div>
+      </div>
+      <div class="tg-en">3 chapters · monorepo</div>
+      <div class="toc-chips">
+        <a href="#c3" class="toc-chip"><span class="tc-num">03</span><div class="tc-name"><span class="lang-zh-only">deepseek-harness 家谱</span><span class="lang-en-only">The deepseek-harness family tree</span><span class="tc-en">DeepSeek AI · Cordis · vendor/</span></div></a>
+        <a href="#c4" class="toc-chip"><span class="tc-num">04</span><div class="tc-name"><span class="lang-zh-only">Core spine 六层</span><span class="lang-en-only">The core-spine six layers</span><span class="tc-en">session · system-prompt · tools · agent · agent-loop · llm</span></div></a>
+        <a href="#c5" class="toc-chip tc-special"><span class="tc-num">05</span><div class="tc-name"><span class="lang-zh-only">Everything is a plugin</span><span class="lang-en-only">Everything is a plugin</span><span class="tc-en">no privileged core · Cordis composition only</span></div></a>
+      </div>
+    </div>
+    <div class="toc-group" data-phase="bg">
+      <div class="toc-group-head">
+        <div class="tg-num">0</div>
+        <div class="tg-name lang-zh-only">引子</div>
+        <div class="tg-name lang-en-only">Prologue</div>
+        <div class="tg-count">2</div>
+      </div>
+      <div class="tg-en">2 chapters · framing</div>
+      <div class="toc-chips">
+        <a href="#c1" class="toc-chip"><span class="tc-num">01</span><div class="tc-name"><span class="lang-zh-only">Harness 不是 Product</span><span class="lang-en-only">Harness is not a product</span><span class="tc-en">a third path in the agent product war</span></div></a>
+        <a href="#c2" class="toc-chip"><span class="tc-num">02</span><div class="tc-name"><span class="lang-zh-only">一条消息的 turn/step 全景</span><span class="lang-en-only">turn/step panorama for one message</span><span class="tc-en">from Enter to session log, the full map</span></div></a>
+      </div>
+    </div>
+    <div class="toc-group" data-phase="in">
+      <div class="toc-group-head">
+        <div class="tg-num">I</div>
+        <div class="tg-name lang-zh-only">入口</div>
+        <div class="tg-name lang-en-only">Intake</div>
+        <div class="tg-count">3</div>
+      </div>
+      <div class="tg-en">3 chapters · boot to context</div>
+      <div class="toc-chips">
+        <a href="#c6" class="toc-chip"><span class="tc-num">06</span><div class="tc-name"><span class="lang-zh-only">dsh 启动链</span><span class="lang-en-only">dsh boot chain</span><span class="tc-en">profile → bundle → Loader → ctx</span></div></a>
+        <a href="#c7" class="toc-chip"><span class="tc-num">07</span><div class="tc-name"><span class="lang-zh-only">ctx.agents 生命周期</span><span class="lang-en-only">ctx.agents lifecycle</span><span class="tc-en">create · resume · dispose · scoped ctx</span></div></a>
+        <a href="#c8" class="toc-chip"><span class="tc-num">08</span><div class="tc-name"><span class="lang-zh-only">system-prompt 组装</span><span class="lang-en-only">System prompt assembly</span><span class="tc-en">section waterfall · tool schemas into model</span></div></a>
+      </div>
+    </div>
+    <div class="toc-group" data-phase="heart">
+      <div class="toc-group-head">
+        <div class="tg-num">II</div>
+        <div class="tg-name lang-zh-only">心脏</div>
+        <div class="tg-name lang-en-only">Heart</div>
+        <div class="tg-count">5</div>
+      </div>
+      <div class="tg-en">5 chapters · ReactLoopAgent</div>
+      <div class="toc-chips">
+        <a href="#c9" class="toc-chip tc-special"><span class="tc-num">09</span><div class="tc-name"><span class="lang-zh-only">Session log 不变量</span><span class="lang-en-only">Session log invariant</span><span class="tc-en">deriveMessages · surfaceOp · model-visible means logged</span></div></a>
+        <a href="#c10" class="toc-chip tc-special"><span class="tc-num">10</span><div class="tc-name"><span class="lang-zh-only">ReactLoopAgent 驱动</span><span class="lang-en-only">ReactLoopAgent driver</span><span class="tc-en">wakeDriver · turn/start · step/start</span></div></a>
+        <a href="#c11" class="toc-chip"><span class="tc-num">11</span><div class="tc-name"><span class="lang-zh-only">agent/pre-step 瀑布</span><span class="lang-en-only">agent/pre-step waterfall</span><span class="tc-en">claim inbox · inject context · reject turn</span></div></a>
+        <a href="#c12" class="toc-chip"><span class="tc-num">12</span><div class="tc-name"><span class="lang-zh-only">Tool 执行管线</span><span class="lang-en-only">Tool execution pipeline</span><span class="tc-en">executeToolCalls · parallel barrier · model order</span></div></a>
+        <a href="#c13" class="toc-chip"><span class="tc-num">13</span><div class="tc-name"><span class="lang-zh-only">三域事件矩阵</span><span class="lang-en-only">Three-domain event matrix</span><span class="tc-en">session · agent · capability events</span></div></a>
+      </div>
+    </div>
+    <div class="toc-group" data-phase="llm">
+      <div class="toc-group-head">
+        <div class="tg-num">III</div>
+        <div class="tg-name lang-zh-only">LLM</div>
+        <div class="tg-name lang-en-only">LLM</div>
+        <div class="tg-count">3</div>
+      </div>
+      <div class="tg-en">3 chapters · ctx.llm</div>
+      <div class="toc-chips">
+        <a href="#c14" class="toc-chip"><span class="tc-num">14</span><div class="tc-name"><span class="lang-zh-only">ctx.llm 适配层</span><span class="lang-en-only">ctx.llm adapter seam</span><span class="tc-en">prepareCall · llm/stream · adapter boundary</span></div></a>
+        <a href="#c15" class="toc-chip"><span class="tc-num">15</span><div class="tc-name"><span class="lang-zh-only">assistant/chunk 流式</span><span class="lang-en-only">assistant/chunk streaming</span><span class="tc-en">BlockAssembler · chunk seq · message finalize</span></div></a>
+        <a href="#c16" class="toc-chip"><span class="tc-num">16</span><div class="tc-name"><span class="lang-zh-only">deriveMessages 闭环</span><span class="lang-en-only">deriveMessages closed loop</span><span class="tc-en">boundaryMessages → request · reconstructability</span></div></a>
+      </div>
+    </div>
+    <div class="toc-group" data-phase="web">
+      <div class="toc-group-head">
+        <div class="tg-num">IV</div>
+        <div class="tg-name lang-zh-only">Web</div>
+        <div class="tg-name lang-en-only">Web</div>
+        <div class="tg-count">2</div>
+      </div>
+      <div class="tg-en">2 chapters · search & fetch</div>
+      <div class="toc-chips">
+        <a href="#c17" class="toc-chip tc-special"><span class="tc-num">17</span><div class="tc-name"><span class="lang-zh-only">ctx.web 能力缝</span><span class="lang-en-only">ctx.web capability seam</span><span class="tc-en">search · fetch · Service Definition</span></div></a>
+        <a href="#c18" class="toc-chip"><span class="tc-num">18</span><div class="tc-name"><span class="lang-zh-only">tool-web Consumer</span><span class="lang-en-only">tool-web consumer</span><span class="tc-en">last station before the model hits the network</span></div></a>
+      </div>
+    </div>
+    <div class="toc-group" data-phase="ext">
+      <div class="toc-group-head">
+        <div class="tg-num">V</div>
+        <div class="tg-name lang-zh-only">扩展</div>
+        <div class="tg-name lang-en-only">Extensions</div>
+        <div class="tg-count">3</div>
+      </div>
+      <div class="tg-en">3 chapters · Cordis plugins</div>
+      <div class="toc-chips">
+        <a href="#c19" class="toc-chip"><span class="tc-num">19</span><div class="tc-name"><span class="lang-zh-only">Cordis 插件面</span><span class="lang-en-only">Cordis plugin surface</span><span class="tc-en">inject · Service · Events · effects</span></div></a>
+        <a href="#c20" class="toc-chip"><span class="tc-num">20</span><div class="tc-name"><span class="lang-zh-only">Loader 与 bundle</span><span class="lang-en-only">Loader and bundle</span><span class="tc-en">dsh-base · web-app · headless stack</span></div></a>
+        <a href="#c21" class="toc-chip"><span class="tc-num">21</span><div class="tc-name"><span class="lang-zh-only">cordis.patch 组合</span><span class="lang-en-only">cordis.patch composition</span><span class="tc-en">replace any plugin row · --dump-config</span></div></a>
+      </div>
+    </div>
+    <div class="toc-group" data-phase="persist">
+      <div class="toc-group-head">
+        <div class="tg-num">VI</div>
+        <div class="tg-name lang-zh-only">持久化</div>
+        <div class="tg-name lang-en-only">Persistence</div>
+        <div class="tg-count">2</div>
+      </div>
+      <div class="tg-en">2 chapters · JSONL + compaction</div>
+      <div class="toc-chips">
+        <a href="#c22" class="toc-chip tc-special"><span class="tc-num">22</span><div class="tc-name"><span class="lang-zh-only">SessionEvent JSONL</span><span class="lang-en-only">SessionEvent JSONL</span><span class="tc-en">contiguous seq · fork · session/flush</span></div></a>
+        <a href="#c23" class="toc-chip"><span class="tc-num">23</span><div class="tc-name"><span class="lang-zh-only">Compaction 与 surface</span><span class="lang-en-only">Compaction and surface replace</span><span class="tc-en">log kept · surface replace rebuilds context</span></div></a>
+      </div>
+    </div>
+    <div class="toc-group" data-phase="land">
+      <div class="toc-group-head">
+        <div class="tg-num">VII</div>
+        <div class="tg-name lang-zh-only">全景</div>
+        <div class="tg-name lang-en-only">Landscape</div>
+        <div class="tg-count">2</div>
+      </div>
+      <div class="tg-en">2 chapters · ecosystem</div>
+      <div class="toc-chips">
+        <a href="#c24" class="toc-chip"><span class="tc-num">24</span><div class="tc-name"><span class="lang-zh-only">对比 Pi Harness</span><span class="lang-en-only">vs Pi harness</span><span class="tc-en">turn/step vs runLoop twin loops</span></div></a>
+        <a href="#c25" class="toc-chip"><span class="tc-num">25</span><div class="tc-name"><span class="lang-zh-only">JSON-RPC 与 profiles</span><span class="lang-en-only">JSON-RPC and profiles</span><span class="tc-en">web · headless · Python SDK</span></div></a>
+      </div>
+    </div>
+    <div class="toc-group" data-phase="coda">
+      <div class="toc-group-head">
+        <div class="tg-num">∎</div>
+        <div class="tg-name lang-zh-only">Coda</div>
+        <div class="tg-name lang-en-only">Coda</div>
+        <div class="tg-count">1</div>
+      </div>
+      <div class="tg-en">trace it yourself</div>
+      <div class="toc-chips">
+        <a href="#c26" class="toc-chip"><span class="tc-num">26</span><div class="tc-name"><span class="lang-zh-only">怎么自己 trace 一轮</span><span class="lang-en-only">How to trace a turn yourself</span><span class="tc-en">session/event · event map · --dump-config</span></div></a>
+      </div>
+    </div>
+  </nav>
+
+  <section class="forest-overview" id="forest-overview">
+    <div class="fo-label">
+      <span class="lang-zh-only">OVERVIEW · 森林图</span>
+      <span class="lang-en-only">OVERVIEW · Forest map</span>
+    </div>
+    <h2 class="fo-title lang-zh-only">先见森林，再见树木</h2>
+    <h2 class="fo-title lang-en-only">See the forest before the trees</h2>
+    <div class="lang-zh-only"><p>全文 26 章不是平铺的百科条目，而是一条<strong>固定主线 prompt</strong>从 Web UI 回车追到 SessionEvent 落盘的流水线。下面这张图是望远镜：告诉你 Phase 在哪、章节密度在哪、心脏区（ReactLoopAgent + tools）在哪。</p></div>
+    <div class="lang-en-only"><p>All 26 chapters are not a flat encyclopedia — they are a pipeline tracing one <strong>fixed through-line prompt</strong> from Enter to SessionEvent on disk. The diagram below is the telescope: where phases sit, where chapter density peaks, where the heart (ReactLoopAgent + tools) lives.</p></div>
+    <figure>
+      <div class="figbox"><div class="pi-fig wide panorama"><svg viewBox="0 0 720 290" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true" class="pi-svg">
+  <defs>
+    <marker id="pi-arr" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 Z" fill="#1f5c8c"/>
+    </marker>
+  </defs>
+  <text x="360" y="22" text-anchor="middle" class="svg-label">一条用户消息 · 8 PHASES · 26 CHAPTERS</text>
+
+  <!-- phase columns -->
+  <rect x="16" y="36" width="88" height="200" rx="3" class="svg-box muted"/>
+  <text x="60" y="54" text-anchor="middle" class="svg-micro" font-weight="700">0 引子</text>
+  <text x="60" y="72" text-anchor="middle" class="svg-tiny">C01–02</text>
+  <text x="60" y="100" text-anchor="middle" class="svg-body">心智</text>
+  <text x="60" y="118" text-anchor="middle" class="svg-body">22 站图</text>
+
+  <rect x="108" y="36" width="72" height="200" rx="3" class="svg-box paper"/>
+  <text x="144" y="54" text-anchor="middle" class="svg-micro" font-weight="700">· 背景</text>
+  <text x="144" y="72" text-anchor="middle" class="svg-tiny">C03–05</text>
+
+  <rect x="184" y="36" width="72" height="200" rx="3" class="svg-box accent"/>
+  <text x="220" y="54" text-anchor="middle" class="svg-micro" font-weight="700">I 入口</text>
+  <text x="220" y="72" text-anchor="middle" class="svg-tiny">C06–08</text>
+  <text x="220" y="100" text-anchor="middle" class="svg-body">dsh web</text>
+  <text x="220" y="118" text-anchor="middle" class="svg-body">ctx.*</text>
+
+  <rect x="260" y="36" width="88" height="200" rx="3" fill="#fde8e4" stroke="#c3573a" stroke-width="1.5"/>
+  <text x="304" y="54" text-anchor="middle" class="svg-micro" font-weight="700" fill="#c3573a">II 心脏</text>
+  <text x="304" y="72" text-anchor="middle" class="svg-tiny">C09–13</text>
+  <text x="304" y="100" text-anchor="middle" class="svg-body">turn/step</text>
+  <text x="304" y="118" text-anchor="middle" class="svg-body">tools</text>
+  <text x="304" y="136" text-anchor="middle" class="svg-body">events</text>
+
+  <rect x="352" y="36" width="72" height="200" rx="3" class="svg-box gpu"/>
+  <text x="388" y="54" text-anchor="middle" class="svg-micro" font-weight="700">III LLM</text>
+  <text x="388" y="72" text-anchor="middle" class="svg-tiny">C14–16</text>
+
+  <rect x="428" y="36" width="72" height="200" rx="3" class="svg-box asm"/>
+  <text x="464" y="54" text-anchor="middle" class="svg-micro" font-weight="700">IV Web</text>
+  <text x="464" y="72" text-anchor="middle" class="svg-tiny">C17–18</text>
+
+  <rect x="504" y="36" width="72" height="200" rx="3" class="svg-box copper"/>
+  <text x="540" y="54" text-anchor="middle" class="svg-micro" font-weight="700">V 扩展</text>
+  <text x="540" y="72" text-anchor="middle" class="svg-tiny">C19–21</text>
+
+  <rect x="580" y="36" width="60" height="200" rx="3" class="svg-box muted"/>
+  <text x="610" y="54" text-anchor="middle" class="svg-micro" font-weight="700">VI</text>
+  <text x="610" y="72" text-anchor="middle" class="svg-tiny">C22–23</text>
+
+  <rect x="644" y="36" width="60" height="200" rx="3" class="svg-box paper"/>
+  <text x="674" y="54" text-anchor="middle" class="svg-micro" font-weight="700">VII</text>
+  <text x="674" y="72" text-anchor="middle" class="svg-tiny">C24–25</text>
+
+  <!-- through-line arrow -->
+  <path d="M40 250 L680 250" stroke="#1f5c8c" stroke-width="2" marker-end="url(#pi-arr)"/>
+  <text x="360" y="272" text-anchor="middle" class="svg-mute">Enter → turn/start → read → tool/result → deriveMessages → session log</text>
+
+  <!-- highlight heart -->
+  <rect x="268" y="148" width="72" height="28" rx="2" fill="none" stroke="#c3573a" stroke-width="2" stroke-dasharray="4 2"/>
+  <text x="304" y="166" text-anchor="middle" class="svg-micro" fill="#c3573a">主线最密区</text>
+</svg></div></div>
+      <figcaption>
+        <span class="figid">FIG</span>
+        <span class="lang-zh-only">森林图：8 个 Phase 把 26 章串成一条线；Phase II（心脏）是 ReactLoopAgent 与工具执行最密集的区域。</span>
+        <span class="lang-en-only">Forest map: 8 phases string 26 chapters; Phase II (Heart) is the densest ReactLoopAgent + tool region.</span>
+      </figcaption>
+    </figure>
+    <div class="forest-paths">
+      <div class="fp-head">
+        <span class="lang-zh-only">三条阅读路径</span>
+        <span class="lang-en-only">Three reading paths</span>
+      </div>
+      <div class="fp-grid">
+        <a href="#c2" class="fp-card">
+          <div class="fp-tag lang-zh-only">路径 A · 先看森林</div>
+          <div class="fp-tag lang-en-only">Path A · Forest first</div>
+          <div class="fp-title lang-zh-only">C02 22 站全景 → 按需跳章</div>
+          <div class="fp-title lang-en-only">C02 22-station map → jump as needed</div>
+          <div class="fp-desc lang-zh-only">适合已懂 agent 基础、想先建立全局心智模型的读者。</div>
+          <div class="fp-desc lang-en-only">For readers who know agent basics and want the global map first.</div>
+        </a>
+        <a href="#c7" class="fp-card fp-highlight">
+          <div class="fp-tag lang-zh-only">路径 B · 直奔心脏</div>
+          <div class="fp-tag lang-en-only">Path B · Straight to heart</div>
+          <div class="fp-title lang-zh-only">C07 ctx.agents → C10 ReactLoopAgent → C14 ctx.llm</div>
+          <div class="fp-title lang-en-only">C07 ctx.agents → C10 ReactLoopAgent → C14 ctx.llm</div>
+          <div class="fp-desc lang-zh-only">最短源码路径：从 send() 追到 llm/stream。</div>
+          <div class="fp-desc lang-en-only">Shortest source path: send() to llm/stream.</div>
+        </a>
+        <a href="#c26" class="fp-card">
+          <div class="fp-tag lang-zh-only">路径 C · 动手 trace</div>
+          <div class="fp-tag lang-en-only">Path C · Hands-on trace</div>
+          <div class="fp-title lang-zh-only">dsh web → session/event → --dump-config</div>
+          <div class="fp-title lang-en-only">dsh web → session/event → --dump-config</div>
+          <div class="fp-desc lang-zh-only">边跑 DSH 边对照本文章节，最后读 C26 自查清单。</div>
+          <div class="fp-desc lang-en-only">Run DSH alongside chapters; finish with C26 checklist.</div>
+        </a>
+      </div>
+    </div>
+    <div class="fo-legend">
+      <span class="lang-zh-only"><strong>标题层级约定：</strong>每章仅一个 <code>h2</code> 章标题；正文小节为 <code>C07.1</code> 式编号；「深度细读」块内为 <code>C07.4+</code>，FAQ / Case Study 不再占用标题层级。</span>
+      <span class="lang-en-only"><strong>Heading convention:</strong> one <code>h2</code> chapter title; body sections numbered <code>C07.1</code>; deep-dive block uses <code>C07.4+</code>; FAQ / Case Study use labels, not headings.</span>
+    </div>
+  </section>
+
+  <section class="chap" id="c1">
+    <div class="chap-num">CHAPTER&nbsp;01&nbsp;·&nbsp;引子</div>
+    <h2 class="chap-title lang-zh-only">Harness 不是 Product</h2>
+    <h2 class="chap-title lang-en-only">Harness is not a product</h2>
+    <p class="chap-en lang-zh-only">agent 产品战争里的第三条路</p>
+    <p class="chap-en lang-en-only">a third path in the agent product war</p>
+    <nav class="chapter-compass" aria-label="Chapter navigation">
+      <div class="cc-row">
+        <div class="cc-phase"><span class="cc-roman">0</span> · <span class="lang-zh-only">引子</span><span class="lang-en-only">Prologue</span></div>
+        <div class="cc-station"><span class="lang-zh-only">站 00</span><span class="lang-en-only">St. 00</span> · C01/26</div>
+      </div>
+      <div class="cc-forest"><span class="lang-zh-only">森林入口：Harness ≠ Product</span><span class="lang-en-only">Forest entry: Harness ≠ Product</span></div>
+      <div class="cc-links">
+        
+        <a class="cc-map" href="#forest-overview"><span class="lang-zh-only">回到总览</span><span class="lang-en-only">Forest map</span></a>
+        <a class="cc-nav cc-next" href="#c2"><span class="cc-nav-num">C02</span> <span class="lang-zh-only">一条消息的 turn/step 全景</span><span class="lang-en-only">turn/step panorama for one message</span> <span class="cc-arrow">→</span></a>
+      </div>
+    </nav>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>本章回答「这条主线 prompt 在此层长什么样」</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH 没有隐藏魔法——一切可替换行为都在 Cordis 事件或 SessionEvent 里</span></p>
+      <p><span class="swc-pill act">优化</span><span>读源码时先搜 session.append 与 ctx.* 注册点</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>This chapter answers what the through-line prompt looks like at this layer</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH has no hidden magic — replaceable behavior lives in Cordis events or SessionEvents</span></p>
+      <p><span class="swc-pill act">优化</span><span>When reading source, search session.append and ctx.* registration first</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">引子</span><span class="lang-en-only">Prologue</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">docs/</span><span class="lang-en-only">docs/</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">用户回车</span><span class="lang-en-only">user Enter</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">harness 心智</span><span class="lang-en-only">harness mindset</span></div>
+      </div>
+    </div>
+
+    <div class="lang-zh-only"><p>DeepSeek Harness（DSH）不是又一个 ChatGPT 套壳——它是 DeepSeek 开源的 <strong>Cordis 插件 harness</strong>。主线 prompt <code>读取 README.md，用一句话告诉我这个项目做什么</code> 在 DSH 里不会「直接发给模型」：它先进入 <code>ctx.agents</code> 的 inbox，被 <code>ReactLoopAgent</code> 认领，写成 <code>user/message</code> SessionEvent，再经 <code>deriveMessages()</code> 投影成 LLM 请求。</p></div>
+    <div class="lang-en-only"><p>DeepSeek Harness (DSH) is not another ChatGPT wrapper — it is DeepSeek's open <strong>Cordis plugin harness</strong>. The through-line prompt <code>read README.md and tell me what this project does in one sentence</code> never goes straight to the model: it enters <code>ctx.agents</code> inbox, is claimed by <code>ReactLoopAgent</code>, logged as <code>user/message</code> SessionEvent, then projected via <code>deriveMessages()</code> into an LLM request.</p></div>
+
+    <h3 class="sub"><span class="sec-num">C01.1</span> <span class="lang-zh-only">Harness 不是 Product</span><span class="lang-en-only">Harness is not a product</span></h3>
+
+    <div class="lang-zh-only"><p>Claude Code、Cursor 把 agent 循环焊进密封二进制：你能用，但很难逐事件 trace。Pi 把循环写进 TypeScript，但故意省略 MCP 与子 agent。DSH 的赌注是：<strong>一切都是插件</strong>——包括 agent loop 本身——同时保留 MCP、compaction、fork/resume、Agent Teams。</p></div>
+    <div class="lang-en-only"><p>Claude Code and Cursor weld the agent loop into sealed binaries: usable, but hard to trace event-by-event. Pi writes the loop in TypeScript but intentionally omits MCP and sub-agents. DSH bets that <strong>everything is a plugin</strong> — including the agent loop itself — while keeping MCP, compaction, fork/resume, and Agent Teams.</p></div>
+
+    <div class="stage-purpose">
+      <div class="sp-row">
+        <div class="sp-key"><span class="lang-zh-only">产品</span><span class="lang-en-only">Product</span></div>
+        <div class="sp-val"><span class="lang-zh-only">卖体验闭环：安装 → 第一次 commit 零配置</span><span class="lang-en-only">Sells closed-loop UX: install → first commit with zero config</span></div>
+      </div>
+      <div class="sp-row">
+        <div class="sp-key"><span class="lang-zh-only">Harness</span><span class="lang-en-only">Harness</span></div>
+        <div class="sp-val"><span class="lang-zh-only">卖可观测编排：每一站都有源码、测试、dump-config</span><span class="lang-en-only">Sells observable orchestration: every station has source, tests, dump-config</span></div>
+      </div>
+      <div class="sp-row">
+        <div class="sp-key"><span class="lang-zh-only">DSH 差异</span><span class="lang-en-only">DSH difference</span></div>
+        <div class="sp-val"><span class="lang-zh-only">无 privileged core；改行为 = 挂插件或写 patch</span><span class="lang-en-only">No privileged core; change behavior = mount plugin or write patch</span></div>
+      </div>
+      <div class="sp-row">
+        <div class="sp-key"><span class="lang-zh-only">主线</span><span class="lang-en-only">Through-line</span></div>
+        <div class="sp-val"><span class="lang-zh-only">同一句话走完整 turn/step + tool pipeline</span><span class="lang-en-only">Same sentence walks full turn/step + tool pipeline</span></div>
+      </div>
+    </div>
+
+    <div class="formula">
+      <div class="ftitle"><span class="lang-zh-only">架构公式</span><span class="lang-en-only">ARCHITECTURE</span></div>
+      <span class="cond"><span class="term">Product</span> = UX × Integrations × Policy</span>
+      <span class="cond"><span class="term-cu">DSH</span> = Cordis × SessionEvent × ReactLoopAgent × Seams</span>
+      <div class="out"><span class="lang-zh-only">DSH 选择可组合 + 可回放</span><span class="lang-en-only">DSH chooses composability + replayability</span></div>
+    </div>
+
+    <table class="cmp">
+      <thead><tr><th></th><th>Claude Code</th><th>Cursor</th><th>DSH</th></tr></thead>
+      <tbody>
+      <tr><td>内核</td><td>密封 CLI</td><td>密封 IDE</td><td>Cordis 插件树</td></tr>
+      <tr><td>会话</td><td>专有云</td><td>专有</td><td>SessionEvent log</td></tr>
+      <tr><td>扩展</td><td>MCP</td><td>VS Code</td><td>Bundle + patch + npm 插件</td></tr>
+      <tr><td>子 agent</td><td>内置</td><td>内置</td><td>packages/subagent/*</td></tr>
+      <tr><td>trace</td><td>黑盒</td><td>黑盒</td><td>dump-config + session log</td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="sec-num">C01.2</span> <span class="lang-zh-only">为什么开源 harness 仍然重要</span><span class="lang-en-only">Why an open harness still matters</span></h3>
+
+    <div class="lang-zh-only"><p>官方 <code>docs/architecture.md</code> 第一句就点明：改 <code>packages/</code> 前先读 Cordis primer。DSH 把「模型可见即已记录」（Model-visible means logged）写成运行时 invariant——这意味着你 trace 主线 prompt 时，<strong>日志就是真相源</strong>，不是调试输出。</p></div>
+    <div class="lang-en-only"><p>Official <code>docs/architecture.md</code> opens with: read the Cordis primer before changing <code>packages/</code>. DSH encodes «Model-visible means logged» as a runtime invariant — when tracing the through-line prompt, <strong>the log is the source of truth</strong>, not debug output.</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; docs/architecture.md</span>
+        <span class="src-tag">arch</span>
+      </div>
+      <span class="src-line"><span class="src-comment">/** There is no privileged core to patch */</span></span>
+      <span class="src-line"><span class="src-kw">Every part of the product is a plugin</span>, including the model adapter,</span>
+      <span class="src-line">the tool registry, the session log, and the agent loop itself.</span>
+    </div>
+
+    <div class="note copper">
+      <span class="lang-zh-only">DSH 解决的是「想理解 agent 内部机制、还要能改」的开发者；Claude Code/Cursor 解决的是「想马上写代码」的开发者。</span>
+      <span class="lang-en-only">DSH serves developers who want to understand and modify agent internals; Claude Code/Cursor serve developers who want to code immediately.</span>
+    </div>
+
+    <blockquote class="pull copper">
+      <span class="lang-zh-only">产品卖的是答案。<br>DSH 卖的是<strong>能 dump 出下一层配置</strong>的显微镜。</span>
+      <span class="lang-en-only">Products sell answers.<br>DSH sells the microscope that can <strong>dump the next layer of config</strong>.</span>
+      <cite>Field Note · 10</cite>
+    </blockquote>
+
+    <div class="note copper">
+      <span class="lang-zh-only">📘 <strong>架构总览</strong>（<code>docs/architecture.md</code>）· Cordis 插件树、Profile×Bundle 组合、六大 ctx 服务与 turn 流</span>
+      <span class="lang-en-only">📘 <strong>Architecture overview</strong> (<code>docs/architecture.md</code>) · Cordis plugin tree, Profile×Bundle composition, six core ctx services, and turn flow</span>
+    </div>
+
+    <div class="note copper">
+      <span class="lang-zh-only">📘 <strong>Cordis 入门</strong>（<code>docs/cordis-primer.md</code>）· 插件=Service、inject 依赖、waterfall 语义、可逆 effect 五条范式</span>
+      <span class="lang-en-only">📘 <strong>Cordis primer</strong> (<code>docs/cordis-primer.md</code>) · Plugin=Service, inject deps, waterfall semantics, reversible effects — five ideas</span>
+    </div>
+
+    <figure>
+      <div class="figbox"><div class="pi-fig wide"><svg viewBox="0 0 720 160" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true" class="pi-svg">
+  <defs>
+    <marker id="pi-arr" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 Z" fill="#1f5c8c"/>
+    </marker>
+  </defs>
+  <text x="24" y="28" class="svg-label">DSH PLUGIN ECOSYSTEM</text>
+  <rect x="24" y="44" width="160" height="56" rx="4" class="svg-box accent"/>
+  <text x="104" y="68" text-anchor="middle" class="svg-body">core/*</text>
+  <text x="104" y="86" text-anchor="middle" class="svg-mute">session · loop</text>
+  <rect x="200" y="44" width="160" height="56" rx="4" class="svg-box gpu"/>
+  <text x="280" y="68" text-anchor="middle" class="svg-body">capability</text>
+  <text x="280" y="86" text-anchor="middle" class="svg-mute">fs · shell · mcp</text>
+  <rect x="376" y="44" width="160" height="56" rx="4" class="svg-box copper"/>
+  <text x="456" y="68" text-anchor="middle" class="svg-body">bundle</text>
+  <text x="456" y="86" text-anchor="middle" class="svg-mute">base · web · headless</text>
+  <rect x="552" y="44" width="144" height="56" rx="4" class="svg-box muted"/>
+  <text x="624" y="68" text-anchor="middle" class="svg-body">community</text>
+  <text x="624" y="86" text-anchor="middle" class="svg-mute">npm · git patch</text>
+  <text x="360" y="140" text-anchor="middle" class="svg-mute">everything mounts through Cordis · no privileged core</text>
+</svg></div></div>
+      <figcaption>
+        <span class="figid">FIG</span>
+        <span class="lang-zh-only">插件光谱：core 脊柱、capability seam、官方 bundle、社区 npm/git 包共享同一 Cordis 树。</span>
+        <span class="lang-en-only">Plugin spectrum: core spine, capability seams, official bundles, community npm/git packages share one Cordis tree.</span>
+      </figcaption>
+    </figure>
+
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">交叉引用</span><span class="lang-en-only">Cross-ref</span></span> <span class="da-title lang-zh-only">deepseek-harness 文档</span><span class="da-title lang-en-only">deepseek-harness docs</span></div>    <table class="cmp">
+      <thead><tr><th>DOC</th><th>主题</th><th>路径</th><th>摘要</th></tr></thead>
+      <tbody>
+      <tr><td>architecture</td><td>架构总览</td><td><code>docs/architecture.md</code></td><td>Cordis plugin tree, Profile×Bundle composition, six core ctx services, and turn flow</td></tr>
+      <tr><td>cordis-primer</td><td>Cordis 入门</td><td><code>docs/cordis-primer.md</code></td><td>Plugin=Service, inject deps, waterfall semantics, reversible effects — five ideas</td></tr>
+      </tbody>
+    </table>
+
+    <div class="case-study">
+      <div class="cs-tag">CASE STUDY</div>
+      <div class="cs-title"><span class="lang-zh-only">从 Pi 迁移到 DSH</span><span class="lang-en-only">Migrating from Pi to DSH</span></div>
+      <div class="lang-zh-only"><p>Pi 把 agent-loop 写死在 npm 包里；DSH 把 agent-loop 本身做成可替换插件。迁移的第一步不是换 CLI，而是跑 <code>dsh --profile web --dump-config</code> 看清插件树。</p></div>
+      <div class="lang-en-only"><p>Pi hard-codes agent-loop in an npm package; DSH makes agent-loop itself a replaceable plugin. Migration starts with <code>dsh --profile web --dump-config</code> to see the plugin tree.</p></div>
+    </div>
+
+    <div class="trace-box">
+      <div class="tb-tag">TRACE · station station 引子</div>
+      <div class="lang-zh-only"><p>站 00：理解 DSH 是插件组合，不是密封产品。</p></div>
+      <div class="lang-en-only"><p>St. 00: DSH is plugin composition, not a sealed product.</p></div>
+    </div>
+
+    <div class="depth-zone" data-chapter="C01"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C01.4+</span><span class="lang-en-only">Deep dive · C01.4+</span></div>
+
+    <h4 class="sub2 depth-sec"><span class="sec-num">C01.4</span> <span class="lang-zh-only">密封 vs 可组合</span><span class="lang-en-only">Sealed vs composable</span></h4>
+
+    <div class="lang-zh-only"><p>Claude Code / Cursor 把 agent-loop 封在产品里；DSH 把 loop、tools、llm 都做成可 patch 的 Cordis 插件。</p></div>
+    <div class="lang-en-only"><p>Claude Code / Cursor seal agent-loop in the product; DSH makes loop, tools, llm patchable Cordis plugins.</p></div>
+
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">交叉引用</span><span class="lang-en-only">Cross-ref</span></span> <span class="da-title lang-zh-only">deepseek-harness 文档</span><span class="da-title lang-en-only">deepseek-harness docs</span></div>    <table class="cmp">
+      <thead><tr><th>DOC</th><th>主题</th><th>路径</th><th>摘要</th></tr></thead>
+      <tbody>
+      <tr><td>architecture</td><td>架构总览</td><td><code>docs/architecture.md</code></td><td>Cordis plugin tree, Profile×Bundle composition, six core ctx services, and turn flow</td></tr>
+      <tr><td>cordis-primer</td><td>Cordis 入门</td><td><code>docs/cordis-primer.md</code></td><td>Plugin=Service, inject deps, waterfall semantics, reversible effects — five ideas</td></tr>
+      </tbody>
+    </table>
+
+    </div>
+  </section>
+
+  <section class="chap" id="c2">
+    <div class="chap-num">CHAPTER&nbsp;02&nbsp;·&nbsp;引子</div>
+    <h2 class="chap-title lang-zh-only">一条消息的 turn/step 全景</h2>
+    <h2 class="chap-title lang-en-only">turn/step panorama for one message</h2>
+    <p class="chap-en lang-zh-only">从回车到 session log 的全景图</p>
+    <p class="chap-en lang-en-only">from Enter to session log, the full map</p>
+    <nav class="chapter-compass" aria-label="Chapter navigation">
+      <div class="cc-row">
+        <div class="cc-phase"><span class="cc-roman">0</span> · <span class="lang-zh-only">引子</span><span class="lang-en-only">Prologue</span></div>
+        <div class="cc-station"><span class="lang-zh-only">站 01–22</span><span class="lang-en-only">St. 01–22</span> · C02/26</div>
+      </div>
+      <div class="cc-forest"><span class="lang-zh-only">turn/step 全景图</span><span class="lang-en-only">turn/step panorama</span></div>
+      <div class="cc-links">
+        <a class="cc-nav cc-prev" href="#c1"><span class="cc-arrow">←</span> <span class="cc-nav-num">C01</span> <span class="lang-zh-only">Harness 不是 Product</span><span class="lang-en-only">Harness is not a product</span></a>
+        <a class="cc-map" href="#forest-overview"><span class="lang-zh-only">回到总览</span><span class="lang-en-only">Forest map</span></a>
+        <a class="cc-nav cc-next" href="#c3"><span class="cc-nav-num">C03</span> <span class="lang-zh-only">deepseek-harness 家谱</span><span class="lang-en-only">The deepseek-harness family tree</span> <span class="cc-arrow">→</span></a>
+      </div>
+    </nav>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>本章回答「这条主线 prompt 在此层长什么样」</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH 没有隐藏魔法——一切可替换行为都在 Cordis 事件或 SessionEvent 里</span></p>
+      <p><span class="swc-pill act">优化</span><span>读源码时先搜 session.append 与 ctx.* 注册点</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>This chapter answers what the through-line prompt looks like at this layer</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH has no hidden magic — replaceable behavior lives in Cordis events or SessionEvents</span></p>
+      <p><span class="swc-pill act">优化</span><span>When reading source, search session.append and ctx.* registration first</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">全景</span><span class="lang-en-only">全景</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">Panorama</span><span class="lang-en-only">Panorama</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">docs/</span><span class="lang-en-only">docs/</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">turn flow map</span><span class="lang-en-only">turn flow map</span></div>
+      </div>
+    </div>
+
+    <div class="lang-zh-only"><p>按下回车发送 <code>读取 README.md，用一句话告诉我这个项目做什么</code> 之后，Web UI（:3080）或 headless CLI 不会立刻调用 DeepSeek API——消息先进入 agent inbox，驱动器发出 <code>turn/start</code>，经过 <code>agent/pre-step</code> waterfall，在 <code>step/start</code> 后落成 <code>user/message</code>，然后才是 <code>llm/stream</code>、<code>assistant/chunk*</code>、<code>tool/call*</code>，最后 <code>turn/end</code>。</p></div>
+    <div class="lang-en-only"><p>After Enter on <code>read README.md and tell me what this project does in one sentence</code>, the Web UI (:3080) or headless CLI does not immediately call the DeepSeek API — the message enters agent inbox, the driver emits <code>turn/start</code>, passes <code>agent/pre-step</code> waterfall, lands as <code>user/message</code> after <code>step/start</code>, then <code>llm/stream</code>, <code>assistant/chunk*</code>, <code>tool/call*</code>, and finally <code>turn/end</code>.</p></div>
+
+    <h3 class="sub"><span class="sec-num">C02.1</span> <span class="lang-zh-only">22 站全景地图</span><span class="lang-en-only">22-station panorama map</span></h3>
+
+    <div class="lang-zh-only"><p>下面两图把一条用户消息从 CLI/profile 解析到 compaction 检查的<strong>完整工序</strong>摊开。持住这张地图，C03–C26 每章只解释相邻两站之间的过渡，细节才不会丢。</p></div>
+    <div class="lang-en-only"><p>The two diagrams below lay out the <strong>full path</strong> of one user message from CLI/profile parse to compaction check. Hold this map: chapters C03–C26 each explain one transition between adjacent stations.</p></div>
+
+    <figure>
+      <div class="figbox"><div class="pi-fig panorama"><svg viewBox="0 0 1000 270" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true" class="pi-svg">
+  <defs>
+    <marker id="pi-arr" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 Z" fill="#1f5c8c"/>
+    </marker>
+  </defs>
+  <text x="48" y="32" class="svg-label">22 stations · snake timeline · one user message</text>
+  <text x="48" y="52" class="svg-mute">Enter → … → JSONL on disk</text>
+  <line x1="76" y1="95" x2="108" y2="95" stroke="#c7c4ba" stroke-width="1.5"/><line x1="164" y1="95" x2="196" y2="95" stroke="#c7c4ba" stroke-width="1.5"/><line x1="252" y1="95" x2="284" y2="95" stroke="#c7c4ba" stroke-width="1.5"/><line x1="340" y1="95" x2="372" y2="95" stroke="#c7c4ba" stroke-width="1.5"/><line x1="428" y1="95" x2="460" y2="95" stroke="#c7c4ba" stroke-width="1.5"/><line x1="516" y1="95" x2="548" y2="95" stroke="#c7c4ba" stroke-width="1.5"/><line x1="604" y1="95" x2="636" y2="95" stroke="#c7c4ba" stroke-width="1.5"/><line x1="692" y1="95" x2="724" y2="95" stroke="#c7c4ba" stroke-width="1.5"/><line x1="780" y1="95" x2="812" y2="95" stroke="#c7c4ba" stroke-width="1.5"/><line x1="868" y1="95" x2="900" y2="95" stroke="#c7c4ba" stroke-width="1.5"/><path d="M956 95 L980 95 L980 145 L-4 145 L-4 167 L20 167" fill="none" stroke="#c7c4ba" stroke-width="1.5"/><line x1="76" y1="195" x2="108" y2="195" stroke="#c7c4ba" stroke-width="1.5"/><line x1="164" y1="195" x2="196" y2="195" stroke="#c7c4ba" stroke-width="1.5"/><line x1="252" y1="195" x2="284" y2="195" stroke="#c7c4ba" stroke-width="1.5"/><line x1="340" y1="195" x2="372" y2="195" stroke="#c7c4ba" stroke-width="1.5"/><line x1="428" y1="195" x2="460" y2="195" stroke="#c7c4ba" stroke-width="1.5"/><line x1="516" y1="195" x2="548" y2="195" stroke="#c7c4ba" stroke-width="1.5"/><line x1="604" y1="195" x2="636" y2="195" stroke="#c7c4ba" stroke-width="1.5"/><line x1="692" y1="195" x2="724" y2="195" stroke="#c7c4ba" stroke-width="1.5"/><line x1="780" y1="195" x2="812" y2="195" stroke="#c7c4ba" stroke-width="1.5"/><line x1="868" y1="195" x2="900" y2="195" stroke="#c7c4ba" stroke-width="1.5"/>
+  
+  <rect x="20" y="67" width="56" height="56" rx="4" fill="#767c87" opacity="0.12" stroke="#767c87" stroke-width="1.5"/>
+  <text x="48" y="87" text-anchor="middle" class="svg-tiny" fill="#767c87" font-weight="700">01</text>
+  <text x="48" y="105" text-anchor="middle" class="svg-micro">CLI 解析</text>
+  <rect x="108" y="67" width="56" height="56" rx="4" fill="#767c87" opacity="0.12" stroke="#767c87" stroke-width="1.5"/>
+  <text x="136" y="87" text-anchor="middle" class="svg-tiny" fill="#767c87" font-weight="700">02</text>
+  <text x="136" y="105" text-anchor="middle" class="svg-micro">main 启动</text>
+  <rect x="196" y="67" width="56" height="56" rx="4" fill="#767c87" opacity="0.12" stroke="#767c87" stroke-width="1.5"/>
+  <text x="224" y="87" text-anchor="middle" class="svg-tiny" fill="#767c87" font-weight="700">03</text>
+  <text x="224" y="105" text-anchor="middle" class="svg-micro">Session</text>
+  <rect x="284" y="67" width="56" height="56" rx="4" fill="#767c87" opacity="0.12" stroke="#767c87" stroke-width="1.5"/>
+  <text x="312" y="87" text-anchor="middle" class="svg-tiny" fill="#767c87" font-weight="700">04</text>
+  <text x="312" y="105" text-anchor="middle" class="svg-micro">AGENTS.md</text>
+  <rect x="372" y="67" width="56" height="56" rx="4" fill="#1f5c8c" opacity="0.12" stroke="#1f5c8c" stroke-width="1.5"/>
+  <text x="400" y="87" text-anchor="middle" class="svg-tiny" fill="#1f5c8c" font-weight="700">05</text>
+  <text x="400" y="105" text-anchor="middle" class="svg-micro">prompt 入队</text>
+  <rect x="460" y="67" width="56" height="56" rx="4" fill="#1f5c8c" opacity="0.12" stroke="#1f5c8c" stroke-width="1.5"/>
+  <text x="488" y="87" text-anchor="middle" class="svg-tiny" fill="#1f5c8c" font-weight="700">06</text>
+  <text x="488" y="105" text-anchor="middle" class="svg-micro">agent_star</text>
+  <rect x="548" y="67" width="56" height="56" rx="4" fill="#1f5c8c" opacity="0.12" stroke="#1f5c8c" stroke-width="1.5"/>
+  <text x="576" y="87" text-anchor="middle" class="svg-tiny" fill="#1f5c8c" font-weight="700">07</text>
+  <text x="576" y="105" text-anchor="middle" class="svg-micro">turn_start</text>
+  <rect x="636" y="67" width="56" height="56" rx="4" fill="#6b3aa3" opacity="0.12" stroke="#6b3aa3" stroke-width="1.5"/>
+  <text x="664" y="87" text-anchor="middle" class="svg-tiny" fill="#6b3aa3" font-weight="700">08</text>
+  <text x="664" y="105" text-anchor="middle" class="svg-micro">convertToL</text>
+  <rect x="724" y="67" width="56" height="56" rx="4" fill="#6b3aa3" opacity="0.12" stroke="#6b3aa3" stroke-width="1.5"/>
+  <text x="752" y="87" text-anchor="middle" class="svg-tiny" fill="#6b3aa3" font-weight="700">09</text>
+  <text x="752" y="105" text-anchor="middle" class="svg-micro">streamSimp</text>
+  <rect x="812" y="67" width="56" height="56" rx="4" fill="#6b3aa3" opacity="0.12" stroke="#6b3aa3" stroke-width="1.5"/>
+  <text x="840" y="87" text-anchor="middle" class="svg-tiny" fill="#6b3aa3" font-weight="700">10</text>
+  <text x="840" y="105" text-anchor="middle" class="svg-micro">text_delta</text>
+  <rect x="900" y="67" width="56" height="56" rx="4" fill="#6b3aa3" opacity="0.12" stroke="#6b3aa3" stroke-width="1.5"/>
+  <text x="928" y="87" text-anchor="middle" class="svg-tiny" fill="#6b3aa3" font-weight="700">11</text>
+  <text x="928" y="105" text-anchor="middle" class="svg-micro">toolcall_δ</text>
+  <rect x="20" y="167" width="56" height="56" rx="4" fill="#1f5c8c" opacity="0.12" stroke="#1f5c8c" stroke-width="1.5"/>
+  <text x="48" y="187" text-anchor="middle" class="svg-tiny" fill="#1f5c8c" font-weight="700">12</text>
+  <text x="48" y="205" text-anchor="middle" class="svg-micro">toolUse</text>
+  <rect x="108" y="167" width="56" height="56" rx="4" fill="#1f5c8c" opacity="0.12" stroke="#1f5c8c" stroke-width="1.5"/>
+  <text x="136" y="187" text-anchor="middle" class="svg-tiny" fill="#1f5c8c" font-weight="700">13</text>
+  <text x="136" y="205" text-anchor="middle" class="svg-micro">executeToo</text>
+  <rect x="196" y="167" width="56" height="56" rx="4" fill="#2d6a4f" opacity="0.12" stroke="#2d6a4f" stroke-width="1.5"/>
+  <text x="224" y="187" text-anchor="middle" class="svg-tiny" fill="#2d6a4f" font-weight="700">14</text>
+  <text x="224" y="205" text-anchor="middle" class="svg-micro">read READM</text>
+  <rect x="284" y="167" width="56" height="56" rx="4" fill="#2d6a4f" opacity="0.12" stroke="#2d6a4f" stroke-width="1.5"/>
+  <text x="312" y="187" text-anchor="middle" class="svg-tiny" fill="#2d6a4f" font-weight="700">15</text>
+  <text x="312" y="205" text-anchor="middle" class="svg-micro">tool_resul</text>
+  <rect x="372" y="167" width="56" height="56" rx="4" fill="#6b3aa3" opacity="0.12" stroke="#6b3aa3" stroke-width="1.5"/>
+  <text x="400" y="187" text-anchor="middle" class="svg-tiny" fill="#6b3aa3" font-weight="700">16</text>
+  <text x="400" y="205" text-anchor="middle" class="svg-micro">stream #2</text>
+  <rect x="460" y="167" width="56" height="56" rx="4" fill="#6b3aa3" opacity="0.12" stroke="#6b3aa3" stroke-width="1.5"/>
+  <text x="488" y="187" text-anchor="middle" class="svg-tiny" fill="#6b3aa3" font-weight="700">17</text>
+  <text x="488" y="205" text-anchor="middle" class="svg-micro">assistant </text>
+  <rect x="548" y="167" width="56" height="56" rx="4" fill="#1f5c8c" opacity="0.12" stroke="#1f5c8c" stroke-width="1.5"/>
+  <text x="576" y="187" text-anchor="middle" class="svg-tiny" fill="#1f5c8c" font-weight="700">18</text>
+  <text x="576" y="205" text-anchor="middle" class="svg-micro">message_en</text>
+  <rect x="636" y="167" width="56" height="56" rx="4" fill="#b35a1f" opacity="0.12" stroke="#b35a1f" stroke-width="1.5"/>
+  <text x="664" y="187" text-anchor="middle" class="svg-tiny" fill="#b35a1f" font-weight="700">19</text>
+  <text x="664" y="205" text-anchor="middle" class="svg-micro">JSONL appe</text>
+  <rect x="724" y="167" width="56" height="56" rx="4" fill="#3873a3" opacity="0.12" stroke="#3873a3" stroke-width="1.5"/>
+  <text x="752" y="187" text-anchor="middle" class="svg-tiny" fill="#3873a3" font-weight="700">20</text>
+  <text x="752" y="205" text-anchor="middle" class="svg-micro">TUI diff</text>
+  <rect x="812" y="167" width="56" height="56" rx="4" fill="#3873a3" opacity="0.12" stroke="#3873a3" stroke-width="1.5"/>
+  <text x="840" y="187" text-anchor="middle" class="svg-tiny" fill="#3873a3" font-weight="700">21</text>
+  <text x="840" y="205" text-anchor="middle" class="svg-micro">extensions</text>
+  <rect x="900" y="167" width="56" height="56" rx="4" fill="#b35a1f" opacity="0.12" stroke="#b35a1f" stroke-width="1.5"/>
+  <text x="928" y="187" text-anchor="middle" class="svg-tiny" fill="#b35a1f" font-weight="700">22</text>
+  <text x="928" y="205" text-anchor="middle" class="svg-micro">compaction</text>
+  <rect x="48" y="248" width="10" height="10" fill="#767c87" opacity="0.5"/><text x="62" y="257" class="svg-micro">intake</text><rect x="120" y="248" width="10" height="10" fill="#1f5c8c" opacity="0.5"/><text x="134" y="257" class="svg-micro">heart</text><rect x="192" y="248" width="10" height="10" fill="#6b3aa3" opacity="0.5"/><text x="206" y="257" class="svg-micro">llm</text><rect x="264" y="248" width="10" height="10" fill="#2d6a4f" opacity="0.5"/><text x="278" y="257" class="svg-micro">tool</text><rect x="336" y="248" width="10" height="10" fill="#3873a3" opacity="0.5"/><text x="350" y="257" class="svg-micro">terminal</text><rect x="408" y="248" width="10" height="10" fill="#b35a1f" opacity="0.5"/><text x="422" y="257" class="svg-micro">persist</text>
+</svg></div></div>
+      <figcaption>
+        <span class="figid">FIG</span>
+        <span class="lang-zh-only">22 站全景：从 CLI 解析到 compaction 检查的完整蛇形时间线，颜色按 Phase 编码。</span>
+        <span class="lang-en-only">22-station panorama: snake timeline from CLI parse to compaction check, color-coded by phase.</span>
+      </figcaption>
+    </figure>
+
+    <div class="station-track" role="list" aria-label="22 stations">
+      <div class="st-rail">
+      <div class="st-cell" data-phase="intake" style="--st-color:#767c87">
+        <div class="st-num">01</div>
+        <div class="st-name"><span class="lang-zh-only">CLI 解析</span><span class="lang-en-only">cli.ts argv</span></div>
+        <div class="st-phase">intake</div>
+      </div>
+      <div class="st-cell" data-phase="intake" style="--st-color:#767c87">
+        <div class="st-num">02</div>
+        <div class="st-name"><span class="lang-zh-only">main 启动</span><span class="lang-en-only">main.ts boot</span></div>
+        <div class="st-phase">intake</div>
+      </div>
+      <div class="st-cell" data-phase="intake" style="--st-color:#767c87">
+        <div class="st-num">03</div>
+        <div class="st-name"><span class="lang-zh-only">Session</span><span class="lang-en-only">session factory</span></div>
+        <div class="st-phase">intake</div>
+      </div>
+      <div class="st-cell" data-phase="intake" style="--st-color:#767c87">
+        <div class="st-num">04</div>
+        <div class="st-name"><span class="lang-zh-only">AGENTS.md</span><span class="lang-en-only">context stack</span></div>
+        <div class="st-phase">intake</div>
+      </div>
+      <div class="st-cell" data-phase="heart" style="--st-color:#1f5c8c">
+        <div class="st-num">05</div>
+        <div class="st-name"><span class="lang-zh-only">prompt 入队</span><span class="lang-en-only">prompt queued</span></div>
+        <div class="st-phase">heart</div>
+      </div>
+      <div class="st-cell" data-phase="heart" style="--st-color:#1f5c8c">
+        <div class="st-num">06</div>
+        <div class="st-name"><span class="lang-zh-only">agent_start</span><span class="lang-en-only">agent_start</span></div>
+        <div class="st-phase">heart</div>
+      </div>
+      <div class="st-cell" data-phase="heart" style="--st-color:#1f5c8c">
+        <div class="st-num">07</div>
+        <div class="st-name"><span class="lang-zh-only">turn_start</span><span class="lang-en-only">turn_start</span></div>
+        <div class="st-phase">heart</div>
+      </div>
+      <div class="st-cell" data-phase="llm" style="--st-color:#6b3aa3">
+        <div class="st-num">08</div>
+        <div class="st-name"><span class="lang-zh-only">convertToLlm</span><span class="lang-en-only">→ Message[]</span></div>
+        <div class="st-phase">llm</div>
+      </div>
+      <div class="st-cell" data-phase="llm" style="--st-color:#6b3aa3">
+        <div class="st-num">09</div>
+        <div class="st-name"><span class="lang-zh-only">streamSimple</span><span class="lang-en-only">pi-ai stream</span></div>
+        <div class="st-phase">llm</div>
+      </div>
+      <div class="st-cell" data-phase="llm" style="--st-color:#6b3aa3">
+        <div class="st-num">10</div>
+        <div class="st-name"><span class="lang-zh-only">text_delta</span><span class="lang-en-only">token stream</span></div>
+        <div class="st-phase">llm</div>
+      </div>
+      <div class="st-cell" data-phase="llm" style="--st-color:#6b3aa3">
+        <div class="st-num">11</div>
+        <div class="st-name"><span class="lang-zh-only">toolcall_δ</span><span class="lang-en-only">tool assembly</span></div>
+        <div class="st-phase">llm</div>
+      </div>
+      <div class="st-cell" data-phase="heart" style="--st-color:#1f5c8c">
+        <div class="st-num">12</div>
+        <div class="st-name"><span class="lang-zh-only">toolUse</span><span class="lang-en-only">read request</span></div>
+        <div class="st-phase">heart</div>
+      </div>
+      <div class="st-cell" data-phase="heart" style="--st-color:#1f5c8c">
+        <div class="st-num">13</div>
+        <div class="st-name"><span class="lang-zh-only">executeTool</span><span class="lang-en-only">tool dispatch</span></div>
+        <div class="st-phase">heart</div>
+      </div>
+      <div class="st-cell" data-phase="tool" style="--st-color:#2d6a4f">
+        <div class="st-num">14</div>
+        <div class="st-name"><span class="lang-zh-only">read README</span><span class="lang-en-only">filesystem I/O</span></div>
+        <div class="st-phase">tool</div>
+      </div>
+      <div class="st-cell" data-phase="tool" style="--st-color:#2d6a4f">
+        <div class="st-num">15</div>
+        <div class="st-name"><span class="lang-zh-only">tool_result</span><span class="lang-en-only">tool result</span></div>
+        <div class="st-phase">tool</div>
+      </div>
+      <div class="st-cell" data-phase="llm" style="--st-color:#6b3aa3">
+        <div class="st-num">16</div>
+        <div class="st-name"><span class="lang-zh-only">stream #2</span><span class="lang-en-only">turn 2 model</span></div>
+        <div class="st-phase">llm</div>
+      </div>
+      <div class="st-cell" data-phase="llm" style="--st-color:#6b3aa3">
+        <div class="st-num">17</div>
+        <div class="st-name"><span class="lang-zh-only">assistant stop</span><span class="lang-en-only">final answer</span></div>
+        <div class="st-phase">llm</div>
+      </div>
+      <div class="st-cell" data-phase="heart" style="--st-color:#1f5c8c">
+        <div class="st-num">18</div>
+        <div class="st-name"><span class="lang-zh-only">message_end</span><span class="lang-en-only">message_end</span></div>
+        <div class="st-phase">heart</div>
+      </div>
+      <div class="st-cell" data-phase="persist" style="--st-color:#b35a1f">
+        <div class="st-num">19</div>
+        <div class="st-name"><span class="lang-zh-only">JSONL append</span><span class="lang-en-only">JSONL write</span></div>
+        <div class="st-phase">persist</div>
+      </div>
+      <div class="st-cell" data-phase="terminal" style="--st-color:#3873a3">
+        <div class="st-num">20</div>
+        <div class="st-name"><span class="lang-zh-only">TUI diff</span><span class="lang-en-only">diff render</span></div>
+        <div class="st-phase">terminal</div>
+      </div>
+      <div class="st-cell" data-phase="terminal" style="--st-color:#3873a3">
+        <div class="st-num">21</div>
+        <div class="st-name"><span class="lang-zh-only">extensions</span><span class="lang-en-only">extension hooks</span></div>
+        <div class="st-phase">terminal</div>
+      </div>
+      <div class="st-cell" data-phase="persist" style="--st-color:#b35a1f">
+        <div class="st-num">22</div>
+        <div class="st-name"><span class="lang-zh-only">compaction</span><span class="lang-en-only">context check</span></div>
+        <div class="st-phase">persist</div>
+      </div>
+      </div>
+    </div>
+
+    <h3 class="sub"><span class="sec-num">C02.2</span> <span class="lang-zh-only">主线事件序（简化）</span><span class="lang-en-only">Through-line event order (simplified)</span></h3>
+
+    <figure>
+      <div class="figbox"><div class="event-flow">
+      <div class="ef-row"><div class="ef-type">turn/start</div><div><span class="lang-zh-only">新 turn 打开 · claim inbox 批次</span><span class="lang-en-only">New turn opens · claim inbox batch</span></div></div>
+      <div class="ef-row"><div class="ef-type">agent/pre-step</div><div><span class="lang-zh-only">waterfall：reject 或 enter(messages)</span><span class="lang-en-only">waterfall: reject or enter(messages)</span></div></div>
+      <div class="ef-row"><div class="ef-type">step/start</div><div><span class="lang-zh-only">一步 model 请求 + 工具批次开始</span><span class="lang-en-only">One model request + tool batch begins</span></div></div>
+      <div class="ef-row"><div class="ef-type">user/message</div><div><span class="lang-zh-only">主线 prompt 写入 SessionEvent log</span><span class="lang-en-only">Through-line prompt written to SessionEvent log</span></div></div>
+      <div class="ef-row"><div class="ef-type">llm/stream</div><div><span class="lang-zh-only">DeepSeek adapter 流式返回</span><span class="lang-en-only">DeepSeek adapter streams back</span></div></div>
+      <div class="ef-row"><div class="ef-type">assistant/chunk*</div><div><span class="lang-zh-only">流式 token · UI 订阅 session/event</span><span class="lang-en-only">Streaming tokens · UI subscribes session/event</span></div></div>
+      <div class="ef-row"><div class="ef-type">tool/call</div><div><span class="lang-zh-only">模型选择 read(README.md)</span><span class="lang-en-only">Model chooses read(README.md)</span></div></div>
+      <div class="ef-row"><div class="ef-type">tool/result</div><div><span class="lang-zh-only">工具结果 · 进入 deriveMessages 投影</span><span class="lang-en-only">Tool result · enters deriveMessages projection</span></div></div>
+      <div class="ef-row"><div class="ef-type">turn/end</div><div><span class="lang-zh-only">无更多 step 欠账 · agent idle</span><span class="lang-en-only">No more steps owed · agent idle</span></div></div>
+    </div>
+      </div>
+      <figcaption><span class="figid">EVT</span><span class="lang-zh-only">SessionEvent 流 · 主线 prompt</span><span class="lang-en-only">SessionEvent stream · through-line prompt</span></figcaption>
+    </figure>
+
+    <h3 class="sub"><span class="sec-num">C02.3</span> <span class="lang-zh-only">Turn 与 Step 的嵌套关系</span><span class="lang-en-only">Turn and step nesting</span></h3>
+
+    <div class="lang-zh-only"><p>官方 <code>agent-lifecycle.md</code> 定义：<strong>step</strong> = 一次 model 请求 + 其工具调用；<strong>turn</strong> = 零个或多个 step。主线 prompt 通常产生 <strong>两个 step</strong>（第一次 toolUse read，第二次 stop 回答），包在同一个 turn 里。</p></div>
+    <div class="lang-en-only"><p>Official <code>agent-lifecycle.md</code> defines: a <strong>step</strong> is one model request plus its tool calls; a <strong>turn</strong> is zero or more steps. The through-line prompt usually yields <strong>two steps</strong> (first toolUse read, second stop answer) inside one turn.</p></div>
+
+    <div class="ladder">
+      <div class="ld-row">
+        <div class="ld-num">01</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">Turn 1</span><span class="lang-en-only">turn/start → step 1 → read tool → step/end</span></div>
+
+        </div>
+      </div>
+      <div class="ld-row">
+        <div class="ld-num">02</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">Step 2</span><span class="lang-en-only">step/start → deriveMessages → llm/stream → assistant stop</span></div>
+
+        </div>
+      </div>
+      <div class="ld-row">
+        <div class="ld-num">03</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">Turn close</span><span class="lang-en-only">turn/end → agent/status idle</span></div>
+
+        </div>
+      </div>
+    </div>
+
+    <div class="note copper">
+      <span class="lang-zh-only">📘 <strong>Agent 生命周期</strong>（<code>docs/agent-lifecycle.md</code>）· turn/step 双环、agent/pre-step waterfall、session 与 agent 事件分工</span>
+      <span class="lang-en-only">📘 <strong>Agent lifecycle</strong> (<code>docs/agent-lifecycle.md</code>) · turn/step twin loops, agent/pre-step waterfall, session vs agent event split</span>
+    </div>
+
+    <div class="note copper">
+      <span class="lang-zh-only">C02 是望远镜；C09–C13 是显微镜。</span>
+      <span class="lang-en-only">C02 is the telescope; C09–C13 are the microscope.</span>
+    </div>
+
+    <div class="trace-box">
+      <div class="tb-tag">TRACE · station station 全景</div>
+      <div class="lang-zh-only"><p>站 全景：22 站总览。</p></div>
+      <div class="lang-en-only"><p>St. 全景: 22-station overview.</p></div>
+    </div>
+
+    <div class="depth-zone" data-chapter="C02"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C02.4+</span><span class="lang-en-only">Deep dive · C02.4+</span></div>
+
+    </div>
+  </section>
+
+  <section class="chap" id="c3">
+    <div class="chap-num">CHAPTER&nbsp;03&nbsp;·&nbsp;BACKGROUND</div>
+    <h2 class="chap-title lang-zh-only">deepseek-harness 家谱</h2>
+    <h2 class="chap-title lang-en-only">The deepseek-harness family tree</h2>
+    <p class="chap-en lang-zh-only">DeepSeek AI · Cordis · vendor/</p>
+    <p class="chap-en lang-en-only">DeepSeek AI · Cordis · vendor/</p>
+    <nav class="chapter-compass" aria-label="Chapter navigation">
+      <div class="cc-row">
+        <div class="cc-phase"><span class="cc-roman">·</span> · <span class="lang-zh-only">背景</span><span class="lang-en-only">Background</span></div>
+        <div class="cc-station"><span class="lang-zh-only">—</span><span class="lang-en-only">—</span> · C03/26</div>
+      </div>
+      <div class="cc-forest"><span class="lang-zh-only">Cordis 与 monorepo 家谱</span><span class="lang-en-only">Cordis and monorepo family tree</span></div>
+      <div class="cc-links">
+        <a class="cc-nav cc-prev" href="#c2"><span class="cc-arrow">←</span> <span class="cc-nav-num">C02</span> <span class="lang-zh-only">一条消息的 turn/step 全景</span><span class="lang-en-only">turn/step panorama for one message</span></a>
+        <a class="cc-map" href="#forest-overview"><span class="lang-zh-only">回到总览</span><span class="lang-en-only">Forest map</span></a>
+        <a class="cc-nav cc-next" href="#c4"><span class="cc-nav-num">C04</span> <span class="lang-zh-only">Core spine 六层</span><span class="lang-en-only">The core-spine six layers</span> <span class="cc-arrow">→</span></a>
+      </div>
+    </nav>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>本章回答「这条主线 prompt 在此层长什么样」</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH 没有隐藏魔法——一切可替换行为都在 Cordis 事件或 SessionEvent 里</span></p>
+      <p><span class="swc-pill act">优化</span><span>读源码时先搜 session.append 与 ctx.* 注册点</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>This chapter answers what the through-line prompt looks like at this layer</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH has no hidden magic — replaceable behavior lives in Cordis events or SessionEvents</span></p>
+      <p><span class="swc-pill act">优化</span><span>When reading source, search session.append and ctx.* registration first</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">Cordis</span><span class="lang-en-only">Cordis</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">Cordis</span><span class="lang-en-only">Cordis</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">vendor/</span><span class="lang-en-only">vendor/</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">ctx</span><span class="lang-en-only">ctx</span></div>
+      </div>
+    </div>
+
+    <div class="lang-zh-only"><p>Cordis 是 vendored 在 <code>vendor/</code> 的插件框架：每个能力是一个 <code>Service</code>，通过 <code>ctx.&lt;key&gt;</code> 暴露，通过 <code>inject</code> 声明依赖，通过 <code>ctx.on()</code> / <code>ctx.effect()</code> 注册可逆副作用。DSH 没有「核心二进制」——连 agent loop 也是 <code>@deepseek-ai/dsh-agent-loop</code> 插件。</p></div>
+    <div class="lang-en-only"><p>Cordis is the vendored plugin framework under <code>vendor/</code>: each capability is a <code>Service</code> exposed via <code>ctx.&lt;key&gt;</code>, dependencies via <code>inject</code>, reversible side effects via <code>ctx.on()</code> / <code>ctx.effect()</code>. DSH has no «core binary» — even the agent loop is the <code>@deepseek-ai/dsh-agent-loop</code> plugin.</p></div>
+
+    <h3 class="sub"><span class="sec-num">C03.1</span> <span class="lang-zh-only">Context · Plugin · Mount</span><span class="lang-en-only">Context · Plugin · Mount</span></h3>
+
+    <div class="lang-zh-only"><p>Loader 读取 <code>cordis.yml</code> / patch 行，按服务可用性激活插件——<strong>行顺序无加载语义</strong>。插件 mount 时 claim <code>ctx.sessions</code> 等键；unmount 时 effect  unwind。其他插件通过 key 查找服务，而非 import 具体实现。</p></div>
+    <div class="lang-en-only"><p>Loader reads <code>cordis.yml</code> / patch rows and activates plugins by service availability — <strong>row order has no load semantics</strong>. On mount a plugin claims keys like <code>ctx.sessions</code>; on unmount effects unwind. Other plugins find services by key, not by importing concrete implementations.</p></div>
+
+    <table class="cmp">
+      <thead><tr><th>Cordis 范式</th><th>DSH 例子</th><th>主线 touchpoint</th></tr></thead>
+      <tbody>
+      <tr><td>Service</td><td>ctx.tools</td><td>read 工具注册</td></tr>
+      <tr><td>inject</td><td>agent-loop → session, llm</td><td>ReactLoopAgent 启动</td></tr>
+      <tr><td>waterfall</td><td>agent/pre-step</td><td>compaction · skill 目录注入</td></tr>
+      <tr><td>effect</td><td>systemPrompt section</td><td>AGENTS.md 栈</td></tr>
+      <tr><td>emit</td><td>session/event</td><td>Web UI 渲染</td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="sec-num">C03.2</span> <span class="lang-zh-only">Waterfall 与 short-circuit</span><span class="lang-en-only">Waterfall and short-circuit</span></h3>
+
+    <div class="lang-zh-only"><p><code>ctx.waterfall</code> 是 around-middleware：listener 收到 <code>(payload, next)</code>，调用 <code>next()</code> 继续链，不调用则 short-circuit。<code>agent/pre-step</code> 的返回值<strong>权威</strong>——可以 reject 整个 step 或 rewrite enter(messages)。</p></div>
+    <div class="lang-en-only"><p><code>ctx.waterfall</code> is around-middleware: a listener receives <code>(payload, next)</code>, calls <code>next()</code> to continue the chain, or short-circuits without it. The <code>agent/pre-step</code> return is <strong>authoritative</strong> — it can reject the whole step or rewrite enter(messages).</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; docs/cordis-primer.md</span>
+        <span class="src-tag">cordis</span>
+      </div>
+      <span class="src-line"><span class="src-kw">A plugin</span> waits until injected services exist —</span>
+      <span class="src-line">load order is expressed through <span class="src-str">inject</span>, not manual boot sequencing.</span>
+    </div>
+
+    <figure>
+      <div class="figbox"><div class="pi-fig"><svg viewBox="0 0 720 310" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true" class="pi-svg">
+  <defs>
+    <marker id="pi-arr" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 Z" fill="#1f5c8c"/>
+    </marker>
+  </defs><text x="48" y="28" class="svg-label">Profile × Bundle × Patch · boot composition</text><rect x="120" y="48" width="480" height="32" rx="3" fill="#b35a1f" opacity="0.12" stroke="#b35a1f"/><text x="140" y="68" class="svg-body">L6 · Profile patch</text><text x="520" y="68" text-anchor="end" class="svg-mute">cordis.patch.yml</text><rect x="120" y="86" width="480" height="32" rx="3" fill="#3873a3" opacity="0.12" stroke="#3873a3"/><text x="140" y="106" class="svg-body">L5 · dsh-web-app</text><text x="520" y="106" text-anchor="end" class="svg-mute">browser surface</text><rect x="120" y="124" width="480" height="32" rx="3" fill="#1f5c8c" opacity="0.12" stroke="#1f5c8c"/><text x="140" y="144" class="svg-body">L4 · dsh-base</text><text x="520" y="144" text-anchor="end" class="svg-mute">core plugin rows</text><rect x="120" y="162" width="480" height="32" rx="3" fill="#6b3aa3" opacity="0.12" stroke="#6b3aa3"/><text x="140" y="182" class="svg-body">L3 · Home patch</text><text x="520" y="182" text-anchor="end" class="svg-mute">$DSH_HOME/cordis.patch.yml</text><rect x="120" y="200" width="480" height="32" rx="3" fill="#767c87" opacity="0.12" stroke="#767c87"/><text x="140" y="220" class="svg-body">L2 · --patch</text><text x="520" y="220" text-anchor="end" class="svg-mute">CLI overlay</text><rect x="120" y="238" width="480" height="32" rx="3" fill="#2d6a4f" opacity="0.12" stroke="#2d6a4f"/><text x="140" y="258" class="svg-body">L1 · empty root</text><text x="520" y="258" text-anchor="end" class="svg-mute">entry list []</text><text x="360" y="290" text-anchor="middle" class="svg-mute">dsh --profile web --dump-config prints the merged tree</text></svg></div></div>
+      <figcaption>
+        <span class="figid">FIG</span>
+        <span class="lang-zh-only">Cordis 配置层：Bundle 按序 insert，Profile/Home/--patch 按 id 整行覆盖。</span>
+        <span class="lang-en-only">Cordis config layers: bundles insert in order; profile/home/--patch replace whole rows by id.</span>
+      </figcaption>
+    </figure>
+
+    <div class="note copper">
+      <span class="lang-zh-only">📘 <strong>Cordis 入门</strong>（<code>docs/cordis-primer.md</code>）· 插件=Service、inject 依赖、waterfall 语义、可逆 effect 五条范式</span>
+      <span class="lang-en-only">📘 <strong>Cordis primer</strong> (<code>docs/cordis-primer.md</code>) · Plugin=Service, inject deps, waterfall semantics, reversible effects — five ideas</span>
+    </div>
+
+    <div class="trace-box">
+      <div class="tb-tag">TRACE · station station Cordis</div>
+      <div class="lang-zh-only"><p>站 Cordis：插件挂载。</p></div>
+      <div class="lang-en-only"><p>St. Cordis: plugin mount.</p></div>
+    </div>
+
+    <div class="depth-zone" data-chapter="C03"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C03.4+</span><span class="lang-en-only">Deep dive · C03.4+</span></div>
+
+    </div>
+  </section>
+
+  <section class="chap" id="c4">
+    <div class="chap-num">CHAPTER&nbsp;04&nbsp;·&nbsp;BACKGROUND</div>
+    <h2 class="chap-title lang-zh-only">Core spine 六层</h2>
+    <h2 class="chap-title lang-en-only">The core-spine six layers</h2>
+    <p class="chap-en lang-zh-only">session · system-prompt · tools · agent · agent-loop · llm</p>
+    <p class="chap-en lang-en-only">session · system-prompt · tools · agent · agent-loop · llm</p>
+    <nav class="chapter-compass" aria-label="Chapter navigation">
+      <div class="cc-row">
+        <div class="cc-phase"><span class="cc-roman">·</span> · <span class="lang-zh-only">背景</span><span class="lang-en-only">Background</span></div>
+        <div class="cc-station"><span class="lang-zh-only">—</span><span class="lang-en-only">—</span> · C04/26</div>
+      </div>
+      <div class="cc-forest"><span class="lang-zh-only">Core spine 六包</span><span class="lang-en-only">Core spine six packages</span></div>
+      <div class="cc-links">
+        <a class="cc-nav cc-prev" href="#c3"><span class="cc-arrow">←</span> <span class="cc-nav-num">C03</span> <span class="lang-zh-only">deepseek-harness 家谱</span><span class="lang-en-only">The deepseek-harness family tree</span></a>
+        <a class="cc-map" href="#forest-overview"><span class="lang-zh-only">回到总览</span><span class="lang-en-only">Forest map</span></a>
+        <a class="cc-nav cc-next" href="#c5"><span class="cc-nav-num">C05</span> <span class="lang-zh-only">Everything is a plugin</span><span class="lang-en-only">Everything is a plugin</span> <span class="cc-arrow">→</span></a>
+      </div>
+    </nav>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>本章回答「这条主线 prompt 在此层长什么样」</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH 没有隐藏魔法——一切可替换行为都在 Cordis 事件或 SessionEvent 里</span></p>
+      <p><span class="swc-pill act">优化</span><span>读源码时先搜 session.append 与 ctx.* 注册点</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>This chapter answers what the through-line prompt looks like at this layer</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH has no hidden magic — replaceable behavior lives in Cordis events or SessionEvents</span></p>
+      <p><span class="swc-pill act">优化</span><span>When reading source, search session.append and ctx.* registration first</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">core spine</span><span class="lang-en-only">core spine</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">core spine</span><span class="lang-en-only">core spine</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">packages/core/*</span><span class="lang-en-only">packages/core/*</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">ctx.*</span><span class="lang-en-only">ctx.*</span></div>
+      </div>
+    </div>
+
+    <div class="lang-zh-only"><p>运行中的 <code>dsh</code> 是一棵按序叠加的插件树：<strong>Profile</strong>（命名组合，存于 <code>$DSH_HOME/profiles/&lt;name&gt;</code>）列出 bundles + 用户 <code>cordis.patch.yml</code>；<strong>Bundle</strong>（如 <code>@deepseek-ai/dsh-base</code>）是 Cordis 配置行 + 代码的发行格式。</p></div>
+    <div class="lang-en-only"><p>A running <code>dsh</code> is a plugin tree stacked in order: a <strong>Profile</strong> (named composition under <code>$DSH_HOME/profiles/&lt;name&gt;</code>) lists bundles plus the user's <code>cordis.patch.yml</code>; a <strong>Bundle</strong> (e.g. <code>@deepseek-ai/dsh-base</code>) is the distribution format for Cordis config rows and the code they mount.</p></div>
+
+    <h3 class="sub"><span class="sec-num">C04.1</span> <span class="lang-zh-only">三层叠加顺序</span><span class="lang-en-only">Three-layer stack order</span></h3>
+
+    <div class="ladder">
+      <div class="ld-row">
+        <div class="ld-num">01</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">bundles[]</span><span class="lang-en-only">dsh-base → dsh-web-app（profile 声明顺序）</span></div>
+
+        </div>
+      </div>
+      <div class="ld-row">
+        <div class="ld-num">02</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">profile patch</span><span class="lang-en-only">profiles/web/cordis.patch.yml</span></div>
+
+        </div>
+      </div>
+      <div class="ld-row">
+        <div class="ld-num">03</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">home patch</span><span class="lang-en-only">$DSH_HOME/cordis.patch.yml</span></div>
+
+        </div>
+      </div>
+      <div class="ld-row">
+        <div class="ld-num">04</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">--patch</span><span class="lang-en-only">CLI 一次性 overlay</span></div>
+
+        </div>
+      </div>
+    </div>
+
+    <div class="lang-zh-only"><p>Patch 按 <code>id</code>  targeting：<strong>整行替换 config</strong>，不是 deep-merge。要看机器实际 boot 的树，运行 <code>dsh --profile web --dump-config</code>——输出与 <code>boot()</code> 挂载的树一致（<code>packages/boot/app-boot</code> 的 <code>renderConfigDump</code>）。</p></div>
+    <div class="lang-en-only"><p>Patches target by <code>id</code>: they <strong>replace the whole row config</strong>, not deep-merge. To see the tree your machine actually boots, run <code>dsh --profile web --dump-config</code> — output matches what <code>boot()</code> mounts (<code>renderConfigDump</code> in <code>packages/boot/app-boot</code>).</p></div>
+
+    <h3 class="sub"><span class="sec-num">C04.2</span> <span class="lang-zh-only">官方三个 Bundle</span><span class="lang-en-only">Three official bundles</span></h3>
+
+    <table class="cmp">
+      <thead><tr><th>Bundle</th><th>Package</th><th>Adds</th></tr></thead>
+      <tbody>
+      <tr><td>dsh-base</td><td>packages/bundle/base</td><td>模型 · 工具 · 会话 · 沙箱 · 凭据</td></tr>
+      <tr><td>dsh-web-app</td><td>packages/bundle/web-app</td><td>浏览器 UI · :3080 Host</td></tr>
+      <tr><td>dsh-headless</td><td>packages/bundle/headless</td><td>一次性 runner · 无 HTTP</td></tr>
+      </tbody>
+    </table>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; apps/cli/src/bin.ts</span>
+        <span class="src-tag">dump</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// dsh --profile web --dump-config</span></span>
+      <span class="src-line"><span class="src-fn">renderConfigDump</span>(binName, configPath, layers, warn)</span>
+    </div>
+
+    <div class="stage-purpose">
+      <div class="sp-row">
+        <div class="sp-key"><span class="lang-zh-only">web</span><span class="lang-en-only">web profile</span></div>
+        <div class="sp-val"><span class="lang-zh-only">首次使用自动从模板初始化</span><span class="lang-en-only">auto-init from template on first use</span></div>
+      </div>
+      <div class="sp-row">
+        <div class="sp-key"><span class="lang-zh-only">headless</span><span class="lang-en-only">headless</span></div>
+        <div class="sp-val"><span class="lang-zh-only">单会话 · 打印最终回答 · exit</span><span class="lang-en-only">one session · print final answer · exit</span></div>
+      </div>
+      <div class="sp-row">
+        <div class="sp-key"><span class="lang-zh-only">plugin</span><span class="lang-en-only">dsh plugin</span></div>
+        <div class="sp-val"><span class="lang-zh-only">pnpm 管理 profile 外树插件</span><span class="lang-en-only">pnpm manages out-of-tree profile plugins</span></div>
+      </div>
+    </div>
+
+    <div class="note copper">
+      <span class="lang-zh-only">📘 <strong>架构总览</strong>（<code>docs/architecture.md</code>）· Cordis 插件树、Profile×Bundle 组合、六大 ctx 服务与 turn 流</span>
+      <span class="lang-en-only">📘 <strong>Architecture overview</strong> (<code>docs/architecture.md</code>) · Cordis plugin tree, Profile×Bundle composition, six core ctx services, and turn flow</span>
+    </div>
+
+    <div class="trace-box">
+      <div class="tb-tag">TRACE · station station core spine</div>
+      <div class="lang-zh-only"><p>站 core spine：六包依赖。</p></div>
+      <div class="lang-en-only"><p>St. core spine: six-package spine.</p></div>
+    </div>
+
+    <div class="depth-zone" data-chapter="C04"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C04.4+</span><span class="lang-en-only">Deep dive · C04.4+</span></div>
+
+    </div>
+  </section>
+
+  <section class="chap" id="c5">
+    <div class="chap-num">CHAPTER&nbsp;05&nbsp;·&nbsp;BACKGROUND</div>
+    <h2 class="chap-title lang-zh-only">Everything is a plugin</h2>
+    <h2 class="chap-title lang-en-only">Everything is a plugin</h2>
+    <p class="chap-en lang-zh-only">没有特权核心 · 只有 Cordis 组合</p>
+    <p class="chap-en lang-en-only">no privileged core · Cordis composition only</p>
+    <nav class="chapter-compass" aria-label="Chapter navigation">
+      <div class="cc-row">
+        <div class="cc-phase"><span class="cc-roman">·</span> · <span class="lang-zh-only">背景</span><span class="lang-en-only">Background</span></div>
+        <div class="cc-station"><span class="lang-zh-only">—</span><span class="lang-en-only">—</span> · C05/26</div>
+      </div>
+      <div class="cc-forest"><span class="lang-zh-only">一切皆插件</span><span class="lang-en-only">Everything is a plugin</span></div>
+      <div class="cc-links">
+        <a class="cc-nav cc-prev" href="#c4"><span class="cc-arrow">←</span> <span class="cc-nav-num">C04</span> <span class="lang-zh-only">Core spine 六层</span><span class="lang-en-only">The core-spine six layers</span></a>
+        <a class="cc-map" href="#forest-overview"><span class="lang-zh-only">回到总览</span><span class="lang-en-only">Forest map</span></a>
+        <a class="cc-nav cc-next" href="#c6"><span class="cc-nav-num">C06</span> <span class="lang-zh-only">dsh 启动链</span><span class="lang-en-only">dsh boot chain</span> <span class="cc-arrow">→</span></a>
+      </div>
+    </nav>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>本章回答「这条主线 prompt 在此层长什么样」</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH 没有隐藏魔法——一切可替换行为都在 Cordis 事件或 SessionEvent 里</span></p>
+      <p><span class="swc-pill act">优化</span><span>读源码时先搜 session.append 与 ctx.* 注册点</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>This chapter answers what the through-line prompt looks like at this layer</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH has no hidden magic — replaceable behavior lives in Cordis events or SessionEvents</span></p>
+      <p><span class="swc-pill act">优化</span><span>When reading source, search session.append and ctx.* registration first</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">plugin</span><span class="lang-en-only">plugin</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">plugin</span><span class="lang-en-only">plugin</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">packages/*</span><span class="lang-en-only">packages/*</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">patchable</span><span class="lang-en-only">patchable</span></div>
+      </div>
+    </div>
+
+    <div class="lang-zh-only"><p><code>@deepseek-ai/dsh-base</code> 的 <code>cordis.patch.yml</code> 在空 profile 根上 insert 所有基础插件行——每个 profile 的 <code>dsh.profile.bundles</code> 第一层。文档把<strong>六个 ctx 脊柱服务</strong>列为理解 turn 流的最小集合。</p></div>
+    <div class="lang-en-only"><p><code>@deepseek-ai/dsh-base</code> <code>cordis.patch.yml</code> inserts every base plugin row over the empty profile root — the first layer of every profile's <code>dsh.profile.bundles</code>. Docs list <strong>six ctx spine services</strong> as the minimal set for understanding turn flow.</p></div>
+
+    <h3 class="sub"><span class="sec-num">C05.1</span> <span class="lang-zh-only">六层 ctx 脊柱</span><span class="lang-en-only">Six ctx spine layers</span></h3>
+
+    <table class="cmp">
+      <thead><tr><th>ctx 键</th><th>Package</th><th>职责 / Role</th></tr></thead>
+      <tbody>
+      <tr><td>ctx.sessions</td><td>packages/core/session</td><td>append-only SessionEvent log</td></tr>
+      <tr><td>ctx.systemPrompt</td><td>packages/core/system-prompt</td><td>prompt section + tool schema assembly</td></tr>
+      <tr><td>ctx.tools</td><td>packages/core/tools</td><td>scoped registry + guarded pipeline</td></tr>
+      <tr><td>ctx.agents</td><td>packages/core/agent</td><td>Agent registry + agent/* events</td></tr>
+      <tr><td>ctx.agentLoop</td><td>packages/core/agent-loop</td><td>ReactLoopAgent driver</td></tr>
+      <tr><td>ctx.llm</td><td>packages/llm/llm</td><td>adapter registry + llm/stream waterfall</td></tr>
+      </tbody>
+    </table>
+
+    <figure>
+      <div class="figbox"><div class="pi-fig"><svg viewBox="0 0 720 310" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true" class="pi-svg">
+  <defs>
+    <marker id="pi-arr" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 Z" fill="#1f5c8c"/>
+    </marker>
+  </defs><text x="48" y="28" class="svg-label">Profile × Bundle × Patch · boot composition</text><rect x="120" y="48" width="480" height="32" rx="3" fill="#b35a1f" opacity="0.12" stroke="#b35a1f"/><text x="140" y="68" class="svg-body">L6 · Profile patch</text><text x="520" y="68" text-anchor="end" class="svg-mute">cordis.patch.yml</text><rect x="120" y="86" width="480" height="32" rx="3" fill="#3873a3" opacity="0.12" stroke="#3873a3"/><text x="140" y="106" class="svg-body">L5 · dsh-web-app</text><text x="520" y="106" text-anchor="end" class="svg-mute">browser surface</text><rect x="120" y="124" width="480" height="32" rx="3" fill="#1f5c8c" opacity="0.12" stroke="#1f5c8c"/><text x="140" y="144" class="svg-body">L4 · dsh-base</text><text x="520" y="144" text-anchor="end" class="svg-mute">core plugin rows</text><rect x="120" y="162" width="480" height="32" rx="3" fill="#6b3aa3" opacity="0.12" stroke="#6b3aa3"/><text x="140" y="182" class="svg-body">L3 · Home patch</text><text x="520" y="182" text-anchor="end" class="svg-mute">$DSH_HOME/cordis.patch.yml</text><rect x="120" y="200" width="480" height="32" rx="3" fill="#767c87" opacity="0.12" stroke="#767c87"/><text x="140" y="220" class="svg-body">L2 · --patch</text><text x="520" y="220" text-anchor="end" class="svg-mute">CLI overlay</text><rect x="120" y="238" width="480" height="32" rx="3" fill="#2d6a4f" opacity="0.12" stroke="#2d6a4f"/><text x="140" y="258" class="svg-body">L1 · empty root</text><text x="520" y="258" text-anchor="end" class="svg-mute">entry list []</text><text x="360" y="290" text-anchor="middle" class="svg-mute">dsh --profile web --dump-config prints the merged tree</text></svg></div></div>
+      <figcaption>
+        <span class="figid">FIG</span>
+        <span class="lang-zh-only">Cordis 配置层：Bundle 按序 insert，Profile/Home/--patch 按 id 整行覆盖。</span>
+        <span class="lang-en-only">Cordis config layers: bundles insert in order; profile/home/--patch replace whole rows by id.</span>
+      </figcaption>
+    </figure>
+
+    <h3 class="sub"><span class="sec-num">C05.2</span> <span class="lang-zh-only">dsh-base 还包含什么</span><span class="lang-en-only">What else dsh-base includes</span></h3>
+
+    <div class="lang-zh-only"><p>除六脊柱外，base patch 还 insert 沙箱（<code>bash-sandbox</code> / <code>pwsh-sandbox</code> 平台门控）、审批（<code>user-approval</code>）、settings/credentials、telemetry、spawn/fork subagent providers 等。Windows 与 POSIX 通过 <code>disabled: !!js process.platform === 'win32'</code> 在同一 patch 文件里互斥挂载 shell 栈。</p></div>
+    <div class="lang-en-only"><p>Beyond the six spine services, the base patch also inserts sandbox (<code>bash-sandbox</code> / <code>pwsh-sandbox</code> platform gating), approval (<code>user-approval</code>), settings/credentials, telemetry, spawn/fork subagent providers, etc. Windows and POSIX mutually exclude shell stacks in one patch file via <code>disabled: !!js process.platform === 'win32'</code>.</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/bundle/base/cordis.patch.yml</span>
+        <span class="src-tag">base</span>
+      </div>
+      <span class="src-line">- id: session</span>
+      <span class="src-line">  name: '@deepseek-ai/dsh-session'</span>
+      <span class="src-line">- id: agent-loop</span>
+      <span class="src-line">  name: '@deepseek-ai/dsh-agent-loop'</span>
+    </div>
+
+    <div class="formula">
+      <div class="ftitle"><span class="lang-zh-only">依赖方向</span><span class="lang-en-only">DEPENDENCY</span></div>
+      <span class="cond"><span class="term">agent-loop</span> → agents · sessions · llm · tools</span>
+      <span class="cond"><span class="term-cu">systemPrompt</span> ← context plugins (AGENTS.md, skills)</span>
+      <div class="out"><span class="lang-zh-only">上层组装下层，通过 inject 而非 import</span><span class="lang-en-only">Upper layers compose lower via inject, not import</span></div>
+    </div>
+
+    <div class="keynum-row">
+      <div class="keynum">
+        <div class="kn-val">219+</div>
+        <div class="kn-label"><span class="lang-zh-only">workspace 包</span><span class="lang-en-only">packages</span></div>
+        <div class="kn-desc"><span class="lang-zh-only">官方 monorepo 插件数量级</span><span class="lang-en-only">order-of-magnitude official monorepo plugins</span></div>
+      </div>
+      <div class="keynum">
+        <div class="kn-val">6</div>
+        <div class="kn-label"><span class="lang-zh-only">ctx 脊柱</span><span class="lang-en-only">ctx spine</span></div>
+        <div class="kn-desc"><span class="lang-zh-only">session · prompt · tools · agents · loop · llm</span><span class="lang-en-only">session · prompt · tools · agents · loop · llm</span></div>
+      </div>
+      <div class="keynum">
+        <div class="kn-val">0</div>
+        <div class="kn-label"><span class="lang-zh-only">privileged core</span><span class="lang-en-only">privileged core</span></div>
+        <div class="kn-desc"><span class="lang-zh-only">vendor/Cordis 也可被 patch 替换</span><span class="lang-en-only">vendor/Cordis can also be patched</span></div>
+      </div>
+    </div>
+
+    <div class="note copper">
+      <span class="lang-zh-only">📘 <strong>能力接缝图</strong>（<code>docs/capability-seams.md</code>）· ctx.fs / ctx.shell / ctx.sandbox 等可替换 seam 与实现包映射</span>
+      <span class="lang-en-only">📘 <strong>Capability seams</strong> (<code>docs/capability-seams.md</code>) · Swappable seams (ctx.fs, ctx.shell, ctx.sandbox) and implementation packages</span>
+    </div>
+
+    <div class="trace-box">
+      <div class="tb-tag">TRACE · station station plugin</div>
+      <div class="lang-zh-only"><p>站 plugin：无特权核心。</p></div>
+      <div class="lang-en-only"><p>St. plugin: no privileged core.</p></div>
+    </div>
+
+    <div class="depth-zone" data-chapter="C05"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C05.4+</span><span class="lang-en-only">Deep dive · C05.4+</span></div>
+
+    </div>
+  </section>
+
+  <section class="chap" id="c6">
+    <div class="chap-num">CHAPTER&nbsp;06&nbsp;·&nbsp;INTAKE</div>
+    <h2 class="chap-title lang-zh-only">dsh 启动链</h2>
+    <h2 class="chap-title lang-en-only">dsh boot chain</h2>
+    <p class="chap-en lang-zh-only">profile → bundle → Loader → ctx</p>
+    <p class="chap-en lang-en-only">profile → bundle → Loader → ctx</p>
+    <nav class="chapter-compass" aria-label="Chapter navigation">
+      <div class="cc-row">
+        <div class="cc-phase"><span class="cc-roman">I</span> · <span class="lang-zh-only">入口</span><span class="lang-en-only">Intake</span></div>
+        <div class="cc-station"><span class="lang-zh-only">站 01–03</span><span class="lang-en-only">St. 01–03</span> · C06/26</div>
+      </div>
+      <div class="cc-forest"><span class="lang-zh-only">dsh web 启动链</span><span class="lang-en-only">dsh web boot chain</span></div>
+      <div class="cc-links">
+        <a class="cc-nav cc-prev" href="#c5"><span class="cc-arrow">←</span> <span class="cc-nav-num">C05</span> <span class="lang-zh-only">Everything is a plugin</span><span class="lang-en-only">Everything is a plugin</span></a>
+        <a class="cc-map" href="#forest-overview"><span class="lang-zh-only">回到总览</span><span class="lang-en-only">Forest map</span></a>
+        <a class="cc-nav cc-next" href="#c7"><span class="cc-nav-num">C07</span> <span class="lang-zh-only">ctx.agents 生命周期</span><span class="lang-en-only">ctx.agents lifecycle</span> <span class="cc-arrow">→</span></a>
+      </div>
+    </nav>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>本章回答「这条主线 prompt 在此层长什么样」</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH 没有隐藏魔法——一切可替换行为都在 Cordis 事件或 SessionEvent 里</span></p>
+      <p><span class="swc-pill act">优化</span><span>读源码时先搜 session.append 与 ctx.* 注册点</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>This chapter answers what the through-line prompt looks like at this layer</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH has no hidden magic — replaceable behavior lives in Cordis events or SessionEvents</span></p>
+      <p><span class="swc-pill act">优化</span><span>When reading source, search session.append and ctx.* registration first</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">boot</span><span class="lang-en-only">boot</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">boot</span><span class="lang-en-only">boot</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">apps/cli</span><span class="lang-en-only">apps/cli</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">profile</span><span class="lang-en-only">profile</span></div>
+      </div>
+    </div>
+
+    <div class="lang-zh-only"><p>你在 shell 输入 <code>dsh web</code>（<code>--profile web</code> 别名），启动链从 <code>apps/cli/src/args.ts</code> 解析 launcher flags，<code>src/bin.ts</code> 加载对应 runner，<code>packages/boot/app-boot</code> 的 <code>boot()</code> 创建 Cordis root、compose profile layers、mount include 树，Host 绑定 loopback :3080，浏览器加载 Web surface。</p></div>
+    <div class="lang-en-only"><p>You type <code>dsh web</code> (alias of <code>--profile web</code>); the boot chain parses launcher flags in <code>apps/cli/src/args.ts</code>, <code>src/bin.ts</code> loads the runner, <code>boot()</code> in <code>packages/boot/app-boot</code> creates the Cordis root, composes profile layers, mounts the include tree, Host binds loopback :3080, browser loads the Web surface.</p></div>
+
+    <h3 class="sub"><span class="sec-num">C06.1</span> <span class="lang-zh-only">CLI → Profile → :3080</span><span class="lang-en-only">CLI → Profile → :3080</span></h3>
+
+    <div class="ladder">
+      <div class="ld-row">
+        <div class="ld-num">01</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">apps/cli</span><span class="lang-en-only">dsh web · --profile web</span></div>
+
+        </div>
+      </div>
+      <div class="ld-row">
+        <div class="ld-num">02</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">app-boot</span><span class="lang-en-only">loadProfile · composeEntries · boot()</span></div>
+
+        </div>
+      </div>
+      <div class="ld-row">
+        <div class="ld-num">03</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">dsh-base + dsh-web-app</span><span class="lang-en-only">Cordis plugin tree</span></div>
+
+        </div>
+      </div>
+      <div class="ld-row">
+        <div class="ld-num">04</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">packages/host</span><span class="lang-en-only">HTTP Host · static dist</span></div>
+
+        </div>
+      </div>
+      <div class="ld-row">
+        <div class="ld-num">05</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">packages/web</span><span class="lang-en-only">React client · session/event SSE</span></div>
+
+        </div>
+      </div>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; apps/cli/README.md</span>
+        <span class="src-tag">cli</span>
+      </div>
+      <span class="src-line">| <code>dsh web</code> | Alias of <code>--profile web</code> |</span>
+      <span class="src-line">The invoking directory is the default workspace root.</span>
+    </div>
+
+    <h3 class="sub"><span class="sec-num">C06.2</span> <span class="lang-zh-only">Launcher 与 App 参数分界</span><span class="lang-en-only">Launcher vs app argument boundary</span></h3>
+
+    <div class="lang-zh-only"><p>Launcher 只解析自己的 flags；第一个无法识别的 token 起属于 profile 注入的 app 插件（如 <code>--port 8080</code> 给 web app）。这意味着 <code>dsh --profile web --help</code> 显示的是 Web UI 帮助，不是 launcher 帮助。</p></div>
+    <div class="lang-en-only"><p>The launcher parses only its own flags; from the first unrecognized token onward belongs to the profile's injected app plugin (e.g. <code>--port 8080</code> for the web app). So <code>dsh --profile web --help</code> shows Web UI help, not launcher help.</p></div>
+
+    <table class="cmp">
+      <thead><tr><th>阶段</th><th>模块</th><th>失败行为</th></tr></thead>
+      <tbody>
+      <tr><td>parse</td><td>apps/cli/src/args.ts</td><td>exit nonzero</td></tr>
+      <tr><td>compose</td><td>app-boot/loadProfile</td><td>profile 缺失 → 模板初始化或 fail loud</td></tr>
+      <tr><td>mount</td><td>app-boot/boot</td><td>partial ctx dispose + labelled stderr</td></tr>
+      <tr><td>serve</td><td>packages/host</td><td>Web surface 未加载则不创建 tray</td></tr>
+      </tbody>
+    </table>
+
+    <div class="note copper">
+      <span class="lang-zh-only">冷启动时用户尚未输入主线 prompt，但 Cordis 树已就绪、:3080 已在听。</span>
+      <span class="lang-en-only">On cold boot the user has not typed the through-line prompt yet, but the Cordis tree is ready and :3080 is listening.</span>
+    </div>
+
+    <div class="trace-box">
+      <div class="tb-tag">TRACE · station station boot</div>
+      <div class="lang-zh-only"><p>站 boot：dsh web 启动。</p></div>
+      <div class="lang-en-only"><p>St. boot: dsh web boot.</p></div>
+    </div>
+
+    <div class="depth-zone" data-chapter="C06"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C06.4+</span><span class="lang-en-only">Deep dive · C06.4+</span></div>
+
+    </div>
+  </section>
+
+  <section class="chap" id="c7">
+    <div class="chap-num">CHAPTER&nbsp;07&nbsp;·&nbsp;INTAKE</div>
+    <h2 class="chap-title lang-zh-only">ctx.agents 生命周期</h2>
+    <h2 class="chap-title lang-en-only">ctx.agents lifecycle</h2>
+    <p class="chap-en lang-zh-only">create · resume · dispose · scoped ctx</p>
+    <p class="chap-en lang-en-only">create · resume · dispose · scoped ctx</p>
+    <nav class="chapter-compass" aria-label="Chapter navigation">
+      <div class="cc-row">
+        <div class="cc-phase"><span class="cc-roman">I</span> · <span class="lang-zh-only">入口</span><span class="lang-en-only">Intake</span></div>
+        <div class="cc-station"><span class="lang-zh-only">站 04–06</span><span class="lang-en-only">St. 04–06</span> · C07/26</div>
+      </div>
+      <div class="cc-forest"><span class="lang-zh-only">ctx.agents 生命周期</span><span class="lang-en-only">ctx.agents lifecycle</span></div>
+      <div class="cc-links">
+        <a class="cc-nav cc-prev" href="#c6"><span class="cc-arrow">←</span> <span class="cc-nav-num">C06</span> <span class="lang-zh-only">dsh 启动链</span><span class="lang-en-only">dsh boot chain</span></a>
+        <a class="cc-map" href="#forest-overview"><span class="lang-zh-only">回到总览</span><span class="lang-en-only">Forest map</span></a>
+        <a class="cc-nav cc-next" href="#c8"><span class="cc-nav-num">C08</span> <span class="lang-zh-only">system-prompt 组装</span><span class="lang-en-only">System prompt assembly</span> <span class="cc-arrow">→</span></a>
+      </div>
+    </nav>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>本章回答「这条主线 prompt 在此层长什么样」</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH 没有隐藏魔法——一切可替换行为都在 Cordis 事件或 SessionEvent 里</span></p>
+      <p><span class="swc-pill act">优化</span><span>读源码时先搜 session.append 与 ctx.* 注册点</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>This chapter answers what the through-line prompt looks like at this layer</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH has no hidden magic — replaceable behavior lives in Cordis events or SessionEvents</span></p>
+      <p><span class="swc-pill act">优化</span><span>When reading source, search session.append and ctx.* registration first</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">agents</span><span class="lang-en-only">agents</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">agents</span><span class="lang-en-only">agents</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">packages/core/agent</span><span class="lang-en-only">packages/core/agent</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">ctx.agents</span><span class="lang-en-only">ctx.agents</span></div>
+      </div>
+    </div>
+
+    <div class="lang-zh-only"><p><code>ctx.sessions</code>（<code>packages/core/session</code>）维护 append-only <code>SessionEvent</code> log；<code>ctx.agents</code>（<code>packages/core/agent</code>）维护 live <code>Agent</code> registry。主线 prompt 通过 <code>agent.followup(content)</code> 进入 inbox，由 <code>ReactLoopAgent</code>（<code>packages/core/agent-loop/src/agent.ts</code>）驱动。</p></div>
+    <div class="lang-en-only"><p><code>ctx.sessions</code> (<code>packages/core/session</code>) maintains the append-only <code>SessionEvent</code> log; <code>ctx.agents</code> (<code>packages/core/agent</code>) maintains the live <code>Agent</code> registry. The through-line prompt enters via <code>agent.followup(content)</code> into inbox, driven by <code>ReactLoopAgent</code> (<code>packages/core/agent-loop/src/agent.ts</code>).</p></div>
+
+    <h3 class="sub"><span class="sec-num">C07.1</span> <span class="lang-zh-only">Session 与 Agent 的分工</span><span class="lang-en-only">Session vs Agent split</span></h3>
+
+    <table class="cmp">
+      <thead><tr><th>对象</th><th>持久?</th><th>主线时刻</th></tr></thead>
+      <tbody>
+      <tr><td>Session</td><td>✓ log + persistence</td><td>user/message · tool/result 落盘</td></tr>
+      <tr><td>Agent</td><td>△ runtime only</td><td>inbox claim · turn/step 状态机</td></tr>
+      <tr><td>Inbox</td><td>✗</td><td>followup 排队 · next-step vs later</td></tr>
+      <tr><td>Driver</td><td>✗</td><td>ReactLoopAgent 认领 prepared session</td></tr>
+      </tbody>
+    </table>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/core/agent-loop/src/agent.ts</span>
+        <span class="src-tag">agent</span>
+      </div>
+      <span class="src-line"><span class="src-kw">export class</span> <span class="src-cls">ReactLoopAgent</span> <span class="src-kw">implements</span> <span class="src-cls">Agent</span> {</span>
+      <span class="src-line">  <span class="src-kw">constructor</span>(loopCtx, id, options, <span class="src-arg">session</span>: <span class="src-cls">Session</span>)</span>
+      <span class="src-line">  <span class="src-comment">/** Drives one session through turn and step boundaries. */</span></span>
+    </div>
+
+    <h3 class="sub"><span class="sec-num">C07.2</span> <span class="lang-zh-only">一个 prepared session 只能被一个 driver 认领</span><span class="lang-en-only">One prepared session, one driver</span></h3>
+
+    <div class="lang-zh-only"><p>架构文档强调：lifecycle owner 通过 <code>ctx.agents</code> 创建 agent，而不是直接 new <code>ReactLoopAgent</code>。包导出刻意不提供 <code>./src/*</code> 逃逸 hatch——可观测行为全部经由 session events + <code>agent/*</code> 分类体系。</p></div>
+    <div class="lang-en-only"><p>Architecture docs stress: lifecycle owners create agents through <code>ctx.agents</code>, not by directly constructing <code>ReactLoopAgent</code>. Package exports deliberately expose no <code>./src/*</code> escape hatch — all observable behavior goes through session events + the <code>agent/*</code> taxonomy.</p></div>
+
+    <figure>
+      <div class="figbox"><div class="event-flow">
+      <div class="ef-row"><div class="ef-type">agent/inbox/inserted</div><div><span class="lang-zh-only">followup 入队</span><span class="lang-en-only">followup queued</span></div></div>
+      <div class="ef-row"><div class="ef-type">agent/inbox/claimed</div><div><span class="lang-zh-only">claim 批次绑定 turn</span><span class="lang-en-only">claimed batch bound to turn</span></div></div>
+      <div class="ef-row"><div class="ef-type">agent/status</div><div><span class="lang-zh-only">running ↔ idle</span><span class="lang-en-only">running ↔ idle</span></div></div>
+      <div class="ef-row"><div class="ef-type">session/created</div><div><span class="lang-zh-only">新会话 · persistence 订阅</span><span class="lang-en-only">new session · persistence subscribes</span></div></div>
+    </div>
+      </div>
+      <figcaption><span class="figid">EVT</span><span class="lang-zh-only">SessionEvent 流 · 主线 prompt</span><span class="lang-en-only">SessionEvent stream · through-line prompt</span></figcaption>
+    </figure>
+
+    <div class="note copper">
+      <span class="lang-zh-only">📘 <strong>Agent 生命周期</strong>（<code>docs/agent-lifecycle.md</code>）· turn/step 双环、agent/pre-step waterfall、session 与 agent 事件分工</span>
+      <span class="lang-en-only">📘 <strong>Agent lifecycle</strong> (<code>docs/agent-lifecycle.md</code>) · turn/step twin loops, agent/pre-step waterfall, session vs agent event split</span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/core/agent-loop/src/agent.ts</span>
+        <span class="src-tag">walkthrough</span>
+      </div>
+      <span class="src-line"><span class="src-ln">  1</span> <span class="src-hl">send(message, target, wakeup)</span></span>
+      <span class="src-line"><span class="src-comment">     // 用户主线入口 / through-line entry</span></span>
+      <span class="src-line"><span class="src-ln">  2</span> <span class="src-hl">inbox.splice(resolvedTarget, ...)</span></span>
+      <span class="src-line"><span class="src-comment">     // claim 下一条 user/message / claim next user/message</span></span>
+      <span class="src-line"><span class="src-ln">  3</span> <span class="src-hl">wakeDriver(wakingAfterAbort)</span></span>
+      <span class="src-line"><span class="src-comment">     // 唤醒 ReactLoopAgent / wake ReactLoopAgent</span></span>
+      <span class="src-line"><span class="src-ln">  4</span> <span class="src-hl">session.append('turn/start', { turn })</span></span>
+      <span class="src-line"><span class="src-comment">     // 持久化 turn 边界 / persist turn boundary</span></span>
+    </div>
+
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">交叉引用</span><span class="lang-en-only">Cross-ref</span></span> <span class="da-title lang-zh-only">deepseek-harness 文档</span><span class="da-title lang-en-only">deepseek-harness docs</span></div>    <table class="cmp">
+      <thead><tr><th>DOC</th><th>主题</th><th>路径</th><th>摘要</th></tr></thead>
+      <tbody>
+      <tr><td>agent-lifecycle</td><td>Agent 生命周期</td><td><code>docs/agent-lifecycle.md</code></td><td>turn/step twin loops, agent/pre-step waterfall, session vs agent event split</td></tr>
+      </tbody>
+    </table>
+
+    <div class="trace-box">
+      <div class="tb-tag">TRACE · station station agents</div>
+      <div class="lang-zh-only"><p>站 agents：Agent 注册。</p></div>
+      <div class="lang-en-only"><p>St. agents: Agent registry.</p></div>
+    </div>
+
+    <div class="depth-zone" data-chapter="C07"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C07.4+</span><span class="lang-en-only">Deep dive · C07.4+</span></div>
+
+    </div>
+  </section>
+
+  <section class="chap" id="c8">
+    <div class="chap-num">CHAPTER&nbsp;08&nbsp;·&nbsp;INTAKE</div>
+    <h2 class="chap-title lang-zh-only">system-prompt 组装</h2>
+    <h2 class="chap-title lang-en-only">System prompt assembly</h2>
+    <p class="chap-en lang-zh-only">section waterfall · tool schema 入模</p>
+    <p class="chap-en lang-en-only">section waterfall · tool schemas into model</p>
+    <nav class="chapter-compass" aria-label="Chapter navigation">
+      <div class="cc-row">
+        <div class="cc-phase"><span class="cc-roman">I</span> · <span class="lang-zh-only">入口</span><span class="lang-en-only">Intake</span></div>
+        <div class="cc-station"><span class="lang-zh-only">站 07</span><span class="lang-en-only">St. 07</span> · C08/26</div>
+      </div>
+      <div class="cc-forest"><span class="lang-zh-only">system-prompt 组装</span><span class="lang-en-only">system-prompt assembly</span></div>
+      <div class="cc-links">
+        <a class="cc-nav cc-prev" href="#c7"><span class="cc-arrow">←</span> <span class="cc-nav-num">C07</span> <span class="lang-zh-only">ctx.agents 生命周期</span><span class="lang-en-only">ctx.agents lifecycle</span></a>
+        <a class="cc-map" href="#forest-overview"><span class="lang-zh-only">回到总览</span><span class="lang-en-only">Forest map</span></a>
+        <a class="cc-nav cc-next" href="#c9"><span class="cc-nav-num">C09</span> <span class="lang-zh-only">Session log 不变量</span><span class="lang-en-only">Session log invariant</span> <span class="cc-arrow">→</span></a>
+      </div>
+    </nav>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>本章回答「这条主线 prompt 在此层长什么样」</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH 没有隐藏魔法——一切可替换行为都在 Cordis 事件或 SessionEvent 里</span></p>
+      <p><span class="swc-pill act">优化</span><span>读源码时先搜 session.append 与 ctx.* 注册点</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>This chapter answers what the through-line prompt looks like at this layer</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH has no hidden magic — replaceable behavior lives in Cordis events or SessionEvents</span></p>
+      <p><span class="swc-pill act">优化</span><span>When reading source, search session.append and ctx.* registration first</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">system-prompt</span><span class="lang-en-only">system-prompt</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">system-prompt</span><span class="lang-en-only">system-prompt</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">packages/core/system-prompt</span><span class="lang-en-only">packages/core/system-prompt</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">assemble</span><span class="lang-en-only">assemble</span></div>
+      </div>
+    </div>
+
+    <div class="lang-zh-only"><p>模型看到的 system 内容不是裸仓库规则——<code>ctx.systemPrompt</code>（<code>packages/core/system-prompt</code>）在每次 step 前通过 <code>system-prompt/assemble</code> waterfall 把 prompt section 与 tool schema 拼成最终前缀。AGENTS.md 栈、skill 目录、plan mode 提示都以 section 形式注入。</p></div>
+    <div class="lang-en-only"><p>The system content the model sees is not bare repo rules — <code>ctx.systemPrompt</code> (<code>packages/core/system-prompt</code>) assembles prompt sections and tool schemas via the <code>system-prompt/assemble</code> waterfall before each step. AGENTS.md stacks, skill catalogs, and plan-mode hints inject as sections.</p></div>
+
+    <h3 class="sub"><span class="sec-num">C08.1</span> <span class="lang-zh-only">Prompt section 叠加</span><span class="lang-en-only">Prompt section stacking</span></h3>
+
+    <div class="ladder">
+      <div class="ld-row">
+        <div class="ld-num">01</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">harness:identity</span><span class="lang-en-only">DSH 身份 · 不可用户覆盖</span></div>
+
+        </div>
+      </div>
+      <div class="ld-row">
+        <div class="ld-num">02</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">harness:source</span><span class="lang-en-only">可选 · checkout 路径（dev boot）</span></div>
+
+        </div>
+      </div>
+      <div class="ld-row">
+        <div class="ld-num">03</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">persona / AGENTS.md</span><span class="lang-en-only">packages/context/agent-instructions</span></div>
+
+        </div>
+      </div>
+      <div class="ld-row">
+        <div class="ld-num">04</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">skills catalog</span><span class="lang-en-only">packages/skill/tool-skill @ pre-step</span></div>
+
+        </div>
+      </div>
+      <div class="ld-row">
+        <div class="ld-num">05</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">tool schemas</span><span class="lang-en-only">ctx.tools 注册 · 动态生成</span></div>
+
+        </div>
+      </div>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/core/system-prompt/README.md</span>
+        <span class="src-tag">sp</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// system-prompt/assemble waterfall</span></span>
+      <span class="src-line">Sections register via <span class="src-fn">ctx.effect()</span> and unwind on plugin unload.</span>
+    </div>
+
+    <h3 class="sub"><span class="sec-num">C08.2</span> <span class="lang-zh-only">主线 prompt 时的模型输入长什么样</span><span class="lang-en-only">What model input looks like at through-line prompt</span></h3>
+
+    <div class="lang-zh-only"><p>简化：<code>[assembled system sections + tool schemas] + deriveMessages() 投影的历史 + 本轮 user/message</code>。<code>agent/request</code> waterfall 允许最后一英里修改 messages / model / tools，然后才进入 <code>llm/stream</code>。</p></div>
+    <div class="lang-en-only"><p>Simplified: <code>[assembled system sections + tool schemas] + deriveMessages() projected history + this step's user/message</code>. The <code>agent/request</code> waterfall allows last-mile edits to messages / model / tools before <code>llm/stream</code>.</p></div>
+
+    <div class="stage-purpose">
+      <div class="sp-row">
+        <div class="sp-key"><span class="lang-zh-only">section</span><span class="lang-en-only">section</span></div>
+        <div class="sp-val"><span class="lang-zh-only">有序注册 · effect 卸载</span><span class="lang-en-only">ordered registration · effect unwinds on unload</span></div>
+      </div>
+      <div class="sp-row">
+        <div class="sp-key"><span class="lang-zh-only">KV cache</span><span class="lang-en-only">KV cache</span></div>
+        <div class="sp-val"><span class="lang-zh-only">identity/source 靠近头部 · 少抖动</span><span class="lang-en-only">identity/source near head · less churn</span></div>
+      </div>
+      <div class="sp-row">
+        <div class="sp-key"><span class="lang-zh-only">web Models 页</span><span class="lang-en-only">web Models page</span></div>
+        <div class="sp-val"><span class="lang-zh-only">写 settings.yaml · 热重载 adapter</span><span class="lang-en-only">writes settings.yaml · hot-reloads adapter</span></div>
+      </div>
+    </div>
+
+    <div class="note copper">
+      <span class="lang-zh-only">📘 <strong>架构总览</strong>（<code>docs/architecture.md</code>）· Cordis 插件树、Profile×Bundle 组合、六大 ctx 服务与 turn 流</span>
+      <span class="lang-en-only">📘 <strong>Architecture overview</strong> (<code>docs/architecture.md</code>) · Cordis plugin tree, Profile×Bundle composition, six core ctx services, and turn flow</span>
+    </div>
+
+    <div class="trace-box">
+      <div class="tb-tag">TRACE · station station system-prompt</div>
+      <div class="lang-zh-only"><p>站 system-prompt：prompt 组装。</p></div>
+      <div class="lang-en-only"><p>St. system-prompt: prompt assembly.</p></div>
+    </div>
+
+    <div class="depth-zone" data-chapter="C08"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C08.4+</span><span class="lang-en-only">Deep dive · C08.4+</span></div>
+
+    </div>
+  </section>
+
+  <section class="chap" id="c9">
+    <div class="chap-num">CHAPTER&nbsp;09&nbsp;·&nbsp;HEART</div>
+    <h2 class="chap-title lang-zh-only">Session log 不变量</h2>
+    <h2 class="chap-title lang-en-only">Session log invariant</h2>
+    <p class="chap-en lang-zh-only">deriveMessages · surfaceOp · model-visible means logged</p>
+    <p class="chap-en lang-en-only">deriveMessages · surfaceOp · model-visible means logged</p>
+    <nav class="chapter-compass" aria-label="Chapter navigation">
+      <div class="cc-row">
+        <div class="cc-phase"><span class="cc-roman">II</span> · <span class="lang-zh-only">心脏</span><span class="lang-en-only">Heart</span></div>
+        <div class="cc-station"><span class="lang-zh-only">站 08–09</span><span class="lang-en-only">St. 08–09</span> · C09/26</div>
+      </div>
+      <div class="cc-forest"><span class="lang-zh-only">Session log 不变量</span><span class="lang-en-only">Session log invariant</span></div>
+      <div class="cc-links">
+        <a class="cc-nav cc-prev" href="#c8"><span class="cc-arrow">←</span> <span class="cc-nav-num">C08</span> <span class="lang-zh-only">system-prompt 组装</span><span class="lang-en-only">System prompt assembly</span></a>
+        <a class="cc-map" href="#forest-overview"><span class="lang-zh-only">回到总览</span><span class="lang-en-only">Forest map</span></a>
+        <a class="cc-nav cc-next" href="#c10"><span class="cc-nav-num">C10</span> <span class="lang-zh-only">ReactLoopAgent 驱动</span><span class="lang-en-only">ReactLoopAgent driver</span> <span class="cc-arrow">→</span></a>
+      </div>
+    </nav>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>本章回答「这条主线 prompt 在此层长什么样」</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH 没有隐藏魔法——一切可替换行为都在 Cordis 事件或 SessionEvent 里</span></p>
+      <p><span class="swc-pill act">优化</span><span>读源码时先搜 session.append 与 ctx.* 注册点</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>This chapter answers what the through-line prompt looks like at this layer</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH has no hidden magic — replaceable behavior lives in Cordis events or SessionEvents</span></p>
+      <p><span class="swc-pill act">优化</span><span>When reading source, search session.append and ctx.* registration first</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">session</span><span class="lang-en-only">session</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">packages/core/session</span><span class="lang-en-only">packages/core/session</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">append</span><span class="lang-en-only">append</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">deriveMessages</span><span class="lang-en-only">deriveMessages</span></div>
+      </div>
+    </div>
+
+    <div class="lang-zh-only"><p>DSH 的心脏是 append-only <strong>SessionEvent log</strong>（<code>packages/core/session</code>）。任何进入模型请求的内容必须能从事务 log 重建——官方 invariant：<strong>Model-visible means logged</strong>，运行时 assert。</p></div>
+    <div class="lang-en-only"><p>DSH's heart is the append-only <strong>SessionEvent log</strong> (<code>packages/core/session</code>). Anything that enters a model request must be reconstructable from the log — official invariant: <strong>Model-visible means logged</strong>, runtime assert.</p></div>
+
+    <h3 class="sub"><span class="sec-num">C09.1</span> <span class="lang-zh-only">Log 是唯一真相源</span><span class="lang-en-only">Log is the single source of truth</span></h3>
+
+    <div class="lang-zh-only"><p><code>session/title</code>、telemetry 噪声等事件可以写入 log 但<strong>不进入</strong> <code>deriveMessages()</code> 投影——surface 是 sole derivation path。fork/resume 重放同一 log 序列，投影 deterministic（见 <code>packages/core/session/tests/properties.spec.ts</code>）。</p></div>
+    <div class="lang-en-only"><p>Events like <code>session/title</code> and telemetry noise may append to the log but do <strong>not</strong> enter the <code>deriveMessages()</code> projection — the surface is the sole derivation path. Fork/resume replay the same log sequence; projection is deterministic (see <code>packages/core/session/tests/properties.spec.ts</code>).</p></div>
+
+    <figure>
+      <div class="figbox"><div class="pi-fig wide"><svg viewBox="0 0 720 250" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true" class="pi-svg">
+  <defs>
+    <marker id="pi-arr" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 Z" fill="#1f5c8c"/>
+    </marker>
+  </defs>
+  <text x="48" y="28" class="svg-label">SessionEvent log · append-only · model-visible means logged</text>
+  <rect x="48" y="44" width="624" height="180" rx="4" class="svg-box paper"/>
+  <text x="64" y="68" class="svg-micro">turn/start</text>
+  <text x="64" y="88" class="svg-micro">step/start</text>
+  <text x="64" y="108" class="svg-micro">user/message · 「读取 README.md…」</text>
+  <text x="64" y="128" class="svg-micro">assistant/chunk* · streaming tokens</text>
+  <text x="64" y="148" class="svg-micro">tool/call · read(path=README.md)</text>
+  <text x="64" y="168" class="svg-micro">tool/result · fixture content</text>
+  <text x="64" y="188" class="svg-micro">assistant/message · stop</text>
+  <text x="64" y="208" class="svg-micro">step/end · turn/end</text>
+  <path d="M520 80 L620 80 L620 180 L520 180" fill="none" stroke="#1f5c8c" stroke-width="1.5" stroke-dasharray="4 2"/>
+  <text x="570" y="132" text-anchor="middle" class="svg-body">deriveMessages()</text>
+  <text x="570" y="152" text-anchor="middle" class="svg-mute">projection</text>
+</svg></div></div>
+      <figcaption>
+        <span class="figid">FIG</span>
+        <span class="lang-zh-only">SessionEvent 日志：唯一真相源；deriveMessages() 把日志投影成 LLM Message[]。</span>
+        <span class="lang-en-only">SessionEvent log: single source of truth; deriveMessages() projects log to LLM Message[].</span>
+      </figcaption>
+    </figure>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; docs/architecture.md</span>
+        <span class="src-tag">inv</span>
+      </div>
+      <span class="src-line"><span class="src-str">Model-visible means logged.</span></span>
+      <span class="src-line">Extend <span class="src-cls">SessionEventMap</span> and render from the log.</span>
+    </div>
+
+    <h3 class="sub"><span class="sec-num">C09.2</span> <span class="lang-zh-only">session/event 广播</span><span class="lang-en-only">session/event broadcast</span></h3>
+
+    <div class="lang-zh-only"><p>每次 append 触发 <code>session/event</code> emit——Web client、ACP、telemetry、compaction 都订阅此总线。UI 渲染<strong>只</strong>应消费 session 域事件做 replay；<code>agent/*</code> 是 live 协调 API。</p></div>
+    <div class="lang-en-only"><p>Each append emits <code>session/event</code> — Web client, ACP, telemetry, compaction all subscribe. UI rendering should <strong>only</strong> consume session-domain events for replay; <code>agent/*</code> is the live coordination API.</p></div>
+
+    <table class="cmp">
+      <thead><tr><th>事件类型</th><th>进入 deriveMessages?</th><th>例子</th></tr></thead>
+      <tbody>
+      <tr><td>user/message</td><td>✓</td><td>主线 prompt</td></tr>
+      <tr><td>assistant/chunk</td><td>△</td><td>流式 · 合成 assistant/message</td></tr>
+      <tr><td>tool/result</td><td>✓</td><td>read README 内容</td></tr>
+      <tr><td>session/title</td><td>✗</td><td>侧边栏标题</td></tr>
+      </tbody>
+    </table>
+
+    <blockquote class="pull copper">
+      <span class="lang-zh-only">JSONL 思维：Pi 把 transcript 当树。<br>DSH 把 log 当<strong>事件溯源带</strong>。</span>
+      <span class="lang-en-only">JSONL mindset: Pi treats transcript as a tree.<br>DSH treats the log as an <strong>event-sourcing tape</strong>.</span>
+      <cite>Field Note · 10</cite>
+    </blockquote>
+
+    <div class="note copper">
+      <span class="lang-zh-only">📘 <strong>架构总览</strong>（<code>docs/architecture.md</code>）· Cordis 插件树、Profile×Bundle 组合、六大 ctx 服务与 turn 流</span>
+      <span class="lang-en-only">📘 <strong>Architecture overview</strong> (<code>docs/architecture.md</code>) · Cordis plugin tree, Profile×Bundle composition, six core ctx services, and turn flow</span>
+    </div>
+
+    <div class="trace-walk">
+      <div class="tw-head">
+        <span class="tw-tag">SOURCE TRACE · C09</span>
+        <span class="lang-zh-only">主线 prompt「读取 README.md，用一句话告诉我这个项目做什么」进入 session log 的第一站</span>
+        <span class="lang-en-only">Through-line prompt enters the session log</span>
+      </div>
+
+    <div class="lang-zh-only"><p>DSH 的心脏契约写在 architecture.md：<strong>Model-visible means logged</strong>。任何进入模型请求的内容都必须能从 session log 重建。<code>Session.append()</code> 是唯一写入点；<code>deriveMessages()</code> 是唯一投影点——把 surface 上的 <code>user/message</code> · <code>assistant/message</code> · <code>tool/result</code> 折叠成 <code>Message[]</code>。</p></div>
+    <div class="lang-en-only"><p>DSH's heart contract in architecture.md: <strong>Model-visible means logged</strong>. Anything reaching a model request must be reconstructable from the session log. <code>Session.append()</code> is the sole write site; <code>deriveMessages()</code> is the sole projection — folding surface <code>user/message</code> · <code>assistant/message</code> · <code>tool/result</code> into <code>Message[]</code>.</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/core/session/src/index.ts</span>
+        <span class="src-tag">append</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 604</span> <span class="src-hl">  append&lt;T extends SessionEventType&gt;(</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">★ append 入口：type + data + surfaceOp</span><span class="lang-en-only">★ append entry: type + data + surfaceOp</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 605</span> <span class="src-hl">    <span class="src-kw">type</span>: T,</span></span>
+      <span class="src-line">      <span class="src-ln"> 606</span> <span class="src-hl">    data: SessionEventMap[T],</span></span>
+      <span class="src-line">      <span class="src-ln"> 607</span> <span class="src-hl">    ...opts: T extends SurfaceEventType ? [opts: SurfaceIntent] : []</span></span>
+      <span class="src-line">      <span class="src-ln"> 608</span> <span class="src-hl">  ): SessionEvent&lt;T&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln"> 609</span> <span class="src-hl">    <span class="src-kw">const</span> surfaceOpts: SurfaceIntent | <span class="src-kw">undefined</span> = opts[0]</span></span>
+      <span class="src-line">      <span class="src-ln"> 610</span> <span class="src-hl">    <span class="src-kw">const</span> surfaceMetadata = {</span></span>
+      <span class="src-line">      <span class="src-ln"> 611</span> <span class="src-hl">      ...surfaceOpts?.sourceEventSeqs === <span class="src-kw">undefined</span> ? {} : { sourceEventSeqs: surfaceOpts.sourceEventSeqs },</span></span>
+      <span class="src-line">      <span class="src-ln"> 612</span> <span class="src-hl">      ...surfaceOpts?.surfaceOp === <span class="src-kw">undefined</span> ? {} : { surfaceOp: surfaceOpts.surfaceOp },</span></span>
+      <span class="src-line">      <span class="src-ln"> 613</span> <span class="src-hl">    }</span></span>
+      <span class="src-line">      <span class="src-ln"> 614</span> <span class="src-hl">    <span class="src-kw">const</span> dataSnapshot = snapshotJsonValue(data)</span></span>
+      <span class="src-line">      <span class="src-ln"> 615</span> <span class="src-hl">    <span class="src-kw">if</span> (dataSnapshot === <span class="src-kw">undefined</span>) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 616</span> <span class="src-hl">      <span class="src-kw">throw</span> <span class="src-kw">new</span> Error(<span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`session event &quot;${<span class="src-kw">type</span>}&quot; carries non-JSON-serializable data`</span>)</span></span>
+      <span class="src-line">      <span class="src-ln"> 617</span> <span class="src-hl">    }</span></span>
+      <span class="src-line">      <span class="src-ln"> 618</span> <span class="src-hl">    assertSupportedRequestHeader(<span class="src-kw">type</span>, dataSnapshot, <span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`session event &quot;${<span class="src-kw">type</span>}&quot;`</span>)</span></span>
+      <span class="src-line">      <span class="src-ln"> 619</span> <span class="src-hl">    <span class="src-kw">const</span> surfaceMetadataSnapshot = snapshotJsonValue(surfaceMetadata)</span></span>
+      <span class="src-line">      <span class="src-ln"> 620</span> <span class="src-hl">    <span class="src-kw">if</span> (surfaceMetadataSnapshot === <span class="src-kw">undefined</span>) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 621</span> <span class="src-hl">      <span class="src-kw">throw</span> <span class="src-kw">new</span> Error(<span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`session event &quot;${<span class="src-kw">type</span>}&quot; carries non-JSON-serializable surface metadata`</span>)</span></span>
+      <span class="src-line">      <span class="src-ln"> 622</span> <span class="src-hl">    }</span></span>
+      <span class="src-line">      <span class="src-ln"> 623</span> <span class="src-hl">    <span class="src-kw">const</span> entry = attachments.get(this)</span></span>
+      <span class="src-line">      <span class="src-ln"> 624</span> <span class="src-hl">    <span class="src-kw">if</span> (entry?.appending) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 625</span> <span class="src-hl">      <span class="src-kw">throw</span> <span class="src-kw">new</span> Error(&#x27;session append cannot reenter <span class="src-kw">while</span> another append is being published&#x27;)</span></span>
+      <span class="src-line">      <span class="src-ln"> 626</span> <span class="src-hl">    }</span></span>
+      <span class="src-line">      <span class="src-ln"> 627</span> <span class="src-hl">    <span class="src-kw">const</span> event = deepFreeze({</span></span>
+      <span class="src-line">      <span class="src-ln"> 628</span> <span class="src-hl">      <span class="src-kw">type</span>,</span></span>
+      <span class="src-line">      <span class="src-ln"> 629</span> <span class="src-hl">      seq: this.log.length,</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">seq = log.length：连续序号不变量</span><span class="lang-en-only">seq = log.length: contiguous seq invariant</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 630</span> <span class="src-hl">      time: Date.now(),</span></span>
+      <span class="src-line">      <span class="src-ln"> 631</span> <span class="src-hl">      data: dataSnapshot,</span></span>
+      <span class="src-line">      <span class="src-ln"> 632</span> <span class="src-hl">      ...(surfaceMetadataSnapshot as { surfaceOp?: unknown; sourceEventSeqs?: unknown }),</span></span>
+      <span class="src-line">      <span class="src-ln"> 633</span> <span class="src-hl">    } as unknown as SessionEvent&lt;T&gt;)</span></span>
+      <span class="src-line">      <span class="src-ln"> 634</span> <span class="src-hl">    this.surfaceManager.validateNext(event as SessionEvent)</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">surfaceManager.validateNext：surface 契约在此 enforce</span><span class="lang-en-only">surfaceManager.validateNext: surface contract enforced here</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 635</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 636</span> <span class="src-hl">    <span class="src-kw">if</span> (entry !== <span class="src-kw">undefined</span>) entry.appending = <span class="src-kw">true</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 637</span> <span class="src-hl">    try {</span></span>
+      <span class="src-line">      <span class="src-ln"> 638</span> <span class="src-hl">      <span class="src-kw">let</span> callbacks: SessionCallback[] | <span class="src-kw">undefined</span></span></span>
+    </div>
+
+    <div class="trace-steps"><div class="ts-label"><span class="lang-zh-only">主线 prompt 写入 session log 时间线</span><span class="lang-en-only">Through-line prompt session log timeline</span></div>    <table class="cmp">
+      <thead><tr><th>#</th><th>location</th><th>主线时刻 / through-line moment</th></tr></thead>
+      <tbody>
+      <tr><td>1</td><td>inbox.insert(user)</td><td>user 消息排队：«读取 README.md，用一句…»</td></tr>
+      <tr><td>2</td><td>turn/start</td><td>turn=1 打开 durable 边界</td></tr>
+      <tr><td>3</td><td>step/start</td><td>step=1 打开 model+tools 边界</td></tr>
+      <tr><td>4</td><td>user/message</td><td>surfaceOp=append · 进入 model-visible surface</td></tr>
+      <tr><td>5</td><td>deriveMessages()</td><td>→ [{role:user, content:…}] 供 buildRequest</td></tr>
+      <tr><td>6</td><td>assistant/chunk×N</td><td>流式 chunk · 不进入 derive（replay/UI）</td></tr>
+      <tr><td>7</td><td>assistant/message</td><td>定稿 assistant · surfaceOp=append</td></tr>
+      <tr><td>8</td><td>tool/call + tool/result</td><td>read README · surfaceOp=append</td></tr>
+      </tbody>
+    </table></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/core/session/src/index.ts</span>
+        <span class="src-tag">derive</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 708</span> <span class="src-hl">  /**</span></span>
+      <span class="src-line">      <span class="src-ln"> 709</span> <span class="src-hl">   * Derive the LLM message history by walking the ordered sequences of</span></span>
+      <span class="src-line">      <span class="src-ln"> 710</span> <span class="src-hl">   * message-producing events maintained by <span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`surfaceOp`</span> markers. The</span></span>
+      <span class="src-line">      <span class="src-ln"> 711</span> <span class="src-hl">   * surface is the single source of derived history: every message-producing</span></span>
+      <span class="src-line">      <span class="src-ln"> 712</span> <span class="src-hl">   * append records its <span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`surfaceOp`</span>, so a raw event with no marker (a chunk, a</span></span>
+      <span class="src-line">      <span class="src-ln"> 713</span> <span class="src-hl">   * turn boundary) is correctly absent, and a compaction <span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`replace`</span> deletes the</span></span>
+      <span class="src-line">      <span class="src-ln"> 714</span> <span class="src-hl">   * shadowed nodes <span class="src-kw">from</span> the derivation. The projection rules are</span></span>
+      <span class="src-line">      <span class="src-ln"> 715</span> <span class="src-hl">   * {@link deriveEventMessage}, folded per node.</span></span>
+      <span class="src-line">      <span class="src-ln"> 716</span> <span class="src-hl">   *</span></span>
+      <span class="src-line">      <span class="src-ln"> 717</span> <span class="src-hl">   * CACHED: each surface node is projected exactly once, when first seen — a</span></span>
+      <span class="src-line">      <span class="src-ln"> 718</span> <span class="src-hl">   * call costs O(<span class="src-kw">new</span> nodes), and a surface rewrite (a <span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`replace`</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 719</span> <span class="src-hl">   * {@link SessionSurface.replaceGeneration}) rebuilds. The returned array is</span></span>
+      <span class="src-line">      <span class="src-ln"> 720</span> <span class="src-hl">   * a fresh snapshot per call (later appends never grow an array a caller</span></span>
+      <span class="src-line">      <span class="src-ln"> 721</span> <span class="src-hl">   * already holds); the <span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`Message`</span> objects in it are SHARED and **deep-frozen**.</span></span>
+      <span class="src-line">      <span class="src-ln"> 722</span> <span class="src-hl">   * Their content reuses the already frozen durable event data, so the cache</span></span>
+      <span class="src-line">      <span class="src-ln"> 723</span> <span class="src-hl">   * needs no second deep clone and consumers still cannot mutate the log.</span></span>
+      <span class="src-line">      <span class="src-ln"> 724</span> <span class="src-hl">   * @returns a fresh array of the shared, frozen derived history.</span></span>
+      <span class="src-line">      <span class="src-ln"> 725</span> <span class="src-hl">   */</span></span>
+      <span class="src-line">      <span class="src-ln"> 726</span> <span class="src-hl">  deriveMessages(): Message[] {</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">★ deriveMessages：O(new nodes) 缓存投影</span><span class="lang-en-only">★ deriveMessages: O(new nodes) cached projection</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 727</span> <span class="src-hl">    <span class="src-kw">const</span> surface = this.surface</span></span>
+      <span class="src-line">      <span class="src-ln"> 728</span> <span class="src-hl">    <span class="src-kw">const</span> nodes = surface.nodes</span></span>
+      <span class="src-line">      <span class="src-ln"> 729</span> <span class="src-hl">    <span class="src-kw">const</span> generation = surface.replaceGeneration</span></span>
+      <span class="src-line">      <span class="src-ln"> 730</span> <span class="src-hl">    <span class="src-kw">if</span> (generation !== this.derivedGeneration) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 731</span> <span class="src-hl">      this.derived = []</span></span>
+      <span class="src-line">      <span class="src-ln"> 732</span> <span class="src-hl">      this.derivedNodes = 0</span></span>
+      <span class="src-line">      <span class="src-ln"> 733</span> <span class="src-hl">      this.derivedGeneration = generation</span></span>
+      <span class="src-line">      <span class="src-ln"> 734</span> <span class="src-hl">    }</span></span>
+      <span class="src-line">      <span class="src-ln"> 735</span> <span class="src-hl">    <span class="src-kw">for</span> (<span class="src-kw">const</span> seq of nodes.slice(this.derivedNodes)) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 736</span> <span class="src-hl">      <span class="src-comment">// Surface sequences are built from this.log — seq is always a valid</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 737</span> <span class="src-hl">      <span class="src-comment">// index by construction. The non-null assertion expresses that invariant.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 738</span> <span class="src-hl">      <span class="src-comment">// oxlint-disable-next-line typescript/no-non-null-assertion</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 739</span> <span class="src-hl">      <span class="src-kw">const</span> msg = this.deriveEventMessage(this.log[seq]!)</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">deriveEventMessage：逐 surface node 折叠</span><span class="lang-en-only">deriveEventMessage: fold per surface node</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 740</span> <span class="src-hl">      <span class="src-comment">// A surface node is one of the five message-producing types, but an</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 741</span> <span class="src-hl">      <span class="src-comment">// empty-content assistant/message (a max-tokens step that hosts only</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 742</span> <span class="src-hl">      <span class="src-comment">// usage) derives to null and must not enter the transcript.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 743</span> <span class="src-hl">      <span class="src-kw">if</span> (msg) this.derived.push(msg)</span></span>
+      <span class="src-line">      <span class="src-ln"> 744</span> <span class="src-hl">    }</span></span>
+      <span class="src-line">      <span class="src-ln"> 745</span> <span class="src-hl">    this.derivedNodes = nodes.length</span></span>
+      <span class="src-line">      <span class="src-ln"> 746</span> <span class="src-hl">    <span class="src-kw">return</span> [...this.derived]</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">返回 fresh array · Message 对象 shared+frozen</span><span class="lang-en-only">returns fresh array · Message objects shared+frozen</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 747</span> <span class="src-hl">  }</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/core/session/src/surface.ts</span>
+        <span class="src-tag">surface-rule</span>
+      </div>
+      <span class="src-line">      <span class="src-ln">  70</span> <span class="src-hl">/**</span></span>
+      <span class="src-line">      <span class="src-ln">  71</span> <span class="src-hl"> * Project a single event into the LLM message it derives to, or <span class="src-kw">null</span> when it</span></span>
+      <span class="src-line">      <span class="src-ln">  72</span> <span class="src-hl"> * produces none — a non-surface event (chunk, boundary, log-only record) or an</span></span>
+      <span class="src-line">      <span class="src-ln">  73</span> <span class="src-hl"> * empty-content assistant/message (which exists only to host usage). This is</span></span>
+      <span class="src-line">      <span class="src-ln">  74</span> <span class="src-hl"> * THE per-node projection rule: <span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`Session.deriveMessages`</span> folds it over the</span></span>
+      <span class="src-line">      <span class="src-ln">  75</span> <span class="src-hl"> * live surface, external reconstructors and pure projections fold the same</span></span>
+      <span class="src-line">      <span class="src-ln">  76</span> <span class="src-hl"> * <span class="src-kw">function</span> over a log prefix&#x27;s surface to rebuild the exact messages any</span></span>
+      <span class="src-line">      <span class="src-ln">  77</span> <span class="src-hl"> * request was built <span class="src-kw">from</span>. The returned message is the already frozen message</span></span>
+      <span class="src-line">      <span class="src-ln">  78</span> <span class="src-hl"> * nested in the event wrapper and shared by delivery, durable history, and</span></span>
+      <span class="src-line">      <span class="src-ln">  79</span> <span class="src-hl"> * model requests.</span></span>
+      <span class="src-line">      <span class="src-ln">  80</span> <span class="src-hl"> * @param event - the event to project.</span></span>
+      <span class="src-line">      <span class="src-ln">  81</span> <span class="src-hl"> * @returns the derived message, or <span class="src-kw">null</span> when the event produces none.</span></span>
+      <span class="src-line">      <span class="src-ln">  82</span> <span class="src-hl"> */</span></span>
+      <span class="src-line">      <span class="src-ln">  83</span> <span class="src-hl"><span class="src-kw">export</span> <span class="src-kw">function</span> deriveEventMessage(event: SessionEvent): Message | <span class="src-kw">null</span> {</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">★ THE per-node projection rule</span><span class="lang-en-only">★ THE per-node projection rule</span></span></span>
+      <span class="src-line">      <span class="src-ln">  84</span> <span class="src-hl">  <span class="src-comment">// Intentionally non-exhaustive: only message-producing events derive</span></span></span>
+      <span class="src-line">      <span class="src-ln">  85</span> <span class="src-hl">  <span class="src-comment">// history; turn/step boundaries, chunks, usage, and errors are trace/replay</span></span></span>
+      <span class="src-line">      <span class="src-ln">  86</span> <span class="src-hl">  <span class="src-comment">// data.</span></span></span>
+      <span class="src-line">      <span class="src-ln">  87</span> <span class="src-hl">  <span class="src-kw">switch</span> (event.<span class="src-kw">type</span>) {</span></span>
+      <span class="src-line">      <span class="src-ln">  88</span> <span class="src-hl">    <span class="src-comment">// Ordinary prompts and injected context project in user role: the event&amp;#x27;s</span></span></span>
+      <span class="src-line">      <span class="src-ln">  89</span> <span class="src-hl">    <span class="src-comment">// model-facing content stays verbatim. Do NOT re-add per-type framing</span></span></span>
+      <span class="src-line">      <span class="src-ln">  90</span> <span class="src-hl">    <span class="src-comment">// (e.g. `&amp;lt;context&amp;gt;`) here: framing is caller-owned — a producer bakes it</span></span></span>
+      <span class="src-line">      <span class="src-ln">  91</span> <span class="src-hl">    <span class="src-comment">// into `content`, as agent-instructions does with `&amp;lt;system-reminder&amp;gt;` — or,</span></span></span>
+      <span class="src-line">      <span class="src-ln">  92</span> <span class="src-hl">    <span class="src-comment">// if reintroduced, must be driven by the event `meta` map and a dedicated</span></span></span>
+      <span class="src-line">      <span class="src-ln">  93</span> <span class="src-hl">    <span class="src-comment">// renderer, keeping this projection a verbatim pass-through. See the</span></span></span>
+      <span class="src-line">      <span class="src-ln">  94</span> <span class="src-hl">    <span class="src-comment">// deferred design note in</span></span></span>
+      <span class="src-line">      <span class="src-ln">  95</span> <span class="src-hl">    <span class="src-comment">// ../../../../.agents/notes/implemented/simplification/2026-07-20-unwrap-injected-content-envelopes.md</span></span></span>
+      <span class="src-line">      <span class="src-ln">  96</span> <span class="src-hl">    <span class="src-kw">case</span> &#x27;user/message&#x27;: {</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">user/message → verbatim user Message</span><span class="lang-en-only">user/message → verbatim user Message</span></span></span>
+      <span class="src-line">      <span class="src-ln">  97</span> <span class="src-hl">      <span class="src-kw">return</span> event.data</span></span>
+      <span class="src-line">      <span class="src-ln">  98</span> <span class="src-hl">    }</span></span>
+      <span class="src-line">      <span class="src-ln">  99</span> <span class="src-hl">    <span class="src-kw">case</span> &#x27;assistant/message&#x27;: {</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">assistant/message → skip empty usage-only</span><span class="lang-en-only">assistant/message → skip empty usage-only</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 100</span> <span class="src-hl">      <span class="src-comment">// Skip an empty-content assistant/message: it exists only to host a</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 101</span> <span class="src-hl">      <span class="src-comment">// max-tokens step&amp;#x27;s usage and must not inject a content-less assistant</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 102</span> <span class="src-hl">      <span class="src-comment">// turn into the provider transcript.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 103</span> <span class="src-hl">      <span class="src-kw">if</span> (event.data.message.content.length === 0) <span class="src-kw">return</span> <span class="src-kw">null</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 104</span> <span class="src-hl">      <span class="src-kw">return</span> event.data.message</span></span>
+      <span class="src-line">      <span class="src-ln"> 105</span> <span class="src-hl">    }</span></span>
+      <span class="src-line">      <span class="src-ln"> 106</span> <span class="src-hl">    <span class="src-kw">case</span> &#x27;tool/result&#x27;: {</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">tool/result → tool result Message</span><span class="lang-en-only">tool/result → tool result Message</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 107</span> <span class="src-hl">      <span class="src-kw">return</span> event.data.message</span></span>
+      <span class="src-line">      <span class="src-ln"> 108</span> <span class="src-hl">    }</span></span>
+      <span class="src-line">      <span class="src-ln"> 109</span> <span class="src-hl">    default:</span></span>
+      <span class="src-line">      <span class="src-ln"> 110</span> <span class="src-hl">      <span class="src-comment">// A non-surface event (boundary, chunk, log-only record) projects to</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 111</span> <span class="src-hl">      <span class="src-comment">// no message. Merge-extensible union: no assertNever here.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 112</span> <span class="src-hl">      <span class="src-kw">return</span> <span class="src-kw">null</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 113</span> <span class="src-hl">  }</span></span>
+      <span class="src-line">      <span class="src-ln"> 114</span> <span class="src-hl">}</span></span>
+    </div>
+
+    <div class="lang-zh-only"><p>注意 <code>assistant/chunk</code> 与 <code>turn/start</code> 不在 surface 上——它们服务 replay 与 UI fidelity，但不进入 <code>deriveMessages()</code>。这是 DSH 与 Pi「AgentMessage 全进 transcript」的最大结构差异：模型历史 = surface 投影，原始 chunk 留在 log 供 fidelity。</p></div>
+    <div class="lang-en-only"><p>Note <code>assistant/chunk</code> and <code>turn/start</code> are not on the surface — they serve replay and UI fidelity but never enter <code>deriveMessages()</code>. Biggest structural difference from Pi's «all AgentMessage in transcript»: model history = surface projection; raw chunks stay in log for fidelity.</p></div>
+
+    <div class="note copper">
+      <span class="lang-zh-only">练习：grep session log 里主线 prompt 的 <code>user/message</code>，确认 <code>surfaceOp:'append'</code> 存在；再 grep 同 turn 的 <code>assistant/chunk</code>，确认无 surfaceOp。</span>
+      <span class="lang-en-only">Exercise: grep the through-line <code>user/message</code> for <code>surfaceOp:'append'</code>; then grep same-turn <code>assistant/chunk</code> and confirm no surfaceOp.</span>
+    </div>
+
+    </div>
+
+    <div class="trace-box">
+      <div class="tb-tag">TRACE · station station session</div>
+      <div class="lang-zh-only"><p>站 08：model-visible means logged — 一切进模型的必须能由 log 重建。</p></div>
+      <div class="lang-en-only"><p>St. 08: model-visible means logged — anything reaching the model must be reconstructable from the log.</p></div>
+    </div>
+
+    <div class="depth-zone" data-chapter="C09"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C09.4+</span><span class="lang-en-only">Deep dive · C09.4+</span></div>
+
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">交叉引用</span><span class="lang-en-only">Cross-ref</span></span> <span class="da-title lang-zh-only">deepseek-harness 文档</span><span class="da-title lang-en-only">deepseek-harness docs</span></div>    <table class="cmp">
+      <thead><tr><th>DOC</th><th>主题</th><th>路径</th><th>摘要</th></tr></thead>
+      <tbody>
+      <tr><td>architecture</td><td>架构总览</td><td><code>docs/architecture.md</code></td><td>Cordis plugin tree, Profile×Bundle composition, six core ctx services, and turn flow</td></tr>
+      </tbody>
+    </table>
+
+    </div>
+  </section>
+
+  <section class="chap" id="c10">
+    <div class="chap-num">CHAPTER&nbsp;10&nbsp;·&nbsp;HEART</div>
+    <h2 class="chap-title lang-zh-only">ReactLoopAgent 驱动</h2>
+    <h2 class="chap-title lang-en-only">ReactLoopAgent driver</h2>
+    <p class="chap-en lang-zh-only">wakeDriver · turn/start · step/start</p>
+    <p class="chap-en lang-en-only">wakeDriver · turn/start · step/start</p>
+    <nav class="chapter-compass" aria-label="Chapter navigation">
+      <div class="cc-row">
+        <div class="cc-phase"><span class="cc-roman">II</span> · <span class="lang-zh-only">心脏</span><span class="lang-en-only">Heart</span></div>
+        <div class="cc-station"><span class="lang-zh-only">站 10–11</span><span class="lang-en-only">St. 10–11</span> · C10/26</div>
+      </div>
+      <div class="cc-forest"><span class="lang-zh-only">ReactLoopAgent 驱动</span><span class="lang-en-only">ReactLoopAgent driver</span></div>
+      <div class="cc-links">
+        <a class="cc-nav cc-prev" href="#c9"><span class="cc-arrow">←</span> <span class="cc-nav-num">C09</span> <span class="lang-zh-only">Session log 不变量</span><span class="lang-en-only">Session log invariant</span></a>
+        <a class="cc-map" href="#forest-overview"><span class="lang-zh-only">回到总览</span><span class="lang-en-only">Forest map</span></a>
+        <a class="cc-nav cc-next" href="#c11"><span class="cc-nav-num">C11</span> <span class="lang-zh-only">agent/pre-step 瀑布</span><span class="lang-en-only">agent/pre-step waterfall</span> <span class="cc-arrow">→</span></a>
+      </div>
+    </nav>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>本章回答「这条主线 prompt 在此层长什么样」</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH 没有隐藏魔法——一切可替换行为都在 Cordis 事件或 SessionEvent 里</span></p>
+      <p><span class="swc-pill act">优化</span><span>读源码时先搜 session.append 与 ctx.* 注册点</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>This chapter answers what the through-line prompt looks like at this layer</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH has no hidden magic — replaceable behavior lives in Cordis events or SessionEvents</span></p>
+      <p><span class="swc-pill act">优化</span><span>When reading source, search session.append and ctx.* registration first</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">agent-loop</span><span class="lang-en-only">agent-loop</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">packages/core/agent-loop</span><span class="lang-en-only">packages/core/agent-loop</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">ReactLoopAgent</span><span class="lang-en-only">ReactLoopAgent</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">turn/step</span><span class="lang-en-only">turn/step</span></div>
+      </div>
+    </div>
+
+    <div class="lang-zh-only"><p><code>ReactLoopAgent</code> 实现 turn/step 双环：<strong>turn</strong> 管理 inbox claim 与 <code>turn/end</code>；<strong>step</strong> 承载一次 <code>llm/stream</code> + 关联 tool batch。主线 prompt 通常在一个 turn 内跑两个 step。</p></div>
+    <div class="lang-en-only"><p><code>ReactLoopAgent</code> implements turn/step twin loops: the <strong>turn</strong> manages inbox claim and <code>turn/end</code>; each <strong>step</strong> holds one <code>llm/stream</code> plus its tool batch. The through-line prompt usually runs two steps within one turn.</p></div>
+
+    <h3 class="sub"><span class="sec-num">C10.1</span> <span class="lang-zh-only">外环 Turn · 内环 Step</span><span class="lang-en-only">Outer turn · inner step</span></h3>
+
+    <figure>
+      <div class="figbox"><div class="pi-fig"><svg viewBox="0 0 720 290" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true" class="pi-svg">
+  <defs>
+    <marker id="pi-arr" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 Z" fill="#1f5c8c"/>
+    </marker>
+  </defs>
+  <text x="360" y="28" text-anchor="middle" class="svg-label">TURN · STEP · ReactLoopAgent</text>
+  <rect x="40" y="50" width="640" height="72" rx="4" class="svg-box accent"/>
+  <text x="360" y="78" text-anchor="middle" class="svg-body">turn/start → claim inbox → agent/pre-step</text>
+  <text x="360" y="98" text-anchor="middle" class="svg-mute">0..N steps per turn · reject closes turn with no step</text>
+  <rect x="80" y="140" width="560" height="100" rx="4" fill="#fde8e4" stroke="#c3573a" stroke-width="1.5"/>
+  <text x="360" y="168" text-anchor="middle" class="svg-body">step/start → user/message → deriveMessages</text>
+  <text x="360" y="188" text-anchor="middle" class="svg-body">llm/stream → assistant/chunk* → tool/call* → step/end</text>
+  <text x="360" y="208" text-anchor="middle" class="svg-mute">one model request + its tool batch</text>
+  <path d="M360 122 L360 140" stroke="#1f5c8c" stroke-width="2" marker-end="url(#pi-arr)"/>
+  <path d="M360 240 L360 258" stroke="#1f5c8c" stroke-width="2" marker-end="url(#pi-arr)"/>
+  <text x="360" y="278" text-anchor="middle" class="svg-mute">tools owe another request → next step · else turn/end</text>
+</svg></div></div>
+      <figcaption>
+        <span class="figid">FIG</span>
+        <span class="lang-zh-only">Turn/Step 双环：外环 turn 管理 inbox 与 turn/end；内环 step 承载一次 llm/stream + 工具批次。</span>
+        <span class="lang-en-only">Turn/step twin loops: outer turn manages inbox and turn/end; inner step holds one llm/stream + tool batch.</span>
+      </figcaption>
+    </figure>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/core/agent-loop/src/agent.ts</span>
+        <span class="src-tag">loop</span>
+      </div>
+      <span class="src-line"><span class="src-comment">// phase: idle | running turn N step M</span></span>
+      <span class="src-line"><span class="src-kw">private</span> phase: Phase</span>
+      <span class="src-line"><span class="src-kw">private readonly</span> dispatch: AgentEventDispatch</span>
+    </div>
+
+    <h3 class="sub"><span class="sec-num">C10.2</span> <span class="lang-zh-only">何时开下一个 step</span><span class="lang-en-only">When the next step opens</span></h3>
+
+    <div class="lang-zh-only"><p>当前 step 在 <code>step/end</code> 后，若 tool batch 仍欠模型一轮、或 next-step inbox 有新输入，驱动器 claim 下一批并再次走 <code>agent/pre-step</code>。若 <code>agent/pre-step</code> reject，claimed batch 仍被移除但 turn 不消耗 step——这是 steering 与 compaction 的挂钩点。</p></div>
+    <div class="lang-en-only"><p>After <code>step/end</code>, if the tool batch still owes the model another round or next-step inbox has new input, the driver claims the next batch and runs <code>agent/pre-step</code> again. If <code>agent/pre-step</code> rejects, the claimed batch is still removed but the turn spends no step — the hook point for steering and compaction.</p></div>
+
+    <figure>
+      <div class="figbox"><div class="event-flow">
+      <div class="ef-row"><div class="ef-type">turn/start</div><div><span class="lang-zh-only">打开 turn · 分配 turn id</span><span class="lang-en-only">open turn · assign turn id</span></div></div>
+      <div class="ef-row"><div class="ef-type">step/start</div><div><span class="lang-zh-only">打开 step · 准备 deriveMessages</span><span class="lang-en-only">open step · prepare deriveMessages</span></div></div>
+      <div class="ef-row"><div class="ef-type">step/end</div><div><span class="lang-zh-only">一步完成 · 检查 continuation</span><span class="lang-en-only">step complete · check continuation</span></div></div>
+      <div class="ef-row"><div class="ef-type">turn/end</div><div><span class="lang-zh-only">turn 关闭 · 无欠账</span><span class="lang-en-only">turn closes · nothing owed</span></div></div>
+    </div>
+      </div>
+      <figcaption><span class="figid">EVT</span><span class="lang-zh-only">SessionEvent 流 · 主线 prompt</span><span class="lang-en-only">SessionEvent stream · through-line prompt</span></figcaption>
+    </figure>
+
+    <div class="note copper">
+      <span class="lang-zh-only">📘 <strong>Agent 生命周期</strong>（<code>docs/agent-lifecycle.md</code>）· turn/step 双环、agent/pre-step waterfall、session 与 agent 事件分工</span>
+      <span class="lang-en-only">📘 <strong>Agent lifecycle</strong> (<code>docs/agent-lifecycle.md</code>) · turn/step twin loops, agent/pre-step waterfall, session vs agent event split</span>
+    </div>
+
+    <blockquote class="pull copper">
+      <span class="lang-zh-only">外环是 inbox 耐心。<br>内环是 model+tool 纪律。</span>
+      <span class="lang-en-only">Outer loop is inbox patience.<br>Inner loop is model+tool discipline.</span>
+      <cite>Field Note · 10</cite>
+    </blockquote>
+
+    <div class="trace-walk">
+      <div class="tw-head">
+        <span class="tw-tag">SOURCE TRACE · C10</span>
+        <span class="lang-zh-only">ReactLoopAgent：turn/start · step/start 完整驱动 trace</span>
+        <span class="lang-en-only">ReactLoopAgent: full turn/start · step/start driver trace</span>
+      </div>
+
+    <div class="lang-zh-only"><p>Pi 的 <code>runLoop</code> 是外环 follow-up × 内环 tool batch；DSH 的 <code>ReactLoopAgent</code> 用 <strong>turn × step</strong> 建模：一个 turn 可含多个 step（模型请求 + tool batch），turn 在 inbox 无 pending 时关闭。主线 prompt 通常 turn=1、step=1(read)+step=2(answer)。</p></div>
+    <div class="lang-en-only"><p>Pi's <code>runLoop</code> is outer follow-up × inner tool batch; DSH's <code>ReactLoopAgent</code> models <strong>turn × step</strong>: one turn may contain multiple steps (model request + tool batch); turn closes when inbox has no pending work. Through-line prompt is usually turn=1, step=1(read)+step=2(answer).</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/core/agent-loop/src/agent.ts</span>
+        <span class="src-tag">wake</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 172</span> <span class="src-hl">  <span class="src-kw">private</span> wakeDriver(wakeAfterAbort = <span class="src-kw">false</span>): void {</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">wakeDriver：idle → running phase</span><span class="lang-en-only">wakeDriver: idle → running phase</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 173</span> <span class="src-hl">    <span class="src-kw">if</span> (this.phase.kind !== &#x27;idle&#x27;) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 174</span> <span class="src-hl">      <span class="src-comment">// Maintenance and aborted drivers cannot deliver the wake: latch it for</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 175</span> <span class="src-hl">      <span class="src-comment">// replay at convergence. Live drivers claim queued work themselves;</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 176</span> <span class="src-hl">      <span class="src-comment">// disposal never latches, so teardown waits on no model turn.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 177</span> <span class="src-hl">      <span class="src-kw">const</span> reason = this.phase.abort.signal.reason as AgentCancelCause | <span class="src-kw">undefined</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 178</span> <span class="src-hl">      <span class="src-kw">if</span> (reason?.kind !== &#x27;disposed&#x27; &amp;&amp; (this.phase.kind === &#x27;maintenance&#x27; || wakeAfterAbort)) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 179</span> <span class="src-hl">        this.phase.wakeRequested = <span class="src-kw">true</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 180</span> <span class="src-hl">      }</span></span>
+      <span class="src-line">      <span class="src-ln"> 181</span> <span class="src-hl">      <span class="src-kw">return</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 182</span> <span class="src-hl">    }</span></span>
+      <span class="src-line">      <span class="src-ln"> 183</span> <span class="src-hl">    <span class="src-kw">const</span> driver = Promise.withResolvers&lt;void&gt;()</span></span>
+      <span class="src-line">      <span class="src-ln"> 184</span> <span class="src-hl">    this.activityDone = driver.promise</span></span>
+      <span class="src-line">      <span class="src-ln"> 185</span> <span class="src-hl">    this.setPhase({</span></span>
+      <span class="src-line">      <span class="src-ln"> 186</span> <span class="src-hl">      kind: &#x27;running&#x27;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 187</span> <span class="src-hl">      abort: <span class="src-kw">new</span> AbortController(),</span></span>
+      <span class="src-line">      <span class="src-ln"> 188</span> <span class="src-hl">      turn: this.phase.lastTurn,</span></span>
+      <span class="src-line">      <span class="src-ln"> 189</span> <span class="src-hl">      step: 0,</span></span>
+      <span class="src-line">      <span class="src-ln"> 190</span> <span class="src-hl">      wakeRequested: <span class="src-kw">false</span>,</span></span>
+      <span class="src-line">      <span class="src-ln"> 191</span> <span class="src-hl">    })</span></span>
+      <span class="src-line">      <span class="src-ln"> 192</span> <span class="src-hl">    this.loopCtx.agents.withInitiator(this, () =&gt; this.kick()).then(driver.resolve, driver.reject)</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">withInitiator(this) → kick()</span><span class="lang-en-only">withInitiator(this) → kick()</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 193</span> <span class="src-hl">  }</span></span>
+      <span class="src-line">      <span class="src-ln"> 194</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 195</span> <span class="src-hl">  <span class="src-kw">async</span> whenIdle(): Promise&lt;void&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln"> 196</span> <span class="src-hl">    <span class="src-kw">let</span> activity: Promise&lt;void&gt;</span></span>
+      <span class="src-line">      <span class="src-ln"> 197</span> <span class="src-hl">    do {</span></span>
+      <span class="src-line">      <span class="src-ln"> 198</span> <span class="src-hl">      <span class="src-kw">await</span> (activity = this.activityDone)</span></span>
+      <span class="src-line">      <span class="src-ln"> 199</span> <span class="src-hl">    } <span class="src-kw">while</span> (activity !== this.activityDone)</span></span>
+      <span class="src-line">      <span class="src-ln"> 200</span> <span class="src-hl">  }</span></span>
+      <span class="src-line">      <span class="src-ln"> 201</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 202</span> <span class="src-hl">  /** Report one failure at its live boundary, then preserve it <span class="src-kw">for</span> driver containment. */</span></span>
+      <span class="src-line">      <span class="src-ln"> 203</span> <span class="src-hl">  <span class="src-kw">private</span> throwError(error: unknown): never {</span></span>
+      <span class="src-line">      <span class="src-ln"> 204</span> <span class="src-hl">    <span class="src-kw">const</span> turn = this.phase.kind === &#x27;running&#x27; ? this.phase.turn : this.phase.lastTurn</span></span>
+      <span class="src-line">      <span class="src-ln"> 205</span> <span class="src-hl">    <span class="src-kw">const</span> step = this.phase.kind === &#x27;running&#x27; ? this.phase.step : 0</span></span>
+      <span class="src-line">      <span class="src-ln"> 206</span> <span class="src-hl">    this.dispatch.emit(&#x27;agent/error&#x27;, { turn, step, error })</span></span>
+      <span class="src-line">      <span class="src-ln"> 207</span> <span class="src-hl">    <span class="src-kw">throw</span> error</span></span>
+      <span class="src-line">      <span class="src-ln"> 208</span> <span class="src-hl">  }</span></span>
+      <span class="src-line">      <span class="src-ln"> 209</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 210</span> <span class="src-hl">  <span class="src-kw">private</span> <span class="src-kw">async</span> kick(): Promise&lt;void&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln"> 211</span> <span class="src-hl">    try {</span></span>
+      <span class="src-line">      <span class="src-ln"> 212</span> <span class="src-hl">      <span class="src-kw">while</span> (<span class="src-kw">await</span> this.turn()) {}</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">★ kick 外环：while (await turn())</span><span class="lang-en-only">★ kick outer: while (await turn())</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 213</span> <span class="src-hl">    } catch (_error) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 214</span> <span class="src-hl">      <span class="src-comment">// Reported failures and cancellation are contained at the driver boundary.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 215</span> <span class="src-hl">    } finally {</span></span>
+      <span class="src-line">      <span class="src-ln"> 216</span> <span class="src-hl">      /* v8 ignore next -- kick owns a running phase until this driver boundary */</span></span>
+      <span class="src-line">      <span class="src-ln"> 217</span> <span class="src-hl">      <span class="src-kw">if</span> (this.phase.kind === &#x27;running&#x27;) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 218</span> <span class="src-hl">        <span class="src-kw">const</span> { turn, wakeRequested } = this.phase</span></span>
+      <span class="src-line">      <span class="src-ln"> 219</span> <span class="src-hl">        this.setPhase({ kind: &#x27;idle&#x27;, lastTurn: turn })</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">turn 结束 → idle · wakeRequested 可重启</span><span class="lang-en-only">turn end → idle · wakeRequested may restart</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 220</span> <span class="src-hl">        <span class="src-kw">if</span> (wakeRequested &amp;&amp; this.inbox.hasPending) this.wakeDriver()</span></span>
+      <span class="src-line">      <span class="src-ln"> 221</span> <span class="src-hl">      }</span></span>
+      <span class="src-line">      <span class="src-ln"> 222</span> <span class="src-hl">    }</span></span>
+      <span class="src-line">      <span class="src-ln"> 223</span> <span class="src-hl">  }</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/core/agent-loop/src/agent.ts</span>
+        <span class="src-tag">turn</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 246</span> <span class="src-hl">  <span class="src-kw">private</span> <span class="src-kw">async</span> turn(): Promise&lt;boolean&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln"> 247</span> <span class="src-hl">    <span class="src-kw">if</span> (this.phase.kind !== &#x27;running&#x27;) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 248</span> <span class="src-hl">      this.throwError(<span class="src-kw">new</span> Error(<span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`agent &quot;${this.id}&quot;: turn without driver reservation`</span>))</span></span>
+      <span class="src-line">      <span class="src-ln"> 249</span> <span class="src-hl">    }</span></span>
+      <span class="src-line">      <span class="src-ln"> 250</span> <span class="src-hl">    <span class="src-kw">const</span> phase = this.phase</span></span>
+      <span class="src-line">      <span class="src-ln"> 251</span> <span class="src-hl">    <span class="src-kw">const</span> { signal } = phase.abort</span></span>
+      <span class="src-line">      <span class="src-ln"> 252</span> <span class="src-hl">    signal.throwIfAborted()</span></span>
+      <span class="src-line">      <span class="src-ln"> 253</span> <span class="src-hl">    <span class="src-kw">const</span> turn = phase.turn + 1</span></span>
+      <span class="src-line">      <span class="src-ln"> 254</span> <span class="src-hl">    try {</span></span>
+      <span class="src-line">      <span class="src-ln"> 255</span> <span class="src-hl">      this.session.append(&#x27;turn/start&#x27;, { turn })</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">★ turn/start 写入 session log</span><span class="lang-en-only">★ turn/start appended to session log</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 256</span> <span class="src-hl">    } catch (error: unknown) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 257</span> <span class="src-hl">      this.throwError(error)</span></span>
+      <span class="src-line">      <span class="src-ln"> 258</span> <span class="src-hl">    }</span></span>
+      <span class="src-line">      <span class="src-ln"> 259</span> <span class="src-hl">    phase.turn = turn</span></span>
+      <span class="src-line">      <span class="src-ln"> 260</span> <span class="src-hl">    <span class="src-kw">let</span> turnEnds: TurnEndReason | <span class="src-kw">null</span> = <span class="src-kw">null</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 261</span> <span class="src-hl">    <span class="src-kw">let</span> target: InboxTarget = &#x27;next-turn&#x27;</span></span>
+      <span class="src-line">      <span class="src-ln"> 262</span> <span class="src-hl">    try {</span></span>
+      <span class="src-line">      <span class="src-ln"> 263</span> <span class="src-hl">      <span class="src-kw">while</span> (<span class="src-kw">true</span>) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 264</span> <span class="src-hl">        signal.throwIfAborted()</span></span>
+      <span class="src-line">      <span class="src-ln"> 265</span> <span class="src-hl">        <span class="src-kw">const</span> step = phase.step + 1</span></span>
+      <span class="src-line">      <span class="src-ln"> 266</span> <span class="src-hl">        <span class="src-kw">const</span> decision = <span class="src-kw">await</span> this.preStep(target, { turn, step })</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">preStep：claim inbox + agent/pre-step</span><span class="lang-en-only">preStep: claim inbox + agent/pre-step</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 267</span> <span class="src-hl">        <span class="src-kw">if</span> (decision.kind === &#x27;reject&#x27;) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 268</span> <span class="src-hl">          turnEnds = { kind: &#x27;blocked&#x27; }</span></span>
+      <span class="src-line">      <span class="src-ln"> 269</span> <span class="src-hl">          <span class="src-kw">return</span> <span class="src-kw">false</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 270</span> <span class="src-hl">        }</span></span>
+      <span class="src-line">      <span class="src-ln"> 271</span> <span class="src-hl">        <span class="src-kw">if</span> (turnEnds &amp;&amp; decision.messages.length === 0) <span class="src-kw">break</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 272</span> <span class="src-hl">        <span class="src-comment">// A removed waking message or an enter decision rewritten to empty</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 273</span> <span class="src-hl">        <span class="src-comment">// still owns the initial turn boundary, but it spends no model call.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 274</span> <span class="src-hl">        <span class="src-kw">if</span> (phase.step === 0 &amp;&amp; decision.messages.length === 0) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 275</span> <span class="src-hl">          turnEnds = { kind: &#x27;completed&#x27; }</span></span>
+      <span class="src-line">      <span class="src-ln"> 276</span> <span class="src-hl">          <span class="src-kw">return</span> <span class="src-kw">false</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 277</span> <span class="src-hl">        }</span></span>
+      <span class="src-line">      <span class="src-ln"> 278</span> <span class="src-hl">        signal.throwIfAborted()</span></span>
+      <span class="src-line">      <span class="src-ln"> 279</span> <span class="src-hl">        this.session.append(&#x27;step/start&#x27;, { turn, step })</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">★ step/start</span><span class="lang-en-only">★ step/start</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 280</span> <span class="src-hl">        phase.step = step</span></span>
+      <span class="src-line">      <span class="src-ln"> 281</span> <span class="src-hl">        try {</span></span>
+      <span class="src-line">      <span class="src-ln"> 282</span> <span class="src-hl">          <span class="src-kw">for</span> (<span class="src-kw">const</span> message of decision.messages) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 283</span> <span class="src-hl">            this.session.append(&#x27;user/message&#x27;, message, { surfaceOp: &#x27;append&#x27; })</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">user/message append · surfaceOp=append</span><span class="lang-en-only">user/message append · surfaceOp=append</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 284</span> <span class="src-hl">          }</span></span>
+      <span class="src-line">      <span class="src-ln"> 285</span> <span class="src-hl">          <span class="src-comment">// max-tokens is sticky: once any step hits the ceiling, later steps</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 286</span> <span class="src-hl">          <span class="src-comment">// that complete normally must not downgrade the turn outcome.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 287</span> <span class="src-hl">          <span class="src-kw">const</span> stepEnd = <span class="src-kw">await</span> this.step(decision.assembly)</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">★ step()：deriveMessages → llm.stream</span><span class="lang-en-only">★ step(): deriveMessages → llm.stream</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 288</span> <span class="src-hl">          <span class="src-comment">// max-tokens stays sticky: a later completed step must not</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 289</span> <span class="src-hl">          <span class="src-comment">// downgrade the turn outcome.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 290</span> <span class="src-hl">          <span class="src-kw">if</span> (turnEnds === <span class="src-kw">null</span> || turnEnds.kind !== &#x27;max-tokens&#x27;) turnEnds = stepEnd</span></span>
+      <span class="src-line">      <span class="src-ln"> 291</span> <span class="src-hl">        } finally {</span></span>
+      <span class="src-line">      <span class="src-ln"> 292</span> <span class="src-hl">          this.session.append(&#x27;step/end&#x27;, { turn, step })</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">step/end</span><span class="lang-en-only">step/end</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 293</span> <span class="src-hl">        }</span></span>
+      <span class="src-line">      <span class="src-ln"> 294</span> <span class="src-hl">        signal.throwIfAborted()</span></span>
+      <span class="src-line">      <span class="src-ln"> 295</span> <span class="src-hl">        <span class="src-kw">if</span> (turnEnds &amp;&amp; this.inbox.nextStep.length === 0) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 296</span> <span class="src-hl">          <span class="src-kw">await</span> this.dispatch.serial(&#x27;agent/turn-stopping&#x27;, { turn, signal })</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">agent/turn-stopping serial hook</span><span class="lang-en-only">agent/turn-stopping serial hook</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 297</span> <span class="src-hl">          signal.throwIfAborted()</span></span>
+      <span class="src-line">      <span class="src-ln"> 298</span> <span class="src-hl">        }</span></span>
+      <span class="src-line">      <span class="src-ln"> 299</span> <span class="src-hl">        <span class="src-kw">if</span> (turnEnds &amp;&amp; this.inbox.nextStep.length === 0) <span class="src-kw">break</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 300</span> <span class="src-hl">        target = &#x27;next-step&#x27;</span></span>
+      <span class="src-line">      <span class="src-ln"> 301</span> <span class="src-hl">      }</span></span>
+      <span class="src-line">      <span class="src-ln"> 302</span> <span class="src-hl">    } catch (error: unknown) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 303</span> <span class="src-hl">      <span class="src-kw">if</span> (signal.aborted) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 304</span> <span class="src-hl">        turnEnds = { kind: &#x27;aborted&#x27;, reason: signal.reason as AgentCancelCause }</span></span>
+      <span class="src-line">      <span class="src-ln"> 305</span> <span class="src-hl">        <span class="src-kw">throw</span> error</span></span>
+      <span class="src-line">      <span class="src-ln"> 306</span> <span class="src-hl">      }</span></span>
+      <span class="src-line">      <span class="src-ln"> 307</span> <span class="src-hl">      <span class="src-comment">// Every failure is structured: an `LlmError` keeps its facts, anything</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 308</span> <span class="src-hl">      <span class="src-comment">// else flattens to `errorChain` text under the `UNKNOWN` code.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 309</span> <span class="src-hl">      turnEnds = {</span></span>
+      <span class="src-line">      <span class="src-ln"> 310</span> <span class="src-hl">        kind: &#x27;error&#x27;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 311</span> <span class="src-hl">        error: error instanceof LlmError</span></span>
+      <span class="src-line">      <span class="src-ln"> 312</span> <span class="src-hl">          ? error.failure</span></span>
+      <span class="src-line">      <span class="src-ln"> 313</span> <span class="src-hl">          : { message: errorChain(error), code: &#x27;UNKNOWN&#x27; },</span></span>
+      <span class="src-line">      <span class="src-ln"> 314</span> <span class="src-hl">      }</span></span>
+      <span class="src-line">      <span class="src-ln"> 315</span> <span class="src-hl">      this.throwError(error)</span></span>
+      <span class="src-line">      <span class="src-ln"> 316</span> <span class="src-hl">    } finally {</span></span>
+      <span class="src-line">      <span class="src-ln"> 317</span> <span class="src-hl">      try {</span></span>
+      <span class="src-line">      <span class="src-ln"> 318</span> <span class="src-hl">        <span class="src-comment">// oxlint-disable-next-line typescript/no-non-null-assertion -- every exit assigns a turn ending</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 319</span> <span class="src-hl">        this.session.append(&#x27;turn/end&#x27;, { turn, reason: turnEnds! })</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">turn/end + reason</span><span class="lang-en-only">turn/end + reason</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 320</span> <span class="src-hl">      } catch (error: unknown) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 321</span> <span class="src-hl">        this.throwError(error)</span></span>
+      <span class="src-line">      <span class="src-ln"> 322</span> <span class="src-hl">      }</span></span>
+      <span class="src-line">      <span class="src-ln"> 323</span> <span class="src-hl">    }</span></span>
+      <span class="src-line">      <span class="src-ln"> 324</span> <span class="src-hl">    <span class="src-kw">if</span> (!this.inbox.hasPending) <span class="src-kw">return</span> <span class="src-kw">false</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 325</span> <span class="src-hl">    phase.abort = <span class="src-kw">new</span> AbortController()</span></span>
+      <span class="src-line">      <span class="src-ln"> 326</span> <span class="src-hl">    <span class="src-comment">// A fresh controller makes a latch set on the old one stale: the live driver claims the queue itself.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 327</span> <span class="src-hl">    phase.wakeRequested = <span class="src-kw">false</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 328</span> <span class="src-hl">    phase.step = 0</span></span>
+      <span class="src-line">      <span class="src-ln"> 329</span> <span class="src-hl">    <span class="src-kw">return</span> <span class="src-kw">true</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 330</span> <span class="src-hl">  }</span></span>
+    </div>
+
+    <div class="trace-steps"><div class="ts-label"><span class="lang-zh-only">主线 prompt · turn/step 状态机</span><span class="lang-en-only">Through-line prompt · turn/step state machine</span></div>    <table class="cmp">
+      <thead><tr><th>#</th><th>location</th><th>主线时刻 / through-line moment</th></tr></thead>
+      <tbody>
+      <tr><td>T0</td><td>wakeDriver</td><td>inbox 有 user prompt · phase=running</td></tr>
+      <tr><td>T1</td><td>turn/start turn=1</td><td>durable turn 边界打开</td></tr>
+      <tr><td>T2</td><td>step=1 start</td><td>preStep → user/message → step()</td></tr>
+      <tr><td>T3</td><td>step=1 end</td><td>toolUse(read) · inbox next-step 有 toolResult context</td></tr>
+      <tr><td>T4</td><td>step=2 start</td><td>deriveMessages 含 tool/result</td></tr>
+      <tr><td>T5</td><td>step=2 end</td><td>stopReason=completed</td></tr>
+      <tr><td>T6</td><td>turn/end</td><td>reason=completed · phase→idle</td></tr>
+      </tbody>
+    </table></div>
+
+    <div class="lang-zh-only"><p>C10 止于 <code>step()</code> 入口——模型流式与 tool 调度在 step 内完成（C12/C15）。下面桥接 trace 展示 step 内第一次 <code>deriveMessages()</code> 如何喂给 <code>buildRequest</code>。</p></div>
+    <div class="lang-en-only"><p>C10 stops at <code>step()</code> entry — streaming and tools finish inside step (C12/C15). Bridge trace below shows first <code>deriveMessages()</code> inside step feeding <code>buildRequest</code>.</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/core/agent-loop/src/agent.ts</span>
+        <span class="src-tag">step-entry</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 332</span> <span class="src-hl">  <span class="src-kw">private</span> <span class="src-kw">async</span> step(assembly: PromptAssembly): Promise&lt;StepEndReason | <span class="src-kw">null</span>&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln"> 333</span> <span class="src-hl">    /* v8 ignore next -- <span class="src-kw">private</span> callers establish the running phase before executing a step */</span></span>
+      <span class="src-line">      <span class="src-ln"> 334</span> <span class="src-hl">    <span class="src-kw">if</span> (this.phase.kind !== &#x27;running&#x27;) <span class="src-kw">throw</span> <span class="src-kw">new</span> Error(<span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`agent &quot;${this.id}&quot;: step outside running phase`</span>)</span></span>
+      <span class="src-line">      <span class="src-ln"> 335</span> <span class="src-hl">    <span class="src-kw">const</span> { turn, step, abort: { signal } } = this.phase</span></span>
+      <span class="src-line">      <span class="src-ln"> 336</span> <span class="src-hl">    signal.throwIfAborted()</span></span>
+      <span class="src-line">      <span class="src-ln"> 337</span> <span class="src-hl">    <span class="src-kw">const</span> system = renderPrompt(assembly)</span></span>
+      <span class="src-line">      <span class="src-ln"> 338</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 339</span> <span class="src-hl">    <span class="src-kw">while</span> (<span class="src-kw">true</span>) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 340</span> <span class="src-hl">      <span class="src-kw">const</span> { request, preparedCall } = <span class="src-kw">await</span> this.buildRequest(</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">buildRequest：agent/request waterfall</span><span class="lang-en-only">buildRequest: agent/request waterfall</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 341</span> <span class="src-hl">        turn, step, assembly.tools, system, this.session.deriveMessages(), signal,</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">★ deriveMessages() → boundaryMessages</span><span class="lang-en-only">★ deriveMessages() → boundaryMessages</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 342</span> <span class="src-hl">      )</span></span>
+    </div>
+
+    <div class="note copper">
+      <span class="lang-zh-only">对照 docs/agent-lifecycle.md 序列图：turn/* 与 step/* 全是 durable session events；agent/* 是 live extension points。</span>
+      <span class="lang-en-only">Cross-read docs/agent-lifecycle.md sequence: turn/* and step/* are durable session events; agent/* are live extension points.</span>
+    </div>
+
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/core/agent-loop/src/agent.ts</span>
+        <span class="src-tag">walkthrough</span>
+      </div>
+      <span class="src-line"><span class="src-ln">  1</span> <span class="src-hl">'agent/pre-step', { messages: claimed }</span></span>
+      <span class="src-line"><span class="src-comment">     // 瀑布：可 reject/rewrite / waterfall: reject/rewrite</span></span>
+      <span class="src-line"><span class="src-ln">  2</span> <span class="src-hl">session.append('step/start', { turn, step })</span></span>
+      <span class="src-line"><span class="src-comment">     // step 边界 / step boundary</span></span>
+      <span class="src-line"><span class="src-ln">  3</span> <span class="src-hl">session.deriveMessages()</span></span>
+      <span class="src-line"><span class="src-comment">     // 投影 model history / project model history</span></span>
+      <span class="src-line"><span class="src-ln">  4</span> <span class="src-hl">await executeToolCalls(...)</span></span>
+      <span class="src-line"><span class="src-comment">     // 执行 read 等 / execute read etc</span></span>
+    </div>
+
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">交叉引用</span><span class="lang-en-only">Cross-ref</span></span> <span class="da-title lang-zh-only">deepseek-harness 文档</span><span class="da-title lang-en-only">deepseek-harness docs</span></div>    <table class="cmp">
+      <thead><tr><th>DOC</th><th>主题</th><th>路径</th><th>摘要</th></tr></thead>
+      <tbody>
+      <tr><td>agent-lifecycle</td><td>Agent 生命周期</td><td><code>docs/agent-lifecycle.md</code></td><td>turn/step twin loops, agent/pre-step waterfall, session vs agent event split</td></tr>
+      <tr><td>tool-execution-pipeline</td><td>工具执行管线</td><td><code>docs/tool-execution-pipeline.md</code></td><td>tools/pre-execute → execute → post-execute waterfalls and approval chain</td></tr>
+      </tbody>
+    </table>
+
+    <div class="trace-box">
+      <div class="tb-tag">TRACE · station station agent-loop</div>
+      <div class="lang-zh-only"><p>站 10：turn 包裹一个或多个 step；主线 read 通常占一个 step。</p></div>
+      <div class="lang-en-only"><p>St. 10: turn wraps one or more steps; through-line read usually costs one step.</p></div>
+    </div>
+
+    <div class="depth-zone" data-chapter="C10"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C10.4+</span><span class="lang-en-only">Deep dive · C10.4+</span></div>
+
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">交叉引用</span><span class="lang-en-only">Cross-ref</span></span> <span class="da-title lang-zh-only">deepseek-harness 文档</span><span class="da-title lang-en-only">deepseek-harness docs</span></div>    <table class="cmp">
+      <thead><tr><th>DOC</th><th>主题</th><th>路径</th><th>摘要</th></tr></thead>
+      <tbody>
+      <tr><td>agent-lifecycle</td><td>Agent 生命周期</td><td><code>docs/agent-lifecycle.md</code></td><td>turn/step twin loops, agent/pre-step waterfall, session vs agent event split</td></tr>
+      </tbody>
+    </table>
+
+    </div>
+  </section>
+
+  <section class="chap" id="c11">
+    <div class="chap-num">CHAPTER&nbsp;11&nbsp;·&nbsp;HEART</div>
+    <h2 class="chap-title lang-zh-only">agent/pre-step 瀑布</h2>
+    <h2 class="chap-title lang-en-only">agent/pre-step waterfall</h2>
+    <p class="chap-en lang-zh-only">claim inbox · inject context · reject turn</p>
+    <p class="chap-en lang-en-only">claim inbox · inject context · reject turn</p>
+    <nav class="chapter-compass" aria-label="Chapter navigation">
+      <div class="cc-row">
+        <div class="cc-phase"><span class="cc-roman">II</span> · <span class="lang-zh-only">心脏</span><span class="lang-en-only">Heart</span></div>
+        <div class="cc-station"><span class="lang-zh-only">站 12</span><span class="lang-en-only">St. 12</span> · C11/26</div>
+      </div>
+      <div class="cc-forest"><span class="lang-zh-only">agent/pre-step 瀑布</span><span class="lang-en-only">agent/pre-step waterfall</span></div>
+      <div class="cc-links">
+        <a class="cc-nav cc-prev" href="#c10"><span class="cc-arrow">←</span> <span class="cc-nav-num">C10</span> <span class="lang-zh-only">ReactLoopAgent 驱动</span><span class="lang-en-only">ReactLoopAgent driver</span></a>
+        <a class="cc-map" href="#forest-overview"><span class="lang-zh-only">回到总览</span><span class="lang-en-only">Forest map</span></a>
+        <a class="cc-nav cc-next" href="#c12"><span class="cc-nav-num">C12</span> <span class="lang-zh-only">Tool 执行管线</span><span class="lang-en-only">Tool execution pipeline</span> <span class="cc-arrow">→</span></a>
+      </div>
+    </nav>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>本章回答「这条主线 prompt 在此层长什么样」</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH 没有隐藏魔法——一切可替换行为都在 Cordis 事件或 SessionEvent 里</span></p>
+      <p><span class="swc-pill act">优化</span><span>读源码时先搜 session.append 与 ctx.* 注册点</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>This chapter answers what the through-line prompt looks like at this layer</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH has no hidden magic — replaceable behavior lives in Cordis events or SessionEvents</span></p>
+      <p><span class="swc-pill act">优化</span><span>When reading source, search session.append and ctx.* registration first</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">pre-step</span><span class="lang-en-only">pre-step</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">pre-step</span><span class="lang-en-only">pre-step</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">agent-loop</span><span class="lang-en-only">agent-loop</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">waterfall</span><span class="lang-en-only">waterfall</span></div>
+      </div>
+    </div>
+
+    <div class="lang-zh-only"><p>每个 step 开始前，<code>agent/pre-step</code> waterfall（<code>packages/core/agent-loop</code> dispatch，listeners 遍布 compaction、skill、plan-mode、subagent 等）接收 <code>{ agent, turn, ... }</code> 与 <code>next</code>。返回值 <strong>reject</strong> 或 <strong>enter(messages)</strong> 权威。</p></div>
+    <div class="lang-en-only"><p>Before each step, the <code>agent/pre-step</code> waterfall (<code>packages/core/agent-loop</code> dispatch; listeners across compaction, skill, plan-mode, subagent, etc.) receives <code>{ agent, turn, ... }</code> and <code>next</code>. The return <strong>reject</strong> or <strong>enter(messages)</strong> is authoritative.</p></div>
+
+    <h3 class="sub"><span class="sec-num">C11.1</span> <span class="lang-zh-only">Waterfall 监听者矩阵（节选）</span><span class="lang-en-only">Waterfall listener matrix (excerpt)</span></h3>
+
+    <table class="cmp">
+      <thead><tr><th>Listener 包</th><th>pre-step 行为</th><th>主线相关</th></tr></thead>
+      <tbody>
+      <tr><td>compaction-basic</td><td>token 压力 · 摘要</td><td>长会话</td></tr>
+      <tr><td>tool-skill</td><td>skill 目录 system-reminder</td><td>可选</td></tr>
+      <tr><td>plan-mode</td><td>plan 工具门控</td><td>—</td></tr>
+      <tr><td>session-checkpoint-policy</td><td>checkpoint 边界</td><td>持久性</td></tr>
+      <tr><td>subagent-in-process-driver</td><td>子 agent 上下文</td><td>C25</td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="sec-num">C11.2</span> <span class="lang-zh-only">Case study：reject vs enter</span><span class="lang-en-only">Case study: reject vs enter</span></h3>
+
+    <div class="lang-zh-only"><p>Compaction 在 pre-step 检测到 overflow 时可能 reject 当前 enter 提案，先跑摘要再开新 turn。Skill 插件在 enter 上追加 user-role <code>&lt;system-reminder&gt;</code> 目录——这些消息若进入模型，必须先有对应 <code>user/message</code> SessionEvent（invariant）。</p></div>
+    <div class="lang-en-only"><p>Compaction may reject the current enter proposal at pre-step when detecting overflow, summarize first, then open a fresh turn. The skill plugin appends user-role <code>&lt;system-reminder&gt;</code> catalog to enter — if these reach the model, matching <code>user/message</code> SessionEvents must exist first (invariant).</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/core/agent/src/runtime-types.ts</span>
+        <span class="src-tag">pre</span>
+      </div>
+      <span class="src-line"><span class="src-str">agent/pre-step</span> · mode: <span class="src-str">waterfall</span></span>
+      <span class="src-line">Listeners: compaction-basic, tool-skill, plan-mode, ...</span>
+    </div>
+
+    <div class="note copper">
+      <span class="lang-zh-only">📘 <strong>事件生产消费矩阵</strong>（<code>docs/event-producer-consumer.md</code>）· 每个 harness 事件的 dispatch 模式、声明位置、生产者与消费者包</span>
+      <span class="lang-en-only">📘 <strong>Event producer-consumer matrix</strong> (<code>docs/event-producer-consumer.md</code>) · Dispatch mode, declaration site, producers and listeners per harness event</span>
+    </div>
+
+    <div class="trace-walk">
+      <div class="tw-head">
+        <span class="tw-tag">SOURCE TRACE · C11</span>
+        <span class="lang-zh-only">agent/pre-step 瀑布：14 个 listener 如何改写入模内容</span>
+        <span class="lang-en-only">agent/pre-step waterfall: how 14 listeners reshape model input</span>
+      </div>
+
+    <div class="lang-zh-only"><p><code>preStep()</code> 在 claim inbox 之后、<code>step/start</code> 之前调用 <code>dispatch.waterfall('agent/pre-step')</code>。listener 可 <code>reject</code> 整轮（turn 仍 durable 落盘但无 step）、或 <code>enter</code> 并改写 messages——compaction、plan-mode、agent-instructions、goal-round-driver 等 14 个包在此挂钩。</p></div>
+    <div class="lang-en-only"><p><code>preStep()</code> after inbox claim, before <code>step/start</code>, calls <code>dispatch.waterfall('agent/pre-step')</code>. Listeners may <code>reject</code> the turn (durable turn logged, no step), or <code>enter</code> and rewrite messages — compaction, plan-mode, agent-instructions, goal-round-driver, and 12 other packages hook here.</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/core/agent-loop/src/agent.ts</span>
+        <span class="src-tag">pre-step</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 225</span> <span class="src-hl">  <span class="src-kw">private</span> <span class="src-kw">async</span> preStep(target: InboxTarget, position: { turn: number; step: number }): Promise&lt;PreparedStep&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln"> 226</span> <span class="src-hl">    /* v8 ignore next -- <span class="src-kw">private</span> callers establish the running phase before proposing a step */</span></span>
+      <span class="src-line">      <span class="src-ln"> 227</span> <span class="src-hl">    <span class="src-kw">if</span> (this.phase.kind !== &#x27;running&#x27;) <span class="src-kw">throw</span> <span class="src-kw">new</span> Error(<span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`agent &quot;${this.id}&quot;: pre-step outside running phase`</span>)</span></span>
+      <span class="src-line">      <span class="src-ln"> 228</span> <span class="src-hl">    <span class="src-kw">const</span> signal = this.phase.abort.signal</span></span>
+      <span class="src-line">      <span class="src-ln"> 229</span> <span class="src-hl">    <span class="src-kw">const</span> claimed = this.inbox.claim(target, position.turn)</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">inbox.claim(target, turn)：next-turn 或 next-step</span><span class="lang-en-only">inbox.claim(target, turn): next-turn or next-step</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 230</span> <span class="src-hl">    <span class="src-kw">const</span> assembly = <span class="src-kw">await</span> this.loopCtx.systemPrompt.assemble(assembleContextFor(this, signal))</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">systemPrompt.assemble：section + tool schema</span><span class="lang-en-only">systemPrompt.assemble: sections + tool schema</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 231</span> <span class="src-hl">    signal.throwIfAborted()</span></span>
+      <span class="src-line">      <span class="src-ln"> 232</span> <span class="src-hl">    <span class="src-kw">const</span> sections = renderContextSections(assembly)</span></span>
+      <span class="src-line">      <span class="src-ln"> 233</span> <span class="src-hl">    <span class="src-kw">const</span> context = this.runtimeContext.project(joinContextSections(sections), sections)</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">runtimeContext.project：注入 context section</span><span class="lang-en-only">runtimeContext.project: inject context section</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 234</span> <span class="src-hl">    <span class="src-kw">const</span> decision = <span class="src-kw">await</span> this.dispatch.waterfall(</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">★ agent/pre-step waterfall</span><span class="lang-en-only">★ agent/pre-step waterfall</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 235</span> <span class="src-hl">      &#x27;agent/pre-step&#x27;, { messages: claimed, ...position, signal },</span></span>
+      <span class="src-line">      <span class="src-ln"> 236</span> <span class="src-hl">      (): Promise&lt;PreStepDecision&gt; =&gt; Promise.resolve&lt;PreStepDecision&gt;({</span></span>
+      <span class="src-line">      <span class="src-ln"> 237</span> <span class="src-hl">        kind: &#x27;enter&#x27;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 238</span> <span class="src-hl">        messages: context === <span class="src-kw">undefined</span> ? claimed : [...claimed, context],</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">默认 enter：claimed + context messages</span><span class="lang-en-only">default enter: claimed + context messages</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 239</span> <span class="src-hl">      }),</span></span>
+      <span class="src-line">      <span class="src-ln"> 240</span> <span class="src-hl">    )</span></span>
+      <span class="src-line">      <span class="src-ln"> 241</span> <span class="src-hl">    signal.throwIfAborted()</span></span>
+      <span class="src-line">      <span class="src-ln"> 242</span> <span class="src-hl">    <span class="src-kw">return</span> decision.kind === &#x27;reject&#x27; ? decision : { ...decision, assembly }</span></span>
+      <span class="src-line">      <span class="src-ln"> 243</span> <span class="src-hl">  }</span></span>
+    </div>
+
+    <div class="trace-steps"><div class="ts-label"><span class="lang-zh-only">agent/pre-step 部分 listener（event map）</span><span class="lang-en-only">agent/pre-step sample listeners (event map)</span></div>    <table class="cmp">
+      <thead><tr><th>#</th><th>location</th><th>主线时刻 / through-line moment</th></tr></thead>
+      <tbody>
+      <tr><td>1</td><td>agent-instructions</td><td>AGENTS.md 风格 system-reminder 注入</td></tr>
+      <tr><td>2</td><td>compaction-basic</td><td>压缩摘要替换 early messages</td></tr>
+      <tr><td>3</td><td>plan-mode</td><td>plan 状态 gate</td></tr>
+      <tr><td>4</td><td>goal-round-driver</td><td>goal 驱动 continue/reject</td></tr>
+      <tr><td>5</td><td>session-reference</td><td>跨 session 引用注入</td></tr>
+      <tr><td>6</td><td>time-context</td><td>时间戳 section</td></tr>
+      </tbody>
+    </table></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/core/agent-loop/src/agent.ts</span>
+        <span class="src-tag">turn-reject</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 266</span> <span class="src-hl">        <span class="src-kw">const</span> decision = <span class="src-kw">await</span> this.preStep(target, { turn, step })</span></span>
+      <span class="src-line">      <span class="src-ln"> 267</span> <span class="src-hl">        <span class="src-kw">if</span> (decision.kind === &#x27;reject&#x27;) {</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">decision.kind === 'reject' → turnEnds=blocked</span><span class="lang-en-only">decision.kind === 'reject' → turnEnds=blocked</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 268</span> <span class="src-hl">          turnEnds = { kind: &#x27;blocked&#x27; }</span></span>
+      <span class="src-line">      <span class="src-ln"> 269</span> <span class="src-hl">          <span class="src-kw">return</span> <span class="src-kw">false</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 270</span> <span class="src-hl">        }</span></span>
+      <span class="src-line">      <span class="src-ln"> 271</span> <span class="src-hl">        <span class="src-kw">if</span> (turnEnds &amp;&amp; decision.messages.length === 0) <span class="src-kw">break</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 272</span> <span class="src-hl">        <span class="src-comment">// A removed waking message or an enter decision rewritten to empty</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 273</span> <span class="src-hl">        <span class="src-comment">// still owns the initial turn boundary, but it spends no model call.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 274</span> <span class="src-hl">        <span class="src-kw">if</span> (phase.step === 0 &amp;&amp; decision.messages.length === 0) {</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">首 step enter 空 messages → turn 无 model call 关闭</span><span class="lang-en-only">first step enter empty → turn closes without model call</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 275</span> <span class="src-hl">          turnEnds = { kind: &#x27;completed&#x27; }</span></span>
+      <span class="src-line">      <span class="src-ln"> 276</span> <span class="src-hl">          <span class="src-kw">return</span> <span class="src-kw">false</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 277</span> <span class="src-hl">        }</span></span>
+    </div>
+
+    <div class="lang-zh-only"><p>主线 prompt 的第一次 pre-step 通常只做两件事：把 claimed user 消息与 runtime context section 合并；compaction 若未触发则 messages 原样进入 step。</p></div>
+    <div class="lang-en-only"><p>Through-line's first pre-step usually merges claimed user messages with runtime context section; if compaction hasn't fired, messages enter step unchanged.</p></div>
+
+    <div class="note copper">
+      <span class="lang-zh-only">打开 docs/event-producer-consumer.md 搜索 <code>agent/pre-step</code>，对照 listener 列与 packages/ 目录。</span>
+      <span class="lang-en-only">Open docs/event-producer-consumer.md, search <code>agent/pre-step</code>, cross-read listener column with packages/.</span>
+    </div>
+
+    </div>
+
+    <div class="trace-box">
+      <div class="tb-tag">TRACE · station station pre-step</div>
+      <div class="lang-zh-only"><p>站 pre-step：reject/rewrite。</p></div>
+      <div class="lang-en-only"><p>St. pre-step: reject/rewrite.</p></div>
+    </div>
+
+    <div class="depth-zone" data-chapter="C11"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C11.4+</span><span class="lang-en-only">Deep dive · C11.4+</span></div>
+
+    </div>
+  </section>
+
+  <section class="chap" id="c12">
+    <div class="chap-num">CHAPTER&nbsp;12&nbsp;·&nbsp;HEART</div>
+    <h2 class="chap-title lang-zh-only">Tool 执行管线</h2>
+    <h2 class="chap-title lang-en-only">Tool execution pipeline</h2>
+    <p class="chap-en lang-zh-only">executeToolCalls · parallel barrier · model order</p>
+    <p class="chap-en lang-en-only">executeToolCalls · parallel barrier · model order</p>
+    <nav class="chapter-compass" aria-label="Chapter navigation">
+      <div class="cc-row">
+        <div class="cc-phase"><span class="cc-roman">II</span> · <span class="lang-zh-only">心脏</span><span class="lang-en-only">Heart</span></div>
+        <div class="cc-station"><span class="lang-zh-only">站 13–14</span><span class="lang-en-only">St. 13–14</span> · C12/26</div>
+      </div>
+      <div class="cc-forest"><span class="lang-zh-only">Tool 执行管线</span><span class="lang-en-only">Tool execution pipeline</span></div>
+      <div class="cc-links">
+        <a class="cc-nav cc-prev" href="#c11"><span class="cc-arrow">←</span> <span class="cc-nav-num">C11</span> <span class="lang-zh-only">agent/pre-step 瀑布</span><span class="lang-en-only">agent/pre-step waterfall</span></a>
+        <a class="cc-map" href="#forest-overview"><span class="lang-zh-only">回到总览</span><span class="lang-en-only">Forest map</span></a>
+        <a class="cc-nav cc-next" href="#c13"><span class="cc-nav-num">C13</span> <span class="lang-zh-only">三域事件矩阵</span><span class="lang-en-only">Three-domain event matrix</span> <span class="cc-arrow">→</span></a>
+      </div>
+    </nav>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>本章回答「这条主线 prompt 在此层长什么样」</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH 没有隐藏魔法——一切可替换行为都在 Cordis 事件或 SessionEvent 里</span></p>
+      <p><span class="swc-pill act">优化</span><span>读源码时先搜 session.append 与 ctx.* 注册点</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>This chapter answers what the through-line prompt looks like at this layer</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH has no hidden magic — replaceable behavior lives in Cordis events or SessionEvents</span></p>
+      <p><span class="swc-pill act">优化</span><span>When reading source, search session.append and ctx.* registration first</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">tools</span><span class="lang-en-only">tools</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">packages/core/tools</span><span class="lang-en-only">packages/core/tools</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">executeToolCalls</span><span class="lang-en-only">executeToolCalls</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">tool/result</span><span class="lang-en-only">tool/result</span></div>
+      </div>
+    </div>
+
+    <div class="lang-zh-only"><p>模型在 <code>assistant/message</code> 里返回 tool-call block 后，驱动器写 <code>tool/call</code> SessionEvent，然后走 <code>tools/pre-execute</code> → monotonic guards → <code>tools/execute</code> → <code>tools/post-execute</code> → <code>tool/result</code>。详见 <code>docs/tool-execution-pipeline.md</code>。</p></div>
+    <div class="lang-en-only"><p>After the model returns a tool-call block in <code>assistant/message</code>, the driver logs <code>tool/call</code> SessionEvent, then runs <code>tools/pre-execute</code> → monotonic guards → <code>tools/execute</code> → <code>tools/post-execute</code> → <code>tool/result</code>. See <code>docs/tool-execution-pipeline.md</code>.</p></div>
+
+    <h3 class="sub"><span class="sec-num">C12.1</span> <span class="lang-zh-only">三段 waterfall</span><span class="lang-en-only">Three waterfalls</span></h3>
+
+    <div class="ladder">
+      <div class="ld-row">
+        <div class="ld-num">01</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">tools/pre-execute</span><span class="lang-en-only">hooks · permission · sandbox · deny/ask</span></div>
+
+        </div>
+      </div>
+      <div class="ld-row">
+        <div class="ld-num">02</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">tools/execute</span><span class="lang-en-only">timeout · retry · 实际 execute()</span></div>
+
+        </div>
+      </div>
+      <div class="ld-row">
+        <div class="ld-num">03</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">tools/post-execute</span><span class="lang-en-only">accept · block · replace · add context</span></div>
+
+        </div>
+      </div>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/core/tools/README.md</span>
+        <span class="src-tag">pipe</span>
+      </div>
+      <span class="src-line"><span class="src-fn">ctx.tools</span> scoped registry</span>
+      <span class="src-line">Tool schemas are <span class="src-kw">generated at boot</span> from mounted plugins.</span>
+    </div>
+
+    <h3 class="sub"><span class="sec-num">C12.2</span> <span class="lang-zh-only">read README 的完整路径</span><span class="lang-en-only">Full path of read README</span></h3>
+
+    <table class="cmp">
+      <thead><tr><th>阶段</th><th>模块</th><th>主线</th></tr></thead>
+      <tbody>
+      <tr><td>tool/call</td><td>agent-loop → session</td><td>read(path=README.md)</td></tr>
+      <tr><td>pre-execute</td><td>user-approval · sandbox</td><td>可能 ask</td></tr>
+      <tr><td>execute</td><td>packages/fs/tool-fs</td><td>fs read · observation policy</td></tr>
+      <tr><td>tool/result</td><td>session append</td><td>进入 deriveMessages</td></tr>
+      </tbody>
+    </table>
+
+    <div class="lang-zh-only"><p>Tool catalog 在 boot 时由<strong>已挂载插件动态生成</strong>——「tool schema 不是静态可知的」。这也是 DSH 与 sealed product 的差异：换 profile patch 可能换整个工具面。</p></div>
+    <div class="lang-en-only"><p>The tool catalog is <strong>generated dynamically at boot</strong> from mounted plugins — «a tool schema is not statically knowable». This differs from sealed products: swapping a profile patch can swap the entire tool surface.</p></div>
+
+    <div class="note copper">
+      <span class="lang-zh-only">📘 <strong>工具执行管线</strong>（<code>docs/tool-execution-pipeline.md</code>）· tools/pre-execute → execute → post-execute 三段 waterfall 与审批链</span>
+      <span class="lang-en-only">📘 <strong>Tool execution pipeline</strong> (<code>docs/tool-execution-pipeline.md</code>) · tools/pre-execute → execute → post-execute waterfalls and approval chain</span>
+    </div>
+
+    <div class="trace-walk">
+      <div class="tw-head">
+        <span class="tw-tag">SOURCE TRACE · C12</span>
+        <span class="lang-zh-only">read README 工具管线 · executeToolCalls</span>
+        <span class="lang-en-only">read README tool pipeline · executeToolCalls</span>
+      </div>
+
+    <div class="lang-zh-only"><p>模型返回 tool-call block 后，<code>step()</code> 调用 <code>executeToolCalls</code>。调度器按 <code>executionMode</code> 分 exclusive barrier 与 parallel pool；结果以 model order 提交，<code>tool/call</code> + <code>tool/result</code> 成对写入 session log。</p></div>
+    <div class="lang-en-only"><p>After model returns tool-call blocks, <code>step()</code> calls <code>executeToolCalls</code>. Scheduler splits exclusive barriers vs parallel pool by <code>executionMode</code>; results commit in model order; <code>tool/call</code> + <code>tool/result</code> pairs land in session log.</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/core/agent-loop/src/agent.ts</span>
+        <span class="src-tag">dispatch</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 410</span> <span class="src-hl">      <span class="src-kw">if</span> (finish.kind === &#x27;max-tokens&#x27;) <span class="src-kw">return</span> { kind: &#x27;max-tokens&#x27; }</span></span>
+      <span class="src-line">      <span class="src-ln"> 411</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 412</span> <span class="src-hl">      <span class="src-kw">const</span> toolCalls = message.content.filter(block =&gt; block.<span class="src-kw">type</span> === &#x27;tool-call&#x27;)</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">filter tool-call blocks from assistant content</span><span class="lang-en-only">filter tool-call blocks from assistant content</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 413</span> <span class="src-hl">      <span class="src-kw">if</span> (toolCalls.length === 0) <span class="src-kw">return</span> { kind: &#x27;completed&#x27; }</span></span>
+      <span class="src-line">      <span class="src-ln"> 414</span> <span class="src-hl">      <span class="src-kw">const</span> { concluded } = <span class="src-kw">await</span> executeToolCalls(</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">★ executeToolCalls 入口</span><span class="lang-en-only">★ executeToolCalls entry</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 415</span> <span class="src-hl">        this.loopCtx, turn, step, toolCalls, signal,</span></span>
+      <span class="src-line">      <span class="src-ln"> 416</span> <span class="src-hl">        context =&gt; this.inbox.splice(&#x27;next-step&#x27;, this.inbox.nextStep.length, 0, [context]),</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">acceptContext → inbox next-step splice</span><span class="lang-en-only">acceptContext → inbox next-step splice</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 417</span> <span class="src-hl">      )</span></span>
+      <span class="src-line">      <span class="src-ln"> 418</span> <span class="src-hl">      <span class="src-kw">return</span> concluded ? { kind: &#x27;completed&#x27; } : <span class="src-kw">null</span></span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/core/agent-loop/src/tool-calls.ts</span>
+        <span class="src-tag">exec</span>
+      </div>
+      <span class="src-line">      <span class="src-ln">  59</span> <span class="src-hl"><span class="src-kw">export</span> <span class="src-kw">async</span> <span class="src-kw">function</span> executeToolCalls(</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">executeToolCalls 签名：ctx + turn + step</span><span class="lang-en-only">executeToolCalls signature: ctx + turn + step</span></span></span>
+      <span class="src-line">      <span class="src-ln">  60</span> <span class="src-hl">  ctx: Context,</span></span>
+      <span class="src-line">      <span class="src-ln">  61</span> <span class="src-hl">  turn: number,</span></span>
+      <span class="src-line">      <span class="src-ln">  62</span> <span class="src-hl">  step: number,</span></span>
+      <span class="src-line">      <span class="src-ln">  63</span> <span class="src-hl">  toolCalls: ToolCallBlock[],</span></span>
+      <span class="src-line">      <span class="src-ln">  64</span> <span class="src-hl">  signal: AbortSignal,</span></span>
+      <span class="src-line">      <span class="src-ln">  65</span> <span class="src-hl">  acceptContext: (context: UserMessage) =&gt; void,</span></span>
+      <span class="src-line">      <span class="src-ln">  66</span> <span class="src-hl">): Promise&lt;{ concluded: boolean }&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln">  67</span> <span class="src-hl">  <span class="src-kw">const</span> agent = ctx.agents.requireInitiator()</span></span>
+      <span class="src-line">      <span class="src-ln">  68</span> <span class="src-hl">  <span class="src-kw">const</span> { session } = agent</span></span>
+      <span class="src-line">      <span class="src-ln">  69</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln">  70</span> <span class="src-hl">  <span class="src-comment">// Inputs are distinct because tools/execute wrappers may replace `exec.signal`.</span></span></span>
+      <span class="src-line">      <span class="src-ln">  71</span> <span class="src-hl">  <span class="src-kw">const</span> planned: PlannedCall[] = toolCalls.map(block =&gt; ({</span></span>
+      <span class="src-line">      <span class="src-ln">  72</span> <span class="src-hl">    block,</span></span>
+      <span class="src-line">      <span class="src-ln">  73</span> <span class="src-hl">    exec: {</span></span>
+      <span class="src-line">      <span class="src-ln">  74</span> <span class="src-hl">      callId: block.id,</span></span>
+      <span class="src-line">      <span class="src-ln">  75</span> <span class="src-hl">      name: block.name,</span></span>
+      <span class="src-line">      <span class="src-ln">  76</span> <span class="src-hl">      arguments: parseArguments(block.arguments),</span></span>
+      <span class="src-line">      <span class="src-ln">  77</span> <span class="src-hl">      agent,</span></span>
+      <span class="src-line">      <span class="src-ln">  78</span> <span class="src-hl">      signal,</span></span>
+      <span class="src-line">      <span class="src-ln">  79</span> <span class="src-hl">    },</span></span>
+      <span class="src-line">      <span class="src-ln">  80</span> <span class="src-hl">  }))</span></span>
+      <span class="src-line">      <span class="src-ln">  81</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln">  82</span> <span class="src-hl">  <span class="src-kw">let</span> next = 0</span></span>
+      <span class="src-line">      <span class="src-ln">  83</span> <span class="src-hl">  <span class="src-kw">let</span> concluded = <span class="src-kw">false</span></span></span>
+      <span class="src-line">      <span class="src-ln">  84</span> <span class="src-hl">  <span class="src-kw">while</span> (next &lt; planned.length) {</span></span>
+      <span class="src-line">      <span class="src-ln">  85</span> <span class="src-hl">    <span class="src-comment">// Commit before classifying again so registry changes affect unstarted calls.</span></span></span>
+      <span class="src-line">      <span class="src-ln">  86</span> <span class="src-hl">    <span class="src-comment">// oxlint-disable-next-line typescript/no-non-null-assertion -- bounded by the loop condition</span></span></span>
+      <span class="src-line">      <span class="src-ln">  87</span> <span class="src-hl">    <span class="src-kw">const</span> first = planned[next]!</span></span>
+      <span class="src-line">      <span class="src-ln">  88</span> <span class="src-hl">    <span class="src-kw">const</span> mode = ctx.tools.executionMode(first.exec).kind</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">executionMode：parallel vs exclusive barrier</span><span class="lang-en-only">executionMode: parallel vs exclusive barrier</span></span></span>
+      <span class="src-line">      <span class="src-ln">  89</span> <span class="src-hl">    <span class="src-kw">const</span> group = mode === &#x27;parallel&#x27; ? planned.slice(next) : [first]</span></span>
+      <span class="src-line">      <span class="src-ln">  90</span> <span class="src-hl">    <span class="src-kw">const</span> outcome = <span class="src-kw">await</span> runGroup(</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">runGroup：一组 call 调度</span><span class="lang-en-only">runGroup: schedule one group of calls</span></span></span>
+      <span class="src-line">      <span class="src-ln">  91</span> <span class="src-hl">      ctx, turn, step, group, mode, signal, acceptContext,</span></span>
+      <span class="src-line">      <span class="src-ln">  92</span> <span class="src-hl">    )</span></span>
+      <span class="src-line">      <span class="src-ln">  93</span> <span class="src-hl">    next += outcome.consumed</span></span>
+      <span class="src-line">      <span class="src-ln">  94</span> <span class="src-hl">    concluded ||= outcome.concluded</span></span>
+      <span class="src-line">      <span class="src-ln">  95</span> <span class="src-hl">    <span class="src-kw">if</span> (outcome.aborted) {</span></span>
+      <span class="src-line">      <span class="src-ln">  96</span> <span class="src-hl">      <span class="src-kw">for</span> (<span class="src-kw">const</span> call of planned.slice(next)) appendSkippedToolCall(session, turn, step, call.block)</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">abort：skipped calls 合成 error result</span><span class="lang-en-only">abort: skipped calls get synthetic error result</span></span></span>
+      <span class="src-line">      <span class="src-ln">  97</span> <span class="src-hl">      <span class="src-kw">return</span> { concluded }</span></span>
+      <span class="src-line">      <span class="src-ln">  98</span> <span class="src-hl">    }</span></span>
+      <span class="src-line">      <span class="src-ln">  99</span> <span class="src-hl">  }</span></span>
+      <span class="src-line">      <span class="src-ln"> 100</span> <span class="src-hl">  <span class="src-kw">return</span> { concluded }</span></span>
+      <span class="src-line">      <span class="src-ln"> 101</span> <span class="src-hl">}</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/core/agent-loop/src/tool-calls.ts</span>
+        <span class="src-tag">append-pair</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 164</span> <span class="src-hl">  <span class="src-kw">const</span> startCall = <span class="src-kw">async</span> (index: number): Promise&lt;void&gt; =&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln"> 165</span> <span class="src-hl">    <span class="src-comment">// oxlint-disable-next-line typescript/no-non-null-assertion -- bounded index</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 166</span> <span class="src-hl">    <span class="src-kw">const</span> call = group[index]!</span></span>
+      <span class="src-line">      <span class="src-ln"> 167</span> <span class="src-hl">    callSeqs[index] = appendToolCall(session, turn, step, call.block)</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">appendToolCall → tool/call event</span><span class="lang-en-only">appendToolCall → tool/call event</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 168</span> <span class="src-hl">    started++</span></span>
+      <span class="src-line">      <span class="src-ln"> 169</span> <span class="src-hl">    <span class="src-kw">const</span> prepared = <span class="src-kw">await</span> ctx.tools[TOOL_RUNTIME_SCHEDULER].prepare(call.exec)</span></span>
+      <span class="src-line">      <span class="src-ln"> 170</span> <span class="src-hl">    throwSchedulerFailure()</span></span>
+      <span class="src-line">      <span class="src-ln"> 171</span> <span class="src-hl">    <span class="src-kw">switch</span> (prepared.kind) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 172</span> <span class="src-hl">      <span class="src-kw">case</span> &#x27;dispatch&#x27;: {</span></span>
+      <span class="src-line">      <span class="src-ln"> 173</span> <span class="src-hl">        <span class="src-kw">const</span> promise = ctx.tools[TOOL_RUNTIME_SCHEDULER].dispatch(prepared.exec).then(</span></span>
+      <span class="src-line">      <span class="src-ln"> 174</span> <span class="src-hl">          (outcome) =&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln"> 175</span> <span class="src-hl">            slots[index] = { exec: prepared.exec, result: outcome.result, needsPost: outcome.kind === &#x27;post-result&#x27; }</span></span>
+      <span class="src-line">      <span class="src-ln"> 176</span> <span class="src-hl">            <span class="src-kw">return</span> index</span></span>
+      <span class="src-line">      <span class="src-ln"> 177</span> <span class="src-hl">          },</span></span>
+      <span class="src-line">      <span class="src-ln"> 178</span> <span class="src-hl">          (error: unknown) =&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln"> 179</span> <span class="src-hl">            schedulerFailure ??= { error }</span></span>
+      <span class="src-line">      <span class="src-ln"> 180</span> <span class="src-hl">            <span class="src-kw">return</span> index</span></span>
+      <span class="src-line">      <span class="src-ln"> 181</span> <span class="src-hl">          },</span></span>
+      <span class="src-line">      <span class="src-ln"> 182</span> <span class="src-hl">        )</span></span>
+      <span class="src-line">      <span class="src-ln"> 183</span> <span class="src-hl">        inFlight.set(index, promise)</span></span>
+      <span class="src-line">      <span class="src-ln"> 184</span> <span class="src-hl">        <span class="src-kw">break</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 185</span> <span class="src-hl">      }</span></span>
+      <span class="src-line">      <span class="src-ln"> 186</span> <span class="src-hl">      <span class="src-kw">case</span> &#x27;post-result&#x27;:</span></span>
+      <span class="src-line">      <span class="src-ln"> 187</span> <span class="src-hl">        slots[index] = { exec: prepared.exec, result: prepared.result, needsPost: <span class="src-kw">true</span> }</span></span>
+      <span class="src-line">      <span class="src-ln"> 188</span> <span class="src-hl">        <span class="src-kw">break</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 189</span> <span class="src-hl">      <span class="src-kw">case</span> &#x27;final-result&#x27;:</span></span>
+      <span class="src-line">      <span class="src-ln"> 190</span> <span class="src-hl">        slots[index] = { exec: prepared.exec, result: prepared.result, needsPost: <span class="src-kw">false</span> }</span></span>
+      <span class="src-line">      <span class="src-ln"> 191</span> <span class="src-hl">        <span class="src-kw">break</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 192</span> <span class="src-hl">      /* v8 ignore next -- closed-union exhaustiveness guard */</span></span>
+      <span class="src-line">      <span class="src-ln"> 193</span> <span class="src-hl">      default:</span></span>
+      <span class="src-line">      <span class="src-ln"> 194</span> <span class="src-hl">        assertNever(prepared, &#x27;tool-call scheduler prepare result&#x27;)</span></span>
+      <span class="src-line">      <span class="src-ln"> 195</span> <span class="src-hl">    }</span></span>
+      <span class="src-line">      <span class="src-ln"> 196</span> <span class="src-hl">  }</span></span>
+      <span class="src-line">      <span class="src-ln"> 197</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 198</span> <span class="src-hl">  <span class="src-kw">const</span> fillPool = <span class="src-kw">async</span> (): Promise&lt;void&gt; =&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln"> 199</span> <span class="src-hl">    <span class="src-kw">while</span> (!aborted &amp;&amp; nextToStart &lt; group.length &amp;&amp; inFlight.size &lt; maxParallelToolCalls) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 200</span> <span class="src-hl">      <span class="src-comment">// Re-read later modes after ordered commits so registry changes can create a barrier.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 201</span> <span class="src-hl">      <span class="src-comment">// oxlint-disable-next-line typescript/no-non-null-assertion -- bounded by the loop condition</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 202</span> <span class="src-hl">      <span class="src-kw">const</span> nextCall = group[nextToStart]!</span></span>
+      <span class="src-line">      <span class="src-ln"> 203</span> <span class="src-hl">      <span class="src-kw">if</span> (nextToStart &gt; 0 &amp;&amp; mode === &#x27;parallel&#x27;</span></span>
+      <span class="src-line">      <span class="src-ln"> 204</span> <span class="src-hl">        &amp;&amp; ctx.tools.executionMode(nextCall.exec).kind !== &#x27;parallel&#x27;) <span class="src-kw">break</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 205</span> <span class="src-hl">      <span class="src-kw">await</span> startCall(nextToStart)</span></span>
+      <span class="src-line">      <span class="src-ln"> 206</span> <span class="src-hl">      nextToStart++</span></span>
+      <span class="src-line">      <span class="src-ln"> 207</span> <span class="src-hl">      throwSchedulerFailure()</span></span>
+      <span class="src-line">      <span class="src-ln"> 208</span> <span class="src-hl">      <span class="src-kw">await</span> commitReady()</span></span>
+      <span class="src-line">      <span class="src-ln"> 209</span> <span class="src-hl">      throwSchedulerFailure()</span></span>
+      <span class="src-line">      <span class="src-ln"> 210</span> <span class="src-hl">      <span class="src-comment">// Abort may arrive while pre-execute awaits.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 211</span> <span class="src-hl">      <span class="src-kw">if</span> (signal.aborted) aborted = <span class="src-kw">true</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 212</span> <span class="src-hl">    }</span></span>
+      <span class="src-line">      <span class="src-ln"> 213</span> <span class="src-hl">  }</span></span>
+      <span class="src-line">      <span class="src-ln"> 214</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 215</span> <span class="src-hl">  <span class="src-comment">// Ordered pre-execute may await; only dispatch/body overlaps. A scheduler</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 216</span> <span class="src-hl">  <span class="src-comment">// failure stops new dispatches and reaches the turn boundary after every</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 217</span> <span class="src-hl">  <span class="src-comment">// already-started dispatch settles.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 218</span> <span class="src-hl">  try {</span></span>
+      <span class="src-line">      <span class="src-ln"> 219</span> <span class="src-hl">    <span class="src-kw">await</span> fillPool()</span></span>
+      <span class="src-line">      <span class="src-ln"> 220</span> <span class="src-hl">    <span class="src-kw">while</span> (inFlight.size &gt; 0) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 221</span> <span class="src-hl">      <span class="src-kw">const</span> settledIndex = <span class="src-kw">await</span> Promise.race(inFlight.values())</span></span>
+      <span class="src-line">      <span class="src-ln"> 222</span> <span class="src-hl">      inFlight.delete(settledIndex)</span></span>
+      <span class="src-line">      <span class="src-ln"> 223</span> <span class="src-hl">      throwSchedulerFailure()</span></span>
+      <span class="src-line">      <span class="src-ln"> 224</span> <span class="src-hl">      <span class="src-kw">await</span> commitReady()</span></span>
+      <span class="src-line">      <span class="src-ln"> 225</span> <span class="src-hl">      throwSchedulerFailure()</span></span>
+      <span class="src-line">      <span class="src-ln"> 226</span> <span class="src-hl">      <span class="src-comment">// Abort may arrive while a tool or ordered commit awaits.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 227</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 228</span> <span class="src-hl">      <span class="src-kw">if</span> (signal.aborted) aborted = <span class="src-kw">true</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 229</span> <span class="src-hl">      <span class="src-kw">await</span> fillPool()</span></span>
+      <span class="src-line">      <span class="src-ln"> 230</span> <span class="src-hl">    }</span></span>
+      <span class="src-line">      <span class="src-ln"> 231</span> <span class="src-hl">  } catch (error: unknown) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 232</span> <span class="src-hl">    schedulerFailure ??= { error }</span></span>
+      <span class="src-line">      <span class="src-ln"> 233</span> <span class="src-hl">    <span class="src-kw">await</span> Promise.allSettled(inFlight.values())</span></span>
+      <span class="src-line">      <span class="src-ln"> 234</span> <span class="src-hl">    <span class="src-kw">throw</span> schedulerFailure.error</span></span>
+      <span class="src-line">      <span class="src-ln"> 235</span> <span class="src-hl">  }</span></span>
+      <span class="src-line">      <span class="src-ln"> 236</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 237</span> <span class="src-hl">  <span class="src-kw">if</span> (aborted) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 238</span> <span class="src-hl">    <span class="src-comment">// Started calls and accepted context settle first; every remaining model</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 239</span> <span class="src-hl">    <span class="src-comment">// call then receives an ordered synthetic result before the turn aborts.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 240</span> <span class="src-hl">    <span class="src-kw">for</span> (<span class="src-kw">const</span> call of group.slice(started)) appendSkippedToolCall(session, turn, step, call.block)</span></span>
+      <span class="src-line">      <span class="src-ln"> 241</span> <span class="src-hl">    <span class="src-kw">return</span> { consumed: group.length, aborted: <span class="src-kw">true</span>, concluded }</span></span>
+      <span class="src-line">      <span class="src-ln"> 242</span> <span class="src-hl">  }</span></span>
+      <span class="src-line">      <span class="src-ln"> 243</span> <span class="src-hl">  /* v8 ignore next -- unreachable: a non-aborted group commits every started call */</span></span>
+      <span class="src-line">      <span class="src-ln"> 244</span> <span class="src-hl">  <span class="src-kw">if</span> (committed !== started) <span class="src-kw">throw</span> <span class="src-kw">new</span> Error(&#x27;tool-call scheduler: uncommitted settled calls&#x27;)</span></span>
+      <span class="src-line">      <span class="src-ln"> 245</span> <span class="src-hl">  <span class="src-kw">return</span> { consumed: started, aborted: <span class="src-kw">false</span>, concluded }</span></span>
+      <span class="src-line">      <span class="src-ln"> 246</span> <span class="src-hl">}</span></span>
+      <span class="src-line">      <span class="src-ln"> 247</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 248</span> <span class="src-hl">/** Append the durable call/result pair <span class="src-kw">for</span> a model call skipped after cancellation. */</span></span>
+      <span class="src-line">      <span class="src-ln"> 249</span> <span class="src-hl"><span class="src-kw">function</span> appendSkippedToolCall(session: Session, turn: number, step: number, block: ToolCallBlock): void {</span></span>
+      <span class="src-line">      <span class="src-ln"> 250</span> <span class="src-hl">  <span class="src-kw">const</span> callSeq = appendToolCall(session, turn, step, block)</span></span>
+      <span class="src-line">      <span class="src-ln"> 251</span> <span class="src-hl">  appendToolResult(session, turn, step, block, {</span></span>
+      <span class="src-line">      <span class="src-ln"> 252</span> <span class="src-hl">    content: [{ <span class="src-kw">type</span>: &#x27;text&#x27;, text: &#x27;Error: tool call aborted before dispatch&#x27; }],</span></span>
+      <span class="src-line">      <span class="src-ln"> 253</span> <span class="src-hl">    isError: <span class="src-kw">true</span>,</span></span>
+      <span class="src-line">      <span class="src-ln"> 254</span> <span class="src-hl">    error: {</span></span>
+      <span class="src-line">      <span class="src-ln"> 255</span> <span class="src-hl">      message: &#x27;tool call aborted before dispatch&#x27;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 256</span> <span class="src-hl">      info: { name: &#x27;AbortError&#x27;, code: TOOL_ABORTED_BEFORE_DISPATCH },</span></span>
+      <span class="src-line">      <span class="src-ln"> 257</span> <span class="src-hl">    },</span></span>
+      <span class="src-line">      <span class="src-ln"> 258</span> <span class="src-hl">  }, callSeq)</span></span>
+      <span class="src-line">      <span class="src-ln"> 259</span> <span class="src-hl">}</span></span>
+      <span class="src-line">      <span class="src-ln"> 260</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 261</span> <span class="src-hl">/** Append a started call and <span class="src-kw">return</span> the event seq that its result must cite. */</span></span>
+      <span class="src-line">      <span class="src-ln"> 262</span> <span class="src-hl"><span class="src-kw">function</span> appendToolCall(session: Session, turn: number, step: number, block: ToolCallBlock): number {</span></span>
+      <span class="src-line">      <span class="src-ln"> 263</span> <span class="src-hl">  <span class="src-kw">const</span> event = session.append(&#x27;tool/call&#x27;, { turn, step, callId: block.id, name: block.name, arguments: block.arguments })</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">tool/call seq 被 result 引用</span><span class="lang-en-only">tool/call seq cited by result</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 264</span> <span class="src-hl">  <span class="src-kw">return</span> event.seq</span></span>
+      <span class="src-line">      <span class="src-ln"> 265</span> <span class="src-hl">}</span></span>
+      <span class="src-line">      <span class="src-ln"> 266</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 267</span> <span class="src-hl">/** Append a model-ordered result linked to its call event. */</span></span>
+      <span class="src-line">      <span class="src-ln"> 268</span> <span class="src-hl"><span class="src-kw">function</span> appendToolResult(</span></span>
+      <span class="src-line">      <span class="src-ln"> 269</span> <span class="src-hl">  session: Session,</span></span>
+      <span class="src-line">      <span class="src-ln"> 270</span> <span class="src-hl">  turn: number,</span></span>
+      <span class="src-line">      <span class="src-ln"> 271</span> <span class="src-hl">  step: number,</span></span>
+      <span class="src-line">      <span class="src-ln"> 272</span> <span class="src-hl">  block: ToolCallBlock,</span></span>
+      <span class="src-line">      <span class="src-ln"> 273</span> <span class="src-hl">  result: ToolExecutionResult,</span></span>
+      <span class="src-line">      <span class="src-ln"> 274</span> <span class="src-hl">  callSeq: number,</span></span>
+      <span class="src-line">      <span class="src-ln"> 275</span> <span class="src-hl">): void {</span></span>
+      <span class="src-line">      <span class="src-ln"> 276</span> <span class="src-hl">  <span class="src-kw">const</span> message = createToolResultMessage({</span></span>
+      <span class="src-line">      <span class="src-ln"> 277</span> <span class="src-hl">    callId: block.id,</span></span>
+      <span class="src-line">      <span class="src-ln"> 278</span> <span class="src-hl">    content: result.content,</span></span>
+      <span class="src-line">      <span class="src-ln"> 279</span> <span class="src-hl">    isError: result.isError,</span></span>
+      <span class="src-line">      <span class="src-ln"> 280</span> <span class="src-hl">  })</span></span>
+      <span class="src-line">      <span class="src-ln"> 281</span> <span class="src-hl">  session.append(&#x27;tool/result&#x27;, {</span></span>
+      <span class="src-line">      <span class="src-ln"> 282</span> <span class="src-hl">    turn, step,</span></span>
+      <span class="src-line">      <span class="src-ln"> 283</span> <span class="src-hl">    message,</span></span>
+      <span class="src-line">      <span class="src-ln"> 284</span> <span class="src-hl">    ...result.error?.info ? { error: result.error.info } : {},</span></span>
+      <span class="src-line">      <span class="src-ln"> 285</span> <span class="src-hl">    <span class="src-comment">// The tool&amp;#x27;s private presentation payload (e.g. a result-time diff),</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 286</span> <span class="src-hl">    <span class="src-comment">// persisted so a UI bridge reproduces the card on replay.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 287</span> <span class="src-hl">    ...result.meta !== <span class="src-kw">undefined</span> ? { meta: result.meta } : {},</span></span>
+      <span class="src-line">      <span class="src-ln"> 288</span> <span class="src-hl">  }, { surfaceOp: &#x27;append&#x27;, sourceEventSeqs: [callSeq] })</span></span>
+      <span class="src-line">      <span class="src-ln"> 289</span> <span class="src-hl">}</span></span>
+    </div>
+
+    <div class="trace-steps"><div class="ts-label"><span class="lang-zh-only">read(README.md) 逐步</span><span class="lang-en-only">read(README.md) step by step</span></div>    <table class="cmp">
+      <thead><tr><th>#</th><th>location</th><th>主线时刻 / through-line moment</th></tr></thead>
+      <tbody>
+      <tr><td>1</td><td>tools/pre-execute</td><td>hook 链 · approval 可能拦截</td></tr>
+      <tr><td>2</td><td>tools/execute</td><td>tool-fs read 执行</td></tr>
+      <tr><td>3</td><td>tool/call</td><td>callId · name=read · arguments JSON</td></tr>
+      <tr><td>4</td><td>tools/post-execute</td><td>spill · repeat reminder</td></tr>
+      <tr><td>5</td><td>tool/result</td><td>README 内容 · surfaceOp=append</td></tr>
+      <tr><td>6</td><td>acceptContext</td><td>additionalContexts → inbox next-step</td></tr>
+      <tr><td>7</td><td>step=2 deriveMessages</td><td>user+assistant+toolResult → Message[]</td></tr>
+      </tbody>
+    </table></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/fs/tool-fs/src/read.ts</span>
+        <span class="src-tag">read-tool</span>
+      </div>
+      <span class="src-line">      <span class="src-ln">   1</span> <span class="src-hl">/**</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">tool-fs read：FS capability consumer</span><span class="lang-en-only">tool-fs read: FS capability consumer</span></span></span>
+      <span class="src-line">      <span class="src-ln">   2</span> <span class="src-hl"> * Model-facing UTF-8 read. It performs one provider stat <span class="src-kw">for</span> <span class="src-kw">type</span>, routing, and observed version,</span></span>
+      <span class="src-line">      <span class="src-ln">   3</span> <span class="src-hl"> * streams large or size-unknown files, renders a bounded window, then emits the observation.</span></span>
+      <span class="src-line">      <span class="src-ln">   4</span> <span class="src-hl"> * @module @deepseek-ai/dsh-tool-fs/src/read</span></span>
+      <span class="src-line">      <span class="src-ln">   5</span> <span class="src-hl"> */</span></span>
+      <span class="src-line">      <span class="src-ln">   6</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln">   7</span> <span class="src-hl"><span class="src-kw">import</span> <span class="src-kw">type</span> { Context } <span class="src-kw">from</span> &#x27;@deepseek-ai/cordis&#x27;</span></span>
+      <span class="src-line">      <span class="src-ln">   8</span> <span class="src-hl"><span class="src-kw">import</span> { defineTool } <span class="src-kw">from</span> &#x27;@deepseek-ai/dsh-tools&#x27;</span></span>
+      <span class="src-line">      <span class="src-ln">   9</span> <span class="src-hl"><span class="src-kw">import</span> <span class="src-kw">type</span> { GenericCallView, ReadResultView, ToolResult } <span class="src-kw">from</span> &#x27;@deepseek-ai/dsh-tools&#x27;</span></span>
+      <span class="src-line">      <span class="src-ln">  10</span> <span class="src-hl"><span class="src-kw">import</span> <span class="src-kw">type</span> {} <span class="src-kw">from</span> &#x27;@deepseek-ai/dsh-fs&#x27;</span></span>
+      <span class="src-line">      <span class="src-ln">  11</span> <span class="src-hl"><span class="src-kw">import</span> <span class="src-kw">type</span> {} <span class="src-kw">from</span> &#x27;@deepseek-ai/dsh-system-prompt&#x27;</span></span>
+      <span class="src-line">      <span class="src-ln">  12</span> <span class="src-hl"><span class="src-kw">import</span> { buildWindow, formatReadOutput, langFromPath, readMetaFromMeta } <span class="src-kw">from</span> &#x27;./read-render.ts&#x27;</span></span>
+      <span class="src-line">      <span class="src-ln">  13</span> <span class="src-hl"><span class="src-kw">import</span> { resolveRegularReadTarget } <span class="src-kw">from</span> &#x27;./read-target.ts&#x27;</span></span>
+      <span class="src-line">      <span class="src-ln">  14</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln">  15</span> <span class="src-hl">/** Default and maximum number of lines returned by one <span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`read`</span> call (the <span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`readLimit`</span> config). */</span></span>
+      <span class="src-line">      <span class="src-ln">  16</span> <span class="src-hl"><span class="src-kw">export</span> <span class="src-kw">const</span> READ_LIMIT = 2000</span></span>
+      <span class="src-line">      <span class="src-ln">  17</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln">  18</span> <span class="src-hl">/**</span></span>
+      <span class="src-line">      <span class="src-ln">  19</span> <span class="src-hl"> * Default streaming threshold (the <span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`readStreamMinSize`</span> config): files at or</span></span>
+      <span class="src-line">      <span class="src-ln">  20</span> <span class="src-hl"> * above this size stream; smaller files read whole into memory.</span></span>
+      <span class="src-line">      <span class="src-ln">  21</span> <span class="src-hl"> */</span></span>
+      <span class="src-line">      <span class="src-ln">  22</span> <span class="src-hl"><span class="src-kw">export</span> <span class="src-kw">const</span> STREAM_MIN_SIZE = 10 * 1024 * 1024</span></span>
+      <span class="src-line">      <span class="src-ln">  23</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln">  24</span> <span class="src-hl">/** Resolved read-tool caps — plugin config after defaulting (see <span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`Config`</span> in index.ts). */</span></span>
+      <span class="src-line">      <span class="src-ln">  25</span> <span class="src-hl"><span class="src-kw">export</span> <span class="src-kw">interface</span> ReadToolCaps {</span></span>
+      <span class="src-line">      <span class="src-ln">  26</span> <span class="src-hl">  /** Default and maximum number of lines returned by one call. */</span></span>
+      <span class="src-line">      <span class="src-ln">  27</span> <span class="src-hl">  limit: number</span></span>
+      <span class="src-line">      <span class="src-ln">  28</span> <span class="src-hl">  /** Maximum characters returned <span class="src-kw">for</span> a single line. */</span></span>
+      <span class="src-line">      <span class="src-ln">  29</span> <span class="src-hl">  maxLineLength: number</span></span>
+      <span class="src-line">      <span class="src-ln">  30</span> <span class="src-hl">  /** Maximum bytes returned <span class="src-kw">for</span> selected file lines. */</span></span>
+      <span class="src-line">      <span class="src-ln">  31</span> <span class="src-hl">  maxBytes: number</span></span>
+      <span class="src-line">      <span class="src-ln">  32</span> <span class="src-hl">  /** Files at or above this size stream; smaller files read whole into memory. */</span></span>
+      <span class="src-line">      <span class="src-ln">  33</span> <span class="src-hl">  streamMinSize: number</span></span>
+      <span class="src-line">      <span class="src-ln">  34</span> <span class="src-hl">}</span></span>
+      <span class="src-line">      <span class="src-ln">  35</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln">  36</span> <span class="src-hl">/** Validated <span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`read`</span> arguments after defaulting. */</span></span>
+      <span class="src-line">      <span class="src-ln">  37</span> <span class="src-hl"><span class="src-kw">interface</span> ReadInput {</span></span>
+      <span class="src-line">      <span class="src-ln">  38</span> <span class="src-hl">  filePath: string</span></span>
+      <span class="src-line">      <span class="src-ln">  39</span> <span class="src-hl">  offset: number</span></span>
+      <span class="src-line">      <span class="src-ln">  40</span> <span class="src-hl">  limit: number</span></span>
+    </div>
+
+    <div class="note copper">
+      <span class="lang-zh-only">abort 时 <code>appendSkippedToolCall</code> 仍写 tool/call+tool/result 合成对——replay 与 deriveMessages 保持 valid。</span>
+      <span class="lang-en-only">On abort <code>appendSkippedToolCall</code> still writes synthetic tool/call+tool/result pair — replay and deriveMessages stay valid.</span>
+    </div>
+
+    </div>
+
+    <div class="trace-box">
+      <div class="tb-tag">TRACE · station station tools</div>
+      <div class="lang-zh-only"><p>站 13：read README 走 tools/pre-execute → execute → post-execute 瀑布。</p></div>
+      <div class="lang-en-only"><p>St. 13: read README goes through tools/pre-execute → execute → post-execute waterfall.</p></div>
+    </div>
+
+    <div class="depth-zone" data-chapter="C12"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C12.4+</span><span class="lang-en-only">Deep dive · C12.4+</span></div>
+
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">交叉引用</span><span class="lang-en-only">Cross-ref</span></span> <span class="da-title lang-zh-only">deepseek-harness 文档</span><span class="da-title lang-en-only">deepseek-harness docs</span></div>    <table class="cmp">
+      <thead><tr><th>DOC</th><th>主题</th><th>路径</th><th>摘要</th></tr></thead>
+      <tbody>
+      <tr><td>tool-execution-pipeline</td><td>工具执行管线</td><td><code>docs/tool-execution-pipeline.md</code></td><td>tools/pre-execute → execute → post-execute waterfalls and approval chain</td></tr>
+      </tbody>
+    </table>
+
+    </div>
+  </section>
+
+  <section class="chap" id="c13">
+    <div class="chap-num">CHAPTER&nbsp;13&nbsp;·&nbsp;HEART</div>
+    <h2 class="chap-title lang-zh-only">三域事件矩阵</h2>
+    <h2 class="chap-title lang-en-only">Three-domain event matrix</h2>
+    <p class="chap-en lang-zh-only">session · agent · capability events</p>
+    <p class="chap-en lang-en-only">session · agent · capability events</p>
+    <nav class="chapter-compass" aria-label="Chapter navigation">
+      <div class="cc-row">
+        <div class="cc-phase"><span class="cc-roman">II</span> · <span class="lang-zh-only">心脏</span><span class="lang-en-only">Heart</span></div>
+        <div class="cc-station"><span class="lang-zh-only">站 15</span><span class="lang-en-only">St. 15</span> · C13/26</div>
+      </div>
+      <div class="cc-forest"><span class="lang-zh-only">三域事件矩阵</span><span class="lang-en-only">Three-domain event matrix</span></div>
+      <div class="cc-links">
+        <a class="cc-nav cc-prev" href="#c12"><span class="cc-arrow">←</span> <span class="cc-nav-num">C12</span> <span class="lang-zh-only">Tool 执行管线</span><span class="lang-en-only">Tool execution pipeline</span></a>
+        <a class="cc-map" href="#forest-overview"><span class="lang-zh-only">回到总览</span><span class="lang-en-only">Forest map</span></a>
+        <a class="cc-nav cc-next" href="#c14"><span class="cc-nav-num">C14</span> <span class="lang-zh-only">ctx.llm 适配层</span><span class="lang-en-only">ctx.llm adapter seam</span> <span class="cc-arrow">→</span></a>
+      </div>
+    </nav>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>本章回答「这条主线 prompt 在此层长什么样」</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH 没有隐藏魔法——一切可替换行为都在 Cordis 事件或 SessionEvent 里</span></p>
+      <p><span class="swc-pill act">优化</span><span>读源码时先搜 session.append 与 ctx.* 注册点</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>This chapter answers what the through-line prompt looks like at this layer</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH has no hidden magic — replaceable behavior lives in Cordis events or SessionEvents</span></p>
+      <p><span class="swc-pill act">优化</span><span>When reading source, search session.append and ctx.* registration first</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">events</span><span class="lang-en-only">events</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">events</span><span class="lang-en-only">events</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">docs/</span><span class="lang-en-only">docs/</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">三域</span><span class="lang-en-only">三域</span></div>
+      </div>
+    </div>
+
+    <div class="lang-zh-only"><p>DSH 事件分三域（<code>docs/architecture.md#events</code>）：<strong>session</strong>（ durable replay）、<strong>agent</strong>（live 协调）、<strong>capability</strong>（策略 seam，如 <code>tools/*</code>、<code>fs/*</code>）。选错域是最常见的插件 bug。</p></div>
+    <div class="lang-en-only"><p>DSH events split into three domains (<code>docs/architecture.md#events</code>): <strong>session</strong> (durable replay), <strong>agent</strong> (live coordination), <strong>capability</strong> (policy seams like <code>tools/*</code>, <code>fs/*</code>). Picking the wrong domain is the most common plugin bug.</p></div>
+
+    <h3 class="sub"><span class="sec-num">C13.1</span> <span class="lang-zh-only">三域对照</span><span class="lang-en-only">Three-domain comparison</span></h3>
+
+    <figure>
+      <div class="figbox"><div class="pi-fig wide"><svg viewBox="0 0 720 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true" class="pi-svg">
+  <defs>
+    <marker id="pi-arr" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 Z" fill="#1f5c8c"/>
+    </marker>
+  </defs>
+  <rect x="40" y="50" width="200" height="120" rx="4" fill="#1f5c8c" opacity="0.1" stroke="#1f5c8c"/>
+  <text x="140" y="78" text-anchor="middle" class="svg-label">session/*</text>
+  <text x="140" y="100" text-anchor="middle" class="svg-body">durable replay</text>
+  <text x="140" y="120" text-anchor="middle" class="svg-mute">turn/start · user/message</text>
+  <text x="140" y="140" text-anchor="middle" class="svg-mute">tool/result · session/event</text>
+  <rect x="260" y="50" width="200" height="120" rx="4" fill="#c3573a" opacity="0.1" stroke="#c3573a"/>
+  <text x="360" y="78" text-anchor="middle" class="svg-label">agent/*</text>
+  <text x="360" y="100" text-anchor="middle" class="svg-body">live coordination</text>
+  <text x="360" y="120" text-anchor="middle" class="svg-mute">pre-step · request</text>
+  <text x="360" y="140" text-anchor="middle" class="svg-mute">inbox · status</text>
+  <rect x="480" y="50" width="200" height="120" rx="4" fill="#2d6a4f" opacity="0.1" stroke="#2d6a4f"/>
+  <text x="580" y="78" text-anchor="middle" class="svg-label">capability/*</text>
+  <text x="580" y="100" text-anchor="middle" class="svg-body">policy seams</text>
+  <text x="580" y="120" text-anchor="middle" class="svg-mute">tools/* · fs/*</text>
+  <text x="580" y="140" text-anchor="middle" class="svg-mute">telemetry/*</text>
+</svg></div></div>
+      <figcaption>
+        <span class="figid">FIG</span>
+        <span class="lang-zh-only">三事件域：session 可回放事实、agent 运行中协调、capability 策略接缝互不 import 循环。</span>
+        <span class="lang-en-only">Three event domains: session replay facts, agent live coordination, capability policy seams.</span>
+      </figcaption>
+    </figure>
+
+    <table class="cmp">
+      <thead><tr><th>域</th><th>持久?</th><th>典型事件</th><th>消费者</th></tr></thead>
+      <tbody>
+      <tr><td>session/*</td><td>✓</td><td>user/message · tool/result</td><td>Web UI · persistence</td></tr>
+      <tr><td>agent/*</td><td>✗</td><td>pre-step · inbox/claimed</td><td>SDK · subagent driver</td></tr>
+      <tr><td>capability/*</td><td>△</td><td>fs/write-intent · tools/result</td><td>policy · telemetry</td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="sec-num">C13.2</span> <span class="lang-zh-only">主线一轮的域 crossing</span><span class="lang-en-only">Domain crossing for one through-line turn</span></h3>
+
+    <div class="lang-zh-only"><p>用户输入：SDK → <code>agent/inbox/inserted</code>（agent）→ claim → <code>user/message</code>（session）→ UI 经 <code>session/event</code> 渲染。工具：model → <code>tool/call</code>（session）→ <code>tools/pre-execute</code>（capability）→ <code>tool/result</code>（session）。</p></div>
+    <div class="lang-en-only"><p>User input: SDK → <code>agent/inbox/inserted</code> (agent) → claim → <code>user/message</code> (session) → UI renders via <code>session/event</code>. Tools: model → <code>tool/call</code> (session) → <code>tools/pre-execute</code> (capability) → <code>tool/result</code> (session).</p></div>
+
+    <div class="note copper">
+      <span class="lang-zh-only">📘 <strong>事件生产消费矩阵</strong>（<code>docs/event-producer-consumer.md</code>）· 每个 harness 事件的 dispatch 模式、声明位置、生产者与消费者包</span>
+      <span class="lang-en-only">📘 <strong>Event producer-consumer matrix</strong> (<code>docs/event-producer-consumer.md</code>) · Dispatch mode, declaration site, producers and listeners per harness event</span>
+    </div>
+
+    <div class="trace-walk">
+      <div class="tw-head">
+        <span class="tw-tag">SOURCE TRACE · C13</span>
+        <span class="lang-zh-only">三域事件：session · agent · capability</span>
+        <span class="lang-en-only">Three event domains: session · agent · capability</span>
+      </div>
+
+    <div class="lang-zh-only"><p>DSH 扩展点分三域（architecture.md）：<strong>Session events</strong> 是 durable facts（<code>session/event</code> 广播）；<strong>Agent events</strong>（<code>agent/*</code>）携带 live Agent handle；<strong>Capability events</strong>（<code>tools/*</code> · <code>fs/*</code> · <code>llm/stream</code>）挂策略而不 import loop。主线一轮同时触及三域。</p></div>
+    <div class="lang-en-only"><p>DSH extension points split three domains (architecture.md): <strong>Session events</strong> are durable facts (broadcast via <code>session/event</code>); <strong>Agent events</strong> (<code>agent/*</code>) carry live Agent handle; <strong>Capability events</strong> (<code>tools/*</code> · <code>fs/*</code> · <code>llm/stream</code>) attach policy without importing the loop. One through-line turn touches all three.</p></div>
+
+    <div class="trace-steps"><div class="ts-label"><span class="lang-zh-only">主线 prompt · 三域事件序列（简化）</span><span class="lang-en-only">Through-line prompt · three-domain event sequence (simplified)</span></div>    <table class="cmp">
+      <thead><tr><th>#</th><th>location</th><th>主线时刻 / through-line moment</th></tr></thead>
+      <tbody>
+      <tr><td>S1</td><td>session/event turn/start</td><td>durable · persistence 订阅</td></tr>
+      <tr><td>S2</td><td>session/event user/message</td><td>surface append</td></tr>
+      <tr><td>A1</td><td>agent/pre-step</td><td>waterfall · 14 listeners</td></tr>
+      <tr><td>A2</td><td>agent/request</td><td>waterfall · config proposal</td></tr>
+      <tr><td>C1</td><td>llm/stream</td><td>waterfall · retry/replay</td></tr>
+      <tr><td>S3</td><td>session/event assistant/chunk×N</td><td>UI/replay · 非 surface</td></tr>
+      <tr><td>S4</td><td>session/event assistant/message</td><td>surface append</td></tr>
+      <tr><td>C2</td><td>tools/pre-execute → execute → post-execute</td><td>read README</td></tr>
+      <tr><td>S5</td><td>session/event tool/call + tool/result</td><td>surface append</td></tr>
+      <tr><td>A3</td><td>agent/turn-stopping</td><td>serial · hooks</td></tr>
+      <tr><td>S6</td><td>session/event turn/end</td><td>durable close</td></tr>
+      </tbody>
+    </table></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/core/session/src/index.ts</span>
+        <span class="src-tag">session-events</span>
+      </div>
+      <span class="src-line">      <span class="src-ln">  40</span> <span class="src-hl">  }</span></span>
+      <span class="src-line">      <span class="src-ln">  41</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln">  42</span> <span class="src-hl">  <span class="src-kw">interface</span> Events {</span></span>
+      <span class="src-line">      <span class="src-ln">  43</span> <span class="src-hl">    /**</span></span>
+      <span class="src-line">      <span class="src-ln">  44</span> <span class="src-hl">     * Creation announcement during session publication. A synchronous <span class="src-kw">throw</span> vetoes and rolls</span></span>
+      <span class="src-line">      <span class="src-ln">  45</span> <span class="src-hl">     * back with a paired disposal; detach requested during dispatch is deferred.</span></span>
+      <span class="src-line">      <span class="src-ln">  46</span> <span class="src-hl">     * A returned-promise rejection is logged but cannot retroactively veto this</span></span>
+      <span class="src-line">      <span class="src-ln">  47</span> <span class="src-hl">     * synchronous boundary.</span></span>
+      <span class="src-line">      <span class="src-ln">  48</span> <span class="src-hl">     * Scope-filtered dispatch (<span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`@deepseek-ai/dsh-scope`</span>): agent-scoped listeners</span></span>
+      <span class="src-line">      <span class="src-ln">  49</span> <span class="src-hl">     * receive only sessions entered through that agent&#x27;s context.</span></span>
+      <span class="src-line">      <span class="src-ln">  50</span> <span class="src-hl">     * @param session - the session just entered and announced.</span></span>
+      <span class="src-line">      <span class="src-ln">  51</span> <span class="src-hl">     * @dshScopeScan unsupported</span></span>
+      <span class="src-line">      <span class="src-ln">  52</span> <span class="src-hl">     * @mode emit</span></span>
+      <span class="src-line">      <span class="src-ln">  53</span> <span class="src-hl">     */</span></span>
+      <span class="src-line">      <span class="src-ln">  54</span> <span class="src-hl">    &#x27;session/created&#x27;(this: Scoped&lt;Session&gt;, session: Session): void</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">session/created emit</span><span class="lang-en-only">session/created emit</span></span></span>
+      <span class="src-line">      <span class="src-ln">  55</span> <span class="src-hl">    /**</span></span>
+      <span class="src-line">      <span class="src-ln">  56</span> <span class="src-hl">     * Emitted once when an announced session leaves the store, including</span></span>
+      <span class="src-line">      <span class="src-ln">  57</span> <span class="src-hl">     * publication rollback, but never <span class="src-kw">for</span> an entry whose creation announcement</span></span>
+      <span class="src-line">      <span class="src-ln">  58</span> <span class="src-hl">     * did not begin. Listener failures are logged and contained.</span></span>
+      <span class="src-line">      <span class="src-ln">  59</span> <span class="src-hl">     * Scope-filtered dispatch (<span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`@deepseek-ai/dsh-scope`</span>) reuses the owner scope.</span></span>
+      <span class="src-line">      <span class="src-ln">  60</span> <span class="src-hl">     * @param session - the session that is no longer live in the store.</span></span>
+      <span class="src-line">      <span class="src-ln">  61</span> <span class="src-hl">     * @dshScopeScan unsupported</span></span>
+      <span class="src-line">      <span class="src-ln">  62</span> <span class="src-hl">     * @mode emit</span></span>
+      <span class="src-line">      <span class="src-ln">  63</span> <span class="src-hl">     */</span></span>
+      <span class="src-line">      <span class="src-ln">  64</span> <span class="src-hl">    &#x27;session/disposed&#x27;(this: Scoped&lt;Session&gt;, session: Session): void</span></span>
+      <span class="src-line">      <span class="src-ln">  65</span> <span class="src-hl">    /**</span></span>
+      <span class="src-line">      <span class="src-ln">  66</span> <span class="src-hl">     * Post-commit, fire-and-forget append feed. The listener snapshot resolves</span></span>
+      <span class="src-line">      <span class="src-ln">  67</span> <span class="src-hl">     * before the log push, but callbacks run after it; observer failures are</span></span>
+      <span class="src-line">      <span class="src-ln">  68</span> <span class="src-hl">     * logged and contained without making the committed append fail.</span></span>
+      <span class="src-line">      <span class="src-ln">  69</span> <span class="src-hl">     * Scope-filtered dispatch (<span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`@deepseek-ai/dsh-scope`</span>): agent-scoped listeners</span></span>
+      <span class="src-line">      <span class="src-ln">  70</span> <span class="src-hl">     * receive only events <span class="src-kw">from</span> sessions entered through that agent&#x27;s context.</span></span>
+      <span class="src-line">      <span class="src-ln">  71</span> <span class="src-hl">     * @param session - the session whose log grew.</span></span>
+      <span class="src-line">      <span class="src-ln">  72</span> <span class="src-hl">     * @param event - the appended event, exactly as recorded.</span></span>
+      <span class="src-line">      <span class="src-ln">  73</span> <span class="src-hl">     * @dshScopeScan unsupported</span></span>
+      <span class="src-line">      <span class="src-ln">  74</span> <span class="src-hl">     * @mode emit</span></span>
+      <span class="src-line">      <span class="src-ln">  75</span> <span class="src-hl">     */</span></span>
+      <span class="src-line">      <span class="src-ln">  76</span> <span class="src-hl">    &#x27;session/event&#x27;(this: Scoped&lt;Session&gt;, session: Session, event: SessionEvent): void</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">★ session/event：每次 append 广播</span><span class="lang-en-only">★ session/event: broadcast on every append</span></span></span>
+      <span class="src-line">      <span class="src-ln">  77</span> <span class="src-hl">    /**</span></span>
+      <span class="src-line">      <span class="src-ln">  78</span> <span class="src-hl">     * Awaited parallel durability checkpoint: every listener runs and the</span></span>
+      <span class="src-line">      <span class="src-ln">  79</span> <span class="src-hl">     * caller awaits all of them, with no waterfall veto. Scope-filtered dispatch</span></span>
+      <span class="src-line">      <span class="src-ln">  80</span> <span class="src-hl">     * (<span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`@deepseek-ai/dsh-scope`</span>) reuses the session&#x27;s owner scope.</span></span>
+      <span class="src-line">      <span class="src-ln">  81</span> <span class="src-hl">     * @param session - the session whose buffered events must reach durable storage.</span></span>
+      <span class="src-line">      <span class="src-ln">  82</span> <span class="src-hl">     * @dshScopeScan unsupported</span></span>
+      <span class="src-line">      <span class="src-ln">  83</span> <span class="src-hl">     * @mode parallel</span></span>
+      <span class="src-line">      <span class="src-ln">  84</span> <span class="src-hl">     */</span></span>
+      <span class="src-line">      <span class="src-ln">  85</span> <span class="src-hl">    &#x27;session/flush&#x27;(this: Scoped&lt;Session&gt;, session: Session): Promise&lt;void&gt; | void</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">session/flush parallel：persistence 落盘</span><span class="lang-en-only">session/flush parallel: persistence flush</span></span></span>
+      <span class="src-line">      <span class="src-ln">  86</span> <span class="src-hl">  }</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/core/agent/src/runtime-types.ts</span>
+        <span class="src-tag">agent-events</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 170</span> <span class="src-hl">     * Agent status changed (<span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`idle`</span> ⇄ <span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`running`</span>). A waking delivery enters</span></span>
+      <span class="src-line">      <span class="src-ln"> 171</span> <span class="src-hl">     * <span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`running`</span> synchronously after reserving cancellation; <span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`idle`</span> means no</span></span>
+      <span class="src-line">      <span class="src-ln"> 172</span> <span class="src-hl">     * driver remains scheduled or active.</span></span>
+      <span class="src-line">      <span class="src-ln"> 173</span> <span class="src-hl">     * @param payload.agent - the agent whose status flipped.</span></span>
+      <span class="src-line">      <span class="src-ln"> 174</span> <span class="src-hl">     * @param payload.status - the status just entered (the transition&#x27;s destination).</span></span>
+      <span class="src-line">      <span class="src-ln"> 175</span> <span class="src-hl">     * Scope-filtered dispatch (<span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`@deepseek-ai/dsh-scope`</span>): agent-scoped listeners receive only that agent.</span></span>
+      <span class="src-line">      <span class="src-ln"> 176</span> <span class="src-hl">     * @mode emit</span></span>
+      <span class="src-line">      <span class="src-ln"> 177</span> <span class="src-hl">     */</span></span>
+      <span class="src-line">      <span class="src-ln"> 178</span> <span class="src-hl">    &#x27;agent/status&#x27;(this: Scoped&lt;Agent&gt;, payload: { agent: Agent; status: AgentStatus }): void</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">agent/status emit</span><span class="lang-en-only">agent/status emit</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 179</span> <span class="src-hl">    /**</span></span>
+      <span class="src-line">      <span class="src-ln"> 180</span> <span class="src-hl">     * One message entered the live inbox.</span></span>
+      <span class="src-line">      <span class="src-ln"> 181</span> <span class="src-hl">     * @param payload.agent - the agent whose inbox changed.</span></span>
+      <span class="src-line">      <span class="src-ln"> 182</span> <span class="src-hl">     * @param payload.message - the inserted message.</span></span>
+      <span class="src-line">      <span class="src-ln"> 183</span> <span class="src-hl">     * Scope-filtered dispatch (<span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`@deepseek-ai/dsh-scope`</span>): agent-scoped listeners receive only that agent.</span></span>
+      <span class="src-line">      <span class="src-ln"> 184</span> <span class="src-hl">     * @mode emit</span></span>
+      <span class="src-line">      <span class="src-ln"> 185</span> <span class="src-hl">     */</span></span>
+      <span class="src-line">      <span class="src-ln"> 186</span> <span class="src-hl">    &#x27;agent/inbox/inserted&#x27;(this: Scoped&lt;Agent&gt;, payload: { agent: Agent; message: UserMessage }): void</span></span>
+      <span class="src-line">      <span class="src-ln"> 187</span> <span class="src-hl">    /**</span></span>
+      <span class="src-line">      <span class="src-ln"> 188</span> <span class="src-hl">     * One message left the inbox inside its open turn. If the proposed step</span></span>
+      <span class="src-line">      <span class="src-ln"> 189</span> <span class="src-hl">     * is rejected, the claimed message ends here: it is neither discarded nor</span></span>
+      <span class="src-line">      <span class="src-ln"> 190</span> <span class="src-hl">     * re-emitted as a user/message, and the turn closes without a step.</span></span>
+      <span class="src-line">      <span class="src-ln"> 191</span> <span class="src-hl">     * @param payload.agent - the agent whose inbox changed.</span></span>
+      <span class="src-line">      <span class="src-ln"> 192</span> <span class="src-hl">     * @param payload.message - the claimed message.</span></span>
+      <span class="src-line">      <span class="src-ln"> 193</span> <span class="src-hl">     * @param payload.turn - the owning turn.</span></span>
+      <span class="src-line">      <span class="src-ln"> 194</span> <span class="src-hl">     * Scope-filtered dispatch (<span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`@deepseek-ai/dsh-scope`</span>): agent-scoped listeners receive only that agent.</span></span>
+      <span class="src-line">      <span class="src-ln"> 195</span> <span class="src-hl">     * @mode emit</span></span>
+      <span class="src-line">      <span class="src-ln"> 196</span> <span class="src-hl">     */</span></span>
+      <span class="src-line">      <span class="src-ln"> 197</span> <span class="src-hl">    &#x27;agent/inbox/claimed&#x27;(this: Scoped&lt;Agent&gt;, payload: { agent: Agent; message: UserMessage; turn: number }): void</span></span>
+      <span class="src-line">      <span class="src-ln"> 198</span> <span class="src-hl">    /**</span></span>
+      <span class="src-line">      <span class="src-ln"> 199</span> <span class="src-hl">     * One message was discarded <span class="src-kw">from</span> the live inbox.</span></span>
+      <span class="src-line">      <span class="src-ln"> 200</span> <span class="src-hl">     * @param payload.agent - the agent whose inbox changed.</span></span>
+      <span class="src-line">      <span class="src-ln"> 201</span> <span class="src-hl">     * @param payload.message - the discarded message.</span></span>
+      <span class="src-line">      <span class="src-ln"> 202</span> <span class="src-hl">     * Scope-filtered dispatch (<span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`@deepseek-ai/dsh-scope`</span>): agent-scoped listeners receive only that agent.</span></span>
+      <span class="src-line">      <span class="src-ln"> 203</span> <span class="src-hl">     * @mode emit</span></span>
+      <span class="src-line">      <span class="src-ln"> 204</span> <span class="src-hl">     */</span></span>
+      <span class="src-line">      <span class="src-ln"> 205</span> <span class="src-hl">    &#x27;agent/inbox/discarded&#x27;(this: Scoped&lt;Agent&gt;, payload: { agent: Agent; message: UserMessage }): void</span></span>
+      <span class="src-line">      <span class="src-ln"> 206</span> <span class="src-hl">    <span class="src-comment">// ---- session lifecycle (emit) ----</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 207</span> <span class="src-hl">    /**</span></span>
+      <span class="src-line">      <span class="src-ln"> 208</span> <span class="src-hl">     * The session lifecycle began, once before the first turn. Use</span></span>
+      <span class="src-line">      <span class="src-ln"> 209</span> <span class="src-hl">     * <span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`agent.inject()`</span> to seed model-facing context. This is a notification, not</span></span>
+      <span class="src-line">      <span class="src-ln"> 210</span> <span class="src-hl">     * a veto; disposal requested by a lifecycle owner is rechecked before the</span></span>
+      <span class="src-line">      <span class="src-ln"> 211</span> <span class="src-hl">     * driver starts.</span></span>
+      <span class="src-line">      <span class="src-ln"> 212</span> <span class="src-hl">     * @param payload.agent - the agent whose session lifecycle began.</span></span>
+      <span class="src-line">      <span class="src-ln"> 213</span> <span class="src-hl">     * @param payload.source - why the session started (fresh startup, resume, …).</span></span>
+      <span class="src-line">      <span class="src-ln"> 214</span> <span class="src-hl">     * Scope-filtered dispatch (<span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`@deepseek-ai/dsh-scope`</span>): agent-scoped listeners receive only that agent.</span></span>
+      <span class="src-line">      <span class="src-ln"> 215</span> <span class="src-hl">     * @mode emit</span></span>
+      <span class="src-line">      <span class="src-ln"> 216</span> <span class="src-hl">     */</span></span>
+      <span class="src-line">      <span class="src-ln"> 217</span> <span class="src-hl">    &#x27;agent/session-start&#x27;(this: Scoped&lt;Agent&gt;, payload: { agent: Agent; source: SessionStartSource }): void</span></span>
+      <span class="src-line">      <span class="src-ln"> 218</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 219</span> <span class="src-hl">    <span class="src-comment">// ---- the machine&amp;#x27;s extension points ----</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 220</span> <span class="src-hl">    /**</span></span>
+      <span class="src-line">      <span class="src-ln"> 221</span> <span class="src-hl">     * Reject a proposed step or replace the messages that enter it. Calling</span></span>
+      <span class="src-line">      <span class="src-ln"> 222</span> <span class="src-hl">     * <span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`next()`</span> preserves the current messages.</span></span>
+      <span class="src-line">      <span class="src-ln"> 223</span> <span class="src-hl">     * @param payload.agent - the agent proposing the step.</span></span>
+      <span class="src-line">      <span class="src-ln"> 224</span> <span class="src-hl">     * @param payload.messages - messages removed <span class="src-kw">from</span> the inbox <span class="src-kw">for</span> this step.</span></span>
+      <span class="src-line">      <span class="src-ln"> 225</span> <span class="src-hl">     * @param payload.turn - the turn that will own the step.</span></span>
+      <span class="src-line">      <span class="src-ln"> 226</span> <span class="src-hl">     * @param payload.step - the step proposed by the loop.</span></span>
+      <span class="src-line">      <span class="src-ln"> 227</span> <span class="src-hl">     * @param payload.signal - the current turn&#x27;s cancellation signal.</span></span>
+      <span class="src-line">      <span class="src-ln"> 228</span> <span class="src-hl">     * Scope-filtered dispatch (<span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`@deepseek-ai/dsh-scope`</span>): agent-scoped listeners receive only that agent.</span></span>
+      <span class="src-line">      <span class="src-ln"> 229</span> <span class="src-hl">     * @mode waterfall</span></span>
+      <span class="src-line">      <span class="src-ln"> 230</span> <span class="src-hl">     */</span></span>
+      <span class="src-line">      <span class="src-ln"> 231</span> <span class="src-hl">    &#x27;agent/pre-step&#x27;(this: Scoped&lt;Agent&gt;, payload: { agent: Agent; messages: UserMessage[]; turn: number; step: number; signal: AbortSignal }, next: () =&gt; Promise&lt;PreStepDecision&gt;): Promise&lt;PreStepDecision&gt;</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">agent/pre-step waterfall 类型</span><span class="lang-en-only">agent/pre-step waterfall type</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 232</span> <span class="src-hl">    /**</span></span>
+      <span class="src-line">      <span class="src-ln"> 233</span> <span class="src-hl">     * Replace the frozen call configuration. <span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`<span class="src-kw">await</span> next()`</span> yields the config</span></span>
+      <span class="src-line">      <span class="src-ln"> 234</span> <span class="src-hl">     * the machine would use (agent options on the first request, the logged</span></span>
+      <span class="src-line">      <span class="src-ln"> 235</span> <span class="src-hl">     * header afterwards); <span class="src-kw">return</span> a replacement to <span class="src-kw">switch</span>. Model-visible</span></span>
+      <span class="src-line">      <span class="src-ln"> 236</span> <span class="src-hl">     * content must use logged channels; this waterfall cannot mutate messages.</span></span>
+      <span class="src-line">      <span class="src-ln"> 237</span> <span class="src-hl">     * @param payload.agent - the agent making the model call.</span></span>
+      <span class="src-line">      <span class="src-ln"> 238</span> <span class="src-hl">     * @param payload.turn - the open turn number.</span></span>
+      <span class="src-line">      <span class="src-ln"> 239</span> <span class="src-hl">     * @param payload.step - the step whose request this is.</span></span>
+      <span class="src-line">      <span class="src-ln"> 240</span> <span class="src-hl">     * @param payload.signal - the current turn&#x27;s explicit abort signal.</span></span>
+      <span class="src-line">      <span class="src-ln"> 241</span> <span class="src-hl">     * Scope-filtered dispatch (<span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`@deepseek-ai/dsh-scope`</span>): agent-scoped listeners receive only that agent.</span></span>
+      <span class="src-line">      <span class="src-ln"> 242</span> <span class="src-hl">     * @mode waterfall</span></span>
+      <span class="src-line">      <span class="src-ln"> 243</span> <span class="src-hl">    */</span></span>
+      <span class="src-line">      <span class="src-ln"> 244</span> <span class="src-hl">    &#x27;agent/request&#x27;(this: Scoped&lt;Agent&gt;, payload: { agent: Agent; turn: number; step: number; signal: AbortSignal }, next: () =&gt; Promise&lt;LlmCallConfig&gt;): Promise&lt;LlmCallConfig&gt;</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">agent/request waterfall 类型</span><span class="lang-en-only">agent/request waterfall type</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 245</span> <span class="src-hl">    /**</span></span>
+      <span class="src-line">      <span class="src-ln"> 246</span> <span class="src-hl">     * Handle one failed model-request attempt before the loop retries or closes</span></span>
+      <span class="src-line">      <span class="src-ln"> 247</span> <span class="src-hl">     * its step. A listener returns <span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`{ kind: &#x27;retry&#x27; }`</span> without calling <span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`next()`</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 248</span> <span class="src-hl">     * when it owns recovery, or calls <span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`next()`</span> to delegate. The default</span></span>
+      <span class="src-line">      <span class="src-ln"> 249</span> <span class="src-hl">     * <span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`<span class="src-kw">undefined</span>`</span> leaves the failure terminal.</span></span>
+      <span class="src-line">      <span class="src-ln"> 250</span> <span class="src-hl">     * @param payload.agent - the agent whose request failed.</span></span>
+      <span class="src-line">      <span class="src-ln"> 251</span> <span class="src-hl">     * @param payload.turn - the turn containing the failed request.</span></span>
+      <span class="src-line">      <span class="src-ln"> 252</span> <span class="src-hl">     * @param payload.step - the step containing the failed request attempt.</span></span>
+      <span class="src-line">      <span class="src-ln"> 253</span> <span class="src-hl">     * @param payload.provider - the provider selected <span class="src-kw">for</span> the failed request.</span></span>
+      <span class="src-line">      <span class="src-ln"> 254</span> <span class="src-hl">     * @param payload.failure - serializable facts normalized at the final adapter boundary.</span></span>
+      <span class="src-line">      <span class="src-ln"> 255</span> <span class="src-hl">     * @param payload.retryPolicy - the policy of the adapter registration that served the failed request.</span></span>
+      <span class="src-line">      <span class="src-ln"> 256</span> <span class="src-hl">     * @param payload.signal - the turn abort signal.</span></span>
+      <span class="src-line">      <span class="src-ln"> 257</span> <span class="src-hl">     * Scope-filtered dispatch (<span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`@deepseek-ai/dsh-scope`</span>): agent-scoped listeners receive only that agent.</span></span>
+      <span class="src-line">      <span class="src-ln"> 258</span> <span class="src-hl">     * @mode waterfall</span></span>
+      <span class="src-line">      <span class="src-ln"> 259</span> <span class="src-hl">     */</span></span>
+      <span class="src-line">      <span class="src-ln"> 260</span> <span class="src-hl">    &#x27;agent/request-error&#x27;(this: Scoped&lt;Agent&gt;, payload: { agent: Agent; turn: number; step: number; provider: string; failure: LlmFailure; retryPolicy: ResolvedRetryPolicy | <span class="src-kw">undefined</span>; signal: AbortSignal }, next: () =&gt; Promise&lt;RequestErrorAction&gt;): Promise&lt;RequestErrorAction&gt;</span></span>
+      <span class="src-line">      <span class="src-ln"> 261</span> <span class="src-hl">    /**</span></span>
+      <span class="src-line">      <span class="src-ln"> 262</span> <span class="src-hl">     * The turn is about to close: the model owes no response (no live tool</span></span>
+      <span class="src-line">      <span class="src-ln"> 263</span> <span class="src-hl">     * calls, no fresh steering). Awaited before the boundary commits — a</span></span>
+      <span class="src-line">      <span class="src-ln"> 264</span> <span class="src-hl">     * listener that objects steers (<span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`agent.steer(...)`</span>) and the machine</span></span>
+      <span class="src-line">      <span class="src-ln"> 265</span> <span class="src-hl">     * re-reads its inbox: fresh steering runs another step, none closes the</span></span>
+      <span class="src-line">      <span class="src-ln"> 266</span> <span class="src-hl">     * turn. Data decides, so listener order cannot change the outcome. The</span></span>
+      <span class="src-line">      <span class="src-ln"> 267</span> <span class="src-hl">     * inverse control (stop a tool loop early) is data too: a tool result</span></span>
+      <span class="src-line">      <span class="src-ln"> 268</span> <span class="src-hl">     * carrying <span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`concludesTurn`</span> ends the turn at its step. The conclusion</span></span>
+      <span class="src-line">      <span class="src-ln"> 269</span> <span class="src-hl">     * never short-circuits already-submitted next-step work: same-step</span></span>
+      <span class="src-line">      <span class="src-ln"> 270</span> <span class="src-hl">     * <span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`additionalContexts`</span> or racing steering still runs, and the turn</span></span>
+      <span class="src-line">      <span class="src-ln"> 271</span> <span class="src-hl">     * closes only when that inbox drains.</span></span>
+      <span class="src-line">      <span class="src-ln"> 272</span> <span class="src-hl">     * @param payload.agent - the agent whose turn is at its stop boundary.</span></span>
+      <span class="src-line">      <span class="src-ln"> 273</span> <span class="src-hl">     * @param payload.turn - the turn about to close.</span></span>
+      <span class="src-line">      <span class="src-ln"> 274</span> <span class="src-hl">     * @param payload.signal - the current turn&#x27;s explicit abort signal.</span></span>
+      <span class="src-line">      <span class="src-ln"> 275</span> <span class="src-hl">     * Scope-filtered dispatch (<span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`@deepseek-ai/dsh-scope`</span>): agent-scoped listeners receive only that agent.</span></span>
+      <span class="src-line">      <span class="src-ln"> 276</span> <span class="src-hl">     * @mode serial</span></span>
+      <span class="src-line">      <span class="src-ln"> 277</span> <span class="src-hl">     */</span></span>
+      <span class="src-line">      <span class="src-ln"> 278</span> <span class="src-hl">    &#x27;agent/turn-stopping&#x27;(this: Scoped&lt;Agent&gt;, payload: { agent: Agent; turn: number; signal: AbortSignal }): Promise&lt;void&gt; | void</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">agent/turn-stopping serial 类型</span><span class="lang-en-only">agent/turn-stopping serial type</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 279</span> <span class="src-hl">    <span class="src-comment">// ---- error notifications (emit) ----</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 280</span> <span class="src-hl">    /**</span></span>
+    </div>
+
+    <div class="lang-zh-only"><p>读 event map 时记住 mode 语义：<code>waterfall</code> 必须 call <code>next()</code>；<code>serial</code> 无 next；<code>emit</code> 是 fire-and-forget。错误 domain = 插件挂错钩子 = 静默不生效。</p></div>
+    <div class="lang-en-only"><p>When reading the event map remember mode semantics: <code>waterfall</code> must call <code>next()</code>; <code>serial</code> has no next; <code>emit</code> is fire-and-forget. Wrong domain = plugin on wrong hook = silently no-op.</p></div>
+
+    <div class="note copper">
+      <span class="lang-zh-only">用 <code>docs/event-producer-consumer.md</code> 查任意事件的 Dispatchers/Listeners 列；比 grep <code>ctx.on(</code> 更完整。</span>
+      <span class="lang-en-only">Use <code>docs/event-producer-consumer.md</code> for any event's Dispatchers/Listeners columns; more complete than grepping <code>ctx.on(</code>.</span>
+    </div>
+
+    </div>
+
+    <div class="trace-box">
+      <div class="tb-tag">TRACE · station station events</div>
+      <div class="lang-zh-only"><p>站 events：session/agent/capability。</p></div>
+      <div class="lang-en-only"><p>St. events: three domains.</p></div>
+    </div>
+
+    <div class="depth-zone" data-chapter="C13"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C13.4+</span><span class="lang-en-only">Deep dive · C13.4+</span></div>
+
+    </div>
+  </section>
+
+  <section class="chap" id="c14">
+    <div class="chap-num">CHAPTER&nbsp;14&nbsp;·&nbsp;LLM</div>
+    <h2 class="chap-title lang-zh-only">ctx.llm 适配层</h2>
+    <h2 class="chap-title lang-en-only">ctx.llm adapter seam</h2>
+    <p class="chap-en lang-zh-only">prepareCall · llm/stream · adapter boundary</p>
+    <p class="chap-en lang-en-only">prepareCall · llm/stream · adapter boundary</p>
+    <nav class="chapter-compass" aria-label="Chapter navigation">
+      <div class="cc-row">
+        <div class="cc-phase"><span class="cc-roman">III</span> · <span class="lang-zh-only">LLM</span><span class="lang-en-only">LLM</span></div>
+        <div class="cc-station"><span class="lang-zh-only">站 16</span><span class="lang-en-only">St. 16</span> · C14/26</div>
+      </div>
+      <div class="cc-forest"><span class="lang-zh-only">ctx.llm 适配缝</span><span class="lang-en-only">ctx.llm adapter seam</span></div>
+      <div class="cc-links">
+        <a class="cc-nav cc-prev" href="#c13"><span class="cc-arrow">←</span> <span class="cc-nav-num">C13</span> <span class="lang-zh-only">三域事件矩阵</span><span class="lang-en-only">Three-domain event matrix</span></a>
+        <a class="cc-map" href="#forest-overview"><span class="lang-zh-only">回到总览</span><span class="lang-en-only">Forest map</span></a>
+        <a class="cc-nav cc-next" href="#c15"><span class="cc-nav-num">C15</span> <span class="lang-zh-only">assistant/chunk 流式</span><span class="lang-en-only">assistant/chunk streaming</span> <span class="cc-arrow">→</span></a>
+      </div>
+    </nav>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>本章回答「这条主线 prompt 在此层长什么样」</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH 没有隐藏魔法——一切可替换行为都在 Cordis 事件或 SessionEvent 里</span></p>
+      <p><span class="swc-pill act">优化</span><span>读源码时先搜 session.append 与 ctx.* 注册点</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>This chapter answers what the through-line prompt looks like at this layer</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH has no hidden magic — replaceable behavior lives in Cordis events or SessionEvents</span></p>
+      <p><span class="swc-pill act">优化</span><span>When reading source, search session.append and ctx.* registration first</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">llm</span><span class="lang-en-only">llm</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">llm</span><span class="lang-en-only">llm</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">packages/llm</span><span class="lang-en-only">packages/llm</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">ctx.llm</span><span class="lang-en-only">ctx.llm</span></div>
+      </div>
+    </div>
+
+    <div class="lang-zh-only"><p><code>ctx.llm</code>（<code>packages/llm/llm</code>）是模型适配器 seam：DeepSeek 官方 adapter、pi-ai bridge、replay adapter 都注册为 provider。<code>llm/stream</code> waterfall 包裹实际 HTTP/SSE；agent-loop 只依赖统一 StreamChunk 词汇。</p></div>
+    <div class="lang-en-only"><p><code>ctx.llm</code> (<code>packages/llm/llm</code>) is the model adapter seam: DeepSeek official adapter, pi-ai bridge, replay adapter register as providers. The <code>llm/stream</code> waterfall wraps actual HTTP/SSE; agent-loop depends only on unified StreamChunk vocabulary.</p></div>
+
+    <h3 class="sub"><span class="sec-num">C14.1</span> <span class="lang-zh-only">Adapter 注册与 settings 热重载</span><span class="lang-en-only">Adapter registration and settings hot-reload</span></h3>
+
+    <div class="lang-zh-only"><p><code>dsh-base</code> insert <code>dsh-settings-file</code>：用户 <code>$DSH_HOME/settings.yaml</code> 的 <code>llm-deepseek:</code> section 可在运行时 override adapter entry，Web Models 页写入同一文件。</p></div>
+    <div class="lang-en-only"><p><code>dsh-base</code> inserts <code>dsh-settings-file</code>: the user's <code>llm-deepseek:</code> section in <code>$DSH_HOME/settings.yaml</code> can override adapter entries at runtime; the Web Models page writes the same file.</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/llm/llm/src/index.ts</span>
+        <span class="src-tag">llm</span>
+      </div>
+      <span class="src-line"><span class="src-str">llm/stream</span> · mode: <span class="src-str">waterfall</span></span>
+      <span class="src-line">Listeners: agent-loop, llm-replay, session-checkpoint-policy</span>
+    </div>
+
+    <table class="cmp">
+      <thead><tr><th>Provider 包</th><th>用途</th><th>测试</th></tr></thead>
+      <tbody>
+      <tr><td>llm-deepseek</td><td>生产 DeepSeek API</td><td>—</td></tr>
+      <tr><td>llm-pi-ai</td><td>pi-ai 桥接</td><td>—</td></tr>
+      <tr><td>llm-replay</td><td>离线 replay</td><td>packages/test-support</td></tr>
+      </tbody>
+    </table>
+
+    <div class="stage-purpose">
+      <div class="sp-row">
+        <div class="sp-key"><span class="lang-zh-only">agent/request</span><span class="lang-en-only">agent/request</span></div>
+        <div class="sp-val"><span class="lang-zh-only">最后一英里改 messages/model</span><span class="lang-en-only">last-mile edit messages/model</span></div>
+      </div>
+      <div class="sp-row">
+        <div class="sp-key"><span class="lang-zh-only">llm-retry</span><span class="lang-en-only">llm-retry</span></div>
+        <div class="sp-val"><span class="lang-zh-only">agent/request-error 恢复</span><span class="lang-en-only">agent/request-error recovery</span></div>
+      </div>
+      <div class="sp-row">
+        <div class="sp-key"><span class="lang-zh-only">token-meter</span><span class="lang-en-only">token-meter</span></div>
+        <div class="sp-val"><span class="lang-zh-only">usage 计量 · compaction 输入</span><span class="lang-en-only">usage metering · compaction input</span></div>
+      </div>
+    </div>
+
+    <div class="note copper">
+      <span class="lang-zh-only">📘 <strong>架构总览</strong>（<code>docs/architecture.md</code>）· Cordis 插件树、Profile×Bundle 组合、六大 ctx 服务与 turn 流</span>
+      <span class="lang-en-only">📘 <strong>Architecture overview</strong> (<code>docs/architecture.md</code>) · Cordis plugin tree, Profile×Bundle composition, six core ctx services, and turn flow</span>
+    </div>
+
+    <div class="trace-walk">
+      <div class="tw-head">
+        <span class="tw-tag">SOURCE TRACE · C14</span>
+        <span class="lang-zh-only">ctx.llm：prepareCall · llm/stream 如何接到 ReactLoopAgent</span>
+        <span class="lang-en-only">ctx.llm: how prepareCall · llm/stream connects to ReactLoopAgent</span>
+      </div>
+
+    <div class="lang-zh-only"><p><code>ctx.llm</code>（<code>packages/llm/llm</code>）是 DSH 的 LLM 适配层。<code>prepareCall</code> 绑定 adapter registration；<code>stream()</code> 外包 <code>llm/stream</code> waterfall。ReactLoopAgent 在 <code>buildRequest</code> 里 prepare，在 <code>step()</code> 里 stream。</p></div>
+    <div class="lang-en-only"><p><code>ctx.llm</code> (<code>packages/llm/llm</code>) is DSH's LLM adapter layer. <code>prepareCall</code> binds adapter registration; <code>stream()</code> wraps <code>llm/stream</code> waterfall. ReactLoopAgent prepares in <code>buildRequest</code>, streams in <code>step()</code>.</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/llm/llm/src/index.ts</span>
+        <span class="src-tag">llm-stream-event</span>
+      </div>
+      <span class="src-line">      <span class="src-ln">  47</span> <span class="src-hl">declare module &#x27;@deepseek-ai/cordis&#x27; {</span></span>
+      <span class="src-line">      <span class="src-ln">  48</span> <span class="src-hl">  <span class="src-kw">interface</span> Context {</span></span>
+      <span class="src-line">      <span class="src-ln">  49</span> <span class="src-hl">    llm: LlmRuntime</span></span>
+      <span class="src-line">      <span class="src-ln">  50</span> <span class="src-hl">  }</span></span>
+      <span class="src-line">      <span class="src-ln">  51</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln">  52</span> <span class="src-hl">  <span class="src-kw">interface</span> Events {</span></span>
+      <span class="src-line">      <span class="src-ln">  53</span> <span class="src-hl">    /**</span></span>
+      <span class="src-line">      <span class="src-ln">  54</span> <span class="src-hl">     * Waterfall around every streaming model call (retry, replay, routing).</span></span>
+      <span class="src-line">      <span class="src-ln">  55</span> <span class="src-hl">     * Bound to the {@link LlmRuntime}; call <span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`next()`</span> to reach the resolved</span></span>
+      <span class="src-line">      <span class="src-ln">  56</span> <span class="src-hl">     * adapter&#x27;s stream, or yield your own chunks to short-circuit.</span></span>
+      <span class="src-line">      <span class="src-ln">  57</span> <span class="src-hl">     * @param options - the full request. A LOOP-built request carries the</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">LOOP-built request 携带 markAgentLoopRequest</span><span class="lang-en-only">LOOP-built request carries markAgentLoopRequest</span></span></span>
+      <span class="src-line">      <span class="src-ln">  58</span> <span class="src-hl">     *   process-local {@link markAgentLoopRequest} identity and arrives deep-frozen</span></span>
+      <span class="src-line">      <span class="src-ln">  59</span> <span class="src-hl">     *   (mutation throws): its content is a pure <span class="src-kw">function</span> of the session log (the</span></span>
+      <span class="src-line">      <span class="src-ln">  60</span> <span class="src-hl">     *   reconstructability Agent Note), so listeners read it, never rewrite it.</span></span>
+      <span class="src-line">      <span class="src-ln">  61</span> <span class="src-hl">     *   Hand-built calls do not carry that marker; their messages already obey</span></span>
+      <span class="src-line">      <span class="src-ln">  62</span> <span class="src-hl">     *   the immutable creation contract.</span></span>
+      <span class="src-line">      <span class="src-ln">  63</span> <span class="src-hl">     * @mode waterfall</span></span>
+      <span class="src-line">      <span class="src-ln">  64</span> <span class="src-hl">     */</span></span>
+      <span class="src-line">      <span class="src-ln">  65</span> <span class="src-hl">    &#x27;llm/stream&#x27;(this: LlmRuntime, options: GenerateOptions, next: () =&gt; AsyncIterable&lt;StreamChunk&gt;): AsyncIterable&lt;StreamChunk&gt;</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">★ llm/stream waterfall 声明</span><span class="lang-en-only">★ llm/stream waterfall declaration</span></span></span>
+      <span class="src-line">      <span class="src-ln">  66</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln">  67</span> <span class="src-hl">  }</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/llm/llm/src/index.ts</span>
+        <span class="src-tag">prepare</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 824</span> <span class="src-hl">  <span class="src-kw">async</span> prepareCall(config: LlmCallConfig, signal?: AbortSignal): Promise&lt;PreparedLlmCall&gt; {</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">★ prepareCall：resolve + adapterDefaults</span><span class="lang-en-only">★ prepareCall: resolve + adapterDefaults</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 825</span> <span class="src-hl">    <span class="src-kw">const</span> registration = this.registration(config.provider)</span></span>
+      <span class="src-line">      <span class="src-ln"> 826</span> <span class="src-hl">    <span class="src-kw">const</span> adapterCall = <span class="src-kw">await</span> registration.adapter.prepareCall(config.provider, config.model, signal)</span></span>
+      <span class="src-line">      <span class="src-ln"> 827</span> <span class="src-hl">    <span class="src-kw">const</span> modelInfo = this.normalizeModelInfo(registration, config.model, adapterCall.model)</span></span>
+      <span class="src-line">      <span class="src-ln"> 828</span> <span class="src-hl">    <span class="src-kw">const</span> resolved = this.resolveCallWithInfo(config, modelInfo)</span></span>
+      <span class="src-line">      <span class="src-ln"> 829</span> <span class="src-hl">    <span class="src-kw">const</span> resolvedConfig = deepFreeze(structuredClone(resolved.config))</span></span>
+      <span class="src-line">      <span class="src-ln"> 830</span> <span class="src-hl">    <span class="src-kw">const</span> context = resolved.context === <span class="src-kw">undefined</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 831</span> <span class="src-hl">      ? <span class="src-kw">undefined</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 832</span> <span class="src-hl">      : deepFreeze(structuredClone(resolved.context))</span></span>
+      <span class="src-line">      <span class="src-ln"> 833</span> <span class="src-hl">    <span class="src-kw">const</span> adapterDefaults = deepFreeze&lt;LlmCallConfigAdapterDefaults&gt;({</span></span>
+      <span class="src-line">      <span class="src-ln"> 834</span> <span class="src-hl">      ...config.reasoningEffort === <span class="src-kw">undefined</span> &amp;&amp; resolvedConfig.reasoningEffort !== <span class="src-kw">undefined</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 835</span> <span class="src-hl">        ? { reasoningEffort: <span class="src-kw">true</span> }</span></span>
+      <span class="src-line">      <span class="src-ln"> 836</span> <span class="src-hl">        : {},</span></span>
+      <span class="src-line">      <span class="src-ln"> 837</span> <span class="src-hl">      ...config.maxTokens === <span class="src-kw">undefined</span> &amp;&amp; resolvedConfig.maxTokens !== <span class="src-kw">undefined</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 838</span> <span class="src-hl">        ? { maxTokens: <span class="src-kw">true</span> }</span></span>
+      <span class="src-line">      <span class="src-ln"> 839</span> <span class="src-hl">        : {},</span></span>
+      <span class="src-line">      <span class="src-ln"> 840</span> <span class="src-hl">    })</span></span>
+      <span class="src-line">      <span class="src-ln"> 841</span> <span class="src-hl">    <span class="src-kw">let</span> dispatched = <span class="src-kw">false</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 842</span> <span class="src-hl">    <span class="src-kw">return</span> Object.freeze({</span></span>
+      <span class="src-line">      <span class="src-ln"> 843</span> <span class="src-hl">      config: resolvedConfig,</span></span>
+      <span class="src-line">      <span class="src-ln"> 844</span> <span class="src-hl">      retryPolicy: registration.retryPolicy,</span></span>
+      <span class="src-line">      <span class="src-ln"> 845</span> <span class="src-hl">      adapterDefaults,</span></span>
+      <span class="src-line">      <span class="src-ln"> 846</span> <span class="src-hl">      ...context === <span class="src-kw">undefined</span> ? {} : { context },</span></span>
+      <span class="src-line">      <span class="src-ln"> 847</span> <span class="src-hl">      ...modelInfo.inputModalities === <span class="src-kw">undefined</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 848</span> <span class="src-hl">        ? {}</span></span>
+      <span class="src-line">      <span class="src-ln"> 849</span> <span class="src-hl">        : { inputModalities: Object.freeze([...modelInfo.inputModalities]) },</span></span>
+      <span class="src-line">      <span class="src-ln"> 850</span> <span class="src-hl">      stream: (options: GenerateOptions): AsyncIterable&lt;StreamChunk&gt; =&gt; {</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">prepared stream 只能 dispatch 一次</span><span class="lang-en-only">prepared stream can dispatch only once</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 851</span> <span class="src-hl">        <span class="src-kw">if</span> (dispatched) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 852</span> <span class="src-hl">          <span class="src-kw">throw</span> <span class="src-kw">new</span> LlmError(&#x27;a prepared LLM call can only be dispatched once&#x27;, &#x27;INVALID_PREPARED_CALL&#x27;)</span></span>
+      <span class="src-line">      <span class="src-ln"> 853</span> <span class="src-hl">        }</span></span>
+      <span class="src-line">      <span class="src-ln"> 854</span> <span class="src-hl">        <span class="src-kw">if</span> (!callConfigEquals(options, resolvedConfig)) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 855</span> <span class="src-hl">          <span class="src-kw">throw</span> <span class="src-kw">new</span> LlmError(</span></span>
+      <span class="src-line">      <span class="src-ln"> 856</span> <span class="src-hl">            &#x27;prepared LLM call config changed before adapter dispatch&#x27;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 857</span> <span class="src-hl">            &#x27;INVALID_PREPARED_CALL&#x27;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 858</span> <span class="src-hl">          )</span></span>
+      <span class="src-line">      <span class="src-ln"> 859</span> <span class="src-hl">        }</span></span>
+      <span class="src-line">      <span class="src-ln"> 860</span> <span class="src-hl">        dispatched = <span class="src-kw">true</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 861</span> <span class="src-hl">        <span class="src-kw">return</span> this.streamWithRegistration(options, {</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">streamWithRegistration → llm/stream</span><span class="lang-en-only">streamWithRegistration → llm/stream</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 862</span> <span class="src-hl">          registration,</span></span>
+      <span class="src-line">      <span class="src-ln"> 863</span> <span class="src-hl">          config: resolvedConfig,</span></span>
+      <span class="src-line">      <span class="src-ln"> 864</span> <span class="src-hl">          modelInfo,</span></span>
+      <span class="src-line">      <span class="src-ln"> 865</span> <span class="src-hl">          dispatch: options =&gt; adapterCall.stream(options),</span></span>
+      <span class="src-line">      <span class="src-ln"> 866</span> <span class="src-hl">        })</span></span>
+      <span class="src-line">      <span class="src-ln"> 867</span> <span class="src-hl">      },</span></span>
+      <span class="src-line">      <span class="src-ln"> 868</span> <span class="src-hl">    })</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/llm/llm/src/index.ts</span>
+        <span class="src-tag">stream</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 985</span> <span class="src-hl">  stream(options: GenerateOptions): AsyncIterable&lt;StreamChunk&gt; {</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">LlmRuntime.stream 公共入口</span><span class="lang-en-only">LlmRuntime.stream public entry</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 986</span> <span class="src-hl">    <span class="src-kw">return</span> this.streamWithRegistration(options)</span></span>
+      <span class="src-line">      <span class="src-ln"> 987</span> <span class="src-hl">  }</span></span>
+      <span class="src-line">      <span class="src-ln"> 988</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 989</span> <span class="src-hl">  <span class="src-kw">private</span> streamWithRegistration(</span></span>
+      <span class="src-line">      <span class="src-ln"> 990</span> <span class="src-hl">    options: GenerateOptions,</span></span>
+      <span class="src-line">      <span class="src-ln"> 991</span> <span class="src-hl">    prepared?: PreparedDispatch,</span></span>
+      <span class="src-line">      <span class="src-ln"> 992</span> <span class="src-hl">  ): AsyncIterable&lt;StreamChunk&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln"> 993</span> <span class="src-hl">    <span class="src-kw">return</span> this.ctx.waterfall(</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">★ ctx.waterfall llm/stream</span><span class="lang-en-only">★ ctx.waterfall llm/stream</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 994</span> <span class="src-hl">      this,</span></span>
+      <span class="src-line">      <span class="src-ln"> 995</span> <span class="src-hl">      &#x27;llm/stream&#x27;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 996</span> <span class="src-hl">      options,</span></span>
+      <span class="src-line">      <span class="src-ln"> 997</span> <span class="src-hl">      () =&gt; this.adapterStream(options, prepared),</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">default next → adapterStream</span><span class="lang-en-only">default next → adapterStream</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 998</span> <span class="src-hl">    )</span></span>
+      <span class="src-line">      <span class="src-ln"> 999</span> <span class="src-hl">  }</span></span>
+    </div>
+
+    <div class="trace-steps"><div class="ts-label"><span class="lang-zh-only">主线 turn-1 step-1 · ctx.llm 数据流</span><span class="lang-en-only">Through-line turn-1 step-1 · ctx.llm data flow</span></div>    <table class="cmp">
+      <thead><tr><th>#</th><th>location</th><th>主线时刻 / through-line moment</th></tr></thead>
+      <tbody>
+      <tr><td>in</td><td>deriveMessages()</td><td>user prompt Message[]</td></tr>
+      <tr><td>prep</td><td>prepareCall(config)</td><td>adapter registration bound</td></tr>
+      <tr><td>wf1</td><td>agent/request</td><td>config proposal waterfall</td></tr>
+      <tr><td>req</td><td>markAgentLoopRequest</td><td>deep-frozen GenerateOptions</td></tr>
+      <tr><td>wf2</td><td>llm/stream</td><td>retry · replay · session-checkpoint</td></tr>
+      <tr><td>http</td><td>adapter.stream()</td><td>DeepSeek SSE chunks</td></tr>
+      <tr><td>out</td><td>StreamChunk*</td><td>→ BlockAssembler in step()</td></tr>
+      </tbody>
+    </table></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/core/agent-loop/src/agent.ts</span>
+        <span class="src-tag">build-request</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 457</span> <span class="src-hl">    <span class="src-kw">const</span> proposedConfig = <span class="src-kw">await</span> this.dispatch.waterfall(</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">agent/request waterfall：proposedConfig</span><span class="lang-en-only">agent/request waterfall: proposedConfig</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 458</span> <span class="src-hl">      &#x27;agent/request&#x27;, { turn, step, signal },</span></span>
+      <span class="src-line">      <span class="src-ln"> 459</span> <span class="src-hl">      () =&gt; Promise.resolve(seedConfig),</span></span>
+      <span class="src-line">      <span class="src-ln"> 460</span> <span class="src-hl">    )</span></span>
+      <span class="src-line">      <span class="src-ln"> 461</span> <span class="src-hl">    signal.throwIfAborted()</span></span>
+      <span class="src-line">      <span class="src-ln"> 462</span> <span class="src-hl">    <span class="src-kw">if</span> (!proposedConfig.provider || !proposedConfig.model) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 463</span> <span class="src-hl">      <span class="src-kw">throw</span> <span class="src-kw">new</span> Error(<span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`agent &quot;${this.id}&quot; has no provider/model: set AgentOptions.provider and AgentOptions.model or supply both via the agent/request waterfall`</span>)</span></span>
+      <span class="src-line">      <span class="src-ln"> 464</span> <span class="src-hl">    }</span></span>
+      <span class="src-line">      <span class="src-ln"> 465</span> <span class="src-hl">    <span class="src-kw">let</span> config: LlmCallConfig</span></span>
+      <span class="src-line">      <span class="src-ln"> 466</span> <span class="src-hl">    <span class="src-kw">let</span> preparedCall: PreparedLlmCall | <span class="src-kw">undefined</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 467</span> <span class="src-hl">    try {</span></span>
+      <span class="src-line">      <span class="src-ln"> 468</span> <span class="src-hl">      preparedCall = <span class="src-kw">await</span> this.loopCtx.llm.prepareCall(proposedConfig, signal)</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">★ loopCtx.llm.prepareCall</span><span class="lang-en-only">★ loopCtx.llm.prepareCall</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 469</span> <span class="src-hl">      config = preparedCall.config</span></span>
+      <span class="src-line">      <span class="src-ln"> 470</span> <span class="src-hl">    } catch (error: unknown) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 471</span> <span class="src-hl">      <span class="src-comment">// Middleware may serve an unregistered route; terminal dispatch still requires an adapter.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 472</span> <span class="src-hl">      <span class="src-kw">if</span> (!(error instanceof LlmError) || error.code !== &#x27;NO_ADAPTER&#x27;) <span class="src-kw">throw</span> error</span></span>
+      <span class="src-line">      <span class="src-ln"> 473</span> <span class="src-hl">      config = proposedConfig</span></span>
+      <span class="src-line">      <span class="src-ln"> 474</span> <span class="src-hl">    }</span></span>
+      <span class="src-line">      <span class="src-ln"> 475</span> <span class="src-hl">    signal.throwIfAborted()</span></span>
+      <span class="src-line">      <span class="src-ln"> 476</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 477</span> <span class="src-hl">    <span class="src-kw">const</span> header = canonicalHeader({</span></span>
+      <span class="src-line">      <span class="src-ln"> 478</span> <span class="src-hl">      config,</span></span>
+      <span class="src-line">      <span class="src-ln"> 479</span> <span class="src-hl">      ...preparedCall === <span class="src-kw">undefined</span> ? {} : { adapterDefaults: preparedCall.adapterDefaults },</span></span>
+      <span class="src-line">      <span class="src-ln"> 480</span> <span class="src-hl">      ...system ? { system } : {},</span></span>
+      <span class="src-line">      <span class="src-ln"> 481</span> <span class="src-hl">      ...tools.length &gt; 0 ? { tools } : {},</span></span>
+      <span class="src-line">      <span class="src-ln"> 482</span> <span class="src-hl">    })</span></span>
+      <span class="src-line">      <span class="src-ln"> 483</span> <span class="src-hl">    <span class="src-kw">const</span> baseline = this.session.requestHeader()</span></span>
+      <span class="src-line">      <span class="src-ln"> 484</span> <span class="src-hl">    <span class="src-kw">if</span> (!this.requestHeaderLogged) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 485</span> <span class="src-hl">      this.session.append(&#x27;request/header&#x27;, { header, reason: baseline === <span class="src-kw">undefined</span> ? &#x27;initial&#x27; : &#x27;resume&#x27; })</span></span>
+      <span class="src-line">      <span class="src-ln"> 486</span> <span class="src-hl">      this.requestHeaderLogged = <span class="src-kw">true</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 487</span> <span class="src-hl">    } <span class="src-kw">else</span> <span class="src-kw">if</span> (baseline === <span class="src-kw">undefined</span> || !headerEquals(baseline, header)) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 488</span> <span class="src-hl">      this.session.append(&#x27;request/header&#x27;, { header, reason: &#x27;change&#x27; })</span></span>
+      <span class="src-line">      <span class="src-ln"> 489</span> <span class="src-hl">    }</span></span>
+      <span class="src-line">      <span class="src-ln"> 490</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 491</span> <span class="src-hl">    <span class="src-kw">const</span> contextWindow = preparedCall?.context?.contextWindow</span></span>
+      <span class="src-line">      <span class="src-ln"> 492</span> <span class="src-hl">    <span class="src-kw">const</span> requestContext: RequestContext = {</span></span>
+      <span class="src-line">      <span class="src-ln"> 493</span> <span class="src-hl">      provider: config.provider,</span></span>
+      <span class="src-line">      <span class="src-ln"> 494</span> <span class="src-hl">      model: config.model,</span></span>
+      <span class="src-line">      <span class="src-ln"> 495</span> <span class="src-hl">      ...contextWindow === <span class="src-kw">undefined</span> ? {} : { contextWindow },</span></span>
+      <span class="src-line">      <span class="src-ln"> 496</span> <span class="src-hl">    }</span></span>
+      <span class="src-line">      <span class="src-ln"> 497</span> <span class="src-hl">    <span class="src-kw">const</span> previousContext = session.requestContext()</span></span>
+      <span class="src-line">      <span class="src-ln"> 498</span> <span class="src-hl">    <span class="src-kw">if</span> (previousContext?.provider !== requestContext.provider</span></span>
+      <span class="src-line">      <span class="src-ln"> 499</span> <span class="src-hl">      || previousContext.model !== requestContext.model</span></span>
+      <span class="src-line">      <span class="src-ln"> 500</span> <span class="src-hl">      || previousContext.contextWindow !== requestContext.contextWindow) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 501</span> <span class="src-hl">      session.append(&#x27;request/context&#x27;, requestContext)</span></span>
+      <span class="src-line">      <span class="src-ln"> 502</span> <span class="src-hl">    }</span></span>
+      <span class="src-line">      <span class="src-ln"> 503</span> <span class="src-hl">    signal.throwIfAborted()</span></span>
+      <span class="src-line">      <span class="src-ln"> 504</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 505</span> <span class="src-hl">    <span class="src-kw">const</span> request = markAgentLoopRequest(deepFreeze({</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">★ markAgentLoopRequest(deepFreeze(...))</span><span class="lang-en-only">★ markAgentLoopRequest(deepFreeze(...))</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 506</span> <span class="src-hl">      ...header.config,</span></span>
+      <span class="src-line">      <span class="src-ln"> 507</span> <span class="src-hl">      messages: boundaryMessages,</span></span>
+      <span class="src-line">      <span class="src-ln"> 508</span> <span class="src-hl">      ...header.system !== <span class="src-kw">undefined</span> ? { system: header.system } : {},</span></span>
+      <span class="src-line">      <span class="src-ln"> 509</span> <span class="src-hl">      ...header.tools !== <span class="src-kw">undefined</span> ? { tools: header.tools } : {},</span></span>
+      <span class="src-line">      <span class="src-ln"> 510</span> <span class="src-hl">      sessionId: this.session.id,</span></span>
+      <span class="src-line">      <span class="src-ln"> 511</span> <span class="src-hl">      signal,</span></span>
+      <span class="src-line">      <span class="src-ln"> 512</span> <span class="src-hl">    }))</span></span>
+      <span class="src-line">      <span class="src-ln"> 513</span> <span class="src-hl">    <span class="src-kw">return</span> { request, ...preparedCall === <span class="src-kw">undefined</span> ? {} : { preparedCall } }</span></span>
+    </div>
+
+    <div class="note copper">
+      <span class="lang-zh-only">练习：在 llm-replay 插件短路 <code>llm/stream</code>，观察 session log 是否仍收到相同形状的 assistant/chunk。</span>
+      <span class="lang-en-only">Exercise: short-circuit <code>llm/stream</code> with llm-replay plugin; observe session log still gets same-shaped assistant/chunk.</span>
+    </div>
+
+    </div>
+
+    <div class="trace-box">
+      <div class="tb-tag">TRACE · station station llm</div>
+      <div class="lang-zh-only"><p>站 llm：适配缝。</p></div>
+      <div class="lang-en-only"><p>St. llm: adapter seam.</p></div>
+    </div>
+
+    <div class="depth-zone" data-chapter="C14"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C14.4+</span><span class="lang-en-only">Deep dive · C14.4+</span></div>
+
+    </div>
+  </section>
+
+  <section class="chap" id="c15">
+    <div class="chap-num">CHAPTER&nbsp;15&nbsp;·&nbsp;LLM</div>
+    <h2 class="chap-title lang-zh-only">assistant/chunk 流式</h2>
+    <h2 class="chap-title lang-en-only">assistant/chunk streaming</h2>
+    <p class="chap-en lang-zh-only">BlockAssembler · chunk seq · message finalize</p>
+    <p class="chap-en lang-en-only">BlockAssembler · chunk seq · message finalize</p>
+    <nav class="chapter-compass" aria-label="Chapter navigation">
+      <div class="cc-row">
+        <div class="cc-phase"><span class="cc-roman">III</span> · <span class="lang-zh-only">LLM</span><span class="lang-en-only">LLM</span></div>
+        <div class="cc-station"><span class="lang-zh-only">站 17</span><span class="lang-en-only">St. 17</span> · C15/26</div>
+      </div>
+      <div class="cc-forest"><span class="lang-zh-only">assistant/chunk 流式</span><span class="lang-en-only">assistant/chunk streaming</span></div>
+      <div class="cc-links">
+        <a class="cc-nav cc-prev" href="#c14"><span class="cc-arrow">←</span> <span class="cc-nav-num">C14</span> <span class="lang-zh-only">ctx.llm 适配层</span><span class="lang-en-only">ctx.llm adapter seam</span></a>
+        <a class="cc-map" href="#forest-overview"><span class="lang-zh-only">回到总览</span><span class="lang-en-only">Forest map</span></a>
+        <a class="cc-nav cc-next" href="#c16"><span class="cc-nav-num">C16</span> <span class="lang-zh-only">deriveMessages 闭环</span><span class="lang-en-only">deriveMessages closed loop</span> <span class="cc-arrow">→</span></a>
+      </div>
+    </nav>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>本章回答「这条主线 prompt 在此层长什么样」</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH 没有隐藏魔法——一切可替换行为都在 Cordis 事件或 SessionEvent 里</span></p>
+      <p><span class="swc-pill act">优化</span><span>读源码时先搜 session.append 与 ctx.* 注册点</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>This chapter answers what the through-line prompt looks like at this layer</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH has no hidden magic — replaceable behavior lives in Cordis events or SessionEvents</span></p>
+      <p><span class="swc-pill act">优化</span><span>When reading source, search session.append and ctx.* registration first</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">chunk</span><span class="lang-en-only">chunk</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">chunk</span><span class="lang-en-only">chunk</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">assistant/chunk</span><span class="lang-en-only">assistant/chunk</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">stream</span><span class="lang-en-only">stream</span></div>
+      </div>
+    </div>
+
+    <div class="lang-zh-only"><p>Provider 流式返回的每个 delta 被驱动器写成 <code>assistant/chunk</code> SessionEvent；UI 经 <code>session/event</code> 增量渲染聊天气泡。流结束后写 <code>assistant/message</code> 定稿（含 usage、<code>sourceEventSeqs</code> 指向 chunk 序列）。</p></div>
+    <div class="lang-en-only"><p>Each delta from the provider stream is logged by the driver as <code>assistant/chunk</code> SessionEvent; the UI incrementally renders chat bubbles via <code>session/event</code>. After the stream ends, <code>assistant/message</code> finalizes (with usage, <code>sourceEventSeqs</code> pointing to the chunk sequence).</p></div>
+
+    <h3 class="sub"><span class="sec-num">C15.1</span> <span class="lang-zh-only">Chunk vs Message</span><span class="lang-en-only">Chunk vs Message</span></h3>
+
+    <table class="cmp">
+      <thead><tr><th>artifact</th><th>持久?</th><th>deriveMessages</th><th>UI</th></tr></thead>
+      <tbody>
+      <tr><td>assistant/chunk</td><td>✓</td><td>合成 message</td><td>流式 token</td></tr>
+      <tr><td>assistant/message</td><td>✓</td><td>✓</td><td>定稿气泡</td></tr>
+      <tr><td>empty content</td><td>✓ log</td><td>✗ surface</td><td>max-tokens 等</td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="sec-num">C15.2</span> <span class="lang-zh-only">主线第二次 stream</span><span class="lang-en-only">Second stream on through-line</span></h3>
+
+    <div class="lang-zh-only"><p>read 工具返回后，下一 step 的 <code>llm/stream</code> 将 README 内容纳入 deriveMessages 历史，模型生成一句话项目描述——第二个 <code>assistant/chunk*</code> 序列，最终 <code>assistant/message</code> stop。</p></div>
+    <div class="lang-en-only"><p>After the read tool returns, the next step's <code>llm/stream</code> includes README content in deriveMessages history; the model generates a one-sentence project description — a second <code>assistant/chunk*</code> sequence, ending with <code>assistant/message</code> stop.</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; docs/agent-lifecycle.md</span>
+        <span class="src-tag">chunk</span>
+      </div>
+      <span class="src-line"><code>assistant/message</code> records every successful provider call,</span>
+      <span class="src-line">including content-less and <span class="src-str">max-tokens</span> finishes.</span>
+    </div>
+
+    <div class="trace-walk">
+      <div class="tw-head">
+        <span class="tw-tag">SOURCE TRACE · C15</span>
+        <span class="lang-zh-only">assistant/chunk 流式：从 adapter chunk 到 assistant/message</span>
+        <span class="lang-en-only">assistant/chunk streaming: adapter chunk to assistant/message</span>
+      </div>
+
+    <div class="lang-zh-only"><p><code>step()</code> 的 <code>for await (chunk of stream)</code> 循环是 UI 与 replay 的燃料：每个 chunk 立即 <code>session.append('assistant/chunk')</code>（无 surfaceOp），同时 <code>BlockAssembler.push(chunk)</code> 累积；流结束后 <code>assistant/message</code> 带 <code>sourceEventSeqs: chunkSeqs</code> 定稿入 surface。</p></div>
+    <div class="lang-en-only"><p><code>step()</code>'s <code>for await (chunk of stream)</code> loop fuels UI and replay: each chunk immediately <code>session.append('assistant/chunk')</code> (no surfaceOp), while <code>BlockAssembler.push(chunk)</code> accumulates; after stream, <code>assistant/message</code> with <code>sourceEventSeqs: chunkSeqs</code> finalizes onto surface.</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/core/agent-loop/src/agent.ts</span>
+        <span class="src-tag">chunk-loop</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 339</span> <span class="src-hl">    <span class="src-kw">while</span> (<span class="src-kw">true</span>) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 340</span> <span class="src-hl">      <span class="src-kw">const</span> { request, preparedCall } = <span class="src-kw">await</span> this.buildRequest(</span></span>
+      <span class="src-line">      <span class="src-ln"> 341</span> <span class="src-hl">        turn, step, assembly.tools, system, this.session.deriveMessages(), signal,</span></span>
+      <span class="src-line">      <span class="src-ln"> 342</span> <span class="src-hl">      )</span></span>
+      <span class="src-line">      <span class="src-ln"> 343</span> <span class="src-hl">      <span class="src-kw">const</span> assembler = <span class="src-kw">new</span> BlockAssembler()</span></span>
+      <span class="src-line">      <span class="src-ln"> 344</span> <span class="src-hl">      <span class="src-kw">const</span> chunkSeqs: number[] = []</span></span>
+      <span class="src-line">      <span class="src-ln"> 345</span> <span class="src-hl">      try {</span></span>
+      <span class="src-line">      <span class="src-ln"> 346</span> <span class="src-hl">        <span class="src-kw">const</span> stream = preparedCall?.stream(request) ?? this.loopCtx.llm.stream(request)</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">preparedCall?.stream ?? loopCtx.llm.stream</span><span class="lang-en-only">preparedCall?.stream ?? loopCtx.llm.stream</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 347</span> <span class="src-hl">        signal.throwIfAborted()</span></span>
+      <span class="src-line">      <span class="src-ln"> 348</span> <span class="src-hl">        <span class="src-kw">for</span> <span class="src-kw">await</span> (<span class="src-kw">const</span> chunk of stream) {</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">for await chunk of stream</span><span class="lang-en-only">for await chunk of stream</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 349</span> <span class="src-hl">          signal.throwIfAborted()</span></span>
+      <span class="src-line">      <span class="src-ln"> 350</span> <span class="src-hl">          chunkSeqs.push(this.session.append(&#x27;assistant/chunk&#x27;, { turn, step, chunk }).seq)</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">★ assistant/chunk append · 记录 seq</span><span class="lang-en-only">★ assistant/chunk append · record seq</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 351</span> <span class="src-hl">          assembler.push(chunk)</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">BlockAssembler.push(chunk)</span><span class="lang-en-only">BlockAssembler.push(chunk)</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 352</span> <span class="src-hl">        }</span></span>
+      <span class="src-line">      <span class="src-ln"> 353</span> <span class="src-hl">        signal.throwIfAborted()</span></span>
+      <span class="src-line">      <span class="src-ln"> 354</span> <span class="src-hl">      } catch (error: unknown) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 355</span> <span class="src-hl">        <span class="src-kw">if</span> (signal.aborted) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 356</span> <span class="src-hl">          <span class="src-kw">const</span> content = assembler.interruptedBlocks()</span></span>
+      <span class="src-line">      <span class="src-ln"> 357</span> <span class="src-hl">          <span class="src-kw">if</span> (content.length &gt; 0) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 358</span> <span class="src-hl">            this.session.append(&#x27;assistant/message&#x27;, {</span></span>
+      <span class="src-line">      <span class="src-ln"> 359</span> <span class="src-hl">              turn,</span></span>
+      <span class="src-line">      <span class="src-ln"> 360</span> <span class="src-hl">              step,</span></span>
+      <span class="src-line">      <span class="src-ln"> 361</span> <span class="src-hl">              message: createAssistantMessage({</span></span>
+      <span class="src-line">      <span class="src-ln"> 362</span> <span class="src-hl">                content,</span></span>
+      <span class="src-line">      <span class="src-ln"> 363</span> <span class="src-hl">                source: { provider: request.provider, model: request.model },</span></span>
+      <span class="src-line">      <span class="src-ln"> 364</span> <span class="src-hl">              }),</span></span>
+      <span class="src-line">      <span class="src-ln"> 365</span> <span class="src-hl">              interrupted: <span class="src-kw">true</span>,</span></span>
+      <span class="src-line">      <span class="src-ln"> 366</span> <span class="src-hl">              ...assembler.usage === <span class="src-kw">undefined</span> ? {} : { usage: assembler.usage },</span></span>
+      <span class="src-line">      <span class="src-ln"> 367</span> <span class="src-hl">            }, { surfaceOp: &#x27;append&#x27;, sourceEventSeqs: chunkSeqs })</span></span>
+      <span class="src-line">      <span class="src-ln"> 368</span> <span class="src-hl">          }</span></span>
+      <span class="src-line">      <span class="src-ln"> 369</span> <span class="src-hl">        }</span></span>
+      <span class="src-line">      <span class="src-ln"> 370</span> <span class="src-hl">        <span class="src-kw">throw</span> error</span></span>
+      <span class="src-line">      <span class="src-ln"> 371</span> <span class="src-hl">      }</span></span>
+      <span class="src-line">      <span class="src-ln"> 372</span> <span class="src-hl">      <span class="src-kw">const</span> finish = assembler.finish</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">finish error/aborted → request-error waterfall</span><span class="lang-en-only">finish error/aborted → request-error waterfall</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 373</span> <span class="src-hl">      <span class="src-kw">if</span> (finish.kind === &#x27;error&#x27; || finish.kind === &#x27;aborted&#x27;) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 374</span> <span class="src-hl">        <span class="src-kw">const</span> action = <span class="src-kw">await</span> this.dispatch.waterfall(</span></span>
+      <span class="src-line">      <span class="src-ln"> 375</span> <span class="src-hl">          &#x27;agent/request-error&#x27;, {</span></span>
+      <span class="src-line">      <span class="src-ln"> 376</span> <span class="src-hl">            turn,</span></span>
+      <span class="src-line">      <span class="src-ln"> 377</span> <span class="src-hl">            step,</span></span>
+      <span class="src-line">      <span class="src-ln"> 378</span> <span class="src-hl">            provider: request.provider,</span></span>
+      <span class="src-line">      <span class="src-ln"> 379</span> <span class="src-hl">            failure: finish.failure,</span></span>
+      <span class="src-line">      <span class="src-ln"> 380</span> <span class="src-hl">            retryPolicy: preparedCall?.retryPolicy,</span></span>
+      <span class="src-line">      <span class="src-ln"> 381</span> <span class="src-hl">            signal,</span></span>
+      <span class="src-line">      <span class="src-ln"> 382</span> <span class="src-hl">          },</span></span>
+      <span class="src-line">      <span class="src-ln"> 383</span> <span class="src-hl">          () =&gt; Promise.resolve&lt;RequestErrorAction&gt;(<span class="src-kw">undefined</span>),</span></span>
+      <span class="src-line">      <span class="src-ln"> 384</span> <span class="src-hl">        )</span></span>
+      <span class="src-line">      <span class="src-ln"> 385</span> <span class="src-hl">        signal.throwIfAborted()</span></span>
+      <span class="src-line">      <span class="src-ln"> 386</span> <span class="src-hl">        <span class="src-kw">if</span> (action?.kind !== &#x27;retry&#x27;) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 387</span> <span class="src-hl">          <span class="src-kw">throw</span> <span class="src-kw">new</span> LlmError(finish.failure.message, finish.failure.code, finish.failure)</span></span>
+      <span class="src-line">      <span class="src-ln"> 388</span> <span class="src-hl">        }</span></span>
+      <span class="src-line">      <span class="src-ln"> 389</span> <span class="src-hl">        <span class="src-kw">continue</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 390</span> <span class="src-hl">      }</span></span>
+      <span class="src-line">      <span class="src-ln"> 391</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 392</span> <span class="src-hl">      <span class="src-kw">const</span> message = createAssistantMessage({</span></span>
+      <span class="src-line">      <span class="src-ln"> 393</span> <span class="src-hl">        content: assembler.blocks(),</span></span>
+      <span class="src-line">      <span class="src-ln"> 394</span> <span class="src-hl">        source: {</span></span>
+      <span class="src-line">      <span class="src-ln"> 395</span> <span class="src-hl">          provider: request.provider,</span></span>
+      <span class="src-line">      <span class="src-ln"> 396</span> <span class="src-hl">          model: request.model,</span></span>
+      <span class="src-line">      <span class="src-ln"> 397</span> <span class="src-hl">          ...assembler.replayState !== <span class="src-kw">undefined</span> ? { replayState: assembler.replayState } : {},</span></span>
+      <span class="src-line">      <span class="src-ln"> 398</span> <span class="src-hl">        },</span></span>
+      <span class="src-line">      <span class="src-ln"> 399</span> <span class="src-hl">      })</span></span>
+      <span class="src-line">      <span class="src-ln"> 400</span> <span class="src-hl">      this.session.append(</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">★ assistant/message · surfaceOp=append</span><span class="lang-en-only">★ assistant/message · surfaceOp=append</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 401</span> <span class="src-hl">        &#x27;assistant/message&#x27;,</span></span>
+      <span class="src-line">      <span class="src-ln"> 402</span> <span class="src-hl">        {</span></span>
+      <span class="src-line">      <span class="src-ln"> 403</span> <span class="src-hl">          turn,</span></span>
+      <span class="src-line">      <span class="src-ln"> 404</span> <span class="src-hl">          step,</span></span>
+      <span class="src-line">      <span class="src-ln"> 405</span> <span class="src-hl">          message,</span></span>
+      <span class="src-line">      <span class="src-ln"> 406</span> <span class="src-hl">          ...assembler.usage === <span class="src-kw">undefined</span> ? {} : { usage: assembler.usage },</span></span>
+      <span class="src-line">      <span class="src-ln"> 407</span> <span class="src-hl">        },</span></span>
+      <span class="src-line">      <span class="src-ln"> 408</span> <span class="src-hl">        { surfaceOp: &#x27;append&#x27;, sourceEventSeqs: chunkSeqs },</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">sourceEventSeqs: chunkSeqs 链</span><span class="lang-en-only">sourceEventSeqs: chunkSeqs chain</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 409</span> <span class="src-hl">      )</span></span>
+    </div>
+
+    <div class="trace-steps"><div class="ts-label"><span class="lang-zh-only">主线 turn-1 · tool-call chunk 时间线</span><span class="lang-en-only">Through-line turn-1 · tool-call chunk timeline</span></div>    <table class="cmp">
+      <thead><tr><th>#</th><th>location</th><th>主线时刻 / through-line moment</th></tr></thead>
+      <tbody>
+      <tr><td>1</td><td>chunk text_delta</td><td>可能为空 · 模型先输出 tool-call</td></tr>
+      <tr><td>2</td><td>chunk tool-call start</td><td>read tool 块开始</td></tr>
+      <tr><td>3</td><td>chunk tool-call delta×N</td><td>arguments JSON 增量</td></tr>
+      <tr><td>4</td><td>chunk finish tool-calls</td><td>stopReason=tool-calls</td></tr>
+      <tr><td>5</td><td>assistant/message</td><td>content 含 tool-call block</td></tr>
+      <tr><td>6</td><td>executeToolCalls</td><td>→ tool/call + tool/result</td></tr>
+      </tbody>
+    </table></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/core/agent-loop/src/agent.ts</span>
+        <span class="src-tag">abort-path</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 354</span> <span class="src-hl">      } catch (error: unknown) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 355</span> <span class="src-hl">        <span class="src-kw">if</span> (signal.aborted) {</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">signal.aborted：assembler.interruptedBlocks()</span><span class="lang-en-only">signal.aborted: assembler.interruptedBlocks()</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 356</span> <span class="src-hl">          <span class="src-kw">const</span> content = assembler.interruptedBlocks()</span></span>
+      <span class="src-line">      <span class="src-ln"> 357</span> <span class="src-hl">          <span class="src-kw">if</span> (content.length &gt; 0) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 358</span> <span class="src-hl">            this.session.append(&#x27;assistant/message&#x27;, {</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">interrupted assistant/message 仍落盘</span><span class="lang-en-only">interrupted assistant/message still persisted</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 359</span> <span class="src-hl">              turn,</span></span>
+      <span class="src-line">      <span class="src-ln"> 360</span> <span class="src-hl">              step,</span></span>
+      <span class="src-line">      <span class="src-ln"> 361</span> <span class="src-hl">              message: createAssistantMessage({</span></span>
+      <span class="src-line">      <span class="src-ln"> 362</span> <span class="src-hl">                content,</span></span>
+      <span class="src-line">      <span class="src-ln"> 363</span> <span class="src-hl">                source: { provider: request.provider, model: request.model },</span></span>
+      <span class="src-line">      <span class="src-ln"> 364</span> <span class="src-hl">              }),</span></span>
+      <span class="src-line">      <span class="src-ln"> 365</span> <span class="src-hl">              interrupted: <span class="src-kw">true</span>,</span></span>
+      <span class="src-line">      <span class="src-ln"> 366</span> <span class="src-hl">              ...assembler.usage === <span class="src-kw">undefined</span> ? {} : { usage: assembler.usage },</span></span>
+      <span class="src-line">      <span class="src-ln"> 367</span> <span class="src-hl">            }, { surfaceOp: &#x27;append&#x27;, sourceEventSeqs: chunkSeqs })</span></span>
+      <span class="src-line">      <span class="src-ln"> 368</span> <span class="src-hl">          }</span></span>
+    </div>
+
+    <div class="lang-zh-only"><p>设计要点：chunk 路径与 surface 路径<strong>故意分离</strong>——Web UI 订阅 <code>session/event</code> 渲染 chunk；<code>deriveMessages()</code> 只看 assistant/message 定稿。这与 Pi 的 message_update 单通道不同。</p></div>
+    <div class="lang-en-only"><p>Design note: chunk path and surface path are <strong>deliberately separate</strong> — Web UI subscribes to <code>session/event</code> for chunk render; <code>deriveMessages()</code> only sees finalized assistant/message. Unlike Pi's single message_update channel.</p></div>
+
+    <div class="note copper">
+      <span class="lang-zh-only">Web 客户端 replay：按 seq 顺序读 assistant/chunk 可重建流式 UI；deriveMessages 跳过 chunk 仍得到正确 model history。</span>
+      <span class="lang-en-only">Web client replay: reading assistant/chunk by seq rebuilds streaming UI; deriveMessages skipping chunks still yields correct model history.</span>
+    </div>
+
+    </div>
+
+    <div class="trace-box">
+      <div class="tb-tag">TRACE · station station chunk</div>
+      <div class="lang-zh-only"><p>站 chunk：流式 chunk。</p></div>
+      <div class="lang-en-only"><p>St. chunk: streaming chunks.</p></div>
+    </div>
+
+    <div class="depth-zone" data-chapter="C15"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C15.4+</span><span class="lang-en-only">Deep dive · C15.4+</span></div>
+
+    </div>
+  </section>
+
+  <section class="chap" id="c16">
+    <div class="chap-num">CHAPTER&nbsp;16&nbsp;·&nbsp;LLM</div>
+    <h2 class="chap-title lang-zh-only">deriveMessages 闭环</h2>
+    <h2 class="chap-title lang-en-only">deriveMessages closed loop</h2>
+    <p class="chap-en lang-zh-only">boundaryMessages → request · reconstructability</p>
+    <p class="chap-en lang-en-only">boundaryMessages → request · reconstructability</p>
+    <nav class="chapter-compass" aria-label="Chapter navigation">
+      <div class="cc-row">
+        <div class="cc-phase"><span class="cc-roman">III</span> · <span class="lang-zh-only">LLM</span><span class="lang-en-only">LLM</span></div>
+        <div class="cc-station"><span class="lang-zh-only">站 18</span><span class="lang-en-only">St. 18</span> · C16/26</div>
+      </div>
+      <div class="cc-forest"><span class="lang-zh-only">deriveMessages 闭环</span><span class="lang-en-only">deriveMessages closed loop</span></div>
+      <div class="cc-links">
+        <a class="cc-nav cc-prev" href="#c15"><span class="cc-arrow">←</span> <span class="cc-nav-num">C15</span> <span class="lang-zh-only">assistant/chunk 流式</span><span class="lang-en-only">assistant/chunk streaming</span></a>
+        <a class="cc-map" href="#forest-overview"><span class="lang-zh-only">回到总览</span><span class="lang-en-only">Forest map</span></a>
+        <a class="cc-nav cc-next" href="#c17"><span class="cc-nav-num">C17</span> <span class="lang-zh-only">ctx.web 能力缝</span><span class="lang-en-only">ctx.web capability seam</span> <span class="cc-arrow">→</span></a>
+      </div>
+    </nav>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>本章回答「这条主线 prompt 在此层长什么样」</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH 没有隐藏魔法——一切可替换行为都在 Cordis 事件或 SessionEvent 里</span></p>
+      <p><span class="swc-pill act">优化</span><span>读源码时先搜 session.append 与 ctx.* 注册点</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>This chapter answers what the through-line prompt looks like at this layer</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH has no hidden magic — replaceable behavior lives in Cordis events or SessionEvents</span></p>
+      <p><span class="swc-pill act">优化</span><span>When reading source, search session.append and ctx.* registration first</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">deriveMessages</span><span class="lang-en-only">deriveMessages</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">packages/core/session</span><span class="lang-en-only">packages/core/session</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">step 边界</span><span class="lang-en-only">step boundary</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">llm request</span><span class="lang-en-only">llm request</span></div>
+      </div>
+    </div>
+
+    <div class="lang-zh-only"><p><code>session.deriveMessages()</code>（<code>packages/core/session/src/index.ts</code>）把 SessionEvent log <strong>投影</strong>成 LLM <code>Message[]</code>——这是 agent-loop 在 <code>agent/request</code> 前调用的唯一历史面。Compaction 替换的是 surface generation，不是 log 本身。</p></div>
+    <div class="lang-en-only"><p><code>session.deriveMessages()</code> (<code>packages/core/session/src/index.ts</code>) <strong>projects</strong> the SessionEvent log into LLM <code>Message[]</code> — the sole history surface agent-loop calls before <code>agent/request</code>. Compaction replaces surface generation, not the log itself.</p></div>
+
+    <h3 class="sub"><span class="sec-num">C16.1</span> <span class="lang-zh-only">投影规则（直觉）</span><span class="lang-en-only">Projection rules (intuition)</span></h3>
+
+    <div class="lang-zh-only"><p>user/message → user role；assistant/message + tool/result 配对 → assistant/tool_result blocks；log-only 事件（title、telemetry）跳过。Fork 会话投影与 fork 点之前父会话一致（<code>session.spec.ts</code> 覆盖）。</p></div>
+    <div class="lang-en-only"><p>user/message → user role; assistant/message paired with tool/result → assistant/tool_result blocks; log-only events (title, telemetry) skipped. Forked sessions project identically to parent before fork point (<code>session.spec.ts</code> coverage).</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/core/session/src/index.ts</span>
+        <span class="src-tag">derive</span>
+      </div>
+      <span class="src-line"><span class="src-fn">deriveMessages</span>(): <span class="src-cls">Message</span>[] {</span>
+      <span class="src-line">  <span class="src-comment">// sole derivation path from append-only log</span></span>
+    </div>
+
+    <div class="formula">
+      <div class="ftitle"><span class="lang-zh-only">投影</span><span class="lang-en-only">PROJECTION</span></div>
+      <span class="cond"><span class="term">SessionEvent[]</span> — canonical log</span>
+      <span class="cond"><span class="term-cu">deriveMessages()</span> → Message[]</span>
+      <span class="cond"><span class="term">llm/stream</span> → provider wire format</span>
+      <div class="out"><span class="lang-zh-only">主线 prompt 在 log 与 projection 各出现一次</span><span class="lang-en-only">Through-line prompt appears once in log and once in projection</span></div>
+    </div>
+
+    <div class="note copper">
+      <span class="lang-zh-only">📘 <strong>架构总览</strong>（<code>docs/architecture.md</code>）· Cordis 插件树、Profile×Bundle 组合、六大 ctx 服务与 turn 流</span>
+      <span class="lang-en-only">📘 <strong>Architecture overview</strong> (<code>docs/architecture.md</code>) · Cordis plugin tree, Profile×Bundle composition, six core ctx services, and turn flow</span>
+    </div>
+
+    <div class="trace-walk">
+      <div class="tw-head">
+        <span class="tw-tag">SOURCE TRACE · C16</span>
+        <span class="lang-zh-only">deriveMessages 闭环：reconstructability 不变量</span>
+        <span class="lang-en-only">deriveMessages closed loop: reconstructability invariant</span>
+      </div>
+
+    <div class="lang-zh-only"><p>DSH 运行时断言：<strong>发给模型的 messages 必须是 deriveMessages() 的纯函数</strong>。<code>markAgentLoopRequest</code> 标记 LOOP-built request 为 deep-frozen；<code>llm/stream</code> listener 可读不可改。step=2 的 deriveMessages 输出必须等于 step=1 结束后 log 的 surface 投影——这是主线 prompt 第二圈 model call 能「看见 README 内容」的根基。</p></div>
+    <div class="lang-en-only"><p>DSH runtime asserts: <strong>messages sent to the model must be a pure function of deriveMessages()</strong>. <code>markAgentLoopRequest</code> marks LOOP-built requests deep-frozen; <code>llm/stream</code> listeners read, never rewrite. Step=2 deriveMessages output must equal surface projection after step=1 — foundation for the through-line's second model call «seeing README content».</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/core/session/src/index.ts</span>
+        <span class="src-tag">derive-cache</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 701</span> <span class="src-hl">  /** The derived-message cache: frozen projections, extended per unseen node. */</span></span>
+      <span class="src-line">      <span class="src-ln"> 702</span> <span class="src-hl">  <span class="src-kw">private</span> derived: Message[] = []</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">derived cache：derivedNodes 增量</span><span class="lang-en-only">derived cache: derivedNodes increment</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 703</span> <span class="src-hl">  /** Surface position (nodes projected) the cache has reached. */</span></span>
+      <span class="src-line">      <span class="src-ln"> 704</span> <span class="src-hl">  <span class="src-kw">private</span> derivedNodes = 0</span></span>
+      <span class="src-line">      <span class="src-ln"> 705</span> <span class="src-hl">  /** {@link SurfaceManager.replaceGeneration} the cache was built under. */</span></span>
+      <span class="src-line">      <span class="src-ln"> 706</span> <span class="src-hl">  <span class="src-kw">private</span> derivedGeneration = 0</span></span>
+      <span class="src-line">      <span class="src-ln"> 707</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 708</span> <span class="src-hl">  /**</span></span>
+      <span class="src-line">      <span class="src-ln"> 709</span> <span class="src-hl">   * Derive the LLM message history by walking the ordered sequences of</span></span>
+      <span class="src-line">      <span class="src-ln"> 710</span> <span class="src-hl">   * message-producing events maintained by <span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`surfaceOp`</span> markers. The</span></span>
+      <span class="src-line">      <span class="src-ln"> 711</span> <span class="src-hl">   * surface is the single source of derived history: every message-producing</span></span>
+      <span class="src-line">      <span class="src-ln"> 712</span> <span class="src-hl">   * append records its <span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`surfaceOp`</span>, so a raw event with no marker (a chunk, a</span></span>
+      <span class="src-line">      <span class="src-ln"> 713</span> <span class="src-hl">   * turn boundary) is correctly absent, and a compaction <span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`replace`</span> deletes the</span></span>
+      <span class="src-line">      <span class="src-ln"> 714</span> <span class="src-hl">   * shadowed nodes <span class="src-kw">from</span> the derivation. The projection rules are</span></span>
+      <span class="src-line">      <span class="src-ln"> 715</span> <span class="src-hl">   * {@link deriveEventMessage}, folded per node.</span></span>
+      <span class="src-line">      <span class="src-ln"> 716</span> <span class="src-hl">   *</span></span>
+      <span class="src-line">      <span class="src-ln"> 717</span> <span class="src-hl">   * CACHED: each surface node is projected exactly once, when first seen — a</span></span>
+      <span class="src-line">      <span class="src-ln"> 718</span> <span class="src-hl">   * call costs O(<span class="src-kw">new</span> nodes), and a surface rewrite (a <span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`replace`</span>;</span></span>
+      <span class="src-line">      <span class="src-ln"> 719</span> <span class="src-hl">   * {@link SessionSurface.replaceGeneration}) rebuilds. The returned array is</span></span>
+      <span class="src-line">      <span class="src-ln"> 720</span> <span class="src-hl">   * a fresh snapshot per call (later appends never grow an array a caller</span></span>
+      <span class="src-line">      <span class="src-ln"> 721</span> <span class="src-hl">   * already holds); the <span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`Message`</span> objects in it are SHARED and **deep-frozen**.</span></span>
+      <span class="src-line">      <span class="src-ln"> 722</span> <span class="src-hl">   * Their content reuses the already frozen durable event data, so the cache</span></span>
+      <span class="src-line">      <span class="src-ln"> 723</span> <span class="src-hl">   * needs no second deep clone and consumers still cannot mutate the log.</span></span>
+      <span class="src-line">      <span class="src-ln"> 724</span> <span class="src-hl">   * @returns a fresh array of the shared, frozen derived history.</span></span>
+      <span class="src-line">      <span class="src-ln"> 725</span> <span class="src-hl">   */</span></span>
+      <span class="src-line">      <span class="src-ln"> 726</span> <span class="src-hl">  deriveMessages(): Message[] {</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">★ deriveMessages 公共 API</span><span class="lang-en-only">★ deriveMessages public API</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 727</span> <span class="src-hl">    <span class="src-kw">const</span> surface = this.surface</span></span>
+      <span class="src-line">      <span class="src-ln"> 728</span> <span class="src-hl">    <span class="src-kw">const</span> nodes = surface.nodes</span></span>
+      <span class="src-line">      <span class="src-ln"> 729</span> <span class="src-hl">    <span class="src-kw">const</span> generation = surface.replaceGeneration</span></span>
+      <span class="src-line">      <span class="src-ln"> 730</span> <span class="src-hl">    <span class="src-kw">if</span> (generation !== this.derivedGeneration) {</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">replaceGeneration 变化 → 全量 rebuild</span><span class="lang-en-only">replaceGeneration change → full rebuild</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 731</span> <span class="src-hl">      this.derived = []</span></span>
+      <span class="src-line">      <span class="src-ln"> 732</span> <span class="src-hl">      this.derivedNodes = 0</span></span>
+      <span class="src-line">      <span class="src-ln"> 733</span> <span class="src-hl">      this.derivedGeneration = generation</span></span>
+      <span class="src-line">      <span class="src-ln"> 734</span> <span class="src-hl">    }</span></span>
+      <span class="src-line">      <span class="src-ln"> 735</span> <span class="src-hl">    <span class="src-kw">for</span> (<span class="src-kw">const</span> seq of nodes.slice(this.derivedNodes)) {</span></span>
+      <span class="src-line">      <span class="src-ln"> 736</span> <span class="src-hl">      <span class="src-comment">// Surface sequences are built from this.log — seq is always a valid</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 737</span> <span class="src-hl">      <span class="src-comment">// index by construction. The non-null assertion expresses that invariant.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 738</span> <span class="src-hl">      <span class="src-comment">// oxlint-disable-next-line typescript/no-non-null-assertion</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 739</span> <span class="src-hl">      <span class="src-kw">const</span> msg = this.deriveEventMessage(this.log[seq]!)</span></span>
+      <span class="src-line">      <span class="src-ln"> 740</span> <span class="src-hl">      <span class="src-comment">// A surface node is one of the five message-producing types, but an</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 741</span> <span class="src-hl">      <span class="src-comment">// empty-content assistant/message (a max-tokens step that hosts only</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 742</span> <span class="src-hl">      <span class="src-comment">// usage) derives to null and must not enter the transcript.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 743</span> <span class="src-hl">      <span class="src-kw">if</span> (msg) this.derived.push(msg)</span></span>
+      <span class="src-line">      <span class="src-ln"> 744</span> <span class="src-hl">    }</span></span>
+      <span class="src-line">      <span class="src-ln"> 745</span> <span class="src-hl">    this.derivedNodes = nodes.length</span></span>
+      <span class="src-line">      <span class="src-ln"> 746</span> <span class="src-hl">    <span class="src-kw">return</span> [...this.derived]</span></span>
+      <span class="src-line">      <span class="src-ln"> 747</span> <span class="src-hl">  }</span></span>
+      <span class="src-line">      <span class="src-ln"> 748</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 749</span> <span class="src-hl">  /**</span></span>
+      <span class="src-line">      <span class="src-ln"> 750</span> <span class="src-hl">   * Instance face of the pure per-node <span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`deriveEventMessage`</span> <span class="src-kw">export</span> <span class="src-kw">from</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 751</span> <span class="src-hl">   * <span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`surface.ts`</span>.</span></span>
+      <span class="src-line">      <span class="src-ln"> 752</span> <span class="src-hl">   * @param event - the event to project.</span></span>
+      <span class="src-line">      <span class="src-ln"> 753</span> <span class="src-hl">   * @returns the derived message, or <span class="src-kw">null</span> when the event produces none.</span></span>
+      <span class="src-line">      <span class="src-ln"> 754</span> <span class="src-hl">   */</span></span>
+      <span class="src-line">      <span class="src-ln"> 755</span> <span class="src-hl">  deriveEventMessage(event: SessionEvent): Message | <span class="src-kw">null</span> {</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">deriveEventMessage 委托 surface.ts</span><span class="lang-en-only">deriveEventMessage delegates to surface.ts</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 756</span> <span class="src-hl">    <span class="src-kw">return</span> deriveEventMessage(event)</span></span>
+      <span class="src-line">      <span class="src-ln"> 757</span> <span class="src-hl">  }</span></span>
+    </div>
+
+    <div class="trace-steps"><div class="ts-label"><span class="lang-zh-only">主线 prompt · deriveMessages 两次投影</span><span class="lang-en-only">Through-line prompt · two deriveMessages projections</span></div>    <table class="cmp">
+      <thead><tr><th>#</th><th>location</th><th>主线时刻 / through-line moment</th></tr></thead>
+      <tbody>
+      <tr><td>P1</td><td>step=1 开始</td><td>[user]</td></tr>
+      <tr><td>P2</td><td>step=1 结束</td><td>[user, assistant(tool-call)]</td></tr>
+      <tr><td>P3</td><td>tool/result 落盘</td><td>[user, assistant, tool-result]</td></tr>
+      <tr><td>P4</td><td>step=2 开始</td><td>deriveMessages → 同上</td></tr>
+      <tr><td>P5</td><td>step=2 结束</td><td>[user, assistant, tool-result, assistant(answer)]</td></tr>
+      </tbody>
+    </table></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/core/agent-loop/src/agent.ts</span>
+        <span class="src-tag">build-boundary</span>
+      </div>
+      <span class="src-line">      <span class="src-ln"> 426</span> <span class="src-hl">  <span class="src-kw">private</span> <span class="src-kw">async</span> buildRequest(</span></span>
+      <span class="src-line">      <span class="src-ln"> 427</span> <span class="src-hl">    turn: number,</span></span>
+      <span class="src-line">      <span class="src-ln"> 428</span> <span class="src-hl">    step: number,</span></span>
+      <span class="src-line">      <span class="src-ln"> 429</span> <span class="src-hl">    tools: GenerateOptions[&#x27;tools&#x27;] &amp; object,</span></span>
+      <span class="src-line">      <span class="src-ln"> 430</span> <span class="src-hl">    system: string,</span></span>
+      <span class="src-line">      <span class="src-ln"> 431</span> <span class="src-hl">    boundaryMessages: Message[],</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">boundaryMessages 参数 = deriveMessages()</span><span class="lang-en-only">boundaryMessages param = deriveMessages()</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 432</span> <span class="src-hl">    signal: AbortSignal,</span></span>
+      <span class="src-line">      <span class="src-ln"> 433</span> <span class="src-hl">  ): Promise&lt;{ request: GenerateOptions; preparedCall?: PreparedLlmCall }&gt; {</span></span>
+      <span class="src-line">      <span class="src-ln"> 434</span> <span class="src-hl">    <span class="src-kw">const</span> { session } = this</span></span>
+      <span class="src-line">      <span class="src-ln"> 435</span> <span class="src-hl"></span></span>
+      <span class="src-line">      <span class="src-ln"> 436</span> <span class="src-hl">    <span class="src-comment">// A loop instance starts from its declared route, restoring only an explicit</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 437</span> <span class="src-hl">    <span class="src-comment">// effort owned by that exact model. Later steps re-resolve marked defaults.</span></span></span>
+      <span class="src-line">      <span class="src-ln"> 438</span> <span class="src-hl">    <span class="src-kw">const</span> persistedHeader = session.requestHeader()</span></span>
+      <span class="src-line">      <span class="src-ln"> 439</span> <span class="src-hl">    <span class="src-kw">const</span> persistedConfig = persistedHeader?.config</span></span>
+      <span class="src-line">      <span class="src-ln"> 440</span> <span class="src-hl">    <span class="src-kw">const</span> route = { provider: this.options.provider ?? &#x27;&#x27;, model: this.options.model ?? &#x27;&#x27; }</span></span>
+      <span class="src-line">      <span class="src-ln"> 441</span> <span class="src-hl">    <span class="src-kw">const</span> reasoningEffort = persistedConfig?.provider === route.provider</span></span>
+      <span class="src-line">      <span class="src-ln"> 442</span> <span class="src-hl">      &amp;&amp; persistedConfig.model === route.model</span></span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/llm/llm/src/index.ts</span>
+        <span class="src-tag">mark-loop</span>
+      </div>
+      <span class="src-line">      <span class="src-ln">  52</span> <span class="src-hl">  <span class="src-kw">interface</span> Events {</span></span>
+      <span class="src-line">      <span class="src-ln">  53</span> <span class="src-hl">    /**</span></span>
+      <span class="src-line">      <span class="src-ln">  54</span> <span class="src-hl">     * Waterfall around every streaming model call (retry, replay, routing).</span></span>
+      <span class="src-line">      <span class="src-ln">  55</span> <span class="src-hl">     * Bound to the {@link LlmRuntime}; call <span <span class="src-kw">class</span>=<span <span class="src-kw">class</span>="src-str">"src-str"</span>>`next()`</span> to reach the resolved</span></span>
+      <span class="src-line">      <span class="src-ln">  56</span> <span class="src-hl">     * adapter&#x27;s stream, or yield your own chunks to short-circuit.</span></span>
+      <span class="src-line">      <span class="src-ln">  57</span> <span class="src-hl">     * @param options - the full request. A LOOP-built request carries the</span> <span class="src-tag">◀ trace</span></span>
+      <span class="src-line">      <span class="src-comment">     ↳ <span class="lang-zh-only">LOOP request deep-frozen · listener 不可 mutate</span><span class="lang-en-only">LOOP request deep-frozen · listeners cannot mutate</span></span></span>
+      <span class="src-line">      <span class="src-ln">  58</span> <span class="src-hl">     *   process-local {@link markAgentLoopRequest} identity and arrives deep-frozen</span></span>
+      <span class="src-line">      <span class="src-ln">  59</span> <span class="src-hl">     *   (mutation throws): its content is a pure <span class="src-kw">function</span> of the session log (the</span></span>
+      <span class="src-line">      <span class="src-ln">  60</span> <span class="src-hl">     *   reconstructability Agent Note), so listeners read it, never rewrite it.</span></span>
+      <span class="src-line">      <span class="src-ln">  61</span> <span class="src-hl">     *   Hand-built calls do not carry that marker; their messages already obey</span></span>
+      <span class="src-line">      <span class="src-ln">  62</span> <span class="src-hl">     *   the immutable creation contract.</span></span>
+      <span class="src-line">      <span class="src-ln">  63</span> <span class="src-hl">     * @mode waterfall</span></span>
+      <span class="src-line">      <span class="src-ln">  64</span> <span class="src-hl">     */</span></span>
+      <span class="src-line">      <span class="src-ln">  65</span> <span class="src-hl">    &#x27;llm/stream&#x27;(this: LlmRuntime, options: GenerateOptions, next: () =&gt; AsyncIterable&lt;StreamChunk&gt;): AsyncIterable&lt;StreamChunk&gt;</span></span>
+      <span class="src-line">      <span class="src-ln">  66</span> <span class="src-hl"></span></span>
+    </div>
+
+    <div class="lang-zh-only"><p>Compaction 走 surface <code>replace</code> 而非删 log——<code>replaceGeneration</code> bump 后 deriveMessages 重建 cache，模型看到摘要版 history，但 JSONL 仍保留完整原始 events。</p></div>
+    <div class="lang-en-only"><p>Compaction uses surface <code>replace</code>, not log deletion — after <code>replaceGeneration</code> bump deriveMessages rebuilds cache; model sees summarized history while JSONL keeps full original events.</p></div>
+
+    <div class="note copper">
+      <span class="lang-zh-only">实验：step=1 结束后打印 <code>session.deriveMessages().length</code>，再 append 一条无 surfaceOp 的 debug event，确认 length 不变。</span>
+      <span class="lang-en-only">Experiment: after step=1 print <code>session.deriveMessages().length</code>, append a debug event without surfaceOp, confirm length unchanged.</span>
+    </div>
+
+    </div>
+
+    <div class="trace-box">
+      <div class="tb-tag">TRACE · station station deriveMessages</div>
+      <div class="lang-zh-only"><p>站 18：每次 model 请求前 deriveMessages() 从 log 投影 history。</p></div>
+      <div class="lang-en-only"><p>St. 18: deriveMessages() projects history from log before each model request.</p></div>
+    </div>
+
+    <div class="depth-zone" data-chapter="C16"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C16.4+</span><span class="lang-en-only">Deep dive · C16.4+</span></div>
+
+    </div>
+  </section>
+
+  <section class="chap" id="c17">
+    <div class="chap-num">CHAPTER&nbsp;17&nbsp;·&nbsp;WEB</div>
+    <h2 class="chap-title lang-zh-only">ctx.web 能力缝</h2>
+    <h2 class="chap-title lang-en-only">ctx.web capability seam</h2>
+    <p class="chap-en lang-zh-only">search · fetch · Service Definition</p>
+    <p class="chap-en lang-en-only">search · fetch · Service Definition</p>
+    <nav class="chapter-compass" aria-label="Chapter navigation">
+      <div class="cc-row">
+        <div class="cc-phase"><span class="cc-roman">IV</span> · <span class="lang-zh-only">Web</span><span class="lang-en-only">Web</span></div>
+        <div class="cc-station"><span class="lang-zh-only">站 19</span><span class="lang-en-only">St. 19</span> · C17/26</div>
+      </div>
+      <div class="cc-forest"><span class="lang-zh-only">ctx.web 能力缝</span><span class="lang-en-only">ctx.web capability seam</span></div>
+      <div class="cc-links">
+        <a class="cc-nav cc-prev" href="#c16"><span class="cc-arrow">←</span> <span class="cc-nav-num">C16</span> <span class="lang-zh-only">deriveMessages 闭环</span><span class="lang-en-only">deriveMessages closed loop</span></a>
+        <a class="cc-map" href="#forest-overview"><span class="lang-zh-only">回到总览</span><span class="lang-en-only">Forest map</span></a>
+        <a class="cc-nav cc-next" href="#c18"><span class="cc-nav-num">C18</span> <span class="lang-zh-only">tool-web Consumer</span><span class="lang-en-only">tool-web consumer</span> <span class="cc-arrow">→</span></a>
+      </div>
+    </nav>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>本章回答「这条主线 prompt 在此层长什么样」</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH 没有隐藏魔法——一切可替换行为都在 Cordis 事件或 SessionEvent 里</span></p>
+      <p><span class="swc-pill act">优化</span><span>读源码时先搜 session.append 与 ctx.* 注册点</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>This chapter answers what the through-line prompt looks like at this layer</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH has no hidden magic — replaceable behavior lives in Cordis events or SessionEvents</span></p>
+      <p><span class="swc-pill act">优化</span><span>When reading source, search session.append and ctx.* registration first</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">web</span><span class="lang-en-only">web</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">web</span><span class="lang-en-only">web</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">packages/web</span><span class="lang-en-only">packages/web</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">ctx.web</span><span class="lang-en-only">ctx.web</span></div>
+      </div>
+    </div>
+
+    <div class="lang-zh-only"><p>Web client（<code>packages/web</code> + <code>packages/client</code>）订阅 <code>session/event</code> replay 流，把 <code>user/message</code>、<code>assistant/chunk</code>、<code>tool/call</code>、<code>tool/result</code> 渲染为聊天气泡与 tool 卡片。Host（<code>packages/host</code>）提供同源静态资源与 API 代理。</p></div>
+    <div class="lang-en-only"><p>The Web client (<code>packages/web</code> + <code>packages/client</code>) subscribes to the <code>session/event</code> replay stream, rendering <code>user/message</code>, <code>assistant/chunk</code>, <code>tool/call</code>, <code>tool/result</code> as chat bubbles and tool cards. Host (<code>packages/host</code>) serves same-origin static assets and API proxy.</p></div>
+
+    <h3 class="sub"><span class="sec-num">C17.1</span> <span class="lang-zh-only">session/event 驱动渲染</span><span class="lang-en-only">session/event-driven rendering</span></h3>
+
+    <table class="cmp">
+      <thead><tr><th>SessionEvent</th><th>UI 组件</th><th>流式?</th></tr></thead>
+      <tbody>
+      <tr><td>user/message</td><td>User bubble</td><td>✗</td></tr>
+      <tr><td>assistant/chunk</td><td>Assistant bubble delta</td><td>✓</td></tr>
+      <tr><td>tool/call</td><td>Pending tool card</td><td>✗</td></tr>
+      <tr><td>tool/result</td><td>Completed tool card</td><td>✗</td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="sec-num">C17.2</span> <span class="lang-zh-only">为何 UI 不直接听 agent/*</span><span class="lang-en-only">Why UI does not listen to agent/* directly</span></h3>
+
+    <div class="lang-zh-only"><p>SDK 文档明确：需要可回放 transcript 的消费方应使用 <code>session/event</code>；<code>agent/*</code> 用于 queue/status、prompt 拦截、steering。Web UI 刷新后必须从 log replay 重建，而非重建 agent 内存态。</p></div>
+    <div class="lang-en-only"><p>SDK docs are explicit: consumers needing replayable transcript should use <code>session/event</code>; <code>agent/*</code> is for queue/status, prompt interception, steering. After a Web UI refresh, rebuild from log replay, not from agent memory state.</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/web/README.md</span>
+        <span class="src-tag">web</span>
+      </div>
+      <span class="src-line">Default profile <span class="src-str">web</span> · loopback <span class="src-str">:3080</span></span>
+      <span class="src-line">Session list + event stream rendering</span>
+    </div>
+
+    <div class="trace-box">
+      <div class="tb-tag">TRACE · station station web</div>
+      <div class="lang-zh-only"><p>站 web：Web 能力。</p></div>
+      <div class="lang-en-only"><p>St. web: Web capability.</p></div>
+    </div>
+
+    <div class="depth-zone" data-chapter="C17"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C17.4+</span><span class="lang-en-only">Deep dive · C17.4+</span></div>
+
+    </div>
+  </section>
+
+  <section class="chap" id="c18">
+    <div class="chap-num">CHAPTER&nbsp;18&nbsp;·&nbsp;WEB</div>
+    <h2 class="chap-title lang-zh-only">tool-web Consumer</h2>
+    <h2 class="chap-title lang-en-only">tool-web consumer</h2>
+    <p class="chap-en lang-zh-only">模型调网络的最后一站</p>
+    <p class="chap-en lang-en-only">last station before the model hits the network</p>
+    <nav class="chapter-compass" aria-label="Chapter navigation">
+      <div class="cc-row">
+        <div class="cc-phase"><span class="cc-roman">IV</span> · <span class="lang-zh-only">Web</span><span class="lang-en-only">Web</span></div>
+        <div class="cc-station"><span class="lang-zh-only">站 20</span><span class="lang-en-only">St. 20</span> · C18/26</div>
+      </div>
+      <div class="cc-forest"><span class="lang-zh-only">tool-web Consumer</span><span class="lang-en-only">tool-web consumer</span></div>
+      <div class="cc-links">
+        <a class="cc-nav cc-prev" href="#c17"><span class="cc-arrow">←</span> <span class="cc-nav-num">C17</span> <span class="lang-zh-only">ctx.web 能力缝</span><span class="lang-en-only">ctx.web capability seam</span></a>
+        <a class="cc-map" href="#forest-overview"><span class="lang-zh-only">回到总览</span><span class="lang-en-only">Forest map</span></a>
+        <a class="cc-nav cc-next" href="#c19"><span class="cc-nav-num">C19</span> <span class="lang-zh-only">Cordis 插件面</span><span class="lang-en-only">Cordis plugin surface</span> <span class="cc-arrow">→</span></a>
+      </div>
+    </nav>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>本章回答「这条主线 prompt 在此层长什么样」</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH 没有隐藏魔法——一切可替换行为都在 Cordis 事件或 SessionEvent 里</span></p>
+      <p><span class="swc-pill act">优化</span><span>读源码时先搜 session.append 与 ctx.* 注册点</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>This chapter answers what the through-line prompt looks like at this layer</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH has no hidden magic — replaceable behavior lives in Cordis events or SessionEvents</span></p>
+      <p><span class="swc-pill act">优化</span><span>When reading source, search session.append and ctx.* registration first</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">tool-web</span><span class="lang-en-only">tool-web</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">tool-web</span><span class="lang-en-only">tool-web</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">packages/tool-web</span><span class="lang-en-only">packages/tool-web</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">consumer</span><span class="lang-en-only">consumer</span></div>
+      </div>
+    </div>
+
+    <div class="lang-zh-only"><p>Web surface 的 chat 节点与 settings 卡片是独立前端包（<code>packages/web</code>）里的 React 组件：输入框提交 → API → <code>agent.followup</code>；设置页写入 <code>settings.yaml</code> 与 credential store，触发 <code>settings/updated</code> 与 adapter 热重载。</p></div>
+    <div class="lang-en-only"><p>Chat nodes and settings cards on the Web surface are React components in <code>packages/web</code>: input submit → API → <code>agent.followup</code>; settings pages write <code>settings.yaml</code> and credential store, firing <code>settings/updated</code> and adapter hot-reload.</p></div>
+
+    <h3 class="sub"><span class="sec-num">C18.1</span> <span class="lang-zh-only">Chat 提交路径</span><span class="lang-en-only">Chat submit path</span></h3>
+
+    <div class="ladder">
+      <div class="ld-row">
+        <div class="ld-num">01</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">Browser input</span><span class="lang-en-only">主线 prompt 文本</span></div>
+
+        </div>
+      </div>
+      <div class="ld-row">
+        <div class="ld-num">02</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">Host API</span><span class="lang-en-only">packages/host · same-origin</span></div>
+
+        </div>
+      </div>
+      <div class="ld-row">
+        <div class="ld-num">03</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">agent.followup</span><span class="lang-en-only">inbox inserted</span></div>
+
+        </div>
+      </div>
+      <div class="ld-row">
+        <div class="ld-num">04</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">session/event</span><span class="lang-en-only">UI optimistic + replay</span></div>
+
+        </div>
+      </div>
+    </div>
+
+    <h3 class="sub"><span class="sec-num">C18.2</span> <span class="lang-zh-only">Settings 卡片触达的 backend</span><span class="lang-en-only">Backend touched by settings cards</span></h3>
+
+    <table class="cmp">
+      <thead><tr><th>Settings UI</th><th>写入</th><th>Cordis 响应</th></tr></thead>
+      <tbody>
+      <tr><td>Models</td><td>settings.yaml llm-*</td><td>llm/adapters-updated</td></tr>
+      <tr><td>Credentials</td><td>.credentials.yaml</td><td>credentials/record-updated</td></tr>
+      <tr><td>Permissions</td><td>approval preset</td><td>user-approval</td></tr>
+      <tr><td>Profile plugins</td><td>dsh plugin add</td><td>HMR recomposes tree</td></tr>
+      </tbody>
+    </table>
+
+    <div class="stage-purpose">
+      <div class="sp-row">
+        <div class="sp-key"><span class="lang-zh-only">:3080</span><span class="lang-en-only">:3080</span></div>
+        <div class="sp-val"><span class="lang-zh-only">默认 loopback · 可 --port</span><span class="lang-en-only">default loopback · --port overridable</span></div>
+      </div>
+      <div class="sp-row">
+        <div class="sp-key"><span class="lang-zh-only">headless</span><span class="lang-en-only">headless</span></div>
+        <div class="sp-val"><span class="lang-zh-only">无 UI · stdout 最终回答</span><span class="lang-en-only">no UI · stdout final answer</span></div>
+      </div>
+      <div class="sp-row">
+        <div class="sp-key"><span class="lang-zh-only">ACP</span><span class="lang-en-only">ACP</span></div>
+        <div class="sp-val"><span class="lang-zh-only">packages/acp · IDE 集成</span><span class="lang-en-only">packages/acp · IDE integration</span></div>
+      </div>
+    </div>
+
+    <div class="trace-box">
+      <div class="tb-tag">TRACE · station station tool-web</div>
+      <div class="lang-zh-only"><p>站 tool-web：模型调网。</p></div>
+      <div class="lang-en-only"><p>St. tool-web: model hits network.</p></div>
+    </div>
+
+    <div class="depth-zone" data-chapter="C18"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C18.4+</span><span class="lang-en-only">Deep dive · C18.4+</span></div>
+
+    </div>
+  </section>
+
+  <section class="chap" id="c19">
+    <div class="chap-num">CHAPTER&nbsp;19&nbsp;·&nbsp;EXTENSIONS</div>
+    <h2 class="chap-title lang-zh-only">Cordis 插件面</h2>
+    <h2 class="chap-title lang-en-only">Cordis plugin surface</h2>
+    <p class="chap-en lang-zh-only">inject · Service · Events · effects</p>
+    <p class="chap-en lang-en-only">inject · Service · Events · effects</p>
+    <nav class="chapter-compass" aria-label="Chapter navigation">
+      <div class="cc-row">
+        <div class="cc-phase"><span class="cc-roman">V</span> · <span class="lang-zh-only">扩展</span><span class="lang-en-only">Extensions</span></div>
+        <div class="cc-station"><span class="lang-zh-only">—</span><span class="lang-en-only">—</span> · C19/26</div>
+      </div>
+      <div class="cc-forest"><span class="lang-zh-only">Cordis 插件面</span><span class="lang-en-only">Cordis plugin surface</span></div>
+      <div class="cc-links">
+        <a class="cc-nav cc-prev" href="#c18"><span class="cc-arrow">←</span> <span class="cc-nav-num">C18</span> <span class="lang-zh-only">tool-web Consumer</span><span class="lang-en-only">tool-web consumer</span></a>
+        <a class="cc-map" href="#forest-overview"><span class="lang-zh-only">回到总览</span><span class="lang-en-only">Forest map</span></a>
+        <a class="cc-nav cc-next" href="#c20"><span class="cc-nav-num">C20</span> <span class="lang-zh-only">Loader 与 bundle</span><span class="lang-en-only">Loader and bundle</span> <span class="cc-arrow">→</span></a>
+      </div>
+    </nav>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>本章回答「这条主线 prompt 在此层长什么样」</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH 没有隐藏魔法——一切可替换行为都在 Cordis 事件或 SessionEvent 里</span></p>
+      <p><span class="swc-pill act">优化</span><span>读源码时先搜 session.append 与 ctx.* 注册点</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>This chapter answers what the through-line prompt looks like at this layer</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH has no hidden magic — replaceable behavior lives in Cordis events or SessionEvents</span></p>
+      <p><span class="swc-pill act">优化</span><span>When reading source, search session.append and ctx.* registration first</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">extensions</span><span class="lang-en-only">extensions</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">extensions</span><span class="lang-en-only">extensions</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">Cordis</span><span class="lang-en-only">Cordis</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">inject</span><span class="lang-en-only">inject</span></div>
+      </div>
+    </div>
+
+    <div class="lang-zh-only"><p>官方 monorepo 有 200+ workspace 包（<code>packages/README.md</code>），社区可通过 <code>dsh plugin --profile &lt;name&gt; add &lt;pkg&gt;</code> 把 npm/git 包加入 profile。包 manifest 声明 <code>dsh.bundle.patch</code> 时自动进入 bundle 层栈。</p></div>
+    <div class="lang-en-only"><p>The official monorepo has 200+ workspace packages (<code>packages/README.md</code>); the community adds npm/git packages via <code>dsh plugin --profile &lt;name&gt; add &lt;pkg&gt;</code>. When a package manifest declares <code>dsh.bundle.patch</code>, it joins the bundle layer stack automatically.</p></div>
+
+    <h3 class="sub"><span class="sec-num">C19.1</span> <span class="lang-zh-only">插件形态</span><span class="lang-en-only">Plugin shapes</span></h3>
+
+    <table class="cmp">
+      <thead><tr><th>形态</th><th>例子</th><th>扩展点</th></tr></thead>
+      <tbody>
+      <tr><td>core plugin</td><td>dsh-session</td><td>claim ctx.sessions</td></tr>
+      <tr><td>tool plugin</td><td>tool-bash · tool-fs</td><td>ctx.tools.register</td></tr>
+      <tr><td>capability</td><td>dsh-sandbox-local</td><td>ctx.sandbox seam</td></tr>
+      <tr><td>bundle</td><td>dsh-web-app</td><td>cordis.patch.yml insert</td></tr>
+      <tr><td>MCP</td><td>packages/mcp/*</td><td>外部工具协议</td></tr>
+      </tbody>
+    </table>
+
+    <figure>
+      <div class="figbox"><div class="pi-fig wide"><svg viewBox="0 0 720 160" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true" class="pi-svg">
+  <defs>
+    <marker id="pi-arr" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 Z" fill="#1f5c8c"/>
+    </marker>
+  </defs>
+  <text x="24" y="28" class="svg-label">DSH PLUGIN ECOSYSTEM</text>
+  <rect x="24" y="44" width="160" height="56" rx="4" class="svg-box accent"/>
+  <text x="104" y="68" text-anchor="middle" class="svg-body">core/*</text>
+  <text x="104" y="86" text-anchor="middle" class="svg-mute">session · loop</text>
+  <rect x="200" y="44" width="160" height="56" rx="4" class="svg-box gpu"/>
+  <text x="280" y="68" text-anchor="middle" class="svg-body">capability</text>
+  <text x="280" y="86" text-anchor="middle" class="svg-mute">fs · shell · mcp</text>
+  <rect x="376" y="44" width="160" height="56" rx="4" class="svg-box copper"/>
+  <text x="456" y="68" text-anchor="middle" class="svg-body">bundle</text>
+  <text x="456" y="86" text-anchor="middle" class="svg-mute">base · web · headless</text>
+  <rect x="552" y="44" width="144" height="56" rx="4" class="svg-box muted"/>
+  <text x="624" y="68" text-anchor="middle" class="svg-body">community</text>
+  <text x="624" y="86" text-anchor="middle" class="svg-mute">npm · git patch</text>
+  <text x="360" y="140" text-anchor="middle" class="svg-mute">everything mounts through Cordis · no privileged core</text>
+</svg></div></div>
+      <figcaption>
+        <span class="figid">FIG</span>
+        <span class="lang-zh-only">插件光谱：core 脊柱、capability seam、官方 bundle、社区 npm/git 包共享同一 Cordis 树。</span>
+        <span class="lang-en-only">Plugin spectrum: core spine, capability seams, official bundles, community npm/git packages share one Cordis tree.</span>
+      </figcaption>
+    </figure>
+
+    <h3 class="sub"><span class="sec-num">C19.2</span> <span class="lang-zh-only">发布自己的插件</span><span class="lang-en-only">Publishing your own plugin</span></h3>
+
+    <div class="lang-zh-only"><p><code>docs/user/develop/basic/publish.md</code>：manifest 加 <code>dsh.bundle</code> 或作为 plain dependency；用户可在 profile <code>cordis.patch.yml</code> 按 id 覆盖你的行而无需改包。</p></div>
+    <div class="lang-en-only"><p><code>docs/user/develop/basic/publish.md</code>: add <code>dsh.bundle</code> to manifest or ship as plain dependency; users can override your rows by id in profile <code>cordis.patch.yml</code> without touching your package.</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; docs/user/develop/basic/publish.md</span>
+        <span class="src-tag">pub</span>
+      </div>
+      <span class="src-line">Users can override your rows in profile <code>cordis.patch.yml</code></span>
+      <span class="src-line">without touching your package.</span>
+    </div>
+
+    <div class="trace-box">
+      <div class="tb-tag">TRACE · station station extensions</div>
+      <div class="lang-zh-only"><p>站 extensions：插件 API。</p></div>
+      <div class="lang-en-only"><p>St. extensions: plugin API.</p></div>
+    </div>
+
+    <div class="depth-zone" data-chapter="C19"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C19.4+</span><span class="lang-en-only">Deep dive · C19.4+</span></div>
+
+    </div>
+  </section>
+
+  <section class="chap" id="c20">
+    <div class="chap-num">CHAPTER&nbsp;20&nbsp;·&nbsp;EXTENSIONS</div>
+    <h2 class="chap-title lang-zh-only">Loader 与 bundle</h2>
+    <h2 class="chap-title lang-en-only">Loader and bundle</h2>
+    <p class="chap-en lang-zh-only">dsh-base · web-app · headless 层叠</p>
+    <p class="chap-en lang-en-only">dsh-base · web-app · headless stack</p>
+    <nav class="chapter-compass" aria-label="Chapter navigation">
+      <div class="cc-row">
+        <div class="cc-phase"><span class="cc-roman">V</span> · <span class="lang-zh-only">扩展</span><span class="lang-en-only">Extensions</span></div>
+        <div class="cc-station"><span class="lang-zh-only">—</span><span class="lang-en-only">—</span> · C20/26</div>
+      </div>
+      <div class="cc-forest"><span class="lang-zh-only">Loader 与 bundle</span><span class="lang-en-only">Loader and bundle</span></div>
+      <div class="cc-links">
+        <a class="cc-nav cc-prev" href="#c19"><span class="cc-arrow">←</span> <span class="cc-nav-num">C19</span> <span class="lang-zh-only">Cordis 插件面</span><span class="lang-en-only">Cordis plugin surface</span></a>
+        <a class="cc-map" href="#forest-overview"><span class="lang-zh-only">回到总览</span><span class="lang-en-only">Forest map</span></a>
+        <a class="cc-nav cc-next" href="#c21"><span class="cc-nav-num">C21</span> <span class="lang-zh-only">cordis.patch 组合</span><span class="lang-en-only">cordis.patch composition</span> <span class="cc-arrow">→</span></a>
+      </div>
+    </nav>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>本章回答「这条主线 prompt 在此层长什么样」</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH 没有隐藏魔法——一切可替换行为都在 Cordis 事件或 SessionEvent 里</span></p>
+      <p><span class="swc-pill act">优化</span><span>读源码时先搜 session.append 与 ctx.* 注册点</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>This chapter answers what the through-line prompt looks like at this layer</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH has no hidden magic — replaceable behavior lives in Cordis events or SessionEvents</span></p>
+      <p><span class="swc-pill act">优化</span><span>When reading source, search session.append and ctx.* registration first</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">loader</span><span class="lang-en-only">loader</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">loader</span><span class="lang-en-only">loader</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">packages/bundle</span><span class="lang-en-only">packages/bundle</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">dsh-base</span><span class="lang-en-only">dsh-base</span></div>
+      </div>
+    </div>
+
+    <div class="lang-zh-only"><p>Capability seams 把「能做什么」从 loop 里拆出来：<code>ctx.fs</code>（<code>packages/fs/fs</code>）、<code>ctx.shell</code>（bash/pwsh 栈）、<code>ctx.sandbox</code>（策略 + 平台 runner）。换 seam 实现 = 换 patch 行，无需 fork agent-loop。</p></div>
+    <div class="lang-en-only"><p>Capability seams separate «what can be done» from the loop: <code>ctx.fs</code> (<code>packages/fs/fs</code>), <code>ctx.shell</code> (bash/pwsh stacks), <code>ctx.sandbox</code> (policy + platform runners). Swap seam implementation = swap patch row, no agent-loop fork needed.</p></div>
+
+    <h3 class="sub"><span class="sec-num">C20.1</span> <span class="lang-zh-only">fs · shell · sandbox 三角</span><span class="lang-en-only">fs · shell · sandbox triangle</span></h3>
+
+    <table class="cmp">
+      <thead><tr><th>Seam</th><th>默认实现</th><th>policy 事件</th></tr></thead>
+      <tbody>
+      <tr><td>ctx.fs</td><td>fs-sandbox + tool-fs</td><td>fs/write-intent · fs/observed</td></tr>
+      <tr><td>ctx.shell</td><td>tool-bash / tool-pwsh</td><td>sandbox approval</td></tr>
+      <tr><td>ctx.sandbox</td><td>dsh-sandbox-local / windows-acl</td><td>danger-full-access 等 preset</td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="sec-num">C20.2</span> <span class="lang-zh-only">read README 经过哪些 seam</span><span class="lang-en-only">Which seams read README passes through</span></h3>
+
+    <div class="lang-zh-only"><p>主线 read 走 <code>tool-fs</code> → <code>fs/read</code> capability → <code>fs-observation-policy</code> 可能要求先 observe 再 write。bash 工具走 shell + sandbox approval，与 read 并行安全策略不同。</p></div>
+    <div class="lang-en-only"><p>Through-line read goes <code>tool-fs</code> → <code>fs/read</code> capability → <code>fs-observation-policy</code> may require observe-before-write. Bash tools go through shell + sandbox approval — parallel safety policy differs from read.</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; docs/capability-seams.md</span>
+        <span class="src-tag">seams</span>
+      </div>
+      <span class="src-line">A service can be a core spine service, a swappable capability seam,</span>
+      <span class="src-line">or a bundle/composition point.</span>
+    </div>
+
+    <div class="note copper">
+      <span class="lang-zh-only">📘 <strong>能力接缝图</strong>（<code>docs/capability-seams.md</code>）· ctx.fs / ctx.shell / ctx.sandbox 等可替换 seam 与实现包映射</span>
+      <span class="lang-en-only">📘 <strong>Capability seams</strong> (<code>docs/capability-seams.md</code>) · Swappable seams (ctx.fs, ctx.shell, ctx.sandbox) and implementation packages</span>
+    </div>
+
+    <div class="trace-box">
+      <div class="tb-tag">TRACE · station station loader</div>
+      <div class="lang-zh-only"><p>站 loader：bundle 层叠。</p></div>
+      <div class="lang-en-only"><p>St. loader: bundle stack.</p></div>
+    </div>
+
+    <div class="depth-zone" data-chapter="C20"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C20.4+</span><span class="lang-en-only">Deep dive · C20.4+</span></div>
+
+    </div>
+  </section>
+
+  <section class="chap" id="c21">
+    <div class="chap-num">CHAPTER&nbsp;21&nbsp;·&nbsp;EXTENSIONS</div>
+    <h2 class="chap-title lang-zh-only">cordis.patch 组合</h2>
+    <h2 class="chap-title lang-en-only">cordis.patch composition</h2>
+    <p class="chap-en lang-zh-only">替换任意 plugin row · --dump-config</p>
+    <p class="chap-en lang-en-only">replace any plugin row · --dump-config</p>
+    <nav class="chapter-compass" aria-label="Chapter navigation">
+      <div class="cc-row">
+        <div class="cc-phase"><span class="cc-roman">V</span> · <span class="lang-zh-only">扩展</span><span class="lang-en-only">Extensions</span></div>
+        <div class="cc-station"><span class="lang-zh-only">—</span><span class="lang-en-only">—</span> · C21/26</div>
+      </div>
+      <div class="cc-forest"><span class="lang-zh-only">cordis.patch 组合</span><span class="lang-en-only">cordis.patch composition</span></div>
+      <div class="cc-links">
+        <a class="cc-nav cc-prev" href="#c20"><span class="cc-arrow">←</span> <span class="cc-nav-num">C20</span> <span class="lang-zh-only">Loader 与 bundle</span><span class="lang-en-only">Loader and bundle</span></a>
+        <a class="cc-map" href="#forest-overview"><span class="lang-zh-only">回到总览</span><span class="lang-en-only">Forest map</span></a>
+        <a class="cc-nav cc-next" href="#c22"><span class="cc-nav-num">C22</span> <span class="lang-zh-only">SessionEvent JSONL</span><span class="lang-en-only">SessionEvent JSONL</span> <span class="cc-arrow">→</span></a>
+      </div>
+    </nav>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>本章回答「这条主线 prompt 在此层长什么样」</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH 没有隐藏魔法——一切可替换行为都在 Cordis 事件或 SessionEvent 里</span></p>
+      <p><span class="swc-pill act">优化</span><span>读源码时先搜 session.append 与 ctx.* 注册点</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>This chapter answers what the through-line prompt looks like at this layer</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH has no hidden magic — replaceable behavior lives in Cordis events or SessionEvents</span></p>
+      <p><span class="swc-pill act">优化</span><span>When reading source, search session.append and ctx.* registration first</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">patch</span><span class="lang-en-only">patch</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">patch</span><span class="lang-en-only">patch</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">cordis.patch.yml</span><span class="lang-en-only">cordis.patch.yml</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">overlay</span><span class="lang-en-only">overlay</span></div>
+      </div>
+    </div>
+
+    <div class="lang-zh-only"><p>Customization 发生在 patch 层，不是 fork monorepo：<code>profiles/&lt;name&gt;/cordis.patch.yml</code> 按 id 覆盖 bundle 行；<code>$DSH_HOME/cordis.patch.yml</code> 机器级；<code>--patch</code> 一次性。HMR（<code>cordis-plugin-hmr</code>）可在 dev 时热重载 patch。</p></div>
+    <div class="lang-en-only"><p>Customization happens at the patch layer, not by forking the monorepo: <code>profiles/&lt;name&gt;/cordis.patch.yml</code> overrides bundle rows by id; <code>$DSH_HOME/cordis.patch.yml</code> is machine-wide; <code>--patch</code> is one-shot. HMR (<code>cordis-plugin-hmr</code>) can hot-reload patches in dev.</p></div>
+
+    <h3 class="sub"><span class="sec-num">C21.1</span> <span class="lang-zh-only">Patch 纪律</span><span class="lang-en-only">Patch discipline</span></h3>
+
+    <div class="lang-zh-only"><p>覆盖一行必须<strong>重述整行 config</strong>——不是 deep-merge。例如 Windows 恢复 bash 栈：必须同时 disable pwsh 行并 re-enable bash 行，否则 duplicate service 注册 fail loud。</p></div>
+    <div class="lang-en-only"><p>Overriding a row must <strong>restate the entire row config</strong> — no deep-merge. E.g. restoring bash stack on Windows: disable pwsh rows AND re-enable bash rows, otherwise duplicate service registration fails loud.</p></div>
+
+    <table class="cmp">
+      <thead><tr><th>层</th><th>路径</th><th>典型用途</th></tr></thead>
+      <tbody>
+      <tr><td>bundle</td><td>packages/bundle/*/cordis.patch.yml</td><td>官方能力组合</td></tr>
+      <tr><td>profile</td><td>$DSH_HOME/profiles/web/cordis.patch.yml</td><td>用户 profile 定制</td></tr>
+      <tr><td>home</td><td>$DSH_HOME/cordis.patch.yml</td><td>机器级 override</td></tr>
+      <tr><td>CLI</td><td>--patch file.yml</td><td>CI 一次性</td></tr>
+      </tbody>
+    </table>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/boot/app-boot/README.md</span>
+        <span class="src-tag">watch</span>
+      </div>
+      <span class="src-line"><span class="src-fn">watchUserPatches</span>(ctx, options)</span>
+      <span class="src-line">Rejected patch leaves last good tree running.</span>
+    </div>
+
+    <div class="note copper">
+      <span class="lang-zh-only">📘 <strong>架构总览</strong>（<code>docs/architecture.md</code>）· Cordis 插件树、Profile×Bundle 组合、六大 ctx 服务与 turn 流</span>
+      <span class="lang-en-only">📘 <strong>Architecture overview</strong> (<code>docs/architecture.md</code>) · Cordis plugin tree, Profile×Bundle composition, six core ctx services, and turn flow</span>
+    </div>
+
+    <div class="trace-box">
+      <div class="tb-tag">TRACE · station station patch</div>
+      <div class="lang-zh-only"><p>站 patch：组合定制。</p></div>
+      <div class="lang-en-only"><p>St. patch: composition customize.</p></div>
+    </div>
+
+    <div class="depth-zone" data-chapter="C21"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C21.4+</span><span class="lang-en-only">Deep dive · C21.4+</span></div>
+
+    </div>
+  </section>
+
+  <section class="chap" id="c22">
+    <div class="chap-num">CHAPTER&nbsp;22&nbsp;·&nbsp;PERSISTENCE</div>
+    <h2 class="chap-title lang-zh-only">SessionEvent JSONL</h2>
+    <h2 class="chap-title lang-en-only">SessionEvent JSONL</h2>
+    <p class="chap-en lang-zh-only">seq 连续 · fork · session/flush</p>
+    <p class="chap-en lang-en-only">contiguous seq · fork · session/flush</p>
+    <nav class="chapter-compass" aria-label="Chapter navigation">
+      <div class="cc-row">
+        <div class="cc-phase"><span class="cc-roman">VI</span> · <span class="lang-zh-only">持久化</span><span class="lang-en-only">Persistence</span></div>
+        <div class="cc-station"><span class="lang-zh-only">站 21</span><span class="lang-en-only">St. 21</span> · C22/26</div>
+      </div>
+      <div class="cc-forest"><span class="lang-zh-only">SessionEvent JSONL</span><span class="lang-en-only">SessionEvent JSONL on disk</span></div>
+      <div class="cc-links">
+        <a class="cc-nav cc-prev" href="#c21"><span class="cc-arrow">←</span> <span class="cc-nav-num">C21</span> <span class="lang-zh-only">cordis.patch 组合</span><span class="lang-en-only">cordis.patch composition</span></a>
+        <a class="cc-map" href="#forest-overview"><span class="lang-zh-only">回到总览</span><span class="lang-en-only">Forest map</span></a>
+        <a class="cc-nav cc-next" href="#c23"><span class="cc-nav-num">C23</span> <span class="lang-zh-only">Compaction 与 surface</span><span class="lang-en-only">Compaction and surface replace</span> <span class="cc-arrow">→</span></a>
+      </div>
+    </nav>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>本章回答「这条主线 prompt 在此层长什么样」</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH 没有隐藏魔法——一切可替换行为都在 Cordis 事件或 SessionEvent 里</span></p>
+      <p><span class="swc-pill act">优化</span><span>读源码时先搜 session.append 与 ctx.* 注册点</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>This chapter answers what the through-line prompt looks like at this layer</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH has no hidden magic — replaceable behavior lives in Cordis events or SessionEvents</span></p>
+      <p><span class="swc-pill act">优化</span><span>When reading source, search session.append and ctx.* registration first</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">persist</span><span class="lang-en-only">persist</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">persist</span><span class="lang-en-only">persist</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">session</span><span class="lang-en-only">session</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">JSONL</span><span class="lang-en-only">JSONL</span></div>
+      </div>
+    </div>
+
+    <div class="lang-zh-only"><p>Session fork/resume（<code>packages/session/session-persistence*</code>、subagent fork tools）从某一 log 点创建分支会话，子会话 append 独立事件链。Resume 重放 persistence 存储的 log，<code>deriveMessages()</code> 确定性重建模型历史。</p></div>
+    <div class="lang-en-only"><p>Session fork/resume (<code>packages/session/session-persistence*</code>, subagent fork tools) creates branch sessions from a log point; child sessions append independent event chains. Resume replays persisted log; <code>deriveMessages()</code> deterministically rebuilds model history.</p></div>
+
+    <h3 class="sub"><span class="sec-num">C22.1</span> <span class="lang-zh-only">Fork 语义</span><span class="lang-en-only">Fork semantics</span></h3>
+
+    <div class="lang-zh-only"><p>Fork 复制 log 前缀而非 agent 内存；子 agent（<code>packages/subagent/subagent</code>）可用 in-process driver 或独立 profile。父会话可 park 等待子 agent report——全程仍通过 session/agent 事件可观测。</p></div>
+    <div class="lang-en-only"><p>Fork copies log prefix, not agent memory; child agents (<code>packages/subagent/subagent</code>) may use in-process driver or separate profile. Parent can park awaiting child report — still observable via session/agent events throughout.</p></div>
+
+    <table class="cmp">
+      <thead><tr><th>操作</th><th>API/工具</th><th>log 效果</th></tr></thead>
+      <tbody>
+      <tr><td>fork session</td><td>subagent_fork tool</td><td>新 session id · 共享前缀</td></tr>
+      <tr><td>resume</td><td>headless --resume</td><td>重放 JSONL/SQLite</td></tr>
+      <tr><td>checkpoint</td><td>session-checkpoint-policy</td><td>副作用前强制 persist</td></tr>
+      </tbody>
+    </table>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/session/session-persistence-jsonl/README.md</span>
+        <span class="src-tag">persist</span>
+      </div>
+      <span class="src-line">Append-only event log on disk</span>
+      <span class="src-line"><span class="src-fn">deriveMessages()</span> identical after replay</span>
+    </div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/core/session/</span>
+        <span class="src-tag">walkthrough</span>
+      </div>
+      <span class="src-line"><span class="src-ln">  1</span> <span class="src-hl">session.append(type, data)</span></span>
+      <span class="src-line"><span class="src-comment">     // 追加 SessionEvent / append SessionEvent</span></span>
+      <span class="src-line"><span class="src-ln">  2</span> <span class="src-hl">seq 单调递增</span></span>
+      <span class="src-line"><span class="src-comment">     // 重放与 fork 基础 / replay and fork basis</span></span>
+      <span class="src-line"><span class="src-ln">  3</span> <span class="src-hl">ctx.sessions.fork(source, boundary)</span></span>
+      <span class="src-line"><span class="src-comment">     // 分支会话 / branch session</span></span>
+      <span class="src-line"><span class="src-ln">  4</span> <span class="src-hl">session/event 广播</span></span>
+      <span class="src-line"><span class="src-comment">     // Web UI 订阅 / Web UI subscribes</span></span>
+    </div>
+
+    <div class="depth-aside-head"><span class="da-tag"><span class="lang-zh-only">交叉引用</span><span class="lang-en-only">Cross-ref</span></span> <span class="da-title lang-zh-only">deepseek-harness 文档</span><span class="da-title lang-en-only">deepseek-harness docs</span></div>    <table class="cmp">
+      <thead><tr><th>DOC</th><th>主题</th><th>路径</th><th>摘要</th></tr></thead>
+      <tbody>
+      <tr><td>architecture</td><td>架构总览</td><td><code>docs/architecture.md</code></td><td>Cordis plugin tree, Profile×Bundle composition, six core ctx services, and turn flow</td></tr>
+      </tbody>
+    </table>
+
+    <div class="trace-box">
+      <div class="tb-tag">TRACE · station station persist</div>
+      <div class="lang-zh-only"><p>站 persist：落盘。</p></div>
+      <div class="lang-en-only"><p>St. persist: persistence.</p></div>
+    </div>
+
+    <div class="depth-zone" data-chapter="C22"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C22.4+</span><span class="lang-en-only">Deep dive · C22.4+</span></div>
+
+    </div>
+  </section>
+
+  <section class="chap" id="c23">
+    <div class="chap-num">CHAPTER&nbsp;23&nbsp;·&nbsp;PERSISTENCE</div>
+    <h2 class="chap-title lang-zh-only">Compaction 与 surface</h2>
+    <h2 class="chap-title lang-en-only">Compaction and surface replace</h2>
+    <p class="chap-en lang-zh-only">log 不删 · surface replace 重建上下文</p>
+    <p class="chap-en lang-en-only">log kept · surface replace rebuilds context</p>
+    <nav class="chapter-compass" aria-label="Chapter navigation">
+      <div class="cc-row">
+        <div class="cc-phase"><span class="cc-roman">VI</span> · <span class="lang-zh-only">持久化</span><span class="lang-en-only">Persistence</span></div>
+        <div class="cc-station"><span class="lang-zh-only">站 22</span><span class="lang-en-only">St. 22</span> · C23/26</div>
+      </div>
+      <div class="cc-forest"><span class="lang-zh-only">Compaction · surface</span><span class="lang-en-only">Compaction · surface replace</span></div>
+      <div class="cc-links">
+        <a class="cc-nav cc-prev" href="#c22"><span class="cc-arrow">←</span> <span class="cc-nav-num">C22</span> <span class="lang-zh-only">SessionEvent JSONL</span><span class="lang-en-only">SessionEvent JSONL</span></a>
+        <a class="cc-map" href="#forest-overview"><span class="lang-zh-only">回到总览</span><span class="lang-en-only">Forest map</span></a>
+        <a class="cc-nav cc-next" href="#c24"><span class="cc-nav-num">C24</span> <span class="lang-zh-only">对比 Pi Harness</span><span class="lang-en-only">vs Pi harness</span> <span class="cc-arrow">→</span></a>
+      </div>
+    </nav>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>本章回答「这条主线 prompt 在此层长什么样」</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH 没有隐藏魔法——一切可替换行为都在 Cordis 事件或 SessionEvent 里</span></p>
+      <p><span class="swc-pill act">优化</span><span>读源码时先搜 session.append 与 ctx.* 注册点</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>This chapter answers what the through-line prompt looks like at this layer</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH has no hidden magic — replaceable behavior lives in Cordis events or SessionEvents</span></p>
+      <p><span class="swc-pill act">优化</span><span>When reading source, search session.append and ctx.* registration first</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">compaction</span><span class="lang-en-only">compaction</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">compaction</span><span class="lang-en-only">compaction</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">packages/compaction</span><span class="lang-en-only">packages/compaction</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">surface</span><span class="lang-en-only">surface</span></div>
+      </div>
+    </div>
+
+    <div class="lang-zh-only"><p><code>dsh-compaction-basic</code>（<code>packages/compaction/compaction-basic</code>）在 <code>agent/pre-step</code> 检测 token 压力，在 <code>agent/request-error</code> 处理 canonical overflow。策略：<strong>log 完整保留</strong>，替换 surface generation（摘要 + tool-result pruning）。</p></div>
+    <div class="lang-en-only"><p><code>dsh-compaction-basic</code> (<code>packages/compaction/compaction-basic</code>) detects token pressure at <code>agent/pre-step</code>, handles canonical overflow at <code>agent/request-error</code>. Policy: <strong>log stays complete</strong>, replace surface generation (summary + tool-result pruning).</p></div>
+
+    <h3 class="sub"><span class="sec-num">C23.1</span> <span class="lang-zh-only">Compaction 触发链</span><span class="lang-en-only">Compaction trigger chain</span></h3>
+
+    <div class="ladder">
+      <div class="ld-row">
+        <div class="ld-num">01</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">token-meter</span><span class="lang-en-only">计量 deriveMessages token</span></div>
+
+        </div>
+      </div>
+      <div class="ld-row">
+        <div class="ld-num">02</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">agent/pre-step</span><span class="lang-en-only">pressure · 可选 pruning</span></div>
+
+        </div>
+      </div>
+      <div class="ld-row">
+        <div class="ld-num">03</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">LLM overflow</span><span class="lang-en-only">agent/request-error</span></div>
+
+        </div>
+      </div>
+      <div class="ld-row">
+        <div class="ld-num">04</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">summary LLM call</span><span class="lang-en-only">新 surface generation</span></div>
+
+        </div>
+      </div>
+      <div class="ld-row">
+        <div class="ld-num">05</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">fresh retry turn</span><span class="lang-en-only">仅当 surface 前进</span></div>
+
+        </div>
+      </div>
+    </div>
+
+    <div class="lang-zh-only"><p>Recovery 发生在 failed step 与 failed turn 之间：若 pruning/summary 未 advance surface generation，原始 request error 仍权威——避免 silent loss。</p></div>
+    <div class="lang-en-only"><p>Recovery happens between failed step and failed turn: if pruning/summary does not advance surface generation, the original request error remains authoritative — avoiding silent loss.</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/compaction/compaction-basic/README.md</span>
+        <span class="src-tag">compact</span>
+      </div>
+      <span class="src-line">Uses <span class="src-str">agent/pre-step</span> for pressure before derivation</span>
+      <span class="src-line">and <span class="src-str">agent/request-error</span> for overflow recovery.</span>
+    </div>
+
+    <div class="note copper">
+      <span class="lang-zh-only">📘 <strong>Agent 生命周期</strong>（<code>docs/agent-lifecycle.md</code>）· turn/step 双环、agent/pre-step waterfall、session 与 agent 事件分工</span>
+      <span class="lang-en-only">📘 <strong>Agent lifecycle</strong> (<code>docs/agent-lifecycle.md</code>) · turn/step twin loops, agent/pre-step waterfall, session vs agent event split</span>
+    </div>
+
+    <div class="trace-box">
+      <div class="tb-tag">TRACE · station station compaction</div>
+      <div class="lang-zh-only"><p>站 compaction：压缩。</p></div>
+      <div class="lang-en-only"><p>St. compaction: compaction.</p></div>
+    </div>
+
+    <div class="depth-zone" data-chapter="C23"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C23.4+</span><span class="lang-en-only">Deep dive · C23.4+</span></div>
+
+    </div>
+  </section>
+
+  <section class="chap" id="c24">
+    <div class="chap-num">CHAPTER&nbsp;24&nbsp;·&nbsp;LANDSCAPE</div>
+    <h2 class="chap-title lang-zh-only">对比 Pi Harness</h2>
+    <h2 class="chap-title lang-en-only">vs Pi harness</h2>
+    <p class="chap-en lang-zh-only">turn/step vs runLoop 双环</p>
+    <p class="chap-en lang-en-only">turn/step vs runLoop twin loops</p>
+    <nav class="chapter-compass" aria-label="Chapter navigation">
+      <div class="cc-row">
+        <div class="cc-phase"><span class="cc-roman">VII</span> · <span class="lang-zh-only">全景</span><span class="lang-en-only">Landscape</span></div>
+        <div class="cc-station"><span class="lang-zh-only">—</span><span class="lang-en-only">—</span> · C24/26</div>
+      </div>
+      <div class="cc-forest"><span class="lang-zh-only">对比 Pi Harness</span><span class="lang-en-only">vs Pi harness</span></div>
+      <div class="cc-links">
+        <a class="cc-nav cc-prev" href="#c23"><span class="cc-arrow">←</span> <span class="cc-nav-num">C23</span> <span class="lang-zh-only">Compaction 与 surface</span><span class="lang-en-only">Compaction and surface replace</span></a>
+        <a class="cc-map" href="#forest-overview"><span class="lang-zh-only">回到总览</span><span class="lang-en-only">Forest map</span></a>
+        <a class="cc-nav cc-next" href="#c25"><span class="cc-nav-num">C25</span> <span class="lang-zh-only">JSON-RPC 与 profiles</span><span class="lang-en-only">JSON-RPC and profiles</span> <span class="cc-arrow">→</span></a>
+      </div>
+    </nav>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>本章回答「这条主线 prompt 在此层长什么样」</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH 没有隐藏魔法——一切可替换行为都在 Cordis 事件或 SessionEvent 里</span></p>
+      <p><span class="swc-pill act">优化</span><span>读源码时先搜 session.append 与 ctx.* 注册点</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>This chapter answers what the through-line prompt looks like at this layer</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH has no hidden magic — replaceable behavior lives in Cordis events or SessionEvents</span></p>
+      <p><span class="swc-pill act">优化</span><span>When reading source, search session.append and ctx.* registration first</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">对比</span><span class="lang-en-only">Compare</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">—</span><span class="lang-en-only">—</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">Pi vs DSH</span><span class="lang-en-only">Pi vs DSH</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">设计取舍</span><span class="lang-en-only">trade-offs</span></div>
+      </div>
+    </div>
+
+    <div class="lang-zh-only"><p>四条路线对比：Claude Code（密封 CLI + MCP）、Cursor（密封 IDE）、Pi（minimal harness + JSONL）、DSH（Cordis 全插件 + SessionEvent + MCP/subagent/compaction）。主线 prompt 在 DSH 可经 <code>--dump-config</code> + session log 完整 trace。</p></div>
+    <div class="lang-en-only"><p>Four routes compared: Claude Code (sealed CLI + MCP), Cursor (sealed IDE), Pi (minimal harness + JSONL), DSH (full Cordis plugins + SessionEvent + MCP/subagent/compaction). The through-line prompt is fully traceable in DSH via <code>--dump-config</code> + session log.</p></div>
+
+    <h3 class="sub"><span class="sec-num">C24.1</span> <span class="lang-zh-only">设计取舍表</span><span class="lang-en-only">Design trade-off table</span></h3>
+
+    <table class="cmp">
+      <thead><tr><th>维度</th><th>Claude Code</th><th>Cursor</th><th>Pi</th><th>DSH</th></tr></thead>
+      <tbody>
+      <tr><td>目标用户</td><td>开箱 CLI</td><td>IDE 用户</td><td>读源码</td><td>改 harness</td></tr>
+      <tr><td>内核</td><td>密封</td><td>密封</td><td>agent-loop.ts</td><td>Cordis 插件树</td></tr>
+      <tr><td>会话</td><td>专有</td><td>专有</td><td>JSONL 树</td><td>SessionEvent log</td></tr>
+      <tr><td>MCP</td><td>✓</td><td>△</td><td>✗</td><td>✓ packages/mcp</td></tr>
+      <tr><td>子 agent</td><td>✓</td><td>✓</td><td>✗</td><td>✓ packages/subagent</td></tr>
+      <tr><td>compaction</td><td>黑盒</td><td>黑盒</td><td>✓</td><td>✓ plugin</td></tr>
+      <tr><td>trace 主线</td><td>✗</td><td>✗</td><td>✓ verbose</td><td>✓ dump-config + log</td></tr>
+      </tbody>
+    </table>
+
+    <figure>
+      <div class="figbox"><div class="pi-fig wide"><svg viewBox="0 0 720 150" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true" class="pi-svg">
+  <defs>
+    <marker id="pi-arr" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 Z" fill="#1f5c8c"/>
+    </marker>
+  </defs>
+  <text x="360" y="24" text-anchor="middle" class="svg-label">HARNESS COMPARISON · README through-line</text>
+  <text x="120" y="52" text-anchor="middle" class="svg-micro">Claude Code</text>
+  <text x="280" y="52" text-anchor="middle" class="svg-micro">Cursor</text>
+  <text x="440" y="52" text-anchor="middle" class="svg-micro">Pi</text>
+  <text x="600" y="52" text-anchor="middle" class="svg-micro" font-weight="700">DSH</text>
+  <rect x="40" y="60" width="640" height="8" rx="4" fill="#c7c4ba" opacity="0.5"/>
+  <circle cx="120" cy="64" r="10" fill="#767c87"/>
+  <circle cx="280" cy="64" r="10" fill="#767c87"/>
+  <circle cx="440" cy="64" r="10" fill="#1f5c8c"/>
+  <circle cx="600" cy="64" r="14" fill="#2d6a4f" stroke="#15171c" stroke-width="2"/>
+  <text x="360" y="110" text-anchor="middle" class="svg-body">DSH = Cordis composability + SessionEvent log + MCP/subagent/compaction</text>
+  <text x="360" y="132" text-anchor="middle" class="svg-mute">sealed products optimize UX · harnesses optimize traceability</text>
+</svg></div></div>
+      <figcaption>
+        <span class="figid">FIG</span>
+        <span class="lang-zh-only">Harness 对比光谱：DSH 在可组合性与可观测性轴上最靠右，同时保留 MCP 与子 agent。</span>
+        <span class="lang-en-only">Harness comparison: DSH sits furthest on composability and traceability while keeping MCP and subagents.</span>
+      </figcaption>
+    </figure>
+
+    <h3 class="sub"><span class="sec-num">C24.2</span> <span class="lang-zh-only">怎么选</span><span class="lang-en-only">How to choose</span></h3>
+
+    <div class="lang-zh-only"><p>不是「哪个更好」——是「你要闭包体验还是开卷考试」。DSH 牺牲「零配置直觉」，换取任意层 patch、官方 200+ 插件组合、以及与 DeepSeek 模型栈的一等集成。</p></div>
+    <div class="lang-en-only"><p>Not «which is better» — «do you want closed-loop UX or open-book exam». DSH sacrifices «zero-config intuition» for patch-any-layer, 200+ official plugin combinations, and first-class DeepSeek model stack integration.</p></div>
+
+    <div class="note copper">
+      <span class="lang-zh-only">Pi 与 DSH 都开源可读；Pi 极简，DSH 全栈可组合。</span>
+      <span class="lang-en-only">Pi and DSH are both open and readable; Pi is minimal, DSH is fully composable.</span>
+    </div>
+
+    <table class="cmp">
+      <thead><tr><th>特性</th><th>Pi</th><th>DSH</th><th>Claude Code</th></tr></thead>
+      <tbody>
+      <tr><td>插件化 agent-loop</td><td>✗</td><td>✓</td><td>✗</td></tr>
+      <tr><td>MCP</td><td>✗</td><td>✓</td><td>✓</td></tr>
+      <tr><td>SessionEvent 日志</td><td>JSONL messages</td><td>append-only events</td><td>✗</td></tr>
+      <tr><td>deriveMessages</td><td>convertToLlm</td><td>log projection</td><td>✗</td></tr>
+      <tr><td>子 agent</td><td>✗</td><td>✓</td><td>✓</td></tr>
+      <tr><td>源码可读</td><td>✓</td><td>✓</td><td>✗</td></tr>
+      <tr><td>Web UI</td><td>TUI</td><td>✓ :3080</td><td>✗</td></tr>
+      </tbody>
+    </table>
+
+    <div class="trace-box">
+      <div class="tb-tag">TRACE · station station 对比</div>
+      <div class="lang-zh-only"><p>站 24：Pi runLoop 双环 vs DSH turn/step — 同一主线 prompt 的不同编排哲学。</p></div>
+      <div class="lang-en-only"><p>St. 24: Pi runLoop twin loops vs DSH turn/step — same prompt, different orchestration philosophy.</p></div>
+    </div>
+
+    <div class="depth-zone" data-chapter="C24"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C24.4+</span><span class="lang-en-only">Deep dive · C24.4+</span></div>
+
+    </div>
+  </section>
+
+  <section class="chap" id="c25">
+    <div class="chap-num">CHAPTER&nbsp;25&nbsp;·&nbsp;LANDSCAPE</div>
+    <h2 class="chap-title lang-zh-only">JSON-RPC 与 profiles</h2>
+    <h2 class="chap-title lang-en-only">JSON-RPC and profiles</h2>
+    <p class="chap-en lang-zh-only">web · headless · Python SDK</p>
+    <p class="chap-en lang-en-only">web · headless · Python SDK</p>
+    <nav class="chapter-compass" aria-label="Chapter navigation">
+      <div class="cc-row">
+        <div class="cc-phase"><span class="cc-roman">VII</span> · <span class="lang-zh-only">全景</span><span class="lang-en-only">Landscape</span></div>
+        <div class="cc-station"><span class="lang-zh-only">—</span><span class="lang-en-only">—</span> · C25/26</div>
+      </div>
+      <div class="cc-forest"><span class="lang-zh-only">JSON-RPC · profiles</span><span class="lang-en-only">JSON-RPC · profiles</span></div>
+      <div class="cc-links">
+        <a class="cc-nav cc-prev" href="#c24"><span class="cc-arrow">←</span> <span class="cc-nav-num">C24</span> <span class="lang-zh-only">对比 Pi Harness</span><span class="lang-en-only">vs Pi harness</span></a>
+        <a class="cc-map" href="#forest-overview"><span class="lang-zh-only">回到总览</span><span class="lang-en-only">Forest map</span></a>
+        <a class="cc-nav cc-next" href="#c26"><span class="cc-nav-num">C26</span> <span class="lang-zh-only">怎么自己 trace 一轮</span><span class="lang-en-only">How to trace a turn yourself</span> <span class="cc-arrow">→</span></a>
+      </div>
+    </nav>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>本章回答「这条主线 prompt 在此层长什么样」</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH 没有隐藏魔法——一切可替换行为都在 Cordis 事件或 SessionEvent 里</span></p>
+      <p><span class="swc-pill act">优化</span><span>读源码时先搜 session.append 与 ctx.* 注册点</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>This chapter answers what the through-line prompt looks like at this layer</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH has no hidden magic — replaceable behavior lives in Cordis events or SessionEvents</span></p>
+      <p><span class="swc-pill act">优化</span><span>When reading source, search session.append and ctx.* registration first</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">rpc</span><span class="lang-en-only">rpc</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">rpc</span><span class="lang-en-only">rpc</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">profiles</span><span class="lang-en-only">profiles</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">headless</span><span class="lang-en-only">headless</span></div>
+      </div>
+    </div>
+
+    <div class="lang-zh-only"><p><code>packages/subagent/subagent</code> 提供 spawn/fork/send_message/interrupt/report 工具；<code>tool-agent-team</code> 扩展 Agent Teams。MCP（<code>packages/mcp/*</code>）把外部工具协议接入 <code>ctx.tools</code>。子 agent 不是黑盒线程——而是独立 session + driver，事件仍走 session/agent 域。</p></div>
+    <div class="lang-en-only"><p><code>packages/subagent/subagent</code> provides spawn/fork/send_message/interrupt/report tools; <code>tool-agent-team</code> extends Agent Teams. MCP (<code>packages/mcp/*</code>) attaches external tool protocols to <code>ctx.tools</code>. Sub-agents are not black-box threads — separate session + driver, events still use session/agent domains.</p></div>
+
+    <h3 class="sub"><span class="sec-num">C25.1</span> <span class="lang-zh-only">Subagent 控制面</span><span class="lang-en-only">Subagent control plane</span></h3>
+
+    <table class="cmp">
+      <thead><tr><th>工具</th><th>作用</th><th>观测</th></tr></thead>
+      <tbody>
+      <tr><td>subagent</td><td>spawn 子 agent</td><td>agent/created · subagent/end</td></tr>
+      <tr><td>subagent_fork</td><td>fork session 分支</td><td>新 session/created</td></tr>
+      <tr><td>send_message</td><td>向子 agent 发消息</td><td>agent/inbox/inserted</td></tr>
+      <tr><td>report</td><td>子 agent 回报父 agent</td><td>tool/result</td></tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub"><span class="sec-num">C25.2</span> <span class="lang-zh-only">Agent Teams</span><span class="lang-en-only">Agent Teams</span></h3>
+
+    <div class="lang-zh-only"><p>Teams 在 <code>agent/created</code> 时注册成员关系，协调多 agent inbox 与 DM。主线 prompt 通常走单 agent；Teams 用于并行 research、 Ralph 循环（<code>packages/workflow</code>）等高级场景。</p></div>
+    <div class="lang-en-only"><p>Teams register membership at <code>agent/created</code>, coordinating multi-agent inbox and DMs. The through-line prompt usually runs single-agent; Teams serve parallel research, Ralph loops (<code>packages/workflow</code>), etc.</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; packages/subagent/subagent/README.md</span>
+        <span class="src-tag">sub</span>
+      </div>
+      <span class="src-line">Child sessions are first-class <span class="src-cls">Session</span> objects</span>
+      <span class="src-line">with their own <span class="src-cls">ReactLoopAgent</span> driver.</span>
+    </div>
+
+    <div class="stage-purpose">
+      <div class="sp-row">
+        <div class="sp-key"><span class="lang-zh-only">in-process</span><span class="lang-en-only">in-process driver</span></div>
+        <div class="sp-val"><span class="lang-zh-only">同 Cordis 树 · 低开销</span><span class="lang-en-only">same Cordis tree · low overhead</span></div>
+      </div>
+      <div class="sp-row">
+        <div class="sp-key"><span class="lang-zh-only">Codex/CC bundle</span><span class="lang-en-only">product provider bundles</span></div>
+        <div class="sp-val"><span class="lang-zh-only">可选 hook bridge</span><span class="lang-en-only">optional hook bridge bundles</span></div>
+      </div>
+      <div class="sp-row">
+        <div class="sp-key"><span class="lang-zh-only">Python SDK</span><span class="lang-en-only">Python SDK</span></div>
+        <div class="sp-val"><span class="lang-zh-only">JSON-RPC 驱 Node runtime</span><span class="lang-en-only">JSON-RPC drives Node runtime</span></div>
+      </div>
+    </div>
+
+    <div class="trace-box">
+      <div class="tb-tag">TRACE · station station rpc</div>
+      <div class="lang-zh-only"><p>站 rpc：多入口。</p></div>
+      <div class="lang-en-only"><p>St. rpc: multi entry.</p></div>
+    </div>
+
+    <div class="depth-zone" data-chapter="C25"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C25.4+</span><span class="lang-en-only">Deep dive · C25.4+</span></div>
+
+    </div>
+  </section>
+
+  <section class="chap" id="c26">
+    <div class="chap-num">CHAPTER&nbsp;26&nbsp;·&nbsp;CODA</div>
+    <h2 class="chap-title lang-zh-only">怎么自己 trace 一轮</h2>
+    <h2 class="chap-title lang-en-only">How to trace a turn yourself</h2>
+    <p class="chap-en lang-zh-only">session/event · event map · --dump-config</p>
+    <p class="chap-en lang-en-only">session/event · event map · --dump-config</p>
+    <nav class="chapter-compass" aria-label="Chapter navigation">
+      <div class="cc-row">
+        <div class="cc-phase"><span class="cc-roman">∎</span> · <span class="lang-zh-only">Coda</span><span class="lang-en-only">Coda</span></div>
+        <div class="cc-station"><span class="lang-zh-only">—</span><span class="lang-en-only">—</span> · C26/26</div>
+      </div>
+      <div class="cc-forest"><span class="lang-zh-only">自己 trace 一轮</span><span class="lang-en-only">Trace a turn yourself</span></div>
+      <div class="cc-links">
+        <a class="cc-nav cc-prev" href="#c25"><span class="cc-arrow">←</span> <span class="cc-nav-num">C25</span> <span class="lang-zh-only">JSON-RPC 与 profiles</span><span class="lang-en-only">JSON-RPC and profiles</span></a>
+        <a class="cc-map" href="#forest-overview"><span class="lang-zh-only">回到总览</span><span class="lang-en-only">Forest map</span></a>
+        
+      </div>
+    </nav>
+    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+      <p><span class="swc-pill ">直觉</span><span>本章回答「这条主线 prompt 在此层长什么样」</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH 没有隐藏魔法——一切可替换行为都在 Cordis 事件或 SessionEvent 里</span></p>
+      <p><span class="swc-pill act">优化</span><span>读源码时先搜 session.append 与 ctx.* 注册点</span></p>
+    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+      <p><span class="swc-pill ">直觉</span><span>This chapter answers what the through-line prompt looks like at this layer</span></p>
+      <p><span class="swc-pill rev">反直觉</span><span>DSH has no hidden magic — replaceable behavior lives in Cordis events or SessionEvents</span></p>
+      <p><span class="swc-pill act">优化</span><span>When reading source, search session.append and ctx.* registration first</span></p>
+    </aside>
+
+    <div class="stage-banner">
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">模块</span><span class="lang-en-only">Module</span></div>
+        <div class="sb-val"><span class="lang-zh-only">Coda</span><span class="lang-en-only">Coda</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">包</span><span class="lang-en-only">Package</span></div>
+        <div class="sb-val"><span class="lang-zh-only">apps/cli</span><span class="lang-en-only">apps/cli</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">线程</span><span class="lang-en-only">Thread</span></div>
+        <div class="sb-val"><span class="lang-zh-only">--dump-config</span><span class="lang-en-only">--dump-config</span></div>
+      </div>
+      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">输出</span><span class="lang-en-only">Output</span></div>
+        <div class="sb-val"><span class="lang-zh-only">session log</span><span class="lang-en-only">session log</span></div>
+      </div>
+    </div>
+
+    <div class="lang-zh-only"><p>自己 trace 主线 prompt 的三件套：<code>dsh --profile web --dump-config</code> 看 boot 树、浏览器/WebSocket 看 <code>session/event</code> 流、打开 persistence 存储的 session log 文件对照 <code>deriveMessages()</code>。</p></div>
+    <div class="lang-en-only"><p>Trace the through-line yourself with three tools: <code>dsh --profile web --dump-config</code> for the boot tree, browser/WebSocket for the <code>session/event</code> stream, and the persisted session log file compared against <code>deriveMessages()</code>.</p></div>
+
+    <h3 class="sub"><span class="sec-num">C26.1</span> <span class="lang-zh-only">推荐 trace 顺序</span><span class="lang-en-only">Recommended trace order</span></h3>
+
+    <div class="ladder">
+      <div class="ld-row">
+        <div class="ld-num">01</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">dsh --profile web --dump-config</span><span class="lang-en-only">确认插件树含 agent-loop · tool-fs</span></div>
+
+        </div>
+      </div>
+      <div class="ld-row">
+        <div class="ld-num">02</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">发送主线 prompt</span><span class="lang-en-only">观察 turn/start → user/message → tool/call</span></div>
+
+        </div>
+      </div>
+      <div class="ld-row">
+        <div class="ld-num">03</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">session log 文件</span><span class="lang-en-only">packages/session/session-persistence-jsonl</span></div>
+
+        </div>
+      </div>
+      <div class="ld-row">
+        <div class="ld-num">04</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">deriveMessages 对照</span><span class="lang-en-only">packages/core/session/tests/session.spec.ts</span></div>
+
+        </div>
+      </div>
+    </div>
+
+    <h3 class="sub"><span class="sec-num">C26.2</span> <span class="lang-zh-only">推荐阅读顺序</span><span class="lang-en-only">Suggested reading order</span></h3>
+
+    <div class="lang-zh-only"><p>1. <code>docs/architecture.md</code> turn flow → 2. <code>packages/core/agent-loop/src/agent.ts</code> ReactLoopAgent → 3. 本文 C02 22 站 → 4. <code>docs/agent-lifecycle.md</code> 序列图。</p></div>
+    <div class="lang-en-only"><p>1. <code>docs/architecture.md</code> turn flow → 2. <code>packages/core/agent-loop/src/agent.ts</code> ReactLoopAgent → 3. this article C02 22 stations → 4. <code>docs/agent-lifecycle.md</code> sequence diagram.</p></div>
+
+    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; apps/cli/README.md</span>
+        <span class="src-tag">trace</span>
+      </div>
+      <span class="src-line">$ dsh --profile web --dump-config</span>
+      <span class="src-line">$ dsh web  <span class="src-comment"># :3080 · 发送主线 prompt</span></span>
+    </div>
+
+    <blockquote class="pull copper">
+      <span class="lang-zh-only">读完之后，用一句话回答：<br>「读取 README.md，用一句话告诉我这个项目做什么」——<br>在 DSH 里，这句话究竟触发了什么？</span>
+      <span class="lang-en-only">After reading, answer in one sentence:<br>«read README.md and tell me what this project does in one sentence» —<br>what exactly does that line trigger in DSH?</span>
+      <cite>Field Note · 10</cite>
+    </blockquote>
+
+    <div class="note">
+      <span class="lang-zh-only">答案应能指出：followup → turn/start → agent/pre-step → user/message → deriveMessages → llm/stream ×2 → tool-fs read → assistant/message stop → session/event → UI。</span>
+      <span class="lang-en-only">Answer should cite: followup → turn/start → agent/pre-step → user/message → deriveMessages → llm/stream ×2 → tool-fs read → assistant/message stop → session/event → UI.</span>
+    </div>
+
+    <div class="note copper">
+      <span class="lang-zh-only">📘 <strong>架构总览</strong>（<code>docs/architecture.md</code>）· Cordis 插件树、Profile×Bundle 组合、六大 ctx 服务与 turn 流</span>
+      <span class="lang-en-only">📘 <strong>Architecture overview</strong> (<code>docs/architecture.md</code>) · Cordis plugin tree, Profile×Bundle composition, six core ctx services, and turn flow</span>
+    </div>
+
+    <div class="note copper">
+      <span class="lang-zh-only">📘 <strong>Agent 生命周期</strong>（<code>docs/agent-lifecycle.md</code>）· turn/step 双环、agent/pre-step waterfall、session 与 agent 事件分工</span>
+      <span class="lang-en-only">📘 <strong>Agent lifecycle</strong> (<code>docs/agent-lifecycle.md</code>) · turn/step twin loops, agent/pre-step waterfall, session vs agent event split</span>
+    </div>
+
+    <div class="trace-box">
+      <div class="tb-tag">TRACE · station station Coda</div>
+      <div class="lang-zh-only"><p>站 26：clone repo → dsh web → 读 session/event 与 event map。</p></div>
+      <div class="lang-en-only"><p>St. 26: clone repo → dsh web → read session/event and event map.</p></div>
+    </div>
+
+    <div class="depth-zone" data-chapter="C26"><div class="depth-zone-label"><span class="dz-tag">DEPTH</span> <span class="lang-zh-only">深度细读 · C26.4+</span><span class="lang-en-only">Deep dive · C26.4+</span></div>
+
+    <div class="case-study">
+      <div class="cs-tag">CASE STUDY</div>
+      <div class="cs-title"><span class="lang-zh-only">自己 trace 一轮</span><span class="lang-en-only">Trace a turn yourself</span></div>
+      <div class="lang-zh-only"><p>1. <code>git clone deepseek-ai/deepseek-harness</code><br>2. <code>pnpm i && pnpm dsh web</code><br>3. 发送主线 prompt<br>4. 在 DevTools 或日志里过滤 <code>session/event</code></p></div>
+      <div class="lang-en-only"><p>1. <code>git clone deepseek-ai/deepseek-harness</code><br>2. <code>pnpm i && pnpm dsh web</code><br>3. Send through-line prompt<br>4. Filter <code>session/event</code> in DevTools or logs</p></div>
+    </div>
+
+    </div>
+  </section>
+
+  <footer class="footer">
+    <div class="ft-rule"><span class="ft-mark">END · FIELD NOTE 11</span></div>
+    <p class="lang-zh-only">这是 Field Note 系列的第十一篇。<strong>姐妹篇</strong>:</p>
+    <p class="lang-en-only">Eleventh in the Field Note series. <strong>Sister pieces</strong>:</p>
+    <div class="ft-links">
+      <a href="https://ursb.me/immersive/pi-agent/">Pi Agent · 26 站</a>
+      <a href="https://ursb.me/immersive/llm-inference-life/">LLM 推理 · 28 站</a>
+      <a href="https://ursb.me/immersive/chromium-renderer/">Chromium · 渲染管线</a>
+    </div>
+    <p class="lang-zh-only" style="margin-top:24px;font-style:italic;color:var(--ink-mute);">"一条用户消息看起来只是聊天框里的一行字——它真正做的事情，是在 Cordis 插件树里穿过 turn/step 边界，在 SessionEvent 日志上留下可 fork 的 seq 链，然后被 Web UI 从 session/event 流式渲染成你看到的 chunk。"</p>
+    <p class="lang-en-only" style="margin-top:24px;font-style:italic;color:var(--ink-mute);">"A user message looks like one line in the chat box. What it really does: cross turn/step boundaries in the Cordis plugin tree, leave a forkable seq chain on the SessionEvent log, then get streamed into chunks you see via session/event in the Web UI."</p>
+    <p style="margin-top:28px;">© 2026 <a href="https://ursb.me">Airing</a> · <span class="lang-zh-only">本文为 Field Note 长文,欢迎转载注明出处</span><span class="lang-en-only">long-form Field Note, attribution appreciated</span></p>
+  </footer>
+
+</div>
+
+
+<script>
+(function() {
+  var zh = document.getElementById('lang-zh');
+  var en = document.getElementById('lang-en');
+  function setLang(lang) {
+    if (lang === 'en') {
+      document.body.classList.add('lang-en');
+      document.documentElement.lang = 'en';
+      en.classList.add('active'); en.setAttribute('aria-pressed', 'true');
+      zh.classList.remove('active'); zh.setAttribute('aria-pressed', 'false');
+    } else {
+      document.body.classList.remove('lang-en');
+      document.documentElement.lang = 'zh-CN';
+      zh.classList.add('active'); zh.setAttribute('aria-pressed', 'true');
+      en.classList.remove('active'); en.setAttribute('aria-pressed', 'false');
+    }
+    try { localStorage.setItem('dsh-lang', lang); } catch (e) {}
+  }
+  zh.addEventListener('click', function() { setLang('zh'); });
+  en.addEventListener('click', function() { setLang('en'); });
+  try {
+    var saved = localStorage.getItem('dsh-lang');
+    if (saved === 'en') setLang('en');
+  } catch (e) {}
+})();
+
+(function() {
+  var bar = document.getElementById('readProgress');
+  if (!bar) return;
+  function update() {
+    var h = document.documentElement.scrollHeight - window.innerHeight;
+    bar.style.width = (h > 0 ? (window.scrollY / h) * 100 : 0) + '%';
+  }
+  window.addEventListener('scroll', update, { passive: true });
+  update();
+})();
+
+(function() {
+  var cells = document.querySelectorAll('#pbTrack .pb-cell');
+  if (!cells.length) return;
+  var i = -1;
+  function tick() {
+    cells.forEach(function(c, idx) { c.classList.toggle('lit', idx <= i); });
+    i++;
+    if (i >= cells.length + 3) i = -1;
+    setTimeout(tick, 380);
+  }
+  tick();
+  cells.forEach(function(c) {
+    c.addEventListener('click', function() {
+      var target = document.querySelector(c.dataset.jump || '');
+      if (target) target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    });
+  });
+})();
+
+(function () {
+  var sideItems = Array.prototype.map.call(
+    document.querySelectorAll('.toc-side li[data-section]'),
+    function (li) { return { node: li, el: document.getElementById(li.dataset.section) }; }
+  ).filter(function (o) { return o.el; });
+  if (!sideItems.length) return;
+  function update() {
+    var offset = window.innerHeight * 0.32;
+    var activeIdx = 0;
+    for (var i = 0; i < sideItems.length; i++) {
+      if (sideItems[i].el.getBoundingClientRect().top - offset < 0) activeIdx = i;
+    }
+    var activeId = sideItems[activeIdx].el.id;
+    sideItems.forEach(function (o) {
+      o.node.classList.toggle('active', o.el.id === activeId);
+    });
+  }
+  window.addEventListener('scroll', update, { passive: true });
+  window.addEventListener('resize', update);
+  update();
+})();
+
+(function() {
+  var filmstrip = document.getElementById('card-filmstrip');
+  var cfTrack = document.getElementById('cf-track');
+  var cfCurrent = document.getElementById('cf-current');
+  if (!filmstrip || !cfTrack) return;
+  document.body.classList.add('has-filmstrip');
+  var cells = Array.prototype.slice.call(cfTrack.querySelectorAll('.cf-cell'));
+  var sections = cells.map(function(c) {
+    return { cell: c, el: document.querySelector(c.getAttribute('href')) };
+  }).filter(function(o) { return o.el; });
+
+  function updateFilmstrip() {
+    var offset = window.innerHeight * 0.25;
+    var activeIdx = 0;
+    for (var i = 0; i < sections.length; i++) {
+      if (sections[i].el.getBoundingClientRect().top - offset < 0) activeIdx = i;
+    }
+    var active = sections[activeIdx];
+    cells.forEach(function(c) { c.classList.remove('active'); });
+    if (active) {
+      active.cell.classList.add('active');
+      if (cfCurrent) cfCurrent.textContent = 'C' + (active.cell.dataset.chap || '');
+      active.cell.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'center' });
+    }
+    filmstrip.classList.toggle('is-visible', window.scrollY > 400);
+  }
+  window.addEventListener('scroll', updateFilmstrip, { passive: true });
+  updateFilmstrip();
+})();
+</script>
+
+
+<section class="ursb-interactive">
+  <div class="ursb-fbody">
+    <div class="ui-divider"><span class="ui-divider-mark">✦ ✦ ✦</span></div>
+
+    <div class="ui-stats-row">
+      <button class="ui-like" id="uiLikeBtn" type="button" disabled>
+        <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round" stroke-linecap="round" aria-hidden="true">
+          <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/>
+        </svg>
+        <span class="ui-count" id="uiLikeCount">—</span>
+        <span><span lang="zh">点赞</span><span lang="en">Likes</span></span>
+      </button>
+      <div class="ui-views" title="Page views">
+        <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round" stroke-linecap="round" aria-hidden="true">
+          <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/>
+        </svg>
+        <span class="ui-count" id="uiViewCount">—</span>
+        <span><span lang="zh">阅读</span><span lang="en">Reads</span></span>
+      </div>
+      <button class="ui-share" id="uiShareBtn" type="button">
+        <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round" stroke-linecap="round" aria-hidden="true">
+          <path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8"/><polyline points="16 6 12 2 8 6"/><line x1="12" y1="2" x2="12" y2="15"/>
+        </svg>
+        <span class="ui-share-text"><span lang="zh">分享</span><span lang="en">Share</span></span>
+      </button>
+      <div class="ui-online" data-online="page" data-online-template='<span class="ui-online-dot"></span><span class="ui-count">{n}</span><span><span lang="zh">在读</span><span lang="en">reading</span></span>' data-online-min="1" style="display:none"></div>
+    </div>
+
+    <h3 class="ui-section-title">
+      <span lang="zh">留下评论</span><span lang="en">Leave a comment</span>
+    </h3>
+    <form class="ui-comment-form" id="uiCommentForm" autocomplete="off">
+      <div class="ui-form-row">
+        <input type="text" name="nickname" id="uiNickname" required maxlength="40">
+        <input type="email" name="email" id="uiEmail" maxlength="120">
+      </div>
+      <textarea name="content" id="uiContent" required maxlength="2000" rows="4"></textarea>
+      <div class="ui-form-foot">
+        <span class="ui-form-status" id="uiFormStatus"></span>
+        <button type="submit" id="uiSubmitBtn">
+          <span lang="zh">发布评论</span><span lang="en">Post comment</span>
+        </button>
+      </div>
+    </form>
+
+    <h3 class="ui-section-title">
+      <span lang="zh">评论</span><span lang="en">Comments</span>
+      <span id="uiCommentCount" class="ui-count-small">—</span>
+    </h3>
+    <div class="ui-comment-list" id="uiCommentList">
+      <div class="ui-comment-loading">
+        <span lang="zh">加载中…</span><span lang="en">Loading…</span>
+      </div>
+    </div>
+  </div>
+</section>
+
+<script>
+/* ursb.me INTERACTIVE FOOTER — likes / views / comments
+   Talks to https://chat.ursb.me, slug = "note/chromium-renderer" */
+(function() {
+  var API_BASE = 'https://chat.ursb.me';
+  var POST_SLUG = 'note/dsh';
+  var ENC = encodeURIComponent(POST_SLUG);
+
+  var likeBtn = document.getElementById('uiLikeBtn');
+  var likeCount = document.getElementById('uiLikeCount');
+  var viewCount = document.getElementById('uiViewCount');
+  var shareBtn = document.getElementById('uiShareBtn');
+  var commentForm = document.getElementById('uiCommentForm');
+  var commentList = document.getElementById('uiCommentList');
+  var commentCount = document.getElementById('uiCommentCount');
+  var formStatus = document.getElementById('uiFormStatus');
+  var submitBtn = document.getElementById('uiSubmitBtn');
+  var nicknameInput = document.getElementById('uiNickname');
+  var emailInput = document.getElementById('uiEmail');
+  var contentInput = document.getElementById('uiContent');
+  if (!likeBtn) return;
+
+  var I18N = {
+    zh: { nicknamePh: '昵称*', emailPh: '邮箱（可选，仅用于回复通知）', contentPh: '说点什么…',
+          posting: '提交中…', posted: '✓ 已发布', postFailed: '✗ 发布失败：',
+          shareCopied: '✓ 已复制链接', loading: '加载中…', empty: '还没有评论，来抢沙发吧。',
+          loadFailed: '评论加载失败', justNow: '刚刚', mAgo: ' 分钟前', hAgo: ' 小时前', dAgo: ' 天前' },
+    en: { nicknamePh: 'Nickname*', emailPh: 'Email (optional, for reply notifications)', contentPh: 'Say something…',
+          posting: 'Posting…', posted: '✓ Posted', postFailed: '✗ Failed: ',
+          shareCopied: '✓ Link copied', loading: 'Loading…', empty: 'Be the first to comment.',
+          loadFailed: 'Failed to load comments', justNow: 'just now', mAgo: 'm ago', hAgo: 'h ago', dAgo: 'd ago' }
+  };
+  function t() {
+    var lang = (document.documentElement.lang || '').toLowerCase();
+    return I18N[lang.indexOf('en') === 0 ? 'en' : 'zh'];
+  }
+  function applyI18n() {
+    var s = t();
+    if (nicknameInput) nicknameInput.placeholder = s.nicknamePh;
+    if (emailInput) emailInput.placeholder = s.emailPh;
+    if (contentInput) contentInput.placeholder = s.contentPh;
+  }
+  applyI18n();
+  new MutationObserver(applyI18n).observe(document.documentElement, { attributes: true, attributeFilter: ['lang'] });
+
+  fetch(API_BASE + '/api/posts/' + ENC + '/view', { method: 'POST' }).catch(function(){});
+
+  fetch(API_BASE + '/api/posts/' + ENC + '/views')
+    .then(function(r) { return r.json(); })
+    .then(function(d) {
+      var pv = (d && (d.pv != null ? d.pv : d.views)) || 0;
+      viewCount.textContent = pv.toLocaleString();
+    })
+    .catch(function() { viewCount.textContent = '—'; });
+
+  fetch(API_BASE + '/api/posts/' + ENC + '/likes')
+    .then(function(r) { return r.json(); })
+    .then(function(d) {
+      likeCount.textContent = ((d && d.count) || 0).toLocaleString();
+      if (d && d.liked) likeBtn.classList.add('liked');
+    })
+    .catch(function() { likeCount.textContent = '—'; })
+    .finally(function() { likeBtn.disabled = false; });
+
+  likeBtn.addEventListener('click', function() {
+    likeBtn.disabled = true;
+    fetch(API_BASE + '/api/posts/' + ENC + '/like', { method: 'POST' })
+      .then(function(r) { return r.json(); })
+      .then(function(d) {
+        likeCount.textContent = ((d && d.count) || 0).toLocaleString();
+        likeBtn.classList.toggle('liked', !!(d && d.liked));
+        if (typeof umami !== 'undefined') umami.track('post-like', { post: POST_SLUG });
+      })
+      .catch(function() {})
+      .finally(function() { likeBtn.disabled = false; });
+  });
+
+  shareBtn.addEventListener('click', function() {
+    var url = window.location.href;
+    var title = document.title;
+    if (navigator.share) { navigator.share({ title: title, url: url }).catch(function(){}); return; }
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(url).then(function() {
+        var label = shareBtn.querySelector('.ui-share-text');
+        var orig = label.innerHTML;
+        label.textContent = t().shareCopied;
+        setTimeout(function() { label.innerHTML = orig; }, 1800);
+      }).catch(function() { window.prompt('Copy URL:', url); });
+    } else { window.prompt('Copy URL:', url); }
+  });
+
+  function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, function(c) {
+      return ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#039;'})[c];
+    });
+  }
+  function fmtDate(s) {
+    if (!s) return '';
+    var d = new Date(s);
+    var diff = (new Date() - d) / 1000;
+    var i18n = t();
+    if (diff < 60) return i18n.justNow;
+    if (diff < 3600) return Math.floor(diff/60) + i18n.mAgo;
+    if (diff < 86400) return Math.floor(diff/3600) + i18n.hAgo;
+    if (diff < 7*86400) return Math.floor(diff/86400) + i18n.dAgo;
+    return d.toLocaleDateString();
+  }
+  function renderComments(comments) {
+    var i18n = t();
+    if (!comments || !comments.length) {
+      commentList.innerHTML = '<div class="ui-comment-empty">' + i18n.empty + '</div>';
+      commentCount.textContent = '(0)';
+      return;
+    }
+    commentCount.textContent = '(' + comments.length + ')';
+    commentList.innerHTML = comments.map(function(c) {
+      return '<div class="ui-comment">' +
+        '<div class="ui-comment-head">' +
+          '<span class="ui-comment-name">' + escapeHtml(c.nickname || 'Anonymous') + '</span>' +
+          '<span class="ui-comment-date">' + escapeHtml(fmtDate(c.created_at || c.createdAt)) + '</span>' +
+        '</div>' +
+        '<div class="ui-comment-body">' + escapeHtml(c.content || '') + '</div>' +
+      '</div>';
+    }).join('');
+  }
+  function loadComments() {
+    fetch(API_BASE + '/api/comments?post_slug=' + encodeURIComponent(POST_SLUG))
+      .then(function(r) { return r.json(); })
+      .then(function(d) {
+        var list = Array.isArray(d) ? d : (d && d.comments) || [];
+        renderComments(list);
+      })
+      .catch(function() {
+        commentList.innerHTML = '<div class="ui-comment-empty">' + t().loadFailed + '</div>';
+      });
+  }
+  loadComments();
+
+  commentForm.addEventListener('submit', function(e) {
+    e.preventDefault();
+    var i18n = t();
+    var payload = {
+      post_slug: POST_SLUG,
+      nickname: (nicknameInput.value || '').trim(),
+      email: (emailInput.value || '').trim() || null,
+      content: (contentInput.value || '').trim(),
+      parent_id: null
+    };
+    if (!payload.nickname || !payload.content) return;
+    submitBtn.disabled = true;
+    formStatus.className = 'ui-form-status';
+    formStatus.textContent = i18n.posting;
+    fetch(API_BASE + '/api/comments', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    })
+      .then(function(r) { return r.json().then(function(j) { return { ok: r.ok, body: j }; }); })
+      .then(function(res) {
+        if (!res.ok) throw new Error((res.body && (res.body.error || res.body.message)) || 'Failed');
+        formStatus.className = 'ui-form-status success';
+        formStatus.textContent = i18n.posted;
+        commentForm.reset();
+        loadComments();
+        if (typeof umami !== 'undefined') umami.track('post-comment', { post: POST_SLUG });
+        setTimeout(function() { formStatus.textContent = ''; formStatus.className = 'ui-form-status'; }, 3000);
+      })
+      .catch(function(err) {
+        formStatus.className = 'ui-form-status error';
+        formStatus.textContent = i18n.postFailed + (err.message || '');
+      })
+      .finally(function() { submitBtn.disabled = false; });
+  });
+})();
+</script>
+
+<!-- Online presence (per-page) -->
+<script>
+(function () {
+  var DOT = '<span class="ui-online-dot"></span>';
+  var N = '<span class="ui-count">{n}</span>';
+  function dual(zh, en) { return '<span lang="zh">' + zh + '</span><span lang="en">' + en + '</span>'; }
+  window.__ONLINE_CONFIG__ = {
+    pageId: 'note/dsh',
+    tiers: [
+      { max: 1,   html: '✦ ' + dual('你是此刻唯一在读的人', 'You are the only one reading right now') },
+      { max: 9,   html: DOT + dual('此刻有 ' + N + ' 人在读', N + ' people reading right now') },
+      { max: 19,  html: DOT + dual(N + ' 人正在读这篇', N + ' reading this piece') },
+      { max: 29,  html: DOT + dual('茶座坐满了,' + N + ' 人', 'A full house, ' + N + ' reading') },
+      { max: 99,  html: '🔥 ' + dual(N + ' 人聚在这,人声渐沸', N + ' gathered here, buzzing') },
+      { max: Infinity, html: '🔥 ' + dual(N + ' 人围读!这篇火了', N + ' readers, this is on fire') }
+    ]
+  };
+})();
+</script>
+<script src="/assets/online-presence.js" defer></script>
+
+
+<script>
+/* ====== TOC scroll-spy (added 2026-06) ====== */
+(function () {
+  var sideItems = Array.prototype.map.call(
+    document.querySelectorAll('.toc-side li[data-section]'),
+    function (li) { return { node: li, el: document.getElementById(li.dataset.section) }; }
+  ).filter(function (o) { return o.el; });
+  if (!sideItems.length) return;
+  function update() {
+    var offset = window.innerHeight * 0.32;
+    var activeIdx = 0;
+    for (var i = 0; i < sideItems.length; i++) {
+      if (sideItems[i].el.getBoundingClientRect().top - offset < 0) activeIdx = i;
+    }
+    var activeId = sideItems[activeIdx].el.id;
+    sideItems.forEach(function (o) {
+      o.node.classList.toggle('active', o.el.id === activeId);
+    });
+  }
+  window.addEventListener('scroll', update, { passive: true });
+  window.addEventListener('resize', update);
+  update();
+})();
+</script>
+
+</body>
+
+
+</body>
+</html>

--- a/scripts/dsh_immersive/_html_helpers.py
+++ b/scripts/dsh_immersive/_html_helpers.py
@@ -1,0 +1,222 @@
+"""HTML builder helpers for Pi Agent immersive chapters."""
+from __future__ import annotations
+
+
+def join(*parts: str) -> str:
+    return "\n\n".join(parts)
+
+
+def p(zh: str, en: str) -> str:
+    return f"""    <div class="lang-zh-only"><p>{zh}</p></div>
+    <div class="lang-en-only"><p>{en}</p></div>"""
+
+
+def h3(zh: str, en: str, sec: str | None = None) -> str:
+    num = f'<span class="sec-num">{sec}</span> ' if sec else ""
+    return (
+        f'    <h3 class="sub">{num}'
+        f'<span class="lang-zh-only">{zh}</span><span class="lang-en-only">{en}</span></h3>'
+    )
+
+
+def h4(zh: str, en: str, sec: str | None = None) -> str:
+    num = f'<span class="sec-num">{sec}</span> ' if sec else ""
+    return (
+        f'    <h4 class="sub2 depth-sec">{num}'
+        f'<span class="lang-zh-only">{zh}</span><span class="lang-en-only">{en}</span></h4>'
+    )
+
+
+def aside_label(tag_zh: str, tag_en: str, title_zh: str, title_en: str) -> str:
+    return (
+        f'    <div class="depth-aside-head">'
+        f'<span class="da-tag"><span class="lang-zh-only">{tag_zh}</span>'
+        f'<span class="lang-en-only">{tag_en}</span></span> '
+        f'<span class="da-title lang-zh-only">{title_zh}</span>'
+        f'<span class="da-title lang-en-only">{title_en}</span></div>'
+    )
+
+
+def depth_zone_open(chap_num: str) -> str:
+    return (
+        f'    <div class="depth-zone" data-chapter="C{chap_num}">'
+        f'<div class="depth-zone-label">'
+        f'<span class="dz-tag">DEPTH</span> '
+        f'<span class="lang-zh-only">深度细读 · C{chap_num}.4+</span>'
+        f'<span class="lang-en-only">Deep dive · C{chap_num}.4+</span></div>'
+    )
+
+
+def depth_zone_close() -> str:
+    return "    </div>"
+
+
+def src(tag: str, path: str, lines: list[str]) -> str:
+    body = "\n".join(f'      <span class="src-line">{line}</span>' for line in lines)
+    return f"""    <div class="src-stack">
+      <div class="src-h">
+        <span>SOURCE &nbsp;·&nbsp; {path}</span>
+        <span class="src-tag">{tag}</span>
+      </div>
+{body}
+    </div>"""
+
+
+def sp(rows: list[tuple[str, str, str, str]]) -> str:
+    rs = []
+    for kz, ke, vz, ve in rows:
+        rs.append(
+            f"""      <div class="sp-row">
+        <div class="sp-key"><span class="lang-zh-only">{kz}</span><span class="lang-en-only">{ke}</span></div>
+        <div class="sp-val"><span class="lang-zh-only">{vz}</span><span class="lang-en-only">{ve}</span></div>
+      </div>"""
+        )
+    return "    <div class=\"stage-purpose\">\n" + "\n".join(rs) + "\n    </div>"
+
+
+def note(zh: str, en: str, copper: bool = False) -> str:
+    cls = "note copper" if copper else "note"
+    return f"""    <div class="{cls}">
+      <span class="lang-zh-only">{zh}</span>
+      <span class="lang-en-only">{en}</span>
+    </div>"""
+
+
+def formula(tz: str, te: str, lines: list[str], oz: str, oe: str) -> str:
+    conds = "\n".join(f'      <span class="cond">{line}</span>' for line in lines)
+    return f"""    <div class="formula">
+      <div class="ftitle"><span class="lang-zh-only">{tz}</span><span class="lang-en-only">{te}</span></div>
+{conds}
+      <div class="out"><span class="lang-zh-only">{oz}</span><span class="lang-en-only">{oe}</span></div>
+    </div>"""
+
+
+def ladder(items: list[tuple]) -> str:
+    """Build a priority ladder. Each item is (zh, en) or (num, zh, en) or (num, zh, en, desc_zh, desc_en)."""
+    steps = []
+    for i, item in enumerate(items, 1):
+        if len(item) == 2:
+            num, z, e, dz, de = f"{i:02d}", item[0], item[1], "", ""
+        elif len(item) == 3:
+            num, z, e, dz, de = item[0], item[1], item[2], "", ""
+        else:
+            num, z, e, dz, de = item[0], item[1], item[2], item[3], item[4]
+        desc = ""
+        if dz or de:
+            desc = (
+                f'        <div class="ld-desc"><span class="lang-zh-only">{dz}</span>'
+                f'<span class="lang-en-only">{de}</span></div>'
+            )
+        steps.append(
+            f"""      <div class="ld-row">
+        <div class="ld-num">{num}</div>
+        <div>
+          <div class="ld-name"><span class="lang-zh-only">{z}</span><span class="lang-en-only">{e}</span></div>
+{desc}
+        </div>
+      </div>"""
+        )
+    return "    <div class=\"ladder\">\n" + "\n".join(steps) + "\n    </div>"
+
+
+def keynums(items: list[tuple[str, str, str, str, str]]) -> str:
+    ks = []
+    for n, lz, le, dz, de in items:
+        ks.append(
+            f"""      <div class="keynum">
+        <div class="kn-val">{n}</div>
+        <div class="kn-label"><span class="lang-zh-only">{lz}</span><span class="lang-en-only">{le}</span></div>
+        <div class="kn-desc"><span class="lang-zh-only">{dz}</span><span class="lang-en-only">{de}</span></div>
+      </div>"""
+        )
+    return "    <div class=\"keynum-row\">\n" + "\n".join(ks) + "\n    </div>"
+
+
+def pull(zh: str, en: str) -> str:
+    return f"""    <blockquote class="pull copper">
+      <span class="lang-zh-only">{zh}</span>
+      <span class="lang-en-only">{en}</span>
+      <cite>Field Note · 10</cite>
+    </blockquote>"""
+
+
+def cmp(headers: list[str], rows: list[list[str]]) -> str:
+    ths = "".join(f"<th>{h}</th>" for h in headers)
+    trs = []
+    for row in rows:
+        tds = "".join(f"<td>{c}</td>" for c in row)
+        trs.append(f"      <tr>{tds}</tr>")
+    return f"""    <table class="cmp">
+      <thead><tr>{ths}</tr></thead>
+      <tbody>
+{chr(10).join(trs)}
+      </tbody>
+    </table>"""
+
+
+def fig(zh: str, en: str, inner: str = '<div class="fig-placeholder">diagram</div>') -> str:
+    return f"""    <figure>
+      <div class="figbox">{inner}</div>
+      <figcaption>
+        <span class="figid">FIG</span>
+        <span class="lang-zh-only">{zh}</span>
+        <span class="lang-en-only">{en}</span>
+      </figcaption>
+    </figure>"""
+
+
+def why_care(pills: list[tuple[str, str, str, str]]) -> str:
+    """Chromium-style 'why this stage matters' block. pill: (kind, zh, en, cls)."""
+    rows_zh = rows_en = ""
+    for kind, zh, en, cls in pills:
+        rows_zh += f'      <p><span class="swc-pill {cls}">{kind}</span><span>{zh}</span></p>\n'
+        rows_en += f'      <p><span class="swc-pill {cls}">{kind}</span><span>{en}</span></p>\n'
+    return f"""    <aside class="stage-why-care lang-zh-only">
+      <div class="swc-label">为什么这一段对你来说很重要</div>
+{rows_zh}    </aside>
+    <aside class="stage-why-care lang-en-only">
+      <div class="swc-label">Why this stage matters to you</div>
+{rows_en}    </aside>"""
+
+
+def stage_banner(cells: list[tuple[str, str, str, str]]) -> str:
+    """Four-column stage metadata banner."""
+    items = []
+    for kz, ke, vz, ve in cells:
+        items.append(
+            f"""      <div class="sb-cell">
+        <div class="sb-key"><span class="lang-zh-only">{kz}</span><span class="lang-en-only">{ke}</span></div>
+        <div class="sb-val"><span class="lang-zh-only">{vz}</span><span class="lang-en-only">{ve}</span></div>
+      </div>"""
+        )
+    return "    <div class=\"stage-banner\">\n" + "\n".join(items) + "\n    </div>"
+
+
+def faq_block(items: list[tuple[str, str, str, str]]) -> str:
+    parts = [aside_label("附录", "Appendix", "常见问题", "FAQ")]
+    for qz, qe, az, ae in items:
+        parts.append(
+            f"""    <details class="extended"><summary><span class="ext-tag">Q</span><span class="lang-zh-only">{qz}</span><span class="lang-en-only">{qe}</span></summary><div style="padding:12px 16px 16px"><div class="lang-zh-only"><p>{az}</p></div><div class="lang-en-only"><p>{ae}</p></div></div></details>"""
+        )
+    return "\n\n".join(parts)
+
+
+def trace_box(station: str, zh: str, en: str) -> str:
+    return f"""    <div class="trace-box">
+      <div class="tb-tag">TRACE · station {station}</div>
+      <div class="lang-zh-only"><p>{zh}</p></div>
+      <div class="lang-en-only"><p>{en}</p></div>
+    </div>"""
+
+
+def section_block(
+    title_zh: str,
+    title_en: str,
+    paragraphs: list[tuple[str, str]],
+    *,
+    sec: str | None = None,
+) -> str:
+    parts = [h4(title_zh, title_en, sec)]
+    for zh, en in paragraphs:
+        parts.append(p(zh, en))
+    return join(*parts)

--- a/scripts/dsh_immersive/chapters.py
+++ b/scripts/dsh_immersive/chapters.py
@@ -1,0 +1,861 @@
+"""Rich HTML chapter bodies for DeepSeek Harness (DSH) immersive article."""
+from __future__ import annotations
+
+from _html_helpers import (
+    cmp,
+    formula,
+    h3,
+    h4,
+    join,
+    keynums,
+    ladder,
+    note,
+    p,
+    pull,
+    sp,
+    src,
+)
+from doc_map import doc_ref
+from visuals import (
+    station_track,
+    viz_22_stations_panorama,
+    viz_cordis_layers,
+    viz_event_domains,
+    viz_harness_compare,
+    viz_plugin_spectrum,
+    viz_session_log,
+    viz_turn_step,
+)
+
+PROMPT_ZH = "读取 README.md，用一句话告诉我这个项目做什么"
+PROMPT_EN = "read README.md and tell me what this project does in one sentence"
+
+
+def event_table(events: list[tuple[str, str, str]]) -> str:
+    inner = ['<div class="event-flow">']
+    for etype, zh, en in events:
+        inner.append(
+            f'      <div class="ef-row"><div class="ef-type">{etype}</div>'
+            f'<div><span class="lang-zh-only">{zh}</span><span class="lang-en-only">{en}</span></div></div>'
+        )
+    inner.append("    </div>")
+    return f"""    <figure>
+      <div class="figbox">{chr(10).join(inner)}
+      </div>
+      <figcaption><span class="figid">EVT</span><span class="lang-zh-only">SessionEvent 流 · 主线 prompt</span><span class="lang-en-only">SessionEvent stream · through-line prompt</span></figcaption>
+    </figure>"""
+
+
+def core_ctx_table() -> str:
+    return cmp(["ctx 键", "Package", "职责 / Role"], [
+        ["ctx.sessions", "packages/core/session", "append-only SessionEvent log"],
+        ["ctx.systemPrompt", "packages/core/system-prompt", "prompt section + tool schema assembly"],
+        ["ctx.tools", "packages/core/tools", "scoped registry + guarded pipeline"],
+        ["ctx.agents", "packages/core/agent", "Agent registry + agent/* events"],
+        ["ctx.agentLoop", "packages/core/agent-loop", "ReactLoopAgent driver"],
+        ["ctx.llm", "packages/llm/llm", "adapter registry + llm/stream waterfall"],
+    ])
+
+
+def build_all_chapters() -> dict[str, str]:
+    return {
+        "c1": chapter_c1(),
+        "c2": chapter_c2(),
+        "c3": chapter_c3(),
+        "c4": chapter_c4(),
+        "c5": chapter_c5(),
+        "c6": chapter_c6(),
+        "c7": chapter_c7(),
+        "c8": chapter_c8(),
+        "c9": chapter_c9(),
+        "c10": chapter_c10(),
+        "c11": chapter_c11(),
+        "c12": chapter_c12(),
+        "c13": chapter_c13(),
+        "c14": chapter_c14(),
+        "c15": chapter_c15(),
+        "c16": chapter_c16(),
+        "c17": chapter_c17(),
+        "c18": chapter_c18(),
+        "c19": chapter_c19(),
+        "c20": chapter_c20(),
+        "c21": chapter_c21(),
+        "c22": chapter_c22(),
+        "c23": chapter_c23(),
+        "c24": chapter_c24(),
+        "c25": chapter_c25(),
+        "c26": chapter_c26(),
+    }
+
+
+def chapter_c1() -> str:
+    return join(
+        p(
+            f"DeepSeek Harness（DSH）不是又一个 ChatGPT 套壳——它是 DeepSeek 开源的 <strong>Cordis 插件 harness</strong>。主线 prompt <code>{PROMPT_ZH}</code> 在 DSH 里不会「直接发给模型」：它先进入 <code>ctx.agents</code> 的 inbox，被 <code>ReactLoopAgent</code> 认领，写成 <code>user/message</code> SessionEvent，再经 <code>deriveMessages()</code> 投影成 LLM 请求。",
+            f"DeepSeek Harness (DSH) is not another ChatGPT wrapper — it is DeepSeek's open <strong>Cordis plugin harness</strong>. The through-line prompt <code>{PROMPT_EN}</code> never goes straight to the model: it enters <code>ctx.agents</code> inbox, is claimed by <code>ReactLoopAgent</code>, logged as <code>user/message</code> SessionEvent, then projected via <code>deriveMessages()</code> into an LLM request.",
+        ),
+        h3("Harness 不是 Product", "Harness is not a product"),
+        p(
+            "Claude Code、Cursor 把 agent 循环焊进密封二进制：你能用，但很难逐事件 trace。Pi 把循环写进 TypeScript，但故意省略 MCP 与子 agent。DSH 的赌注是：<strong>一切都是插件</strong>——包括 agent loop 本身——同时保留 MCP、compaction、fork/resume、Agent Teams。",
+            "Claude Code and Cursor weld the agent loop into sealed binaries: usable, but hard to trace event-by-event. Pi writes the loop in TypeScript but intentionally omits MCP and sub-agents. DSH bets that <strong>everything is a plugin</strong> — including the agent loop itself — while keeping MCP, compaction, fork/resume, and Agent Teams.",
+        ),
+        sp([
+            ("产品", "Product", "卖体验闭环：安装 → 第一次 commit 零配置", "Sells closed-loop UX: install → first commit with zero config"),
+            ("Harness", "Harness", "卖可观测编排：每一站都有源码、测试、dump-config", "Sells observable orchestration: every station has source, tests, dump-config"),
+            ("DSH 差异", "DSH difference", "无 privileged core；改行为 = 挂插件或写 patch", "No privileged core; change behavior = mount plugin or write patch"),
+            ("主线", "Through-line", "同一句话走完整 turn/step + tool pipeline", "Same sentence walks full turn/step + tool pipeline"),
+        ]),
+        formula("架构公式", "ARCHITECTURE", [
+            '<span class="term">Product</span> = UX × Integrations × Policy',
+            '<span class="term-cu">DSH</span> = Cordis × SessionEvent × ReactLoopAgent × Seams',
+        ], "DSH 选择可组合 + 可回放", "DSH chooses composability + replayability"),
+        cmp(["", "Claude Code", "Cursor", "DSH"], [
+            ["内核", "密封 CLI", "密封 IDE", "Cordis 插件树"],
+            ["会话", "专有云", "专有", "SessionEvent log"],
+            ["扩展", "MCP", "VS Code", "Bundle + patch + npm 插件"],
+            ["子 agent", "内置", "内置", "packages/subagent/*"],
+            ["trace", "黑盒", "黑盒", "dump-config + session log"],
+        ]),
+        h3("为什么开源 harness 仍然重要", "Why an open harness still matters"),
+        p(
+            "官方 <code>docs/architecture.md</code> 第一句就点明：改 <code>packages/</code> 前先读 Cordis primer。DSH 把「模型可见即已记录」（Model-visible means logged）写成运行时 invariant——这意味着你 trace 主线 prompt 时，<strong>日志就是真相源</strong>，不是调试输出。",
+            "Official <code>docs/architecture.md</code> opens with: read the Cordis primer before changing <code>packages/</code>. DSH encodes «Model-visible means logged» as a runtime invariant — when tracing the through-line prompt, <strong>the log is the source of truth</strong>, not debug output.",
+        ),
+        src("arch", "docs/architecture.md", [
+            '<span class="src-comment">/** There is no privileged core to patch */</span>',
+            '<span class="src-kw">Every part of the product is a plugin</span>, including the model adapter,',
+            'the tool registry, the session log, and the agent loop itself.',
+        ]),
+        note("DSH 解决的是「想理解 agent 内部机制、还要能改」的开发者；Claude Code/Cursor 解决的是「想马上写代码」的开发者。", "DSH serves developers who want to understand and modify agent internals; Claude Code/Cursor serve developers who want to code immediately.", copper=True),
+        pull("产品卖的是答案。<br>DSH 卖的是<strong>能 dump 出下一层配置</strong>的显微镜。", "Products sell answers.<br>DSH sells the microscope that can <strong>dump the next layer of config</strong>."),
+        doc_ref("architecture"),
+        doc_ref("cordis-primer"),
+        viz_plugin_spectrum(),
+    )
+
+
+def chapter_c2() -> str:
+    return join(
+        p(
+            f"按下回车发送 <code>{PROMPT_ZH}</code> 之后，Web UI（:3080）或 headless CLI 不会立刻调用 DeepSeek API——消息先进入 agent inbox，驱动器发出 <code>turn/start</code>，经过 <code>agent/pre-step</code> waterfall，在 <code>step/start</code> 后落成 <code>user/message</code>，然后才是 <code>llm/stream</code>、<code>assistant/chunk*</code>、<code>tool/call*</code>，最后 <code>turn/end</code>。",
+            f"After Enter on <code>{PROMPT_EN}</code>, the Web UI (:3080) or headless CLI does not immediately call the DeepSeek API — the message enters agent inbox, the driver emits <code>turn/start</code>, passes <code>agent/pre-step</code> waterfall, lands as <code>user/message</code> after <code>step/start</code>, then <code>llm/stream</code>, <code>assistant/chunk*</code>, <code>tool/call*</code>, and finally <code>turn/end</code>.",
+        ),
+        h3("22 站全景地图", "22-station panorama map"),
+        p(
+            "下面两图把一条用户消息从 CLI/profile 解析到 compaction 检查的<strong>完整工序</strong>摊开。持住这张地图，C03–C26 每章只解释相邻两站之间的过渡，细节才不会丢。",
+            "The two diagrams below lay out the <strong>full path</strong> of one user message from CLI/profile parse to compaction check. Hold this map: chapters C03–C26 each explain one transition between adjacent stations.",
+        ),
+        viz_22_stations_panorama(),
+        station_track(),
+        h3("主线事件序（简化）", "Through-line event order (simplified)"),
+        event_table([
+            ("turn/start", "新 turn 打开 · claim inbox 批次", "New turn opens · claim inbox batch"),
+            ("agent/pre-step", "waterfall：reject 或 enter(messages)", "waterfall: reject or enter(messages)"),
+            ("step/start", "一步 model 请求 + 工具批次开始", "One model request + tool batch begins"),
+            ("user/message", "主线 prompt 写入 SessionEvent log", "Through-line prompt written to SessionEvent log"),
+            ("llm/stream", "DeepSeek adapter 流式返回", "DeepSeek adapter streams back"),
+            ("assistant/chunk*", "流式 token · UI 订阅 session/event", "Streaming tokens · UI subscribes session/event"),
+            ("tool/call", "模型选择 read(README.md)", "Model chooses read(README.md)"),
+            ("tool/result", "工具结果 · 进入 deriveMessages 投影", "Tool result · enters deriveMessages projection"),
+            ("turn/end", "无更多 step 欠账 · agent idle", "No more steps owed · agent idle"),
+        ]),
+        h3("Turn 与 Step 的嵌套关系", "Turn and step nesting"),
+        p(
+            "官方 <code>agent-lifecycle.md</code> 定义：<strong>step</strong> = 一次 model 请求 + 其工具调用；<strong>turn</strong> = 零个或多个 step。主线 prompt 通常产生 <strong>两个 step</strong>（第一次 toolUse read，第二次 stop 回答），包在同一个 turn 里。",
+            "Official <code>agent-lifecycle.md</code> defines: a <strong>step</strong> is one model request plus its tool calls; a <strong>turn</strong> is zero or more steps. The through-line prompt usually yields <strong>two steps</strong> (first toolUse read, second stop answer) inside one turn.",
+        ),
+        ladder([
+            ("Turn 1", "turn/start → step 1 → read tool → step/end"),
+            ("Step 2", "step/start → deriveMessages → llm/stream → assistant stop"),
+            ("Turn close", "turn/end → agent/status idle"),
+        ]),
+        doc_ref("agent-lifecycle"),
+        note("C02 是望远镜；C09–C13 是显微镜。", "C02 is the telescope; C09–C13 are the microscope.", copper=True),
+    )
+
+
+def chapter_c3() -> str:
+    return join(
+        p(
+            "Cordis 是 vendored 在 <code>vendor/</code> 的插件框架：每个能力是一个 <code>Service</code>，通过 <code>ctx.&lt;key&gt;</code> 暴露，通过 <code>inject</code> 声明依赖，通过 <code>ctx.on()</code> / <code>ctx.effect()</code> 注册可逆副作用。DSH 没有「核心二进制」——连 agent loop 也是 <code>@deepseek-ai/dsh-agent-loop</code> 插件。",
+            "Cordis is the vendored plugin framework under <code>vendor/</code>: each capability is a <code>Service</code> exposed via <code>ctx.&lt;key&gt;</code>, dependencies via <code>inject</code>, reversible side effects via <code>ctx.on()</code> / <code>ctx.effect()</code>. DSH has no «core binary» — even the agent loop is the <code>@deepseek-ai/dsh-agent-loop</code> plugin.",
+        ),
+        h3("Context · Plugin · Mount", "Context · Plugin · Mount"),
+        p(
+            "Loader 读取 <code>cordis.yml</code> / patch 行，按服务可用性激活插件——<strong>行顺序无加载语义</strong>。插件 mount 时 claim <code>ctx.sessions</code> 等键；unmount 时 effect  unwind。其他插件通过 key 查找服务，而非 import 具体实现。",
+            "Loader reads <code>cordis.yml</code> / patch rows and activates plugins by service availability — <strong>row order has no load semantics</strong>. On mount a plugin claims keys like <code>ctx.sessions</code>; on unmount effects unwind. Other plugins find services by key, not by importing concrete implementations.",
+        ),
+        cmp(["Cordis 范式", "DSH 例子", "主线 touchpoint"], [
+            ["Service", "ctx.tools", "read 工具注册"],
+            ["inject", "agent-loop → session, llm", "ReactLoopAgent 启动"],
+            ["waterfall", "agent/pre-step", "compaction · skill 目录注入"],
+            ["effect", "systemPrompt section", "AGENTS.md 栈"],
+            ["emit", "session/event", "Web UI 渲染"],
+        ]),
+        h3("Waterfall 与 short-circuit", "Waterfall and short-circuit"),
+        p(
+            "<code>ctx.waterfall</code> 是 around-middleware：listener 收到 <code>(payload, next)</code>，调用 <code>next()</code> 继续链，不调用则 short-circuit。<code>agent/pre-step</code> 的返回值<strong>权威</strong>——可以 reject 整个 step 或 rewrite enter(messages)。",
+            "<code>ctx.waterfall</code> is around-middleware: a listener receives <code>(payload, next)</code>, calls <code>next()</code> to continue the chain, or short-circuits without it. The <code>agent/pre-step</code> return is <strong>authoritative</strong> — it can reject the whole step or rewrite enter(messages).",
+        ),
+        src("cordis", "docs/cordis-primer.md", [
+            '<span class="src-kw">A plugin</span> waits until injected services exist —',
+            'load order is expressed through <span class="src-str">inject</span>, not manual boot sequencing.',
+        ]),
+        viz_cordis_layers(),
+        doc_ref("cordis-primer"),
+    )
+
+
+def chapter_c4() -> str:
+    return join(
+        p(
+            "运行中的 <code>dsh</code> 是一棵按序叠加的插件树：<strong>Profile</strong>（命名组合，存于 <code>$DSH_HOME/profiles/&lt;name&gt;</code>）列出 bundles + 用户 <code>cordis.patch.yml</code>；<strong>Bundle</strong>（如 <code>@deepseek-ai/dsh-base</code>）是 Cordis 配置行 + 代码的发行格式。",
+            "A running <code>dsh</code> is a plugin tree stacked in order: a <strong>Profile</strong> (named composition under <code>$DSH_HOME/profiles/&lt;name&gt;</code>) lists bundles plus the user's <code>cordis.patch.yml</code>; a <strong>Bundle</strong> (e.g. <code>@deepseek-ai/dsh-base</code>) is the distribution format for Cordis config rows and the code they mount.",
+        ),
+        h3("三层叠加顺序", "Three-layer stack order"),
+        ladder([
+            ("bundles[]", "dsh-base → dsh-web-app（profile 声明顺序）"),
+            ("profile patch", "profiles/web/cordis.patch.yml"),
+            ("home patch", "$DSH_HOME/cordis.patch.yml"),
+            ("--patch", "CLI 一次性 overlay"),
+        ]),
+        p(
+            "Patch 按 <code>id</code>  targeting：<strong>整行替换 config</strong>，不是 deep-merge。要看机器实际 boot 的树，运行 <code>dsh --profile web --dump-config</code>——输出与 <code>boot()</code> 挂载的树一致（<code>packages/boot/app-boot</code> 的 <code>renderConfigDump</code>）。",
+            "Patches target by <code>id</code>: they <strong>replace the whole row config</strong>, not deep-merge. To see the tree your machine actually boots, run <code>dsh --profile web --dump-config</code> — output matches what <code>boot()</code> mounts (<code>renderConfigDump</code> in <code>packages/boot/app-boot</code>).",
+        ),
+        h3("官方三个 Bundle", "Three official bundles"),
+        cmp(["Bundle", "Package", "Adds"], [
+            ["dsh-base", "packages/bundle/base", "模型 · 工具 · 会话 · 沙箱 · 凭据"],
+            ["dsh-web-app", "packages/bundle/web-app", "浏览器 UI · :3080 Host"],
+            ["dsh-headless", "packages/bundle/headless", "一次性 runner · 无 HTTP"],
+        ]),
+        src("dump", "apps/cli/src/bin.ts", [
+            '<span class="src-comment">// dsh --profile web --dump-config</span>',
+            '<span class="src-fn">renderConfigDump</span>(binName, configPath, layers, warn)',
+        ]),
+        sp([
+            ("web", "web profile", "首次使用自动从模板初始化", "auto-init from template on first use"),
+            ("headless", "headless", "单会话 · 打印最终回答 · exit", "one session · print final answer · exit"),
+            ("plugin", "dsh plugin", "pnpm 管理 profile 外树插件", "pnpm manages out-of-tree profile plugins"),
+        ]),
+        doc_ref("architecture"),
+    )
+
+
+def chapter_c5() -> str:
+    return join(
+        p(
+            "<code>@deepseek-ai/dsh-base</code> 的 <code>cordis.patch.yml</code> 在空 profile 根上 insert 所有基础插件行——每个 profile 的 <code>dsh.profile.bundles</code> 第一层。文档把<strong>六个 ctx 脊柱服务</strong>列为理解 turn 流的最小集合。",
+            "<code>@deepseek-ai/dsh-base</code> <code>cordis.patch.yml</code> inserts every base plugin row over the empty profile root — the first layer of every profile's <code>dsh.profile.bundles</code>. Docs list <strong>six ctx spine services</strong> as the minimal set for understanding turn flow.",
+        ),
+        h3("六层 ctx 脊柱", "Six ctx spine layers"),
+        core_ctx_table(),
+        viz_cordis_layers(),
+        h3("dsh-base 还包含什么", "What else dsh-base includes"),
+        p(
+            "除六脊柱外，base patch 还 insert 沙箱（<code>bash-sandbox</code> / <code>pwsh-sandbox</code> 平台门控）、审批（<code>user-approval</code>）、settings/credentials、telemetry、spawn/fork subagent providers 等。Windows 与 POSIX 通过 <code>disabled: !!js process.platform === 'win32'</code> 在同一 patch 文件里互斥挂载 shell 栈。",
+            "Beyond the six spine services, the base patch also inserts sandbox (<code>bash-sandbox</code> / <code>pwsh-sandbox</code> platform gating), approval (<code>user-approval</code>), settings/credentials, telemetry, spawn/fork subagent providers, etc. Windows and POSIX mutually exclude shell stacks in one patch file via <code>disabled: !!js process.platform === 'win32'</code>.",
+        ),
+        src("base", "packages/bundle/base/cordis.patch.yml", [
+            '- id: session',
+            '  name: \'@deepseek-ai/dsh-session\'',
+            '- id: agent-loop',
+            '  name: \'@deepseek-ai/dsh-agent-loop\'',
+        ]),
+        formula("依赖方向", "DEPENDENCY", [
+            '<span class="term">agent-loop</span> → agents · sessions · llm · tools',
+            '<span class="term-cu">systemPrompt</span> ← context plugins (AGENTS.md, skills)',
+        ], "上层组装下层，通过 inject 而非 import", "Upper layers compose lower via inject, not import"),
+        keynums([
+            ("219+", "workspace 包", "packages", "官方 monorepo 插件数量级", "order-of-magnitude official monorepo plugins"),
+            ("6", "ctx 脊柱", "ctx spine", "session · prompt · tools · agents · loop · llm", "session · prompt · tools · agents · loop · llm"),
+            ("0", "privileged core", "privileged core", "vendor/Cordis 也可被 patch 替换", "vendor/Cordis can also be patched"),
+        ]),
+        doc_ref("capability-seams"),
+    )
+
+
+def chapter_c6() -> str:
+    return join(
+        p(
+            "你在 shell 输入 <code>dsh web</code>（<code>--profile web</code> 别名），启动链从 <code>apps/cli/src/args.ts</code> 解析 launcher flags，<code>src/bin.ts</code> 加载对应 runner，<code>packages/boot/app-boot</code> 的 <code>boot()</code> 创建 Cordis root、compose profile layers、mount include 树，Host 绑定 loopback :3080，浏览器加载 Web surface。",
+            "You type <code>dsh web</code> (alias of <code>--profile web</code>); the boot chain parses launcher flags in <code>apps/cli/src/args.ts</code>, <code>src/bin.ts</code> loads the runner, <code>boot()</code> in <code>packages/boot/app-boot</code> creates the Cordis root, composes profile layers, mounts the include tree, Host binds loopback :3080, browser loads the Web surface.",
+        ),
+        h3("CLI → Profile → :3080", "CLI → Profile → :3080"),
+        ladder([
+            ("apps/cli", "dsh web · --profile web"),
+            ("app-boot", "loadProfile · composeEntries · boot()"),
+            ("dsh-base + dsh-web-app", "Cordis plugin tree"),
+            ("packages/host", "HTTP Host · static dist"),
+            ("packages/web", "React client · session/event SSE"),
+        ]),
+        src("cli", "apps/cli/README.md", [
+            '| <code>dsh web</code> | Alias of <code>--profile web</code> |',
+            'The invoking directory is the default workspace root.',
+        ]),
+        h3("Launcher 与 App 参数分界", "Launcher vs app argument boundary"),
+        p(
+            "Launcher 只解析自己的 flags；第一个无法识别的 token 起属于 profile 注入的 app 插件（如 <code>--port 8080</code> 给 web app）。这意味着 <code>dsh --profile web --help</code> 显示的是 Web UI 帮助，不是 launcher 帮助。",
+            "The launcher parses only its own flags; from the first unrecognized token onward belongs to the profile's injected app plugin (e.g. <code>--port 8080</code> for the web app). So <code>dsh --profile web --help</code> shows Web UI help, not launcher help.",
+        ),
+        cmp(["阶段", "模块", "失败行为"], [
+            ["parse", "apps/cli/src/args.ts", "exit nonzero"],
+            ["compose", "app-boot/loadProfile", "profile 缺失 → 模板初始化或 fail loud"],
+            ["mount", "app-boot/boot", "partial ctx dispose + labelled stderr"],
+            ["serve", "packages/host", "Web surface 未加载则不创建 tray"],
+        ]),
+        note("冷启动时用户尚未输入主线 prompt，但 Cordis 树已就绪、:3080 已在听。", "On cold boot the user has not typed the through-line prompt yet, but the Cordis tree is ready and :3080 is listening.", copper=True),
+    )
+
+
+def chapter_c7() -> str:
+    return join(
+        p(
+            "<code>ctx.sessions</code>（<code>packages/core/session</code>）维护 append-only <code>SessionEvent</code> log；<code>ctx.agents</code>（<code>packages/core/agent</code>）维护 live <code>Agent</code> registry。主线 prompt 通过 <code>agent.followup(content)</code> 进入 inbox，由 <code>ReactLoopAgent</code>（<code>packages/core/agent-loop/src/agent.ts</code>）驱动。",
+            "<code>ctx.sessions</code> (<code>packages/core/session</code>) maintains the append-only <code>SessionEvent</code> log; <code>ctx.agents</code> (<code>packages/core/agent</code>) maintains the live <code>Agent</code> registry. The through-line prompt enters via <code>agent.followup(content)</code> into inbox, driven by <code>ReactLoopAgent</code> (<code>packages/core/agent-loop/src/agent.ts</code>).",
+        ),
+        h3("Session 与 Agent 的分工", "Session vs Agent split"),
+        cmp(["对象", "持久?", "主线时刻"], [
+            ["Session", "✓ log + persistence", "user/message · tool/result 落盘"],
+            ["Agent", "△ runtime only", "inbox claim · turn/step 状态机"],
+            ["Inbox", "✗", "followup 排队 · next-step vs later"],
+            ["Driver", "✗", "ReactLoopAgent 认领 prepared session"],
+        ]),
+        src("agent", "packages/core/agent-loop/src/agent.ts", [
+            '<span class="src-kw">export class</span> <span class="src-cls">ReactLoopAgent</span> <span class="src-kw">implements</span> <span class="src-cls">Agent</span> {',
+            '  <span class="src-kw">constructor</span>(loopCtx, id, options, <span class="src-arg">session</span>: <span class="src-cls">Session</span>)',
+            '  <span class="src-comment">/** Drives one session through turn and step boundaries. */</span>',
+        ]),
+        h3("一个 prepared session 只能被一个 driver 认领", "One prepared session, one driver"),
+        p(
+            "架构文档强调：lifecycle owner 通过 <code>ctx.agents</code> 创建 agent，而不是直接 new <code>ReactLoopAgent</code>。包导出刻意不提供 <code>./src/*</code> 逃逸 hatch——可观测行为全部经由 session events + <code>agent/*</code> 分类体系。",
+            "Architecture docs stress: lifecycle owners create agents through <code>ctx.agents</code>, not by directly constructing <code>ReactLoopAgent</code>. Package exports deliberately expose no <code>./src/*</code> escape hatch — all observable behavior goes through session events + the <code>agent/*</code> taxonomy.",
+        ),
+        event_table([
+            ("agent/inbox/inserted", "followup 入队", "followup queued"),
+            ("agent/inbox/claimed", "claim 批次绑定 turn", "claimed batch bound to turn"),
+            ("agent/status", "running ↔ idle", "running ↔ idle"),
+            ("session/created", "新会话 · persistence 订阅", "new session · persistence subscribes"),
+        ]),
+        doc_ref("agent-lifecycle"),
+    )
+
+
+def chapter_c8() -> str:
+    return join(
+        p(
+            "模型看到的 system 内容不是裸仓库规则——<code>ctx.systemPrompt</code>（<code>packages/core/system-prompt</code>）在每次 step 前通过 <code>system-prompt/assemble</code> waterfall 把 prompt section 与 tool schema 拼成最终前缀。AGENTS.md 栈、skill 目录、plan mode 提示都以 section 形式注入。",
+            "The system content the model sees is not bare repo rules — <code>ctx.systemPrompt</code> (<code>packages/core/system-prompt</code>) assembles prompt sections and tool schemas via the <code>system-prompt/assemble</code> waterfall before each step. AGENTS.md stacks, skill catalogs, and plan-mode hints inject as sections.",
+        ),
+        h3("Prompt section 叠加", "Prompt section stacking"),
+        ladder([
+            ("harness:identity", "DSH 身份 · 不可用户覆盖"),
+            ("harness:source", "可选 · checkout 路径（dev boot）"),
+            ("persona / AGENTS.md", "packages/context/agent-instructions"),
+            ("skills catalog", "packages/skill/tool-skill @ pre-step"),
+            ("tool schemas", "ctx.tools 注册 · 动态生成"),
+        ]),
+        src("sp", "packages/core/system-prompt/README.md", [
+            '<span class="src-comment">// system-prompt/assemble waterfall</span>',
+            'Sections register via <span class="src-fn">ctx.effect()</span> and unwind on plugin unload.',
+        ]),
+        h3("主线 prompt 时的模型输入长什么样", "What model input looks like at through-line prompt"),
+        p(
+            "简化：<code>[assembled system sections + tool schemas] + deriveMessages() 投影的历史 + 本轮 user/message</code>。<code>agent/request</code> waterfall 允许最后一英里修改 messages / model / tools，然后才进入 <code>llm/stream</code>。",
+            "Simplified: <code>[assembled system sections + tool schemas] + deriveMessages() projected history + this step's user/message</code>. The <code>agent/request</code> waterfall allows last-mile edits to messages / model / tools before <code>llm/stream</code>.",
+        ),
+        sp([
+            ("section", "section", "有序注册 · effect 卸载", "ordered registration · effect unwinds on unload"),
+            ("KV cache", "KV cache", "identity/source 靠近头部 · 少抖动", "identity/source near head · less churn"),
+            ("web Models 页", "web Models page", "写 settings.yaml · 热重载 adapter", "writes settings.yaml · hot-reloads adapter"),
+        ]),
+        doc_ref("architecture"),
+    )
+
+
+def chapter_c9() -> str:
+    return join(
+        p(
+            "DSH 的心脏是 append-only <strong>SessionEvent log</strong>（<code>packages/core/session</code>）。任何进入模型请求的内容必须能从事务 log 重建——官方 invariant：<strong>Model-visible means logged</strong>，运行时 assert。",
+            "DSH's heart is the append-only <strong>SessionEvent log</strong> (<code>packages/core/session</code>). Anything that enters a model request must be reconstructable from the log — official invariant: <strong>Model-visible means logged</strong>, runtime assert.",
+        ),
+        h3("Log 是唯一真相源", "Log is the single source of truth"),
+        p(
+            "<code>session/title</code>、telemetry 噪声等事件可以写入 log 但<strong>不进入</strong> <code>deriveMessages()</code> 投影——surface 是 sole derivation path。fork/resume 重放同一 log 序列，投影 deterministic（见 <code>packages/core/session/tests/properties.spec.ts</code>）。",
+            "Events like <code>session/title</code> and telemetry noise may append to the log but do <strong>not</strong> enter the <code>deriveMessages()</code> projection — the surface is the sole derivation path. Fork/resume replay the same log sequence; projection is deterministic (see <code>packages/core/session/tests/properties.spec.ts</code>).",
+        ),
+        viz_session_log(),
+        src("inv", "docs/architecture.md", [
+            '<span class="src-str">Model-visible means logged.</span>',
+            'Extend <span class="src-cls">SessionEventMap</span> and render from the log.',
+        ]),
+        h3("session/event 广播", "session/event broadcast"),
+        p(
+            "每次 append 触发 <code>session/event</code> emit——Web client、ACP、telemetry、compaction 都订阅此总线。UI 渲染<strong>只</strong>应消费 session 域事件做 replay；<code>agent/*</code> 是 live 协调 API。",
+            "Each append emits <code>session/event</code> — Web client, ACP, telemetry, compaction all subscribe. UI rendering should <strong>only</strong> consume session-domain events for replay; <code>agent/*</code> is the live coordination API.",
+        ),
+        cmp(["事件类型", "进入 deriveMessages?", "例子"], [
+            ["user/message", "✓", "主线 prompt"],
+            ["assistant/chunk", "△", "流式 · 合成 assistant/message"],
+            ["tool/result", "✓", "read README 内容"],
+            ["session/title", "✗", "侧边栏标题"],
+        ]),
+        pull("JSONL 思维：Pi 把 transcript 当树。<br>DSH 把 log 当<strong>事件溯源带</strong>。", "JSONL mindset: Pi treats transcript as a tree.<br>DSH treats the log as an <strong>event-sourcing tape</strong>."),
+        doc_ref("architecture"),
+    )
+
+
+def chapter_c10() -> str:
+    return join(
+        p(
+            "<code>ReactLoopAgent</code> 实现 turn/step 双环：<strong>turn</strong> 管理 inbox claim 与 <code>turn/end</code>；<strong>step</strong> 承载一次 <code>llm/stream</code> + 关联 tool batch。主线 prompt 通常在一个 turn 内跑两个 step。",
+            "<code>ReactLoopAgent</code> implements turn/step twin loops: the <strong>turn</strong> manages inbox claim and <code>turn/end</code>; each <strong>step</strong> holds one <code>llm/stream</code> plus its tool batch. The through-line prompt usually runs two steps within one turn.",
+        ),
+        h3("外环 Turn · 内环 Step", "Outer turn · inner step"),
+        viz_turn_step(),
+        src("loop", "packages/core/agent-loop/src/agent.ts", [
+            '<span class="src-comment">// phase: idle | running turn N step M</span>',
+            '<span class="src-kw">private</span> phase: Phase',
+            '<span class="src-kw">private readonly</span> dispatch: AgentEventDispatch',
+        ]),
+        h3("何时开下一个 step", "When the next step opens"),
+        p(
+            "当前 step 在 <code>step/end</code> 后，若 tool batch 仍欠模型一轮、或 next-step inbox 有新输入，驱动器 claim 下一批并再次走 <code>agent/pre-step</code>。若 <code>agent/pre-step</code> reject，claimed batch 仍被移除但 turn 不消耗 step——这是 steering 与 compaction 的挂钩点。",
+            "After <code>step/end</code>, if the tool batch still owes the model another round or next-step inbox has new input, the driver claims the next batch and runs <code>agent/pre-step</code> again. If <code>agent/pre-step</code> rejects, the claimed batch is still removed but the turn spends no step — the hook point for steering and compaction.",
+        ),
+        event_table([
+            ("turn/start", "打开 turn · 分配 turn id", "open turn · assign turn id"),
+            ("step/start", "打开 step · 准备 deriveMessages", "open step · prepare deriveMessages"),
+            ("step/end", "一步完成 · 检查 continuation", "step complete · check continuation"),
+            ("turn/end", "turn 关闭 · 无欠账", "turn closes · nothing owed"),
+        ]),
+        doc_ref("agent-lifecycle"),
+        pull("外环是 inbox 耐心。<br>内环是 model+tool 纪律。", "Outer loop is inbox patience.<br>Inner loop is model+tool discipline."),
+    )
+
+
+def chapter_c11() -> str:
+    return join(
+        p(
+            "每个 step 开始前，<code>agent/pre-step</code> waterfall（<code>packages/core/agent-loop</code> dispatch，listeners 遍布 compaction、skill、plan-mode、subagent 等）接收 <code>{ agent, turn, ... }</code> 与 <code>next</code>。返回值 <strong>reject</strong> 或 <strong>enter(messages)</strong> 权威。",
+            "Before each step, the <code>agent/pre-step</code> waterfall (<code>packages/core/agent-loop</code> dispatch; listeners across compaction, skill, plan-mode, subagent, etc.) receives <code>{ agent, turn, ... }</code> and <code>next</code>. The return <strong>reject</strong> or <strong>enter(messages)</strong> is authoritative.",
+        ),
+        h3("Waterfall 监听者矩阵（节选）", "Waterfall listener matrix (excerpt)"),
+        cmp(["Listener 包", "pre-step 行为", "主线相关"], [
+            ["compaction-basic", "token 压力 · 摘要", "长会话"],
+            ["tool-skill", "skill 目录 system-reminder", "可选"],
+            ["plan-mode", "plan 工具门控", "—"],
+            ["session-checkpoint-policy", "checkpoint 边界", "持久性"],
+            ["subagent-in-process-driver", "子 agent 上下文", "C25"],
+        ]),
+        h3("Case study：reject vs enter", "Case study: reject vs enter"),
+        p(
+            "Compaction 在 pre-step 检测到 overflow 时可能 reject 当前 enter 提案，先跑摘要再开新 turn。Skill 插件在 enter 上追加 user-role <code>&lt;system-reminder&gt;</code> 目录——这些消息若进入模型，必须先有对应 <code>user/message</code> SessionEvent（invariant）。",
+            "Compaction may reject the current enter proposal at pre-step when detecting overflow, summarize first, then open a fresh turn. The skill plugin appends user-role <code>&lt;system-reminder&gt;</code> catalog to enter — if these reach the model, matching <code>user/message</code> SessionEvents must exist first (invariant).",
+        ),
+        src("pre", "packages/core/agent/src/runtime-types.ts", [
+            '<span class="src-str">agent/pre-step</span> · mode: <span class="src-str">waterfall</span>',
+            'Listeners: compaction-basic, tool-skill, plan-mode, ...',
+        ]),
+        doc_ref("event-producer-consumer"),
+    )
+
+
+def chapter_c12() -> str:
+    return join(
+        p(
+            "模型在 <code>assistant/message</code> 里返回 tool-call block 后，驱动器写 <code>tool/call</code> SessionEvent，然后走 <code>tools/pre-execute</code> → monotonic guards → <code>tools/execute</code> → <code>tools/post-execute</code> → <code>tool/result</code>。详见 <code>docs/tool-execution-pipeline.md</code>。",
+            "After the model returns a tool-call block in <code>assistant/message</code>, the driver logs <code>tool/call</code> SessionEvent, then runs <code>tools/pre-execute</code> → monotonic guards → <code>tools/execute</code> → <code>tools/post-execute</code> → <code>tool/result</code>. See <code>docs/tool-execution-pipeline.md</code>.",
+        ),
+        h3("三段 waterfall", "Three waterfalls"),
+        ladder([
+            ("tools/pre-execute", "hooks · permission · sandbox · deny/ask"),
+            ("tools/execute", "timeout · retry · 实际 execute()"),
+            ("tools/post-execute", "accept · block · replace · add context"),
+        ]),
+        src("pipe", "packages/core/tools/README.md", [
+            '<span class="src-fn">ctx.tools</span> scoped registry',
+            'Tool schemas are <span class="src-kw">generated at boot</span> from mounted plugins.',
+        ]),
+        h3("read README 的完整路径", "Full path of read README"),
+        cmp(["阶段", "模块", "主线"], [
+            ["tool/call", "agent-loop → session", "read(path=README.md)"],
+            ["pre-execute", "user-approval · sandbox", "可能 ask"],
+            ["execute", "packages/fs/tool-fs", "fs read · observation policy"],
+            ["tool/result", "session append", "进入 deriveMessages"],
+        ]),
+        p(
+            "Tool catalog 在 boot 时由<strong>已挂载插件动态生成</strong>——「tool schema 不是静态可知的」。这也是 DSH 与 sealed product 的差异：换 profile patch 可能换整个工具面。",
+            "The tool catalog is <strong>generated dynamically at boot</strong> from mounted plugins — «a tool schema is not statically knowable». This differs from sealed products: swapping a profile patch can swap the entire tool surface.",
+        ),
+        doc_ref("tool-execution-pipeline"),
+    )
+
+
+def chapter_c13() -> str:
+    return join(
+        p(
+            "DSH 事件分三域（<code>docs/architecture.md#events</code>）：<strong>session</strong>（ durable replay）、<strong>agent</strong>（live 协调）、<strong>capability</strong>（策略 seam，如 <code>tools/*</code>、<code>fs/*</code>）。选错域是最常见的插件 bug。",
+            "DSH events split into three domains (<code>docs/architecture.md#events</code>): <strong>session</strong> (durable replay), <strong>agent</strong> (live coordination), <strong>capability</strong> (policy seams like <code>tools/*</code>, <code>fs/*</code>). Picking the wrong domain is the most common plugin bug.",
+        ),
+        h3("三域对照", "Three-domain comparison"),
+        viz_event_domains(),
+        cmp(["域", "持久?", "典型事件", "消费者"], [
+            ["session/*", "✓", "user/message · tool/result", "Web UI · persistence"],
+            ["agent/*", "✗", "pre-step · inbox/claimed", "SDK · subagent driver"],
+            ["capability/*", "△", "fs/write-intent · tools/result", "policy · telemetry"],
+        ]),
+        h3("主线一轮的域 crossing", "Domain crossing for one through-line turn"),
+        p(
+            "用户输入：SDK → <code>agent/inbox/inserted</code>（agent）→ claim → <code>user/message</code>（session）→ UI 经 <code>session/event</code> 渲染。工具：model → <code>tool/call</code>（session）→ <code>tools/pre-execute</code>（capability）→ <code>tool/result</code>（session）。",
+            "User input: SDK → <code>agent/inbox/inserted</code> (agent) → claim → <code>user/message</code> (session) → UI renders via <code>session/event</code>. Tools: model → <code>tool/call</code> (session) → <code>tools/pre-execute</code> (capability) → <code>tool/result</code> (session).",
+        ),
+        doc_ref("event-producer-consumer"),
+    )
+
+
+def chapter_c14() -> str:
+    return join(
+        p(
+            "<code>ctx.llm</code>（<code>packages/llm/llm</code>）是模型适配器 seam：DeepSeek 官方 adapter、pi-ai bridge、replay adapter 都注册为 provider。<code>llm/stream</code> waterfall 包裹实际 HTTP/SSE；agent-loop 只依赖统一 StreamChunk 词汇。",
+            "<code>ctx.llm</code> (<code>packages/llm/llm</code>) is the model adapter seam: DeepSeek official adapter, pi-ai bridge, replay adapter register as providers. The <code>llm/stream</code> waterfall wraps actual HTTP/SSE; agent-loop depends only on unified StreamChunk vocabulary.",
+        ),
+        h3("Adapter 注册与 settings 热重载", "Adapter registration and settings hot-reload"),
+        p(
+            "<code>dsh-base</code> insert <code>dsh-settings-file</code>：用户 <code>$DSH_HOME/settings.yaml</code> 的 <code>llm-deepseek:</code> section 可在运行时 override adapter entry，Web Models 页写入同一文件。",
+            "<code>dsh-base</code> inserts <code>dsh-settings-file</code>: the user's <code>llm-deepseek:</code> section in <code>$DSH_HOME/settings.yaml</code> can override adapter entries at runtime; the Web Models page writes the same file.",
+        ),
+        src("llm", "packages/llm/llm/src/index.ts", [
+            '<span class="src-str">llm/stream</span> · mode: <span class="src-str">waterfall</span>',
+            'Listeners: agent-loop, llm-replay, session-checkpoint-policy',
+        ]),
+        cmp(["Provider 包", "用途", "测试"], [
+            ["llm-deepseek", "生产 DeepSeek API", "—"],
+            ["llm-pi-ai", "pi-ai 桥接", "—"],
+            ["llm-replay", "离线 replay", "packages/test-support"],
+        ]),
+        sp([
+            ("agent/request", "agent/request", "最后一英里改 messages/model", "last-mile edit messages/model"),
+            ("llm-retry", "llm-retry", "agent/request-error 恢复", "agent/request-error recovery"),
+            ("token-meter", "token-meter", "usage 计量 · compaction 输入", "usage metering · compaction input"),
+        ]),
+        doc_ref("architecture"),
+    )
+
+
+def chapter_c15() -> str:
+    return join(
+        p(
+            "Provider 流式返回的每个 delta 被驱动器写成 <code>assistant/chunk</code> SessionEvent；UI 经 <code>session/event</code> 增量渲染聊天气泡。流结束后写 <code>assistant/message</code> 定稿（含 usage、<code>sourceEventSeqs</code> 指向 chunk 序列）。",
+            "Each delta from the provider stream is logged by the driver as <code>assistant/chunk</code> SessionEvent; the UI incrementally renders chat bubbles via <code>session/event</code>. After the stream ends, <code>assistant/message</code> finalizes (with usage, <code>sourceEventSeqs</code> pointing to the chunk sequence).",
+        ),
+        h3("Chunk vs Message", "Chunk vs Message"),
+        cmp(["artifact", "持久?", "deriveMessages", "UI"], [
+            ["assistant/chunk", "✓", "合成 message", "流式 token"],
+            ["assistant/message", "✓", "✓", "定稿气泡"],
+            ["empty content", "✓ log", "✗ surface", "max-tokens 等"],
+        ]),
+        h3("主线第二次 stream", "Second stream on through-line"),
+        p(
+            "read 工具返回后，下一 step 的 <code>llm/stream</code> 将 README 内容纳入 deriveMessages 历史，模型生成一句话项目描述——第二个 <code>assistant/chunk*</code> 序列，最终 <code>assistant/message</code> stop。",
+            "After the read tool returns, the next step's <code>llm/stream</code> includes README content in deriveMessages history; the model generates a one-sentence project description — a second <code>assistant/chunk*</code> sequence, ending with <code>assistant/message</code> stop.",
+        ),
+        src("chunk", "docs/agent-lifecycle.md", [
+            '<code>assistant/message</code> records every successful provider call,',
+            'including content-less and <span class="src-str">max-tokens</span> finishes.',
+        ]),
+    )
+
+
+def chapter_c16() -> str:
+    return join(
+        p(
+            "<code>session.deriveMessages()</code>（<code>packages/core/session/src/index.ts</code>）把 SessionEvent log <strong>投影</strong>成 LLM <code>Message[]</code>——这是 agent-loop 在 <code>agent/request</code> 前调用的唯一历史面。Compaction 替换的是 surface generation，不是 log 本身。",
+            "<code>session.deriveMessages()</code> (<code>packages/core/session/src/index.ts</code>) <strong>projects</strong> the SessionEvent log into LLM <code>Message[]</code> — the sole history surface agent-loop calls before <code>agent/request</code>. Compaction replaces surface generation, not the log itself.",
+        ),
+        h3("投影规则（直觉）", "Projection rules (intuition)"),
+        p(
+            "user/message → user role；assistant/message + tool/result 配对 → assistant/tool_result blocks；log-only 事件（title、telemetry）跳过。Fork 会话投影与 fork 点之前父会话一致（<code>session.spec.ts</code> 覆盖）。",
+            "user/message → user role; assistant/message paired with tool/result → assistant/tool_result blocks; log-only events (title, telemetry) skipped. Forked sessions project identically to parent before fork point (<code>session.spec.ts</code> coverage).",
+        ),
+        src("derive", "packages/core/session/src/index.ts", [
+            '<span class="src-fn">deriveMessages</span>(): <span class="src-cls">Message</span>[] {',
+            '  <span class="src-comment">// sole derivation path from append-only log</span>',
+        ]),
+        formula("投影", "PROJECTION", [
+            '<span class="term">SessionEvent[]</span> — canonical log',
+            '<span class="term-cu">deriveMessages()</span> → Message[]',
+            '<span class="term">llm/stream</span> → provider wire format',
+        ], "主线 prompt 在 log 与 projection 各出现一次", "Through-line prompt appears once in log and once in projection"),
+        doc_ref("architecture"),
+    )
+
+
+def chapter_c17() -> str:
+    return join(
+        p(
+            "Web client（<code>packages/web</code> + <code>packages/client</code>）订阅 <code>session/event</code> replay 流，把 <code>user/message</code>、<code>assistant/chunk</code>、<code>tool/call</code>、<code>tool/result</code> 渲染为聊天气泡与 tool 卡片。Host（<code>packages/host</code>）提供同源静态资源与 API 代理。",
+            "The Web client (<code>packages/web</code> + <code>packages/client</code>) subscribes to the <code>session/event</code> replay stream, rendering <code>user/message</code>, <code>assistant/chunk</code>, <code>tool/call</code>, <code>tool/result</code> as chat bubbles and tool cards. Host (<code>packages/host</code>) serves same-origin static assets and API proxy.",
+        ),
+        h3("session/event 驱动渲染", "session/event-driven rendering"),
+        cmp(["SessionEvent", "UI 组件", "流式?"], [
+            ["user/message", "User bubble", "✗"],
+            ["assistant/chunk", "Assistant bubble delta", "✓"],
+            ["tool/call", "Pending tool card", "✗"],
+            ["tool/result", "Completed tool card", "✗"],
+        ]),
+        h3("为何 UI 不直接听 agent/*", "Why UI does not listen to agent/* directly"),
+        p(
+            "SDK 文档明确：需要可回放 transcript 的消费方应使用 <code>session/event</code>；<code>agent/*</code> 用于 queue/status、prompt 拦截、steering。Web UI 刷新后必须从 log replay 重建，而非重建 agent 内存态。",
+            "SDK docs are explicit: consumers needing replayable transcript should use <code>session/event</code>; <code>agent/*</code> is for queue/status, prompt interception, steering. After a Web UI refresh, rebuild from log replay, not from agent memory state.",
+        ),
+        src("web", "packages/web/README.md", [
+            'Default profile <span class="src-str">web</span> · loopback <span class="src-str">:3080</span>',
+            'Session list + event stream rendering',
+        ]),
+    )
+
+
+def chapter_c18() -> str:
+    return join(
+        p(
+            "Web surface 的 chat 节点与 settings 卡片是独立前端包（<code>packages/web</code>）里的 React 组件：输入框提交 → API → <code>agent.followup</code>；设置页写入 <code>settings.yaml</code> 与 credential store，触发 <code>settings/updated</code> 与 adapter 热重载。",
+            "Chat nodes and settings cards on the Web surface are React components in <code>packages/web</code>: input submit → API → <code>agent.followup</code>; settings pages write <code>settings.yaml</code> and credential store, firing <code>settings/updated</code> and adapter hot-reload.",
+        ),
+        h3("Chat 提交路径", "Chat submit path"),
+        ladder([
+            ("Browser input", "主线 prompt 文本"),
+            ("Host API", "packages/host · same-origin"),
+            ("agent.followup", "inbox inserted"),
+            ("session/event", "UI optimistic + replay"),
+        ]),
+        h3("Settings 卡片触达的 backend", "Backend touched by settings cards"),
+        cmp(["Settings UI", "写入", "Cordis 响应"], [
+            ["Models", "settings.yaml llm-*", "llm/adapters-updated"],
+            ["Credentials", ".credentials.yaml", "credentials/record-updated"],
+            ["Permissions", "approval preset", "user-approval"],
+            ["Profile plugins", "dsh plugin add", "HMR recomposes tree"],
+        ]),
+        sp([
+            (":3080", ":3080", "默认 loopback · 可 --port", "default loopback · --port overridable"),
+            ("headless", "headless", "无 UI · stdout 最终回答", "no UI · stdout final answer"),
+            ("ACP", "ACP", "packages/acp · IDE 集成", "packages/acp · IDE integration"),
+        ]),
+    )
+
+
+def chapter_c19() -> str:
+    return join(
+        p(
+            "官方 monorepo 有 200+ workspace 包（<code>packages/README.md</code>），社区可通过 <code>dsh plugin --profile &lt;name&gt; add &lt;pkg&gt;</code> 把 npm/git 包加入 profile。包 manifest 声明 <code>dsh.bundle.patch</code> 时自动进入 bundle 层栈。",
+            "The official monorepo has 200+ workspace packages (<code>packages/README.md</code>); the community adds npm/git packages via <code>dsh plugin --profile &lt;name&gt; add &lt;pkg&gt;</code>. When a package manifest declares <code>dsh.bundle.patch</code>, it joins the bundle layer stack automatically.",
+        ),
+        h3("插件形态", "Plugin shapes"),
+        cmp(["形态", "例子", "扩展点"], [
+            ["core plugin", "dsh-session", "claim ctx.sessions"],
+            ["tool plugin", "tool-bash · tool-fs", "ctx.tools.register"],
+            ["capability", "dsh-sandbox-local", "ctx.sandbox seam"],
+            ["bundle", "dsh-web-app", "cordis.patch.yml insert"],
+            ["MCP", "packages/mcp/*", "外部工具协议"],
+        ]),
+        viz_plugin_spectrum(),
+        h3("发布自己的插件", "Publishing your own plugin"),
+        p(
+            "<code>docs/user/develop/basic/publish.md</code>：manifest 加 <code>dsh.bundle</code> 或作为 plain dependency；用户可在 profile <code>cordis.patch.yml</code> 按 id 覆盖你的行而无需改包。",
+            "<code>docs/user/develop/basic/publish.md</code>: add <code>dsh.bundle</code> to manifest or ship as plain dependency; users can override your rows by id in profile <code>cordis.patch.yml</code> without touching your package.",
+        ),
+        src("pub", "docs/user/develop/basic/publish.md", [
+            'Users can override your rows in profile <code>cordis.patch.yml</code>',
+            'without touching your package.',
+        ]),
+    )
+
+
+def chapter_c20() -> str:
+    return join(
+        p(
+            "Capability seams 把「能做什么」从 loop 里拆出来：<code>ctx.fs</code>（<code>packages/fs/fs</code>）、<code>ctx.shell</code>（bash/pwsh 栈）、<code>ctx.sandbox</code>（策略 + 平台 runner）。换 seam 实现 = 换 patch 行，无需 fork agent-loop。",
+            "Capability seams separate «what can be done» from the loop: <code>ctx.fs</code> (<code>packages/fs/fs</code>), <code>ctx.shell</code> (bash/pwsh stacks), <code>ctx.sandbox</code> (policy + platform runners). Swap seam implementation = swap patch row, no agent-loop fork needed.",
+        ),
+        h3("fs · shell · sandbox 三角", "fs · shell · sandbox triangle"),
+        cmp(["Seam", "默认实现", "policy 事件"], [
+            ["ctx.fs", "fs-sandbox + tool-fs", "fs/write-intent · fs/observed"],
+            ["ctx.shell", "tool-bash / tool-pwsh", "sandbox approval"],
+            ["ctx.sandbox", "dsh-sandbox-local / windows-acl", "danger-full-access 等 preset"],
+        ]),
+        h3("read README 经过哪些 seam", "Which seams read README passes through"),
+        p(
+            "主线 read 走 <code>tool-fs</code> → <code>fs/read</code> capability → <code>fs-observation-policy</code> 可能要求先 observe 再 write。bash 工具走 shell + sandbox approval，与 read 并行安全策略不同。",
+            "Through-line read goes <code>tool-fs</code> → <code>fs/read</code> capability → <code>fs-observation-policy</code> may require observe-before-write. Bash tools go through shell + sandbox approval — parallel safety policy differs from read.",
+        ),
+        src("seams", "docs/capability-seams.md", [
+            'A service can be a core spine service, a swappable capability seam,',
+            'or a bundle/composition point.',
+        ]),
+        doc_ref("capability-seams"),
+    )
+
+
+def chapter_c21() -> str:
+    return join(
+        p(
+            "Customization 发生在 patch 层，不是 fork monorepo：<code>profiles/&lt;name&gt;/cordis.patch.yml</code> 按 id 覆盖 bundle 行；<code>$DSH_HOME/cordis.patch.yml</code> 机器级；<code>--patch</code> 一次性。HMR（<code>cordis-plugin-hmr</code>）可在 dev 时热重载 patch。",
+            "Customization happens at the patch layer, not by forking the monorepo: <code>profiles/&lt;name&gt;/cordis.patch.yml</code> overrides bundle rows by id; <code>$DSH_HOME/cordis.patch.yml</code> is machine-wide; <code>--patch</code> is one-shot. HMR (<code>cordis-plugin-hmr</code>) can hot-reload patches in dev.",
+        ),
+        h3("Patch 纪律", "Patch discipline"),
+        p(
+            "覆盖一行必须<strong>重述整行 config</strong>——不是 deep-merge。例如 Windows 恢复 bash 栈：必须同时 disable pwsh 行并 re-enable bash 行，否则 duplicate service 注册 fail loud。",
+            "Overriding a row must <strong>restate the entire row config</strong> — no deep-merge. E.g. restoring bash stack on Windows: disable pwsh rows AND re-enable bash rows, otherwise duplicate service registration fails loud.",
+        ),
+        cmp(["层", "路径", "典型用途"], [
+            ["bundle", "packages/bundle/*/cordis.patch.yml", "官方能力组合"],
+            ["profile", "$DSH_HOME/profiles/web/cordis.patch.yml", "用户 profile 定制"],
+            ["home", "$DSH_HOME/cordis.patch.yml", "机器级 override"],
+            ["CLI", "--patch file.yml", "CI 一次性"],
+        ]),
+        src("watch", "packages/boot/app-boot/README.md", [
+            '<span class="src-fn">watchUserPatches</span>(ctx, options)',
+            'Rejected patch leaves last good tree running.',
+        ]),
+        doc_ref("architecture"),
+    )
+
+
+def chapter_c22() -> str:
+    return join(
+        p(
+            "Session fork/resume（<code>packages/session/session-persistence*</code>、subagent fork tools）从某一 log 点创建分支会话，子会话 append 独立事件链。Resume 重放 persistence 存储的 log，<code>deriveMessages()</code> 确定性重建模型历史。",
+            "Session fork/resume (<code>packages/session/session-persistence*</code>, subagent fork tools) creates branch sessions from a log point; child sessions append independent event chains. Resume replays persisted log; <code>deriveMessages()</code> deterministically rebuilds model history.",
+        ),
+        h3("Fork 语义", "Fork semantics"),
+        p(
+            "Fork 复制 log 前缀而非 agent 内存；子 agent（<code>packages/subagent/subagent</code>）可用 in-process driver 或独立 profile。父会话可 park 等待子 agent report——全程仍通过 session/agent 事件可观测。",
+            "Fork copies log prefix, not agent memory; child agents (<code>packages/subagent/subagent</code>) may use in-process driver or separate profile. Parent can park awaiting child report — still observable via session/agent events throughout.",
+        ),
+        cmp(["操作", "API/工具", "log 效果"], [
+            ["fork session", "subagent_fork tool", "新 session id · 共享前缀"],
+            ["resume", "headless --resume", "重放 JSONL/SQLite"],
+            ["checkpoint", "session-checkpoint-policy", "副作用前强制 persist"],
+        ]),
+        src("persist", "packages/session/session-persistence-jsonl/README.md", [
+            'Append-only event log on disk',
+            '<span class="src-fn">deriveMessages()</span> identical after replay',
+        ]),
+    )
+
+
+def chapter_c23() -> str:
+    return join(
+        p(
+            "<code>dsh-compaction-basic</code>（<code>packages/compaction/compaction-basic</code>）在 <code>agent/pre-step</code> 检测 token 压力，在 <code>agent/request-error</code> 处理 canonical overflow。策略：<strong>log 完整保留</strong>，替换 surface generation（摘要 + tool-result pruning）。",
+            "<code>dsh-compaction-basic</code> (<code>packages/compaction/compaction-basic</code>) detects token pressure at <code>agent/pre-step</code>, handles canonical overflow at <code>agent/request-error</code>. Policy: <strong>log stays complete</strong>, replace surface generation (summary + tool-result pruning).",
+        ),
+        h3("Compaction 触发链", "Compaction trigger chain"),
+        ladder([
+            ("token-meter", "计量 deriveMessages token"),
+            ("agent/pre-step", "pressure · 可选 pruning"),
+            ("LLM overflow", "agent/request-error"),
+            ("summary LLM call", "新 surface generation"),
+            ("fresh retry turn", "仅当 surface 前进"),
+        ]),
+        p(
+            "Recovery 发生在 failed step 与 failed turn 之间：若 pruning/summary 未 advance surface generation，原始 request error 仍权威——避免 silent loss。",
+            "Recovery happens between failed step and failed turn: if pruning/summary does not advance surface generation, the original request error remains authoritative — avoiding silent loss.",
+        ),
+        src("compact", "packages/compaction/compaction-basic/README.md", [
+            'Uses <span class="src-str">agent/pre-step</span> for pressure before derivation',
+            'and <span class="src-str">agent/request-error</span> for overflow recovery.',
+        ]),
+        doc_ref("agent-lifecycle"),
+    )
+
+
+def chapter_c24() -> str:
+    return join(
+        p(
+            "四条路线对比：Claude Code（密封 CLI + MCP）、Cursor（密封 IDE）、Pi（minimal harness + JSONL）、DSH（Cordis 全插件 + SessionEvent + MCP/subagent/compaction）。主线 prompt 在 DSH 可经 <code>--dump-config</code> + session log 完整 trace。",
+            "Four routes compared: Claude Code (sealed CLI + MCP), Cursor (sealed IDE), Pi (minimal harness + JSONL), DSH (full Cordis plugins + SessionEvent + MCP/subagent/compaction). The through-line prompt is fully traceable in DSH via <code>--dump-config</code> + session log.",
+        ),
+        h3("设计取舍表", "Design trade-off table"),
+        cmp(["维度", "Claude Code", "Cursor", "Pi", "DSH"], [
+            ["目标用户", "开箱 CLI", "IDE 用户", "读源码", "改 harness"],
+            ["内核", "密封", "密封", "agent-loop.ts", "Cordis 插件树"],
+            ["会话", "专有", "专有", "JSONL 树", "SessionEvent log"],
+            ["MCP", "✓", "△", "✗", "✓ packages/mcp"],
+            ["子 agent", "✓", "✓", "✗", "✓ packages/subagent"],
+            ["compaction", "黑盒", "黑盒", "✓", "✓ plugin"],
+            ["trace 主线", "✗", "✗", "✓ verbose", "✓ dump-config + log"],
+        ]),
+        viz_harness_compare(),
+        h3("怎么选", "How to choose"),
+        p(
+            "不是「哪个更好」——是「你要闭包体验还是开卷考试」。DSH 牺牲「零配置直觉」，换取任意层 patch、官方 200+ 插件组合、以及与 DeepSeek 模型栈的一等集成。",
+            "Not «which is better» — «do you want closed-loop UX or open-book exam». DSH sacrifices «zero-config intuition» for patch-any-layer, 200+ official plugin combinations, and first-class DeepSeek model stack integration.",
+        ),
+        note("Pi 与 DSH 都开源可读；Pi 极简，DSH 全栈可组合。", "Pi and DSH are both open and readable; Pi is minimal, DSH is fully composable.", copper=True),
+    )
+
+
+def chapter_c25() -> str:
+    return join(
+        p(
+            "<code>packages/subagent/subagent</code> 提供 spawn/fork/send_message/interrupt/report 工具；<code>tool-agent-team</code> 扩展 Agent Teams。MCP（<code>packages/mcp/*</code>）把外部工具协议接入 <code>ctx.tools</code>。子 agent 不是黑盒线程——而是独立 session + driver，事件仍走 session/agent 域。",
+            "<code>packages/subagent/subagent</code> provides spawn/fork/send_message/interrupt/report tools; <code>tool-agent-team</code> extends Agent Teams. MCP (<code>packages/mcp/*</code>) attaches external tool protocols to <code>ctx.tools</code>. Sub-agents are not black-box threads — separate session + driver, events still use session/agent domains.",
+        ),
+        h3("Subagent 控制面", "Subagent control plane"),
+        cmp(["工具", "作用", "观测"], [
+            ["subagent", "spawn 子 agent", "agent/created · subagent/end"],
+            ["subagent_fork", "fork session 分支", "新 session/created"],
+            ["send_message", "向子 agent 发消息", "agent/inbox/inserted"],
+            ["report", "子 agent 回报父 agent", "tool/result"],
+        ]),
+        h3("Agent Teams", "Agent Teams"),
+        p(
+            "Teams 在 <code>agent/created</code> 时注册成员关系，协调多 agent inbox 与 DM。主线 prompt 通常走单 agent；Teams 用于并行 research、 Ralph 循环（<code>packages/workflow</code>）等高级场景。",
+            "Teams register membership at <code>agent/created</code>, coordinating multi-agent inbox and DMs. The through-line prompt usually runs single-agent; Teams serve parallel research, Ralph loops (<code>packages/workflow</code>), etc.",
+        ),
+        src("sub", "packages/subagent/subagent/README.md", [
+            'Child sessions are first-class <span class="src-cls">Session</span> objects',
+            'with their own <span class="src-cls">ReactLoopAgent</span> driver.',
+        ]),
+        sp([
+            ("in-process", "in-process driver", "同 Cordis 树 · 低开销", "same Cordis tree · low overhead"),
+            ("Codex/CC bundle", "product provider bundles", "可选 hook bridge", "optional hook bridge bundles"),
+            ("Python SDK", "Python SDK", "JSON-RPC 驱 Node runtime", "JSON-RPC drives Node runtime"),
+        ]),
+    )
+
+
+def chapter_c26() -> str:
+    return join(
+        p(
+            "自己 trace 主线 prompt 的三件套：<code>dsh --profile web --dump-config</code> 看 boot 树、浏览器/WebSocket 看 <code>session/event</code> 流、打开 persistence 存储的 session log 文件对照 <code>deriveMessages()</code>。",
+            "Trace the through-line yourself with three tools: <code>dsh --profile web --dump-config</code> for the boot tree, browser/WebSocket for the <code>session/event</code> stream, and the persisted session log file compared against <code>deriveMessages()</code>.",
+        ),
+        h3("推荐 trace 顺序", "Recommended trace order"),
+        ladder([
+            ("dsh --profile web --dump-config", "确认插件树含 agent-loop · tool-fs"),
+            ("发送主线 prompt", "观察 turn/start → user/message → tool/call"),
+            ("session log 文件", "packages/session/session-persistence-jsonl"),
+            ("deriveMessages 对照", "packages/core/session/tests/session.spec.ts"),
+        ]),
+        h3("推荐阅读顺序", "Suggested reading order"),
+        p(
+            "1. <code>docs/architecture.md</code> turn flow → 2. <code>packages/core/agent-loop/src/agent.ts</code> ReactLoopAgent → 3. 本文 C02 22 站 → 4. <code>docs/agent-lifecycle.md</code> 序列图。",
+            "1. <code>docs/architecture.md</code> turn flow → 2. <code>packages/core/agent-loop/src/agent.ts</code> ReactLoopAgent → 3. this article C02 22 stations → 4. <code>docs/agent-lifecycle.md</code> sequence diagram.",
+        ),
+        src("trace", "apps/cli/README.md", [
+            '$ dsh --profile web --dump-config',
+            '$ dsh web  <span class="src-comment"># :3080 · 发送主线 prompt</span>',
+        ]),
+        pull(
+            "读完之后，用一句话回答：<br>「读取 README.md，用一句话告诉我这个项目做什么」——<br>在 DSH 里，这句话究竟触发了什么？",
+            "After reading, answer in one sentence:<br>«read README.md and tell me what this project does in one sentence» —<br>what exactly does that line trigger in DSH?",
+        ),
+        note(
+            "答案应能指出：followup → turn/start → agent/pre-step → user/message → deriveMessages → llm/stream ×2 → tool-fs read → assistant/message stop → session/event → UI。",
+            "Answer should cite: followup → turn/start → agent/pre-step → user/message → deriveMessages → llm/stream ×2 → tool-fs read → assistant/message stop → session/event → UI.",
+        ),
+        doc_ref("architecture"),
+        doc_ref("agent-lifecycle"),
+    )

--- a/scripts/dsh_immersive/compass.py
+++ b/scripts/dsh_immersive/compass.py
@@ -1,0 +1,79 @@
+"""Per-chapter compass navigation — where you are in the forest."""
+from __future__ import annotations
+
+from meta import CHAPTERS, TOC_GROUPS, TOC_GROUPS_BG
+
+COMPASS_META: dict[str, tuple[str, str, str, str, str, str, str]] = {
+    "c1": ("0", "引子", "Prologue", "站 00", "St. 00", "森林入口：Harness ≠ Product", "Forest entry: Harness ≠ Product"),
+    "c2": ("0", "引子", "Prologue", "站 01–22", "St. 01–22", "turn/step 全景图", "turn/step panorama"),
+    "c3": ("·", "背景", "Background", "—", "—", "Cordis 与 monorepo 家谱", "Cordis and monorepo family tree"),
+    "c4": ("·", "背景", "Background", "—", "—", "Core spine 六包", "Core spine six packages"),
+    "c5": ("·", "背景", "Background", "—", "—", "一切皆插件", "Everything is a plugin"),
+    "c6": ("I", "入口", "Intake", "站 01–03", "St. 01–03", "dsh web 启动链", "dsh web boot chain"),
+    "c7": ("I", "入口", "Intake", "站 04–06", "St. 04–06", "ctx.agents 生命周期", "ctx.agents lifecycle"),
+    "c8": ("I", "入口", "Intake", "站 07", "St. 07", "system-prompt 组装", "system-prompt assembly"),
+    "c9": ("II", "心脏", "Heart", "站 08–09", "St. 08–09", "Session log 不变量", "Session log invariant"),
+    "c10": ("II", "心脏", "Heart", "站 10–11", "St. 10–11", "ReactLoopAgent 驱动", "ReactLoopAgent driver"),
+    "c11": ("II", "心脏", "Heart", "站 12", "St. 12", "agent/pre-step 瀑布", "agent/pre-step waterfall"),
+    "c12": ("II", "心脏", "Heart", "站 13–14", "St. 13–14", "Tool 执行管线", "Tool execution pipeline"),
+    "c13": ("II", "心脏", "Heart", "站 15", "St. 15", "三域事件矩阵", "Three-domain event matrix"),
+    "c14": ("III", "LLM", "LLM", "站 16", "St. 16", "ctx.llm 适配缝", "ctx.llm adapter seam"),
+    "c15": ("III", "LLM", "LLM", "站 17", "St. 17", "assistant/chunk 流式", "assistant/chunk streaming"),
+    "c16": ("III", "LLM", "LLM", "站 18", "St. 18", "deriveMessages 闭环", "deriveMessages closed loop"),
+    "c17": ("IV", "Web", "Web", "站 19", "St. 19", "ctx.web 能力缝", "ctx.web capability seam"),
+    "c18": ("IV", "Web", "Web", "站 20", "St. 20", "tool-web Consumer", "tool-web consumer"),
+    "c19": ("V", "扩展", "Extensions", "—", "—", "Cordis 插件面", "Cordis plugin surface"),
+    "c20": ("V", "扩展", "Extensions", "—", "—", "Loader 与 bundle", "Loader and bundle"),
+    "c21": ("V", "扩展", "Extensions", "—", "—", "cordis.patch 组合", "cordis.patch composition"),
+    "c22": ("VI", "持久化", "Persistence", "站 21", "St. 21", "SessionEvent JSONL", "SessionEvent JSONL on disk"),
+    "c23": ("VI", "持久化", "Persistence", "站 22", "St. 22", "Compaction · surface", "Compaction · surface replace"),
+    "c24": ("VII", "全景", "Landscape", "—", "—", "对比 Pi Harness", "vs Pi harness"),
+    "c25": ("VII", "全景", "Landscape", "—", "—", "JSON-RPC · profiles", "JSON-RPC · profiles"),
+    "c26": ("∎", "Coda", "Coda", "—", "—", "自己 trace 一轮", "Trace a turn yourself"),
+}
+
+
+def _chapter_index(cid: str) -> int:
+    return next(i for i, c in enumerate(CHAPTERS) if c[0] == cid)
+
+
+def chapter_compass(cid: str) -> str:
+    idx = _chapter_index(cid)
+    ch = CHAPTERS[idx]
+    num = ch[1]
+    total = len(CHAPTERS)
+    meta = COMPASS_META.get(cid, ("?", ch[2], ch[3], "—", "—", ch[6], ch[7]))
+    roman, pzh, pen, stz, ste, fzh, fen = meta
+
+    prev_link = next_link = ""
+    if idx > 0:
+        pc = CHAPTERS[idx - 1]
+        prev_link = (
+            f'<a class="cc-nav cc-prev" href="#{pc[0]}">'
+            f'<span class="cc-arrow">←</span> '
+            f'<span class="cc-nav-num">C{pc[1]}</span> '
+            f'<span class="lang-zh-only">{pc[4]}</span>'
+            f'<span class="lang-en-only">{pc[5]}</span></a>'
+        )
+    if idx < total - 1:
+        nc = CHAPTERS[idx + 1]
+        next_link = (
+            f'<a class="cc-nav cc-next" href="#{nc[0]}">'
+            f'<span class="cc-nav-num">C{nc[1]}</span> '
+            f'<span class="lang-zh-only">{nc[4]}</span>'
+            f'<span class="lang-en-only">{nc[5]}</span> '
+            f'<span class="cc-arrow">→</span></a>'
+        )
+
+    return f"""    <nav class="chapter-compass" aria-label="Chapter navigation">
+      <div class="cc-row">
+        <div class="cc-phase"><span class="cc-roman">{roman}</span> · <span class="lang-zh-only">{pzh}</span><span class="lang-en-only">{pen}</span></div>
+        <div class="cc-station"><span class="lang-zh-only">{stz}</span><span class="lang-en-only">{ste}</span> · C{num}/{total:02d}</div>
+      </div>
+      <div class="cc-forest"><span class="lang-zh-only">{fzh}</span><span class="lang-en-only">{fen}</span></div>
+      <div class="cc-links">
+        {prev_link}
+        <a class="cc-map" href="#forest-overview"><span class="lang-zh-only">回到总览</span><span class="lang-en-only">Forest map</span></a>
+        {next_link}
+      </div>
+    </nav>"""

--- a/scripts/dsh_immersive/deep_dive.py
+++ b/scripts/dsh_immersive/deep_dive.py
@@ -1,0 +1,169 @@
+"""Deep bilingual expansions for DSH immersive chapters."""
+from __future__ import annotations
+
+from expand import case_study, doc_crossref_table
+from _html_helpers import depth_zone_close, depth_zone_open, faq_block, join, section_block, stage_banner, trace_box, why_care
+from meta import CHAPTERS
+
+PROMPT_ZH = "读取 README.md，用一句话告诉我这个项目做什么"
+PROMPT_EN = "read README.md and tell me what this project does in one sentence"
+
+
+def _why(intuition: tuple[str, str], counter: tuple[str, str], optimize: tuple[str, str]) -> str:
+    return why_care([
+        ("直觉", intuition[0], intuition[1], ""),
+        ("反直觉", counter[0], counter[1], "rev"),
+        ("优化", optimize[0], optimize[1], "act"),
+    ])
+
+
+def _banner(module: tuple[str, str], package: tuple[str, str], thread: tuple[str, str], output: tuple[str, str]) -> str:
+    return stage_banner([
+        ("模块", "Module", module[0], module[1]),
+        ("包", "Package", package[0], package[1]),
+        ("线程", "Thread", thread[0], thread[1]),
+        ("输出", "Output", output[0], output[1]),
+    ])
+
+
+def _trace(station: str, zh: str, en: str) -> str:
+    return trace_box(station, zh, en)
+
+
+def _sec(title_zh: str, title_en: str, sec: str, *paragraphs: tuple[str, str]) -> str:
+    return section_block(title_zh, title_en, list(paragraphs), sec=sec)
+
+
+def deepen(cid: str, base: str) -> str:
+    d = DEPTH.get(cid)
+    if not d:
+        return base
+    ch_num = next(c[1] for c in CHAPTERS if c[0] == cid)
+    parts: list[str] = []
+    if d.get("why"):
+        parts.append(d["why"])
+    if d.get("banner"):
+        parts.append(d["banner"])
+    parts.append(base)
+    if d.get("trace"):
+        parts.append(d["trace"])
+    parts.append(depth_zone_open(ch_num))
+    sec = 4
+    for block in d.get("sections", []):
+        parts.append(_sec(block[0], block[1], f"C{ch_num}.{sec}", *block[2]))
+        sec += 1
+    if d.get("faq"):
+        parts.append(faq_block(d["faq"]))
+    if d.get("case"):
+        parts.append(case_study(*d["case"]))
+    if d.get("docs"):
+        parts.append(doc_crossref_table(d["docs"]))
+    parts.append(depth_zone_close())
+    return join(*parts)
+
+
+def _ch(
+    module: tuple[str, str],
+    package: tuple[str, str],
+    thread: tuple[str, str],
+    output: tuple[str, str],
+    trace_zh: str,
+    trace_en: str,
+    *,
+    sections: list | None = None,
+    faq: list | None = None,
+    case: tuple | None = None,
+    docs: list[str] | None = None,
+) -> dict:
+    return {
+        "why": _why(
+            ("本章回答「这条主线 prompt 在此层长什么样」", "This chapter answers what the through-line prompt looks like at this layer"),
+            ("DSH 没有隐藏魔法——一切可替换行为都在 Cordis 事件或 SessionEvent 里", "DSH has no hidden magic — replaceable behavior lives in Cordis events or SessionEvents"),
+            ("读源码时先搜 session.append 与 ctx.* 注册点", "When reading source, search session.append and ctx.* registration first"),
+        ),
+        "banner": _banner(module, package, thread, output),
+        "trace": _trace(f"station {module[0]}", trace_zh, trace_en),
+        "sections": sections or [],
+        "faq": faq,
+        "case": case,
+        "docs": docs,
+    }
+
+
+DEPTH: dict[str, dict] = {
+    "c1": _ch(
+        ("引子", "Prologue"), ("docs/", "docs/"), ("用户回车", "user Enter"), ("harness 心智", "harness mindset"),
+        "站 00：理解 DSH 是插件组合，不是密封产品。",
+        "St. 00: DSH is plugin composition, not a sealed product.",
+        sections=[("密封 vs 可组合", "Sealed vs composable", [
+            ("Claude Code / Cursor 把 agent-loop 封在产品里；DSH 把 loop、tools、llm 都做成可 patch 的 Cordis 插件。", "Claude Code / Cursor seal agent-loop in the product; DSH makes loop, tools, llm patchable Cordis plugins."),
+        ])],
+        docs=["architecture", "cordis-primer"],
+    ),
+    "c9": _ch(
+        ("session", "session"), ("packages/core/session", "packages/core/session"), ("append", "append"), ("deriveMessages", "deriveMessages"),
+        "站 08：model-visible means logged — 一切进模型的必须能由 log 重建。",
+        "St. 08: model-visible means logged — anything reaching the model must be reconstructable from the log.",
+        docs=["architecture"],
+    ),
+    "c10": _ch(
+        ("agent-loop", "agent-loop"), ("packages/core/agent-loop", "packages/core/agent-loop"), ("ReactLoopAgent", "ReactLoopAgent"), ("turn/step", "turn/step"),
+        "站 10：turn 包裹一个或多个 step；主线 read 通常占一个 step。",
+        "St. 10: turn wraps one or more steps; through-line read usually costs one step.",
+        docs=["agent-lifecycle"],
+    ),
+    "c12": _ch(
+        ("tools", "tools"), ("packages/core/tools", "packages/core/tools"), ("executeToolCalls", "executeToolCalls"), ("tool/result", "tool/result"),
+        "站 13：read README 走 tools/pre-execute → execute → post-execute 瀑布。",
+        "St. 13: read README goes through tools/pre-execute → execute → post-execute waterfall.",
+        docs=["tool-execution-pipeline"],
+    ),
+    "c16": _ch(
+        ("deriveMessages", "deriveMessages"), ("packages/core/session", "packages/core/session"), ("step 边界", "step boundary"), ("llm request", "llm request"),
+        "站 18：每次 model 请求前 deriveMessages() 从 log 投影 history。",
+        "St. 18: deriveMessages() projects history from log before each model request.",
+    ),
+    "c24": _ch(
+        ("对比", "Compare"), ("—", "—"), ("Pi vs DSH", "Pi vs DSH"), ("设计取舍", "trade-offs"),
+        "站 24：Pi runLoop 双环 vs DSH turn/step — 同一主线 prompt 的不同编排哲学。",
+        "St. 24: Pi runLoop twin loops vs DSH turn/step — same prompt, different orchestration philosophy.",
+    ),
+    "c26": _ch(
+        ("Coda", "Coda"), ("apps/cli", "apps/cli"), ("--dump-config", "--dump-config"), ("session log", "session log"),
+        "站 26：clone repo → dsh web → 读 session/event 与 event map。",
+        "St. 26: clone repo → dsh web → read session/event and event map.",
+        case=(
+            "自己 trace 一轮",
+            "Trace a turn yourself",
+            "1. <code>git clone deepseek-ai/deepseek-harness</code><br>2. <code>pnpm i && pnpm dsh web</code><br>3. 发送主线 prompt<br>4. 在 DevTools 或日志里过滤 <code>session/event</code>",
+            "1. <code>git clone deepseek-ai/deepseek-harness</code><br>2. <code>pnpm i && pnpm dsh web</code><br>3. Send through-line prompt<br>4. Filter <code>session/event</code> in DevTools or logs",
+        ),
+    ),
+}
+
+# Light depth for remaining chapters
+for cid, mod, pkg, thr, out, zh, en in [
+    ("c2", "全景", "Panorama", "docs/", "turn flow map", "22 站总览", "22-station overview"),
+    ("c3", "Cordis", "Cordis", "vendor/", "ctx", "插件挂载", "plugin mount"),
+    ("c4", "core spine", "core spine", "packages/core/*", "ctx.*", "六包依赖", "six-package spine"),
+    ("c5", "plugin", "plugin", "packages/*", "patchable", "无特权核心", "no privileged core"),
+    ("c6", "boot", "boot", "apps/cli", "profile", "dsh web 启动", "dsh web boot"),
+    ("c7", "agents", "agents", "packages/core/agent", "ctx.agents", "Agent 注册", "Agent registry"),
+    ("c8", "system-prompt", "system-prompt", "packages/core/system-prompt", "assemble", "prompt 组装", "prompt assembly"),
+    ("c11", "pre-step", "pre-step", "agent-loop", "waterfall", "reject/rewrite", "reject/rewrite"),
+    ("c13", "events", "events", "docs/", "三域", "session/agent/capability", "three domains"),
+    ("c14", "llm", "llm", "packages/llm", "ctx.llm", "适配缝", "adapter seam"),
+    ("c15", "chunk", "chunk", "assistant/chunk", "stream", "流式 chunk", "streaming chunks"),
+    ("c17", "web", "web", "packages/web", "ctx.web", "Web 能力", "Web capability"),
+    ("c18", "tool-web", "tool-web", "packages/tool-web", "consumer", "模型调网", "model hits network"),
+    ("c19", "extensions", "extensions", "Cordis", "inject", "插件 API", "plugin API"),
+    ("c20", "loader", "loader", "packages/bundle", "dsh-base", "bundle 层叠", "bundle stack"),
+    ("c21", "patch", "patch", "cordis.patch.yml", "overlay", "组合定制", "composition customize"),
+    ("c22", "persist", "persist", "session", "JSONL", "落盘", "persistence"),
+    ("c23", "compaction", "compaction", "packages/compaction", "surface", "压缩", "compaction"),
+    ("c25", "rpc", "rpc", "profiles", "headless", "多入口", "multi entry"),
+]:
+    DEPTH[cid] = _ch(
+        (mod, mod), (pkg, pkg), (thr, thr), (out, out),
+        f"站 {mod}：{zh}。", f"St. {mod}: {en}.",
+    )

--- a/scripts/dsh_immersive/doc_map.py
+++ b/scripts/dsh_immersive/doc_map.py
@@ -1,0 +1,68 @@
+"""Cross-reference map between DeepSeek Harness official docs and production packages."""
+
+from __future__ import annotations
+
+from _html_helpers import note
+
+DOC_REFERENCES: list[tuple[str, str, str, str, str, str]] = [
+    (
+        "architecture",
+        "架构总览",
+        "Architecture overview",
+        "docs/architecture.md",
+        "Cordis 插件树、Profile×Bundle 组合、六大 ctx 服务与 turn 流",
+        "Cordis plugin tree, Profile×Bundle composition, six core ctx services, and turn flow",
+    ),
+    (
+        "agent-lifecycle",
+        "Agent 生命周期",
+        "Agent lifecycle",
+        "docs/agent-lifecycle.md",
+        "turn/step 双环、agent/pre-step waterfall、session 与 agent 事件分工",
+        "turn/step twin loops, agent/pre-step waterfall, session vs agent event split",
+    ),
+    (
+        "tool-execution-pipeline",
+        "工具执行管线",
+        "Tool execution pipeline",
+        "docs/tool-execution-pipeline.md",
+        "tools/pre-execute → execute → post-execute 三段 waterfall 与审批链",
+        "tools/pre-execute → execute → post-execute waterfalls and approval chain",
+    ),
+    (
+        "event-producer-consumer",
+        "事件生产消费矩阵",
+        "Event producer-consumer matrix",
+        "docs/event-producer-consumer.md",
+        "每个 harness 事件的 dispatch 模式、声明位置、生产者与消费者包",
+        "Dispatch mode, declaration site, producers and listeners per harness event",
+    ),
+    (
+        "capability-seams",
+        "能力接缝图",
+        "Capability seams",
+        "docs/capability-seams.md",
+        "ctx.fs / ctx.shell / ctx.sandbox 等可替换 seam 与实现包映射",
+        "Swappable seams (ctx.fs, ctx.shell, ctx.sandbox) and implementation packages",
+    ),
+    (
+        "cordis-primer",
+        "Cordis 入门",
+        "Cordis primer",
+        "docs/cordis-primer.md",
+        "插件=Service、inject 依赖、waterfall 语义、可逆 effect 五条范式",
+        "Plugin=Service, inject deps, waterfall semantics, reversible effects — five ideas",
+    ),
+]
+
+
+def doc_ref(doc_id: str) -> str:
+    row = next((r for r in DOC_REFERENCES if r[0] == doc_id), None)
+    if not row:
+        return ""
+    _id, title_zh, title_en, path, summary_zh, summary_en = row
+    return note(
+        f"📘 <strong>{title_zh}</strong>（<code>{path}</code>）· {summary_zh}",
+        f"📘 <strong>{title_en}</strong> (<code>{path}</code>) · {summary_en}",
+        copper=True,
+    )

--- a/scripts/dsh_immersive/expand.py
+++ b/scripts/dsh_immersive/expand.py
@@ -1,0 +1,105 @@
+"""Targeted chapter expansions for DSH immersive article."""
+from __future__ import annotations
+
+from doc_map import DOC_REFERENCES
+
+from _html_helpers import aside_label, cmp, note, p, src
+from heart_trace import heart_trace_block
+
+
+def doc_crossref_table(doc_ids: list[str]) -> str:
+    rows = []
+    for did in doc_ids:
+        row = next((r for r in DOC_REFERENCES if r[0] == did), None)
+        if row:
+            rows.append([did, row[1], f"<code>{row[3]}</code>", row[5]])
+    if not rows:
+        return ""
+    return (
+        aside_label("交叉引用", "Cross-ref", "deepseek-harness 文档", "deepseek-harness docs")
+        + cmp(["DOC", "主题", "路径", "摘要"], rows)
+    )
+
+
+def case_study(title_zh: str, title_en: str, body_zh: str, body_en: str) -> str:
+    return f"""    <div class="case-study">
+      <div class="cs-tag">CASE STUDY</div>
+      <div class="cs-title"><span class="lang-zh-only">{title_zh}</span><span class="lang-en-only">{title_en}</span></div>
+      <div class="lang-zh-only"><p>{body_zh}</p></div>
+      <div class="lang-en-only"><p>{body_en}</p></div>
+    </div>"""
+
+
+def join_blocks(*parts: str) -> str:
+    return "\n\n".join(p for p in parts if p)
+
+
+def source_walkthrough(path: str, lines: list[tuple[str, str, str]]) -> str:
+    code_lines = []
+    for i, (code, czh, cen) in enumerate(lines, 1):
+        code_lines.append(f'<span class="src-ln">{i:3d}</span> <span class="src-hl">{code}</span>')
+        code_lines.append(f'<span class="src-comment">     // {czh} / {cen}</span>')
+    return src("walkthrough", path, code_lines)
+
+
+CHAPTER_EXTRAS: dict[str, str] = {
+    "c1": join_blocks(
+        doc_crossref_table(["architecture", "cordis-primer"]),
+        case_study(
+            "从 Pi 迁移到 DSH",
+            "Migrating from Pi to DSH",
+            "Pi 把 agent-loop 写死在 npm 包里；DSH 把 agent-loop 本身做成可替换插件。迁移的第一步不是换 CLI，而是跑 <code>dsh --profile web --dump-config</code> 看清插件树。",
+            "Pi hard-codes agent-loop in an npm package; DSH makes agent-loop itself a replaceable plugin. Migration starts with <code>dsh --profile web --dump-config</code> to see the plugin tree.",
+        ),
+    ),
+    "c7": join_blocks(
+        source_walkthrough("packages/core/agent-loop/src/agent.ts", [
+            ("send(message, target, wakeup)", "用户主线入口", "through-line entry"),
+            ("inbox.splice(resolvedTarget, ...)", "claim 下一条 user/message", "claim next user/message"),
+            ("wakeDriver(wakingAfterAbort)", "唤醒 ReactLoopAgent", "wake ReactLoopAgent"),
+            ("session.append('turn/start', { turn })", "持久化 turn 边界", "persist turn boundary"),
+        ]),
+        doc_crossref_table(["agent-lifecycle"]),
+    ),
+    "c10": join_blocks(
+        source_walkthrough("packages/core/agent-loop/src/agent.ts", [
+            ("'agent/pre-step', { messages: claimed }", "瀑布：可 reject/rewrite", "waterfall: reject/rewrite"),
+            ("session.append('step/start', { turn, step })", "step 边界", "step boundary"),
+            ("session.deriveMessages()", "投影 model history", "project model history"),
+            ("await executeToolCalls(...)", "执行 read 等", "execute read etc"),
+        ]),
+        doc_crossref_table(["agent-lifecycle", "tool-execution-pipeline"]),
+    ),
+    "c22": join_blocks(
+        source_walkthrough("packages/core/session/", [
+            ("session.append(type, data)", "追加 SessionEvent", "append SessionEvent"),
+            ("seq 单调递增", "重放与 fork 基础", "replay and fork basis"),
+            ("ctx.sessions.fork(source, boundary)", "分支会话", "branch session"),
+            ("session/event 广播", "Web UI 订阅", "Web UI subscribes"),
+        ]),
+        doc_crossref_table(["architecture"]),
+    ),
+    "c24": cmp(
+        ["特性", "Pi", "DSH", "Claude Code"],
+        [
+            ["插件化 agent-loop", "✗", "✓", "✗"],
+            ["MCP", "✗", "✓", "✓"],
+            ["SessionEvent 日志", "JSONL messages", "append-only events", "✗"],
+            ["deriveMessages", "convertToLlm", "log projection", "✗"],
+            ["子 agent", "✗", "✓", "✓"],
+            ["源码可读", "✓", "✓", "✗"],
+            ["Web UI", "TUI", "✓ :3080", "✗"],
+        ],
+    ),
+}
+
+
+def expand_chapter(cid: str, base: str) -> str:
+    parts = [base]
+    ht = heart_trace_block(cid)
+    if ht:
+        parts.append(ht)
+    extra = CHAPTER_EXTRAS.get(cid, "")
+    if extra:
+        parts.append(extra)
+    return "\n\n".join(parts)

--- a/scripts/dsh_immersive/heart_trace.py
+++ b/scripts/dsh_immersive/heart_trace.py
@@ -1,0 +1,824 @@
+"""Long-form deepseek-harness source traces for Heart + LLM chapters C09–C16."""
+from __future__ import annotations
+
+import html
+import re
+from pathlib import Path
+
+from _html_helpers import cmp, join, note, p, src
+
+DSH = Path("/tmp/deepseek-harness")
+PROMPT_ZH = "读取 README.md，用一句话告诉我这个项目做什么"
+PROMPT_EN = "read README.md and tell me what this project does in one sentence"
+
+# ── helpers ──────────────────────────────────────────────────────────
+
+_KW = re.compile(
+    r"\b(async|await|export|function|const|let|return|if|else|for|while|"
+    r"switch|case|break|continue|type|interface|import|from|new|throw|"
+    r"typeof|undefined|null|true|false|private|readonly|class)\b"
+)
+
+
+def _hl(code: str) -> str:
+    """Lightweight TS syntax highlight; protects // comments from later passes."""
+    comments: list[str] = []
+
+    def _stash_comment(m: re.Match[str]) -> str:
+        comments.append(m.group(1))
+        return f"\x00C{len(comments) - 1}\x00"
+
+    s = html.escape(code)
+    s = re.sub(r"(//.*)$", _stash_comment, s)
+    s = re.sub(r"(`[^`]+`)", r'<span class="src-str">\1</span>', s)
+    s = re.sub(r"('[^']*'|\"[^\"]*\")", r'<span class="src-str">\1</span>', s)
+    s = _KW.sub(r'<span class="src-kw">\1</span>', s)
+    for i, c in enumerate(comments):
+        s = s.replace(f"\x00C{i}\x00", f'<span class="src-comment">{html.escape(c)}</span>')
+    return s
+
+
+def _read(rel: str, start: int, end: int) -> list[tuple[int, str]]:
+    path = DSH / rel
+    if not path.is_file():
+        return []
+    lines = path.read_text(encoding="utf-8").splitlines()
+    out: list[tuple[int, str]] = []
+    for i in range(max(0, start - 1), min(end, len(lines))):
+        out.append((i + 1, lines[i]))
+    return out
+
+
+def _annotated_trace(
+    tag: str,
+    rel: str,
+    start: int,
+    end: int,
+    annotations: dict[int, tuple[str, str]],
+    *,
+    highlight_lines: set[int] | None = None,
+) -> str:
+    """Build numbered source block; annotations: line_no → (zh, en)."""
+    rows = _read(rel, start, end)
+    if not rows:
+        return note(
+            f"源码暂不可用：<code>{rel}</code>（需本地 deepseek-harness clone）",
+            f"Source unavailable: <code>{rel}</code> (deepseek-harness clone required)",
+            copper=True,
+        )
+    hl = highlight_lines or set()
+    body: list[str] = []
+    for ln, code in rows:
+        mark = ' <span class="src-tag">◀ trace</span>' if ln in hl else ""
+        ann = annotations.get(ln)
+        body.append(
+            f'      <span class="src-ln">{ln:4d}</span> <span class="src-hl">{_hl(code)}</span>{mark}'
+        )
+        if ann:
+            body.append(
+                f'      <span class="src-comment">     ↳ <span class="lang-zh-only">{ann[0]}</span>'
+                f'<span class="lang-en-only">{ann[1]}</span></span>'
+            )
+    return src(tag, rel, body)
+
+
+def _trace_header(num: str, zh: str, en: str) -> str:
+    return f"""    <div class="trace-walk">
+      <div class="tw-head">
+        <span class="tw-tag">SOURCE TRACE · C{num}</span>
+        <span class="lang-zh-only">{zh}</span>
+        <span class="lang-en-only">{en}</span>
+      </div>"""
+
+
+def _trace_close() -> str:
+    return "    </div>"
+
+
+def _step_table(
+    title_zh: str,
+    title_en: str,
+    rows: list[list[str]],
+) -> str:
+    return (
+        f'    <div class="trace-steps">'
+        f'<div class="ts-label"><span class="lang-zh-only">{title_zh}</span>'
+        f'<span class="lang-en-only">{title_en}</span></div>'
+        + cmp(["#", "location", "主线时刻 / through-line moment"], rows)
+        + "</div>"
+    )
+
+
+# ── C09: session log + deriveMessages ────────────────────────────────
+
+def _trace_c09() -> str:
+    parts = [
+        _trace_header(
+            "09",
+            f"主线 prompt「{PROMPT_ZH}」进入 session log 的第一站",
+            f"Through-line prompt enters the session log",
+        ),
+        p(
+            "DSH 的心脏契约写在 architecture.md：<strong>Model-visible means logged</strong>。"
+            "任何进入模型请求的内容都必须能从 session log 重建。"
+            "<code>Session.append()</code> 是唯一写入点；"
+            "<code>deriveMessages()</code> 是唯一投影点——把 surface 上的 "
+            "<code>user/message</code> · <code>assistant/message</code> · <code>tool/result</code> "
+            "折叠成 <code>Message[]</code>。",
+            "DSH's heart contract in architecture.md: <strong>Model-visible means logged</strong>. "
+            "Anything reaching a model request must be reconstructable from the session log. "
+            "<code>Session.append()</code> is the sole write site; "
+            "<code>deriveMessages()</code> is the sole projection — folding surface "
+            "<code>user/message</code> · <code>assistant/message</code> · <code>tool/result</code> "
+            "into <code>Message[]</code>.",
+        ),
+        _annotated_trace(
+            "append",
+            "packages/core/session/src/index.ts",
+            604,
+            638,
+            {
+                604: ("★ append 入口：type + data + surfaceOp", "★ append entry: type + data + surfaceOp"),
+                629: ("seq = log.length：连续序号不变量", "seq = log.length: contiguous seq invariant"),
+                634: ("surfaceManager.validateNext：surface 契约在此 enforce", "surfaceManager.validateNext: surface contract enforced here"),
+            },
+            highlight_lines={604, 629, 634},
+        ),
+        _step_table(
+            "主线 prompt 写入 session log 时间线",
+            "Through-line prompt session log timeline",
+            [
+                ["1", "inbox.insert(user)", f"user 消息排队：«{PROMPT_ZH[:16]}…»"],
+                ["2", "turn/start", "turn=1 打开 durable 边界"],
+                ["3", "step/start", "step=1 打开 model+tools 边界"],
+                ["4", "user/message", "surfaceOp=append · 进入 model-visible surface"],
+                ["5", "deriveMessages()", "→ [{role:user, content:…}] 供 buildRequest"],
+                ["6", "assistant/chunk×N", "流式 chunk · 不进入 derive（replay/UI）"],
+                ["7", "assistant/message", "定稿 assistant · surfaceOp=append"],
+                ["8", "tool/call + tool/result", "read README · surfaceOp=append"],
+            ],
+        ),
+        _annotated_trace(
+            "derive",
+            "packages/core/session/src/index.ts",
+            708,
+            747,
+            {
+                726: ("★ deriveMessages：O(new nodes) 缓存投影", "★ deriveMessages: O(new nodes) cached projection"),
+                739: ("deriveEventMessage：逐 surface node 折叠", "deriveEventMessage: fold per surface node"),
+                746: ("返回 fresh array · Message 对象 shared+frozen", "returns fresh array · Message objects shared+frozen"),
+            },
+            highlight_lines={726, 739},
+        ),
+        _annotated_trace(
+            "surface-rule",
+            "packages/core/session/src/surface.ts",
+            70,
+            114,
+            {
+                83: ("★ THE per-node projection rule", "★ THE per-node projection rule"),
+                96: ("user/message → verbatim user Message", "user/message → verbatim user Message"),
+                99: ("assistant/message → skip empty usage-only", "assistant/message → skip empty usage-only"),
+                106: ("tool/result → tool result Message", "tool/result → tool result Message"),
+            },
+            highlight_lines={83, 96, 106},
+        ),
+        p(
+            "注意 <code>assistant/chunk</code> 与 <code>turn/start</code> 不在 surface 上——它们服务 replay 与 UI fidelity，"
+            "但不进入 <code>deriveMessages()</code>。这是 DSH 与 Pi「AgentMessage 全进 transcript」的最大结构差异："
+            "模型历史 = surface 投影，原始 chunk 留在 log 供 fidelity。",
+            "Note <code>assistant/chunk</code> and <code>turn/start</code> are not on the surface — they serve replay "
+            "and UI fidelity but never enter <code>deriveMessages()</code>. Biggest structural difference from Pi's "
+            "«all AgentMessage in transcript»: model history = surface projection; raw chunks stay in log for fidelity.",
+        ),
+        note(
+            "练习：grep session log 里主线 prompt 的 <code>user/message</code>，确认 <code>surfaceOp:'append'</code> 存在；"
+            "再 grep 同 turn 的 <code>assistant/chunk</code>，确认无 surfaceOp。",
+            "Exercise: grep the through-line <code>user/message</code> for <code>surfaceOp:'append'</code>; "
+            "then grep same-turn <code>assistant/chunk</code> and confirm no surfaceOp.",
+            copper=True,
+        ),
+        _trace_close(),
+    ]
+    return join(*parts)
+
+
+# ── C10: ReactLoopAgent turn/start ───────────────────────────────────
+
+def _trace_c10() -> str:
+    parts = [
+        _trace_header(
+            "10",
+            "ReactLoopAgent：turn/start · step/start 完整驱动 trace",
+            "ReactLoopAgent: full turn/start · step/start driver trace",
+        ),
+        p(
+            "Pi 的 <code>runLoop</code> 是外环 follow-up × 内环 tool batch；"
+            "DSH 的 <code>ReactLoopAgent</code> 用 <strong>turn × step</strong> 建模："
+            "一个 turn 可含多个 step（模型请求 + tool batch），"
+            "turn 在 inbox 无 pending 时关闭。主线 prompt 通常 turn=1、step=1(read)+step=2(answer)。",
+            "Pi's <code>runLoop</code> is outer follow-up × inner tool batch; "
+            "DSH's <code>ReactLoopAgent</code> models <strong>turn × step</strong>: "
+            "one turn may contain multiple steps (model request + tool batch); "
+            "turn closes when inbox has no pending work. Through-line prompt is usually turn=1, step=1(read)+step=2(answer).",
+        ),
+        _annotated_trace(
+            "wake",
+            "packages/core/agent-loop/src/agent.ts",
+            172,
+            223,
+            {
+                172: ("wakeDriver：idle → running phase", "wakeDriver: idle → running phase"),
+                192: ("withInitiator(this) → kick()", "withInitiator(this) → kick()"),
+                212: ("★ kick 外环：while (await turn())", "★ kick outer: while (await turn())"),
+                219: ("turn 结束 → idle · wakeRequested 可重启", "turn end → idle · wakeRequested may restart"),
+            },
+            highlight_lines={212, 219},
+        ),
+        _annotated_trace(
+            "turn",
+            "packages/core/agent-loop/src/agent.ts",
+            246,
+            330,
+            {
+                255: ("★ turn/start 写入 session log", "★ turn/start appended to session log"),
+                266: ("preStep：claim inbox + agent/pre-step", "preStep: claim inbox + agent/pre-step"),
+                279: ("★ step/start", "★ step/start"),
+                283: ("user/message append · surfaceOp=append", "user/message append · surfaceOp=append"),
+                287: ("★ step()：deriveMessages → llm.stream", "★ step(): deriveMessages → llm.stream"),
+                292: ("step/end", "step/end"),
+                296: ("agent/turn-stopping serial hook", "agent/turn-stopping serial hook"),
+                319: ("turn/end + reason", "turn/end + reason"),
+            },
+            highlight_lines={255, 279, 287, 319},
+        ),
+        _step_table(
+            "主线 prompt · turn/step 状态机",
+            "Through-line prompt · turn/step state machine",
+            [
+                ["T0", "wakeDriver", "inbox 有 user prompt · phase=running"],
+                ["T1", "turn/start turn=1", "durable turn 边界打开"],
+                ["T2", "step=1 start", "preStep → user/message → step()"],
+                ["T3", "step=1 end", "toolUse(read) · inbox next-step 有 toolResult context"],
+                ["T4", "step=2 start", "deriveMessages 含 tool/result"],
+                ["T5", "step=2 end", "stopReason=completed"],
+                ["T6", "turn/end", "reason=completed · phase→idle"],
+            ],
+        ),
+        p(
+            "C10 止于 <code>step()</code> 入口——模型流式与 tool 调度在 step 内完成（C12/C15）。"
+            "下面桥接 trace 展示 step 内第一次 <code>deriveMessages()</code> 如何喂给 <code>buildRequest</code>。",
+            "C10 stops at <code>step()</code> entry — streaming and tools finish inside step (C12/C15). "
+            "Bridge trace below shows first <code>deriveMessages()</code> inside step feeding <code>buildRequest</code>.",
+        ),
+        _annotated_trace(
+            "step-entry",
+            "packages/core/agent-loop/src/agent.ts",
+            332,
+            342,
+            {
+                341: ("★ deriveMessages() → boundaryMessages", "★ deriveMessages() → boundaryMessages"),
+                340: ("buildRequest：agent/request waterfall", "buildRequest: agent/request waterfall"),
+            },
+            highlight_lines={341},
+        ),
+        note(
+            "对照 docs/agent-lifecycle.md 序列图：turn/* 与 step/* 全是 durable session events；"
+            "agent/* 是 live extension points。",
+            "Cross-read docs/agent-lifecycle.md sequence: turn/* and step/* are durable session events; "
+            "agent/* are live extension points.",
+            copper=True,
+        ),
+        _trace_close(),
+    ]
+    return join(*parts)
+
+
+# ── C11: agent/pre-step waterfall ────────────────────────────────────
+
+def _trace_c11() -> str:
+    parts = [
+        _trace_header(
+            "11",
+            "agent/pre-step 瀑布：14 个 listener 如何改写入模内容",
+            "agent/pre-step waterfall: how 14 listeners reshape model input",
+        ),
+        p(
+            "<code>preStep()</code> 在 claim inbox 之后、<code>step/start</code> 之前调用 "
+            "<code>dispatch.waterfall('agent/pre-step')</code>。"
+            "listener 可 <code>reject</code> 整轮（turn 仍 durable 落盘但无 step）、"
+            "或 <code>enter</code> 并改写 messages——compaction、plan-mode、agent-instructions、"
+            "goal-round-driver 等 14 个包在此挂钩。",
+            "<code>preStep()</code> after inbox claim, before <code>step/start</code>, calls "
+            "<code>dispatch.waterfall('agent/pre-step')</code>. "
+            "Listeners may <code>reject</code> the turn (durable turn logged, no step), "
+            "or <code>enter</code> and rewrite messages — compaction, plan-mode, agent-instructions, "
+            "goal-round-driver, and 12 other packages hook here.",
+        ),
+        _annotated_trace(
+            "pre-step",
+            "packages/core/agent-loop/src/agent.ts",
+            225,
+            243,
+            {
+                229: ("inbox.claim(target, turn)：next-turn 或 next-step", "inbox.claim(target, turn): next-turn or next-step"),
+                230: ("systemPrompt.assemble：section + tool schema", "systemPrompt.assemble: sections + tool schema"),
+                233: ("runtimeContext.project：注入 context section", "runtimeContext.project: inject context section"),
+                234: ("★ agent/pre-step waterfall", "★ agent/pre-step waterfall"),
+                238: ("默认 enter：claimed + context messages", "default enter: claimed + context messages"),
+            },
+            highlight_lines={234, 238},
+        ),
+        _step_table(
+            "agent/pre-step 部分 listener（event map）",
+            "agent/pre-step sample listeners (event map)",
+            [
+                ["1", "agent-instructions", "AGENTS.md 风格 system-reminder 注入"],
+                ["2", "compaction-basic", "压缩摘要替换 early messages"],
+                ["3", "plan-mode", "plan 状态 gate"],
+                ["4", "goal-round-driver", "goal 驱动 continue/reject"],
+                ["5", "session-reference", "跨 session 引用注入"],
+                ["6", "time-context", "时间戳 section"],
+            ],
+        ),
+        _annotated_trace(
+            "turn-reject",
+            "packages/core/agent-loop/src/agent.ts",
+            266,
+            277,
+            {
+                267: ("decision.kind === 'reject' → turnEnds=blocked", "decision.kind === 'reject' → turnEnds=blocked"),
+                274: ("首 step enter 空 messages → turn 无 model call 关闭", "first step enter empty → turn closes without model call"),
+            },
+            highlight_lines={267, 274},
+        ),
+        p(
+            "主线 prompt 的第一次 pre-step 通常只做两件事：把 claimed user 消息与 runtime context section 合并；"
+            "compaction 若未触发则 messages 原样进入 step。",
+            "Through-line's first pre-step usually merges claimed user messages with runtime context section; "
+            "if compaction hasn't fired, messages enter step unchanged.",
+        ),
+        note(
+            "打开 docs/event-producer-consumer.md 搜索 <code>agent/pre-step</code>，"
+            "对照 listener 列与 packages/ 目录。",
+            "Open docs/event-producer-consumer.md, search <code>agent/pre-step</code>, "
+            "cross-read listener column with packages/.",
+            copper=True,
+        ),
+        _trace_close(),
+    ]
+    return join(*parts)
+
+
+# ── C12: tool-calls pipeline ─────────────────────────────────────────
+
+def _trace_c12() -> str:
+    parts = [
+        _trace_header(
+            "12",
+            f"read README 工具管线 · executeToolCalls",
+            f"read README tool pipeline · executeToolCalls",
+        ),
+        p(
+            "模型返回 tool-call block 后，<code>step()</code> 调用 <code>executeToolCalls</code>。"
+            "调度器按 <code>executionMode</code> 分 exclusive barrier 与 parallel pool；"
+            "结果以 model order 提交，<code>tool/call</code> + <code>tool/result</code> 成对写入 session log。",
+            "After model returns tool-call blocks, <code>step()</code> calls <code>executeToolCalls</code>. "
+            "Scheduler splits exclusive barriers vs parallel pool by <code>executionMode</code>; "
+            "results commit in model order; <code>tool/call</code> + <code>tool/result</code> pairs land in session log.",
+        ),
+        _annotated_trace(
+            "dispatch",
+            "packages/core/agent-loop/src/agent.ts",
+            410,
+            418,
+            {
+                412: ("filter tool-call blocks from assistant content", "filter tool-call blocks from assistant content"),
+                414: ("★ executeToolCalls 入口", "★ executeToolCalls entry"),
+                416: ("acceptContext → inbox next-step splice", "acceptContext → inbox next-step splice"),
+            },
+            highlight_lines={414},
+        ),
+        _annotated_trace(
+            "exec",
+            "packages/core/agent-loop/src/tool-calls.ts",
+            59,
+            101,
+            {
+                59: ("executeToolCalls 签名：ctx + turn + step", "executeToolCalls signature: ctx + turn + step"),
+                88: ("executionMode：parallel vs exclusive barrier", "executionMode: parallel vs exclusive barrier"),
+                90: ("runGroup：一组 call 调度", "runGroup: schedule one group of calls"),
+                96: ("abort：skipped calls 合成 error result", "abort: skipped calls get synthetic error result"),
+            },
+            highlight_lines={59, 88, 90},
+        ),
+        _annotated_trace(
+            "append-pair",
+            "packages/core/agent-loop/src/tool-calls.ts",
+            164,
+            289,
+            {
+                167: ("appendToolCall → tool/call event", "appendToolCall → tool/call event"),
+                152: ("tools/execute waterfall → dispatch", "tools/execute waterfall → dispatch"),
+                155: ("★ appendToolResult → tool/result · surfaceOp=append", "★ appendToolResult → tool/result · surfaceOp=append"),
+                263: ("tool/call seq 被 result 引用", "tool/call seq cited by result"),
+            },
+            highlight_lines={167, 155, 263},
+        ),
+        _step_table(
+            "read(README.md) 逐步",
+            "read(README.md) step by step",
+            [
+                ["1", "tools/pre-execute", "hook 链 · approval 可能拦截"],
+                ["2", "tools/execute", "tool-fs read 执行"],
+                ["3", "tool/call", "callId · name=read · arguments JSON"],
+                ["4", "tools/post-execute", "spill · repeat reminder"],
+                ["5", "tool/result", "README 内容 · surfaceOp=append"],
+                ["6", "acceptContext", "additionalContexts → inbox next-step"],
+                ["7", "step=2 deriveMessages", "user+assistant+toolResult → Message[]"],
+            ],
+        ),
+        _annotated_trace(
+            "read-tool",
+            "packages/fs/tool-fs/src/read.ts",
+            1,
+            40,
+            {
+                1: ("tool-fs read：FS capability consumer", "tool-fs read: FS capability consumer"),
+            },
+            highlight_lines=set(),
+        ),
+        note(
+            "abort 时 <code>appendSkippedToolCall</code> 仍写 tool/call+tool/result 合成对——"
+            "replay 与 deriveMessages 保持 valid。",
+            "On abort <code>appendSkippedToolCall</code> still writes synthetic tool/call+tool/result pair — "
+            "replay and deriveMessages stay valid.",
+            copper=True,
+        ),
+        _trace_close(),
+    ]
+    return join(*parts)
+
+
+# ── C13: event domains ───────────────────────────────────────────────
+
+def _trace_c13() -> str:
+    parts = [
+        _trace_header(
+            "13",
+            "三域事件：session · agent · capability",
+            "Three event domains: session · agent · capability",
+        ),
+        p(
+            "DSH 扩展点分三域（architecture.md）："
+            "<strong>Session events</strong> 是 durable facts（<code>session/event</code> 广播）；"
+            "<strong>Agent events</strong>（<code>agent/*</code>）携带 live Agent handle；"
+            "<strong>Capability events</strong>（<code>tools/*</code> · <code>fs/*</code> · <code>llm/stream</code>）"
+            "挂策略而不 import loop。主线一轮同时触及三域。",
+            "DSH extension points split three domains (architecture.md): "
+            "<strong>Session events</strong> are durable facts (broadcast via <code>session/event</code>); "
+            "<strong>Agent events</strong> (<code>agent/*</code>) carry live Agent handle; "
+            "<strong>Capability events</strong> (<code>tools/*</code> · <code>fs/*</code> · <code>llm/stream</code>) "
+            "attach policy without importing the loop. One through-line turn touches all three.",
+        ),
+        _step_table(
+            "主线 prompt · 三域事件序列（简化）",
+            "Through-line prompt · three-domain event sequence (simplified)",
+            [
+                ["S1", "session/event turn/start", "durable · persistence 订阅"],
+                ["S2", "session/event user/message", "surface append"],
+                ["A1", "agent/pre-step", "waterfall · 14 listeners"],
+                ["A2", "agent/request", "waterfall · config proposal"],
+                ["C1", "llm/stream", "waterfall · retry/replay"],
+                ["S3", "session/event assistant/chunk×N", "UI/replay · 非 surface"],
+                ["S4", "session/event assistant/message", "surface append"],
+                ["C2", "tools/pre-execute → execute → post-execute", "read README"],
+                ["S5", "session/event tool/call + tool/result", "surface append"],
+                ["A3", "agent/turn-stopping", "serial · hooks"],
+                ["S6", "session/event turn/end", "durable close"],
+            ],
+        ),
+        _annotated_trace(
+            "session-events",
+            "packages/core/session/src/index.ts",
+            40,
+            86,
+            {
+                54: ("session/created emit", "session/created emit"),
+                76: ("★ session/event：每次 append 广播", "★ session/event: broadcast on every append"),
+                85: ("session/flush parallel：persistence 落盘", "session/flush parallel: persistence flush"),
+            },
+            highlight_lines={76, 85},
+        ),
+        _annotated_trace(
+            "agent-events",
+            "packages/core/agent/src/runtime-types.ts",
+            170,
+            280,
+            {
+                178: ("agent/status emit", "agent/status emit"),
+                231: ("agent/pre-step waterfall 类型", "agent/pre-step waterfall type"),
+                244: ("agent/request waterfall 类型", "agent/request waterfall type"),
+                278: ("agent/turn-stopping serial 类型", "agent/turn-stopping serial type"),
+            },
+            highlight_lines={231, 244, 278},
+        ),
+        p(
+            "读 event map 时记住 mode 语义：<code>waterfall</code> 必须 call <code>next()</code>；"
+            "<code>serial</code> 无 next；<code>emit</code> 是 fire-and-forget。"
+            "错误 domain = 插件挂错钩子 = 静默不生效。",
+            "When reading the event map remember mode semantics: <code>waterfall</code> must call <code>next()</code>; "
+            "<code>serial</code> has no next; <code>emit</code> is fire-and-forget. "
+            "Wrong domain = plugin on wrong hook = silently no-op.",
+        ),
+        note(
+            "用 <code>docs/event-producer-consumer.md</code> 查任意事件的 Dispatchers/Listeners 列；"
+            "比 grep <code>ctx.on(</code> 更完整。",
+            "Use <code>docs/event-producer-consumer.md</code> for any event's Dispatchers/Listeners columns; "
+            "more complete than grepping <code>ctx.on(</code>.",
+            copper=True,
+        ),
+        _trace_close(),
+    ]
+    return join(*parts)
+
+
+# ── C14: ctx.llm ─────────────────────────────────────────────────────
+
+def _trace_c14() -> str:
+    parts = [
+        _trace_header(
+            "14",
+            "ctx.llm：prepareCall · llm/stream 如何接到 ReactLoopAgent",
+            "ctx.llm: how prepareCall · llm/stream connects to ReactLoopAgent",
+        ),
+        p(
+            "<code>ctx.llm</code>（<code>packages/llm/llm</code>）是 DSH 的 LLM 适配层。"
+            "<code>prepareCall</code> 绑定 adapter registration；"
+            "<code>stream()</code> 外包 <code>llm/stream</code> waterfall。"
+            "ReactLoopAgent 在 <code>buildRequest</code> 里 prepare，在 <code>step()</code> 里 stream。",
+            "<code>ctx.llm</code> (<code>packages/llm/llm</code>) is DSH's LLM adapter layer. "
+            "<code>prepareCall</code> binds adapter registration; "
+            "<code>stream()</code> wraps <code>llm/stream</code> waterfall. "
+            "ReactLoopAgent prepares in <code>buildRequest</code>, streams in <code>step()</code>.",
+        ),
+        _annotated_trace(
+            "llm-stream-event",
+            "packages/llm/llm/src/index.ts",
+            47,
+            67,
+            {
+                65: ("★ llm/stream waterfall 声明", "★ llm/stream waterfall declaration"),
+                57: ("LOOP-built request 携带 markAgentLoopRequest", "LOOP-built request carries markAgentLoopRequest"),
+            },
+            highlight_lines={65},
+        ),
+        _annotated_trace(
+            "prepare",
+            "packages/llm/llm/src/index.ts",
+            824,
+            868,
+            {
+                824: ("★ prepareCall：resolve + adapterDefaults", "★ prepareCall: resolve + adapterDefaults"),
+                850: ("prepared stream 只能 dispatch 一次", "prepared stream can dispatch only once"),
+                861: ("streamWithRegistration → llm/stream", "streamWithRegistration → llm/stream"),
+            },
+            highlight_lines={824, 850},
+        ),
+        _annotated_trace(
+            "stream",
+            "packages/llm/llm/src/index.ts",
+            985,
+            999,
+            {
+                985: ("LlmRuntime.stream 公共入口", "LlmRuntime.stream public entry"),
+                993: ("★ ctx.waterfall llm/stream", "★ ctx.waterfall llm/stream"),
+                997: ("default next → adapterStream", "default next → adapterStream"),
+            },
+            highlight_lines={985, 993},
+        ),
+        _step_table(
+            "主线 turn-1 step-1 · ctx.llm 数据流",
+            "Through-line turn-1 step-1 · ctx.llm data flow",
+            [
+                ["in", "deriveMessages()", "user prompt Message[]"],
+                ["prep", "prepareCall(config)", "adapter registration bound"],
+                ["wf1", "agent/request", "config proposal waterfall"],
+                ["req", "markAgentLoopRequest", "deep-frozen GenerateOptions"],
+                ["wf2", "llm/stream", "retry · replay · session-checkpoint"],
+                ["http", "adapter.stream()", "DeepSeek SSE chunks"],
+                ["out", "StreamChunk*", "→ BlockAssembler in step()"],
+            ],
+        ),
+        _annotated_trace(
+            "build-request",
+            "packages/core/agent-loop/src/agent.ts",
+            457,
+            513,
+            {
+                457: ("agent/request waterfall：proposedConfig", "agent/request waterfall: proposedConfig"),
+                468: ("★ loopCtx.llm.prepareCall", "★ loopCtx.llm.prepareCall"),
+                505: ("★ markAgentLoopRequest(deepFreeze(...))", "★ markAgentLoopRequest(deepFreeze(...))"),
+            },
+            highlight_lines={468, 505},
+        ),
+        note(
+            "练习：在 llm-replay 插件短路 <code>llm/stream</code>，观察 session log 是否仍收到相同形状的 assistant/chunk。",
+            "Exercise: short-circuit <code>llm/stream</code> with llm-replay plugin; "
+            "observe session log still gets same-shaped assistant/chunk.",
+            copper=True,
+        ),
+        _trace_close(),
+    ]
+    return join(*parts)
+
+
+# ── C15: assistant/chunk streaming ───────────────────────────────────
+
+def _trace_c15() -> str:
+    parts = [
+        _trace_header(
+            "15",
+            "assistant/chunk 流式：从 adapter chunk 到 assistant/message",
+            "assistant/chunk streaming: adapter chunk to assistant/message",
+        ),
+        p(
+            "<code>step()</code> 的 <code>for await (chunk of stream)</code> 循环是 UI 与 replay 的燃料："
+            "每个 chunk 立即 <code>session.append('assistant/chunk')</code>（无 surfaceOp），"
+            "同时 <code>BlockAssembler.push(chunk)</code> 累积；"
+            "流结束后 <code>assistant/message</code> 带 <code>sourceEventSeqs: chunkSeqs</code> 定稿入 surface。",
+            "<code>step()</code>'s <code>for await (chunk of stream)</code> loop fuels UI and replay: "
+            "each chunk immediately <code>session.append('assistant/chunk')</code> (no surfaceOp), "
+            "while <code>BlockAssembler.push(chunk)</code> accumulates; "
+            "after stream, <code>assistant/message</code> with <code>sourceEventSeqs: chunkSeqs</code> finalizes onto surface.",
+        ),
+        _annotated_trace(
+            "chunk-loop",
+            "packages/core/agent-loop/src/agent.ts",
+            339,
+            409,
+            {
+                346: ("preparedCall?.stream ?? loopCtx.llm.stream", "preparedCall?.stream ?? loopCtx.llm.stream"),
+                348: ("for await chunk of stream", "for await chunk of stream"),
+                350: ("★ assistant/chunk append · 记录 seq", "★ assistant/chunk append · record seq"),
+                351: ("BlockAssembler.push(chunk)", "BlockAssembler.push(chunk)"),
+                372: ("finish error/aborted → request-error waterfall", "finish error/aborted → request-error waterfall"),
+                400: ("★ assistant/message · surfaceOp=append", "★ assistant/message · surfaceOp=append"),
+                408: ("sourceEventSeqs: chunkSeqs 链", "sourceEventSeqs: chunkSeqs chain"),
+            },
+            highlight_lines={350, 400, 408},
+        ),
+        _step_table(
+            "主线 turn-1 · tool-call chunk 时间线",
+            "Through-line turn-1 · tool-call chunk timeline",
+            [
+                ["1", "chunk text_delta", "可能为空 · 模型先输出 tool-call"],
+                ["2", "chunk tool-call start", "read tool 块开始"],
+                ["3", "chunk tool-call delta×N", "arguments JSON 增量"],
+                ["4", "chunk finish tool-calls", "stopReason=tool-calls"],
+                ["5", "assistant/message", "content 含 tool-call block"],
+                ["6", "executeToolCalls", "→ tool/call + tool/result"],
+            ],
+        ),
+        _annotated_trace(
+            "abort-path",
+            "packages/core/agent-loop/src/agent.ts",
+            354,
+            368,
+            {
+                355: ("signal.aborted：assembler.interruptedBlocks()", "signal.aborted: assembler.interruptedBlocks()"),
+                358: ("interrupted assistant/message 仍落盘", "interrupted assistant/message still persisted"),
+            },
+            highlight_lines={358},
+        ),
+        p(
+            "设计要点：chunk 路径与 surface 路径<strong>故意分离</strong>——"
+            "Web UI 订阅 <code>session/event</code> 渲染 chunk；"
+            "<code>deriveMessages()</code> 只看 assistant/message 定稿。"
+            "这与 Pi 的 message_update 单通道不同。",
+            "Design note: chunk path and surface path are <strong>deliberately separate</strong> — "
+            "Web UI subscribes to <code>session/event</code> for chunk render; "
+            "<code>deriveMessages()</code> only sees finalized assistant/message. "
+            "Unlike Pi's single message_update channel.",
+        ),
+        note(
+            "Web 客户端 replay：按 seq 顺序读 assistant/chunk 可重建流式 UI；"
+            "deriveMessages 跳过 chunk 仍得到正确 model history。",
+            "Web client replay: reading assistant/chunk by seq rebuilds streaming UI; "
+            "deriveMessages skipping chunks still yields correct model history.",
+            copper=True,
+        ),
+        _trace_close(),
+    ]
+    return join(*parts)
+
+
+# ── C16: deriveMessages closed loop ──────────────────────────────────
+
+def _trace_c16() -> str:
+    parts = [
+        _trace_header(
+            "16",
+            "deriveMessages 闭环：reconstructability 不变量",
+            "deriveMessages closed loop: reconstructability invariant",
+        ),
+        p(
+            "DSH 运行时断言：<strong>发给模型的 messages 必须是 deriveMessages() 的纯函数</strong>。"
+            "<code>markAgentLoopRequest</code> 标记 LOOP-built request 为 deep-frozen；"
+            "<code>llm/stream</code> listener 可读不可改。"
+            "step=2 的 deriveMessages 输出必须等于 step=1 结束后 log 的 surface 投影——"
+            "这是主线 prompt 第二圈 model call 能「看见 README 内容」的根基。",
+            "DSH runtime asserts: <strong>messages sent to the model must be a pure function of deriveMessages()</strong>. "
+            "<code>markAgentLoopRequest</code> marks LOOP-built requests deep-frozen; "
+            "<code>llm/stream</code> listeners read, never rewrite. "
+            "Step=2 deriveMessages output must equal surface projection after step=1 — "
+            "foundation for the through-line's second model call «seeing README content».",
+        ),
+        _annotated_trace(
+            "derive-cache",
+            "packages/core/session/src/index.ts",
+            701,
+            757,
+            {
+                702: ("derived cache：derivedNodes 增量", "derived cache: derivedNodes increment"),
+                730: ("replaceGeneration 变化 → 全量 rebuild", "replaceGeneration change → full rebuild"),
+                726: ("★ deriveMessages 公共 API", "★ deriveMessages public API"),
+                755: ("deriveEventMessage 委托 surface.ts", "deriveEventMessage delegates to surface.ts"),
+            },
+            highlight_lines={726, 730},
+        ),
+        _step_table(
+            "主线 prompt · deriveMessages 两次投影",
+            "Through-line prompt · two deriveMessages projections",
+            [
+                ["P1", "step=1 开始", "[user]"],
+                ["P2", "step=1 结束", "[user, assistant(tool-call)]"],
+                ["P3", "tool/result 落盘", "[user, assistant, tool-result]"],
+                ["P4", "step=2 开始", "deriveMessages → 同上"],
+                ["P5", "step=2 结束", "[user, assistant, tool-result, assistant(answer)]"],
+            ],
+        ),
+        _annotated_trace(
+            "build-boundary",
+            "packages/core/agent-loop/src/agent.ts",
+            426,
+            442,
+            {
+                431: ("boundaryMessages 参数 = deriveMessages()", "boundaryMessages param = deriveMessages()"),
+                505: ("messages: boundaryMessages 进入 request", "messages: boundaryMessages enter request"),
+            },
+            highlight_lines={431, 505},
+        ),
+        _annotated_trace(
+            "mark-loop",
+            "packages/llm/llm/src/index.ts",
+            52,
+            66,
+            {
+                57: ("LOOP request deep-frozen · listener 不可 mutate", "LOOP request deep-frozen · listeners cannot mutate"),
+            },
+            highlight_lines={57},
+        ),
+        p(
+            "Compaction 走 surface <code>replace</code> 而非删 log——"
+            "<code>replaceGeneration</code> bump 后 deriveMessages 重建 cache，"
+            "模型看到摘要版 history，但 JSONL 仍保留完整原始 events。",
+            "Compaction uses surface <code>replace</code>, not log deletion — "
+            "after <code>replaceGeneration</code> bump deriveMessages rebuilds cache; "
+            "model sees summarized history while JSONL keeps full original events.",
+        ),
+        note(
+            "实验：step=1 结束后打印 <code>session.deriveMessages().length</code>，"
+            "再 append 一条无 surfaceOp 的 debug event，确认 length 不变。",
+            "Experiment: after step=1 print <code>session.deriveMessages().length</code>, "
+            "append a debug event without surfaceOp, confirm length unchanged.",
+            copper=True,
+        ),
+        _trace_close(),
+    ]
+    return join(*parts)
+
+
+# ── public API ───────────────────────────────────────────────────────
+
+_HEART = {
+    "c9": _trace_c09,
+    "c10": _trace_c10,
+    "c11": _trace_c11,
+    "c12": _trace_c12,
+    "c13": _trace_c13,
+    "c14": _trace_c14,
+    "c15": _trace_c15,
+    "c16": _trace_c16,
+}
+
+
+def heart_trace_block(cid: str) -> str:
+    fn = _HEART.get(cid)
+    if not fn:
+        return ""
+    return fn()
+
+
+def heart_trace_chars(cid: str) -> int:
+    return len(heart_trace_block(cid))

--- a/scripts/dsh_immersive/meta.py
+++ b/scripts/dsh_immersive/meta.py
@@ -1,0 +1,98 @@
+"""Metadata and TOC structure for DeepSeek Harness immersive article."""
+
+SLUG = "dsh"
+TITLE_ZH = "一条用户消息在 DeepSeek Harness 里的一生"
+TITLE_EN = "The Life of a User Message Inside DeepSeek Harness"
+SUBTITLE_ZH = "Cordis plugins → ReactLoopAgent → turn/step → deriveMessages → tools → session log"
+SUBTITLE_EN = "Cordis plugins → ReactLoopAgent → turn/step → deriveMessages → tools → session log"
+DECK_ZH = (
+    "你在终端里敲下一行「读取 README.md，用一句话告诉我这个项目做什么」之后，这串文字要穿过 26 道工序、"
+    "跨 Cordis 插件树与 core spine 六个包，在 session log 与 surface 投影里变形，最后才变成流式 chunk、"
+    "tool/result 与磁盘上的 SessionEvent JSONL。"
+    "对照 deepseek-harness 生产源码，用与 Pi 文章相同的主线 prompt，把 turn/step 边界、"
+    "agent/pre-step 瀑布、事件三域、deriveMessages 不变量全摊开。"
+)
+DECK_EN = (
+    "After you type «read README.md and tell me what this project does in one sentence», that string "
+    "passes through 26 stations, crosses the Cordis plugin tree and six core-spine packages, morphs across "
+    "session log and surface projection, and only then becomes streaming chunks, tool/result events, and "
+    "SessionEvent JSONL on disk. Cross-reading deepseek-harness production source with the same through-line "
+    "prompt as the Pi article — every turn/step boundary, agent/pre-step waterfall, three event domains, "
+    "and deriveMessages invariant laid bare."
+)
+FIELD_NOTE = "11"
+DATE = "2026-08-23"
+OG_IMAGE = "https://ursb.me/og/dsh.png"
+
+CHAPTERS = [
+    # (id, num, phase_zh, phase_en, title_zh, title_en, subtitle_zh, subtitle_en, special)
+    ("c1", "01", "引子", "Prologue", "Harness 不是 Product", "Harness is not a product",
+     "agent 产品战争里的第三条路", "a third path in the agent product war", False),
+    ("c2", "02", "引子", "Prologue", "一条消息的 turn/step 全景", "turn/step panorama for one message",
+     "从回车到 session log 的全景图", "from Enter to session log, the full map", False),
+    ("c3", "03", "背景", "Background", "deepseek-harness 家谱", "The deepseek-harness family tree",
+     "DeepSeek AI · Cordis · vendor/", "DeepSeek AI · Cordis · vendor/", False),
+    ("c4", "04", "背景", "Background", "Core spine 六层", "The core-spine six layers",
+     "session · system-prompt · tools · agent · agent-loop · llm", "session · system-prompt · tools · agent · agent-loop · llm", False),
+    ("c5", "05", "背景", "Background", "Everything is a plugin", "Everything is a plugin",
+     "没有特权核心 · 只有 Cordis 组合", "no privileged core · Cordis composition only", True),
+    ("c6", "06", "入口", "Intake", "dsh 启动链", "dsh boot chain",
+     "profile → bundle → Loader → ctx", "profile → bundle → Loader → ctx", False),
+    ("c7", "07", "入口", "Intake", "ctx.agents 生命周期", "ctx.agents lifecycle",
+     "create · resume · dispose · scoped ctx", "create · resume · dispose · scoped ctx", False),
+    ("c8", "08", "入口", "Intake", "system-prompt 组装", "System prompt assembly",
+     "section waterfall · tool schema 入模", "section waterfall · tool schemas into model", False),
+    ("c9", "09", "心脏", "Heart", "Session log 不变量", "Session log invariant",
+     "deriveMessages · surfaceOp · model-visible means logged", "deriveMessages · surfaceOp · model-visible means logged", True),
+    ("c10", "10", "心脏", "Heart", "ReactLoopAgent 驱动", "ReactLoopAgent driver",
+     "wakeDriver · turn/start · step/start", "wakeDriver · turn/start · step/start", True),
+    ("c11", "11", "心脏", "Heart", "agent/pre-step 瀑布", "agent/pre-step waterfall",
+     "claim inbox · inject context · reject turn", "claim inbox · inject context · reject turn", False),
+    ("c12", "12", "心脏", "Heart", "Tool 执行管线", "Tool execution pipeline",
+     "executeToolCalls · parallel barrier · model order", "executeToolCalls · parallel barrier · model order", False),
+    ("c13", "13", "心脏", "Heart", "三域事件矩阵", "Three-domain event matrix",
+     "session · agent · capability events", "session · agent · capability events", False),
+    ("c14", "14", "LLM", "LLM", "ctx.llm 适配层", "ctx.llm adapter seam",
+     "prepareCall · llm/stream · adapter boundary", "prepareCall · llm/stream · adapter boundary", False),
+    ("c15", "15", "LLM", "LLM", "assistant/chunk 流式", "assistant/chunk streaming",
+     "BlockAssembler · chunk seq · message finalize", "BlockAssembler · chunk seq · message finalize", False),
+    ("c16", "16", "LLM", "LLM", "deriveMessages 闭环", "deriveMessages closed loop",
+     "boundaryMessages → request · reconstructability", "boundaryMessages → request · reconstructability", False),
+    ("c17", "17", "Web", "Web", "ctx.web 能力缝", "ctx.web capability seam",
+     "search · fetch · Service Definition", "search · fetch · Service Definition", True),
+    ("c18", "18", "Web", "Web", "tool-web Consumer", "tool-web consumer",
+     "模型调网络的最后一站", "last station before the model hits the network", False),
+    ("c19", "19", "扩展", "Extensions", "Cordis 插件面", "Cordis plugin surface",
+     "inject · Service · Events · effects", "inject · Service · Events · effects", False),
+    ("c20", "20", "扩展", "Extensions", "Loader 与 bundle", "Loader and bundle",
+     "dsh-base · web-app · headless 层叠", "dsh-base · web-app · headless stack", False),
+    ("c21", "21", "扩展", "Extensions", "cordis.patch 组合", "cordis.patch composition",
+     "替换任意 plugin row · --dump-config", "replace any plugin row · --dump-config", False),
+    ("c22", "22", "持久化", "Persistence", "SessionEvent JSONL", "SessionEvent JSONL",
+     "seq 连续 · fork · session/flush", "contiguous seq · fork · session/flush", True),
+    ("c23", "23", "持久化", "Persistence", "Compaction 与 surface", "Compaction and surface replace",
+     "log 不删 · surface replace 重建上下文", "log kept · surface replace rebuilds context", False),
+    ("c24", "24", "全景", "Landscape", "对比 Pi Harness", "vs Pi harness",
+     "turn/step vs runLoop 双环", "turn/step vs runLoop twin loops", False),
+    ("c25", "25", "全景", "Landscape", "JSON-RPC 与 profiles", "JSON-RPC and profiles",
+     "web · headless · Python SDK", "web · headless · Python SDK", False),
+    ("c26", "26", "Coda", "Coda", "怎么自己 trace 一轮", "How to trace a turn yourself",
+     "session/event · event map · --dump-config", "session/event · event map · --dump-config", False),
+]
+
+TOC_GROUPS = [
+    ("bg", "0", "引子", "Prologue", "2 chapters · framing", 2, ["c1", "c2"]),
+    ("in", "I", "入口", "Intake", "3 chapters · boot to context", 3, ["c6", "c7", "c8"]),
+    ("heart", "II", "心脏", "Heart", "5 chapters · ReactLoopAgent", 5, ["c9", "c10", "c11", "c12", "c13"]),
+    ("llm", "III", "LLM", "LLM", "3 chapters · ctx.llm", 3, ["c14", "c15", "c16"]),
+    ("web", "IV", "Web", "Web", "2 chapters · search & fetch", 2, ["c17", "c18"]),
+    ("ext", "V", "扩展", "Extensions", "3 chapters · Cordis plugins", 3, ["c19", "c20", "c21"]),
+    ("persist", "VI", "持久化", "Persistence", "2 chapters · JSONL + compaction", 2, ["c22", "c23"]),
+    ("land", "VII", "全景", "Landscape", "2 chapters · ecosystem", 2, ["c24", "c25"]),
+    ("coda", "∎", "Coda", "Coda", "trace it yourself", 1, ["c26"]),
+]
+
+# Background chapters between prologue and intake
+TOC_GROUPS_BG = [
+    ("card", "·", "背景", "Background", "3 chapters · monorepo", 3, ["c3", "c4", "c5"]),
+]

--- a/scripts/dsh_immersive/overview.py
+++ b/scripts/dsh_immersive/overview.py
@@ -1,0 +1,126 @@
+"""Article-level forest overview — see the trees and the forest."""
+from __future__ import annotations
+
+from _html_helpers import fig, join, p
+from visuals import svg_wrap
+
+
+def viz_forest_map() -> str:
+    """8-phase × 26-chapter master map (React C05 style)."""
+    inner = """
+  <text x="360" y="22" text-anchor="middle" class="svg-label">一条用户消息 · 8 PHASES · 26 CHAPTERS</text>
+
+  <!-- phase columns -->
+  <rect x="16" y="36" width="88" height="200" rx="3" class="svg-box muted"/>
+  <text x="60" y="54" text-anchor="middle" class="svg-micro" font-weight="700">0 引子</text>
+  <text x="60" y="72" text-anchor="middle" class="svg-tiny">C01–02</text>
+  <text x="60" y="100" text-anchor="middle" class="svg-body">心智</text>
+  <text x="60" y="118" text-anchor="middle" class="svg-body">22 站图</text>
+
+  <rect x="108" y="36" width="72" height="200" rx="3" class="svg-box paper"/>
+  <text x="144" y="54" text-anchor="middle" class="svg-micro" font-weight="700">· 背景</text>
+  <text x="144" y="72" text-anchor="middle" class="svg-tiny">C03–05</text>
+
+  <rect x="184" y="36" width="72" height="200" rx="3" class="svg-box accent"/>
+  <text x="220" y="54" text-anchor="middle" class="svg-micro" font-weight="700">I 入口</text>
+  <text x="220" y="72" text-anchor="middle" class="svg-tiny">C06–08</text>
+  <text x="220" y="100" text-anchor="middle" class="svg-body">dsh web</text>
+  <text x="220" y="118" text-anchor="middle" class="svg-body">ctx.*</text>
+
+  <rect x="260" y="36" width="88" height="200" rx="3" fill="#fde8e4" stroke="#c3573a" stroke-width="1.5"/>
+  <text x="304" y="54" text-anchor="middle" class="svg-micro" font-weight="700" fill="#c3573a">II 心脏</text>
+  <text x="304" y="72" text-anchor="middle" class="svg-tiny">C09–13</text>
+  <text x="304" y="100" text-anchor="middle" class="svg-body">turn/step</text>
+  <text x="304" y="118" text-anchor="middle" class="svg-body">tools</text>
+  <text x="304" y="136" text-anchor="middle" class="svg-body">events</text>
+
+  <rect x="352" y="36" width="72" height="200" rx="3" class="svg-box gpu"/>
+  <text x="388" y="54" text-anchor="middle" class="svg-micro" font-weight="700">III LLM</text>
+  <text x="388" y="72" text-anchor="middle" class="svg-tiny">C14–16</text>
+
+  <rect x="428" y="36" width="72" height="200" rx="3" class="svg-box asm"/>
+  <text x="464" y="54" text-anchor="middle" class="svg-micro" font-weight="700">IV Web</text>
+  <text x="464" y="72" text-anchor="middle" class="svg-tiny">C17–18</text>
+
+  <rect x="504" y="36" width="72" height="200" rx="3" class="svg-box copper"/>
+  <text x="540" y="54" text-anchor="middle" class="svg-micro" font-weight="700">V 扩展</text>
+  <text x="540" y="72" text-anchor="middle" class="svg-tiny">C19–21</text>
+
+  <rect x="580" y="36" width="60" height="200" rx="3" class="svg-box muted"/>
+  <text x="610" y="54" text-anchor="middle" class="svg-micro" font-weight="700">VI</text>
+  <text x="610" y="72" text-anchor="middle" class="svg-tiny">C22–23</text>
+
+  <rect x="644" y="36" width="60" height="200" rx="3" class="svg-box paper"/>
+  <text x="674" y="54" text-anchor="middle" class="svg-micro" font-weight="700">VII</text>
+  <text x="674" y="72" text-anchor="middle" class="svg-tiny">C24–25</text>
+
+  <!-- through-line arrow -->
+  <path d="M40 250 L680 250" stroke="#1f5c8c" stroke-width="2" marker-end="url(#pi-arr)"/>
+  <text x="360" y="272" text-anchor="middle" class="svg-mute">Enter → turn/start → read → tool/result → deriveMessages → session log</text>
+
+  <!-- highlight heart -->
+  <rect x="268" y="148" width="72" height="28" rx="2" fill="none" stroke="#c3573a" stroke-width="2" stroke-dasharray="4 2"/>
+  <text x="304" y="166" text-anchor="middle" class="svg-micro" fill="#c3573a">主线最密区</text>
+"""
+    return fig(
+        "森林图：8 个 Phase 把 26 章串成一条线；Phase II（心脏）是 ReactLoopAgent 与工具执行最密集的区域。",
+        "Forest map: 8 phases string 26 chapters; Phase II (Heart) is the densest ReactLoopAgent + tool region.",
+        f'<div class="pi-fig wide panorama">{svg_wrap(inner, "0 0 720 290")}</div>',
+    )
+
+
+def reading_paths() -> str:
+    return """    <div class="forest-paths">
+      <div class="fp-head">
+        <span class="lang-zh-only">三条阅读路径</span>
+        <span class="lang-en-only">Three reading paths</span>
+      </div>
+      <div class="fp-grid">
+        <a href="#c2" class="fp-card">
+          <div class="fp-tag lang-zh-only">路径 A · 先看森林</div>
+          <div class="fp-tag lang-en-only">Path A · Forest first</div>
+          <div class="fp-title lang-zh-only">C02 22 站全景 → 按需跳章</div>
+          <div class="fp-title lang-en-only">C02 22-station map → jump as needed</div>
+          <div class="fp-desc lang-zh-only">适合已懂 agent 基础、想先建立全局心智模型的读者。</div>
+          <div class="fp-desc lang-en-only">For readers who know agent basics and want the global map first.</div>
+        </a>
+        <a href="#c7" class="fp-card fp-highlight">
+          <div class="fp-tag lang-zh-only">路径 B · 直奔心脏</div>
+          <div class="fp-tag lang-en-only">Path B · Straight to heart</div>
+          <div class="fp-title lang-zh-only">C07 ctx.agents → C10 ReactLoopAgent → C14 ctx.llm</div>
+          <div class="fp-title lang-en-only">C07 ctx.agents → C10 ReactLoopAgent → C14 ctx.llm</div>
+          <div class="fp-desc lang-zh-only">最短源码路径：从 send() 追到 llm/stream。</div>
+          <div class="fp-desc lang-en-only">Shortest source path: send() to llm/stream.</div>
+        </a>
+        <a href="#c26" class="fp-card">
+          <div class="fp-tag lang-zh-only">路径 C · 动手 trace</div>
+          <div class="fp-tag lang-en-only">Path C · Hands-on trace</div>
+          <div class="fp-title lang-zh-only">dsh web → session/event → --dump-config</div>
+          <div class="fp-title lang-en-only">dsh web → session/event → --dump-config</div>
+          <div class="fp-desc lang-zh-only">边跑 DSH 边对照本文章节，最后读 C26 自查清单。</div>
+          <div class="fp-desc lang-en-only">Run DSH alongside chapters; finish with C26 checklist.</div>
+        </a>
+      </div>
+    </div>"""
+
+
+def forest_overview_section() -> str:
+    """Standalone overview block inserted after TOC, before C01."""
+    return f"""  <section class="forest-overview" id="forest-overview">
+    <div class="fo-label">
+      <span class="lang-zh-only">OVERVIEW · 森林图</span>
+      <span class="lang-en-only">OVERVIEW · Forest map</span>
+    </div>
+    <h2 class="fo-title lang-zh-only">先见森林，再见树木</h2>
+    <h2 class="fo-title lang-en-only">See the forest before the trees</h2>
+{p(
+    "全文 26 章不是平铺的百科条目，而是一条<strong>固定主线 prompt</strong>从 Web UI 回车追到 SessionEvent 落盘的流水线。下面这张图是望远镜：告诉你 Phase 在哪、章节密度在哪、心脏区（ReactLoopAgent + tools）在哪。",
+    "All 26 chapters are not a flat encyclopedia — they are a pipeline tracing one <strong>fixed through-line prompt</strong> from Enter to SessionEvent on disk. The diagram below is the telescope: where phases sit, where chapter density peaks, where the heart (ReactLoopAgent + tools) lives.",
+)}
+{viz_forest_map()}
+{reading_paths()}
+    <div class="fo-legend">
+      <span class="lang-zh-only"><strong>标题层级约定：</strong>每章仅一个 <code>h2</code> 章标题；正文小节为 <code>C07.1</code> 式编号；「深度细读」块内为 <code>C07.4+</code>，FAQ / Case Study 不再占用标题层级。</span>
+      <span class="lang-en-only"><strong>Heading convention:</strong> one <code>h2</code> chapter title; body sections numbered <code>C07.1</code>; deep-dive block uses <code>C07.4+</code>; FAQ / Case Study use labels, not headings.</span>
+    </div>
+  </section>"""

--- a/scripts/dsh_immersive/section_num.py
+++ b/scripts/dsh_immersive/section_num.py
@@ -1,0 +1,18 @@
+"""Auto-number h3 body sections as C{chap}.{n}."""
+from __future__ import annotations
+
+import re
+
+_H3_OPEN = re.compile(r"<h3 class=\"sub\">")
+
+
+def number_body_sections(ch_num: str, body: str) -> str:
+    n = 1
+
+    def repl(_: re.Match[str]) -> str:
+        nonlocal n
+        label = f'<span class="sec-num">C{ch_num}.{n}</span> '
+        n += 1
+        return f'<h3 class="sub">{label}'
+
+    return _H3_OPEN.sub(repl, body)

--- a/scripts/dsh_immersive/shell.py
+++ b/scripts/dsh_immersive/shell.py
@@ -1,0 +1,834 @@
+"""HTML shell assembly for DeepSeek Harness immersive article."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from meta import (
+    CHAPTERS,
+    DATE,
+    DECK_EN,
+    DECK_ZH,
+    FIELD_NOTE,
+    OG_IMAGE,
+    SLUG,
+    SUBTITLE_EN,
+    SUBTITLE_ZH,
+    TITLE_EN,
+    TITLE_ZH,
+    TOC_GROUPS,
+    TOC_GROUPS_BG,
+)
+from doc_map import DOC_REFERENCES
+
+from compass import chapter_compass
+
+TEMPLATE = Path(__file__).resolve().parents[2] / "public/immersive/llm-inference-life/index.html"
+
+# Pipeline cell color by chapter phase
+PIPELINE_COLORS = {
+    "c1": "p0", "c2": "p0",
+    "c3": "p1", "c4": "p1", "c5": "p1",
+    "c6": "p2", "c7": "p2", "c8": "p2",
+    "c9": "p3", "c10": "p3", "c11": "p3", "c12": "p3", "c13": "p3",
+    "c14": "p4", "c15": "p4", "c16": "p4",
+    "c17": "p5", "c18": "p5",
+    "c19": "p6", "c20": "p6", "c21": "p6",
+    "c22": "p7", "c23": "p7",
+    "c24": "p8", "c25": "p8",
+    "c26": "pc",
+}
+
+EXTRA_CSS = """
+  .formula {
+    background: var(--ink); color: var(--bg);
+    padding: 32px; margin: 32px 0;
+    font-family: var(--mono); font-size: 14px; line-height: 1.9;
+    border-radius: 4px; position: relative;
+  }
+  .formula .ftitle {
+    font-family: var(--sans); font-size: 11px;
+    letter-spacing: 0.22em; text-transform: uppercase;
+    margin-bottom: 16px; color: var(--rule);
+  }
+  .formula .cond { display: block; margin: 4px 0; }
+  .formula .cond::before { content: "▸"; color: var(--accent-soft); margin-right: 12px; }
+  .formula .out {
+    margin-top: 16px; padding-top: 16px;
+    border-top: 1px solid #2c2f36; color: var(--accent-soft);
+  }
+  .formula .term { color: #fcd34d; font-weight: 700; }
+  .formula .term-cu { color: #d1855a; font-weight: 700; }
+  .ladder {
+    background: var(--paper); border: 1px solid var(--rule);
+    border-radius: 4px; padding: 22px 24px; margin: 8px 0 24px;
+  }
+  .ladder .ld-row {
+    display: grid; grid-template-columns: 36px 1fr;
+    align-items: center; gap: 14px;
+    padding: 10px 0; border-bottom: 1px dashed var(--rule);
+  }
+  .ladder .ld-row:last-child { border-bottom: none; }
+  .ladder .ld-num {
+    font-family: var(--mono); font-size: 22px; color: var(--accent);
+    font-weight: 700; line-height: 1;
+  }
+  .ladder .ld-row:nth-child(2) .ld-num { color: #3873a3; }
+  .ladder .ld-row:nth-child(3) .ld-num { color: #6285a8; }
+  .ladder .ld-row:nth-child(4) .ld-num { color: #8090a8; }
+  .ladder .ld-name {
+    font-family: var(--serif); font-size: 15px; font-weight: 700; color: var(--ink);
+  }
+  body.lang-en .ladder .ld-name { font-family: var(--serif-en); }
+  .ladder .ld-desc {
+    font-family: var(--sans); font-size: 12px; color: var(--ink-mute);
+    margin-top: 2px;
+  }
+  .pi-fig { width: 100%; overflow-x: auto; }
+  .pi-fig.wide svg { min-width: 720px; }
+  .pi-svg { width: 100%; height: auto; display: block; }
+  .pi-svg .svg-label {
+    font-family: var(--mono); font-size: 10px; letter-spacing: 0.14em;
+    text-transform: uppercase; fill: var(--ink-mute);
+  }
+  .pi-svg .svg-body { font-family: var(--sans); font-size: 12px; fill: var(--ink); }
+  .pi-svg .svg-mute { font-family: var(--sans); font-size: 10.5px; fill: #767c87; }
+  .pi-svg .svg-micro { font-family: var(--mono); font-size: 9px; fill: var(--ink-soft); }
+  .pi-svg .svg-tiny { font-family: var(--mono); font-size: 10px; fill: var(--ink); }
+  .pi-svg .svg-mono { font-family: var(--mono); font-size: 11px; fill: var(--ink-soft); }
+  .pi-svg .svg-box { fill: #faf6ed; stroke: #c7c4ba; stroke-width: 1.5; }
+  .pi-svg .svg-box.accent { fill: #e8f0f8; stroke: #1f5c8c; }
+  .pi-svg .svg-box.copper { fill: #f5ebe0; stroke: #b35a1f; }
+  .pi-svg .svg-box.gpu { fill: #efe8f5; stroke: #6b3aa3; }
+  .pi-svg .svg-box.asm { fill: #e8f2ec; stroke: #2d6a4f; }
+  .pi-svg .svg-box.paper { fill: #f3efe6; stroke: #c7c4ba; }
+  .pi-svg .svg-box.muted { fill: #ebe5d8; stroke: #c7c4ba; }
+  .pi-svg .svg-arrow { stroke: #1f5c8c; stroke-width: 1.5; marker-end: url(#pi-arr); }
+  .pi-fig.panorama svg { min-width: 100%; }
+  .station-track {
+    margin: 20px 0 28px;
+    border: 1px solid var(--rule);
+    border-radius: 4px;
+    background: var(--paper);
+    overflow: hidden;
+  }
+  .station-track .st-rail {
+    display: grid;
+    grid-template-columns: repeat(11, minmax(72px, 1fr));
+    gap: 0;
+    overflow-x: auto;
+    padding: 0;
+    scrollbar-width: thin;
+  }
+  @media (max-width: 900px) {
+    .station-track .st-rail { grid-template-columns: repeat(11, 88px); }
+  }
+  .station-track .st-cell {
+    border-right: 1px solid var(--rule-soft);
+    border-bottom: 1px solid var(--rule-soft);
+    padding: 12px 8px 10px;
+    text-align: center;
+    background: linear-gradient(180deg, var(--paper) 0%, color-mix(in srgb, var(--st-color) 6%, var(--paper)) 100%);
+    min-height: 88px;
+  }
+  .station-track .st-cell:nth-child(n+12) { border-bottom: none; }
+  .station-track .st-num {
+    font-family: var(--mono); font-size: 18px; font-weight: 700;
+    color: var(--st-color); line-height: 1;
+  }
+  .station-track .st-name {
+    font-family: var(--sans); font-size: 11px; font-weight: 600;
+    color: var(--ink); margin-top: 6px; line-height: 1.25;
+  }
+  .station-track .st-phase {
+    font-family: var(--mono); font-size: 8px; letter-spacing: 0.1em;
+    text-transform: uppercase; color: var(--ink-mute); margin-top: 4px;
+  }
+  .stage-why-care {
+    background: linear-gradient(180deg, #fdfbf3, #faf6ed);
+    border: 1px solid var(--rule); border-top: 3px solid var(--accent);
+    border-radius: 4px; padding: 18px 22px 16px; margin: 18px 0 22px;
+  }
+  .stage-why-care .swc-label {
+    font-family: var(--mono); font-size: 9px; color: var(--accent);
+    letter-spacing: 0.12em; text-transform: uppercase; margin-bottom: 10px;
+  }
+  .stage-why-care p {
+    font-family: var(--serif); font-size: 14px; color: var(--ink-soft);
+    line-height: 1.65; margin: 6px 0; display: flex; align-items: baseline; gap: 10px;
+  }
+  body.lang-en .stage-why-care p { font-family: var(--serif-en); }
+  .stage-why-care .swc-pill {
+    flex: 0 0 auto; font-family: var(--mono); font-size: 8px; font-weight: 700;
+    letter-spacing: 0.1em; text-transform: uppercase; color: #fff;
+    background: var(--ink-mute); padding: 2px 7px; border-radius: 2px;
+  }
+  .stage-why-care .swc-pill.rev { background: var(--accent); }
+  .stage-why-care .swc-pill.act { background: var(--copper); }
+  .stage-why-care em { color: var(--ink); font-style: normal; font-weight: 600; }
+  .stage-banner {
+    display: grid; grid-template-columns: repeat(4, 1fr); gap: 0;
+    background: var(--paper); border: 1px solid var(--rule);
+    border-radius: 4px; overflow: hidden; margin: 28px 0 36px;
+  }
+  .stage-banner .sb-cell {
+    padding: 14px 18px; border-right: 1px solid var(--rule-soft);
+  }
+  .stage-banner .sb-cell:last-child { border-right: none; }
+  .stage-banner .sb-key {
+    font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.18em;
+    text-transform: uppercase; color: var(--ink-mute); margin-bottom: 4px;
+  }
+  .stage-banner .sb-val {
+    font-family: var(--sans); font-size: 13.5px; font-weight: 600; color: var(--ink);
+  }
+  .trace-box {
+    margin: 24px 0; padding: 16px 20px;
+    background: var(--paper-2); border: 1px dashed var(--accent);
+    border-radius: 4px;
+  }
+  .trace-box .tb-tag {
+    font-family: var(--mono); font-size: 9px; letter-spacing: 0.16em;
+    color: var(--accent); font-weight: 700; margin-bottom: 8px;
+  }
+  @media (max-width: 760px) {
+    .stage-banner { grid-template-columns: 1fr 1fr; }
+    .stage-why-care p { flex-direction: column; gap: 4px; }
+  }
+  .event-flow {
+    border: 1px solid var(--rule); border-radius: 4px;
+    background: var(--paper-2); padding: 4px 0;
+  }
+  .event-flow .ef-row {
+    display: grid; grid-template-columns: 140px 1fr; gap: 16px;
+    padding: 10px 18px; border-bottom: 1px dashed var(--rule-soft);
+    align-items: baseline;
+  }
+  .event-flow .ef-row:last-child { border-bottom: none; }
+  .event-flow .ef-type {
+    font-family: var(--mono); font-size: 11px; font-weight: 600;
+    color: var(--accent); background: var(--accent-pale, #e8f0f8);
+    padding: 3px 8px; border-radius: 3px; display: inline-block;
+  }
+  .toc-group[data-phase="heart"] { border-left-color: var(--accent); background: linear-gradient(135deg, rgba(31,92,140,0.04) 0%, var(--paper) 60%); }
+  .toc-group[data-phase="llm"] { border-left-color: var(--gpu); background: linear-gradient(135deg, rgba(107,58,163,0.05) 0%, var(--paper) 60%); }
+  .toc-group[data-phase="tui"] { border-left-color: var(--asm); background: linear-gradient(135deg, rgba(45,106,79,0.04) 0%, var(--paper) 60%); }
+  .toc-group[data-phase="ext"] { border-left-color: var(--heat); background: linear-gradient(135deg, rgba(195,87,58,0.05) 0%, var(--paper) 60%); }
+  .toc-group[data-phase="persist"] { border-left-color: var(--copper); background: linear-gradient(135deg, rgba(179,90,31,0.05) 0%, var(--paper) 60%); }
+  .toc-group[data-phase="land"] { border-left-color: var(--gpu-soft); }
+  .toc-group[data-phase="card"] { border-left-color: var(--ink-mute); }
+  .perf-bar .pb-track { grid-template-columns: repeat(26, 1fr); }
+  .perf-bar .pb-cell.lit { transform: translateY(-2px); box-shadow: 0 0 0 2px rgba(31,92,140,0.45); }
+  #readProgress {
+    position: fixed; top: 0; left: 0; height: 2px; width: 0%;
+    background: linear-gradient(90deg, var(--copper), var(--accent));
+    z-index: 200; transition: width 0.08s linear;
+  }
+  .session-tree {
+    font-family: var(--mono); font-size: 11px; line-height: 1.7;
+    padding: 16px; background: var(--paper-2);
+  }
+  .session-tree .st-node { padding: 4px 0 4px 20px; border-left: 2px solid var(--rule); margin-left: 8px; }
+  .session-tree .st-leaf { color: var(--accent); font-weight: 700; }
+  .milestone-table td.owner-user { color: var(--copper); }
+  .milestone-table td.owner-model { color: var(--accent); }
+  .milestone-table td.owner-loop { color: var(--gpu); }
+  .milestone-table td.owner-tool { color: var(--asm); }
+  .milestone-table .owner-user { color: var(--copper); }
+  .milestone-table .owner-model { color: var(--accent); }
+  .milestone-table .owner-loop { color: var(--gpu); }
+  .milestone-table .owner-tool { color: var(--asm); }
+  .case-study {
+    margin: 22px 0; padding: 18px 20px;
+    background: var(--paper-2); border: 1px solid var(--rule);
+    border-left: 3px solid var(--accent); border-radius: 0 4px 4px 0;
+  }
+  .case-study .cs-tag {
+    font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.18em;
+    text-transform: uppercase; color: var(--accent); font-weight: 700; margin-bottom: 8px;
+  }
+  .case-study .cs-title {
+    font-family: var(--serif); font-size: 15px; font-weight: 700;
+    margin-bottom: 8px; color: var(--ink);
+  }
+  body.lang-en .case-study .cs-title { font-family: var(--serif-en); }
+  .sec-num {
+    font-family: var(--mono); font-size: 11px; letter-spacing: 0.06em;
+    color: var(--accent); font-weight: 700; margin-right: 6px;
+  }
+  .chap-compass {
+    margin: 0 0 28px; padding: 14px 18px;
+    background: var(--paper-2); border: 1px solid var(--rule);
+    border-left: 3px solid var(--accent); border-radius: 0 4px 4px 0;
+  }
+  .chap-compass .cc-row { display: flex; flex-wrap: wrap; align-items: center; gap: 8px 12px; }
+  .chap-compass .cc-row + .cc-row { margin-top: 10px; padding-top: 10px; border-top: 1px dashed var(--rule-soft); }
+  .chap-compass .cc-phase, .chap-compass .cc-chap, .chap-compass .cc-station {
+    font-family: var(--mono); font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase;
+  }
+  .chap-compass .cc-chap { color: var(--accent); font-weight: 700; }
+  .chap-compass .cc-sep { color: var(--ink-mute); }
+  .chap-compass .cc-forest-label {
+    font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.16em;
+    text-transform: uppercase; color: var(--ink-mute); margin-right: 8px;
+  }
+  .chap-compass .cc-forest-text { font-size: 13px; color: var(--ink-soft); }
+  .chap-compass .cc-links { justify-content: space-between; width: 100%; }
+  .chap-compass .cc-nav {
+    font-size: 12px; color: var(--ink-soft); text-decoration: none;
+    display: inline-flex; align-items: center; gap: 4px; max-width: 42%;
+  }
+  .chap-compass .cc-nav:hover { color: var(--accent); }
+  .chap-compass .cc-nav-num { font-family: var(--mono); font-weight: 700; }
+  .chap-compass .cc-back-map {
+    font-family: var(--mono); font-size: 10px; letter-spacing: 0.12em;
+    text-transform: uppercase; color: var(--copper); text-decoration: none;
+  }
+  .chap-compass .cc-back-map:hover { text-decoration: underline; }
+  .depth-zone {
+    margin: 32px 0 0; padding: 20px 0 0;
+    border-top: 2px solid var(--rule);
+  }
+  .depth-zone-label {
+    font-family: var(--mono); font-size: 10px; letter-spacing: 0.2em;
+    text-transform: uppercase; color: var(--ink-mute); margin-bottom: 20px;
+  }
+  .depth-zone-label .dz-tag {
+    color: var(--copper); font-weight: 700; margin-right: 8px;
+  }
+  .depth-zone h4.depth-sec {
+    font-size: 15px; margin-top: 24px;
+  }
+  .depth-aside-head {
+    margin: 28px 0 12px; padding: 10px 14px;
+    background: var(--paper-2); border: 1px solid var(--rule); border-radius: 4px;
+  }
+  .depth-aside-head .da-tag {
+    font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.16em;
+    text-transform: uppercase; color: var(--copper); font-weight: 700;
+  }
+  .depth-aside-head .da-title { font-size: 14px; font-weight: 600; color: var(--ink); }
+  .forest-overview {
+    margin: 48px 0 56px; padding: 32px 0 40px;
+    border-top: 2px solid var(--ink); border-bottom: 1px solid var(--rule);
+  }
+  .forest-overview .fo-label {
+    font-family: var(--mono); font-size: 10px; letter-spacing: 0.22em;
+    text-transform: uppercase; color: var(--ink-mute); margin-bottom: 12px;
+  }
+  .forest-overview .fo-title {
+    font-family: var(--serif); font-size: 28px; font-weight: 700;
+    margin-bottom: 16px; line-height: 1.2;
+  }
+  body.lang-en .forest-overview .fo-title { font-family: var(--serif-en); }
+  .forest-paths { margin: 28px 0; }
+  .forest-paths .fp-head {
+    font-family: var(--mono); font-size: 10px; letter-spacing: 0.18em;
+    text-transform: uppercase; color: var(--ink-mute); margin-bottom: 14px;
+  }
+  .forest-paths .fp-grid {
+    display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px;
+  }
+  @media (max-width: 800px) {
+    .forest-paths .fp-grid { grid-template-columns: 1fr; }
+  }
+  .forest-paths .fp-card {
+    display: block; padding: 16px 18px;
+    background: var(--paper); border: 1px solid var(--rule);
+    border-radius: 4px; text-decoration: none; color: inherit;
+    transition: border-color 0.15s, box-shadow 0.15s;
+  }
+  .forest-paths .fp-card:hover {
+    border-color: var(--accent); box-shadow: 0 2px 8px rgba(31,92,140,0.08);
+  }
+  .forest-paths .fp-card.fp-highlight { border-left: 3px solid var(--accent); }
+  .forest-paths .fp-tag {
+    font-family: var(--mono); font-size: 9px; letter-spacing: 0.14em;
+    text-transform: uppercase; color: var(--copper); margin-bottom: 6px;
+  }
+  .forest-paths .fp-title { font-size: 14px; font-weight: 700; margin-bottom: 6px; }
+  .forest-paths .fp-desc { font-size: 12px; color: var(--ink-mute); line-height: 1.5; }
+  .forest-overview .fo-legend {
+    margin-top: 24px; padding: 14px 16px;
+    background: var(--paper-2); border-radius: 4px;
+    font-size: 12.5px; color: var(--ink-soft); line-height: 1.6;
+  }
+  .card-filmstrip {
+    position: fixed; top: 0; left: 0; right: 0; z-index: 150;
+    background: rgba(253,251,243,0.96); border-bottom: 1px solid var(--rule);
+    backdrop-filter: blur(8px); transform: translateY(-100%);
+    transition: transform 0.25s ease; pointer-events: none;
+  }
+  .card-filmstrip.is-visible { transform: translateY(0); pointer-events: auto; }
+  .card-filmstrip .cf-inner { max-width: var(--max-w, 720px); margin: 0 auto; padding: 6px 16px 8px; }
+  .card-filmstrip .cf-header {
+    display: flex; justify-content: space-between; align-items: center;
+    font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.14em;
+    text-transform: uppercase; color: var(--ink-mute); margin-bottom: 4px;
+  }
+  .card-filmstrip .cf-header em { color: var(--accent); font-style: normal; font-weight: 700; }
+  .card-filmstrip .cf-track {
+    display: flex; gap: 4px; overflow-x: auto; padding-bottom: 2px;
+    scrollbar-width: thin;
+  }
+  .card-filmstrip .cf-cell {
+    flex: 0 0 auto; min-width: 36px; padding: 4px 6px;
+    text-align: center; text-decoration: none; color: var(--ink-mute);
+    border: 1px solid transparent; border-radius: 3px;
+    font-family: var(--mono); font-size: 10px; transition: all 0.12s;
+  }
+  .card-filmstrip .cf-cell:hover { border-color: var(--rule); color: var(--ink); }
+  .card-filmstrip .cf-cell.active {
+    border-color: var(--accent); background: var(--accent-pale, #e8f0f8);
+    color: var(--accent); font-weight: 700;
+  }
+  body.has-filmstrip { padding-top: 52px; }
+  body.has-filmstrip .ursb-backlink { top: 58px; }
+  .trace-walk {
+    margin: 36px 0; padding: 22px 24px 8px;
+    border: 2px solid var(--accent); border-radius: 4px;
+    background: linear-gradient(135deg, rgba(31,92,140,0.03) 0%, var(--paper) 50%);
+  }
+  .trace-walk .tw-head {
+    font-family: var(--mono); font-size: 11px; letter-spacing: 0.12em;
+    text-transform: uppercase; margin-bottom: 18px; line-height: 1.6;
+  }
+  .trace-walk .tw-tag {
+    display: block; color: var(--accent); font-weight: 700;
+    margin-bottom: 6px; letter-spacing: 0.18em;
+  }
+  .trace-walk .src-stack { margin: 16px 0 20px; }
+  .trace-walk .src-ln {
+    display: inline-block; width: 44px; text-align: right;
+    color: var(--ink-mute); user-select: none; margin-right: 8px;
+  }
+  .trace-walk .src-hl { font-family: var(--mono); font-size: 12px; }
+  .trace-steps { margin: 24px 0; }
+  .trace-steps .ts-label {
+    font-family: var(--mono); font-size: 10px; letter-spacing: 0.16em;
+    text-transform: uppercase; color: var(--copper); margin-bottom: 10px;
+  }
+"""
+
+
+def extract_css() -> str:
+    text = TEMPLATE.read_text(encoding="utf-8")
+    start = text.index("<style>") + len("<style>")
+    end = text.index("</style>", start)
+    css = text[start:end]
+    # Patch grid for 26 stations
+    css = css.replace("grid-template-columns: repeat(28, 1fr)", "grid-template-columns: repeat(26, 1fr)")
+    return css + EXTRA_CSS
+
+
+def extract_interactive_css() -> str:
+    text = TEMPLATE.read_text(encoding="utf-8")
+    marker = '<style>\n.ursb-interactive'
+    start = text.index(marker) + len("<style>")
+    end = text.index("</style>", start)
+    return text[start:end]
+
+
+def head() -> str:
+    desc_zh = (
+        "你在 Web UI 敲下「读取 README.md，用一句话告诉我这个项目做什么」之后，"
+        "这串文字穿过 26 道工序、跨 Cordis 插件树与 core spine，在 SessionEvent 日志里变形——"
+        "对照 deepseek-ai/deepseek-harness 生产源码与官方 docs 逐行读。"
+    )
+    desc_en = (
+        "After you type read README.md and tell me what this project does in one sentence, "
+        "that string passes through 26 stations across the Cordis plugin tree and core spine — "
+        "cross-reading deepseek-ai/deepseek-harness production source with official docs."
+    )
+    return f"""<!DOCTYPE html>
+<html lang="zh-CN" translate="no">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="google" content="notranslate">
+<meta name="referrer" content="strict-origin-when-cross-origin">
+<link rel="shortcut icon" href="https://airing.ursb.me/image/favicon.ico">
+<link rel="apple-touch-icon" href="https://airing.ursb.me/image/favicon.ico">
+<link rel="icon" href="https://airing.ursb.me/image/favicon.ico">
+<meta name="description" content="{desc_zh}">
+<meta name="author" content="Airing">
+<meta property="og:title" content="{TITLE_ZH} — DSH 源码全景">
+<meta property="og:description" content="Cordis → ReactLoopAgent → turn/step → ctx.llm → tools → SessionEvent log · 真源码逐行。">
+<meta property="og:image" content="{OG_IMAGE}">
+<meta property="og:url" content="https://ursb.me/immersive/{SLUG}/">
+<meta property="og:type" content="article">
+<meta property="og:site_name" content="ursb.me · Airing">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="{TITLE_ZH}">
+<meta name="twitter:description" content="{desc_en}">
+<meta name="twitter:image" content="{OG_IMAGE}">
+<meta name="twitter:creator" content="@airingursb">
+<title>{TITLE_ZH} — DSH 源码全景</title>
+<style>
+{extract_css()}
+</style>
+<script async defer src="https://analytics.ursb.me/script.js" data-website-id="aa8d5a16-df21-4058-a0a8-0191cdd3798d"></script>
+<style>
+{extract_interactive_css()}
+</style>
+</head>
+<body>
+<div id="readProgress" aria-hidden="true"></div>"""
+
+
+def lang_toggle_and_back() -> str:
+    return """
+<a class="ursb-backlink" href="https://ursb.me/notes/dsh/">← ursb.me</a>
+<div class="lang-toggle" role="navigation" aria-label="language">
+  <button id="lang-zh" class="active" aria-pressed="true">中</button>
+  <span class="sep">/</span>
+  <button id="lang-en" aria-pressed="false">EN</button>
+</div>"""
+
+
+def side_toc() -> str:
+    items: list[str] = []
+    chapter_map = {c[0]: c for c in CHAPTERS}
+    prev_phase = None
+    for gid, num, pzh, pen, _sub, _cnt, cids in TOC_GROUPS_BG + TOC_GROUPS:
+        phase_label = f"{num} · {pzh}" if num not in ("0", "∎", "·") else pzh
+        if phase_label != prev_phase and num not in ("0",):
+            items.append(
+                f'    <li class="ts-divider"><span class="lang-zh-only">{phase_label}</span>'
+                f'<span class="lang-en-only">{num} · {pen}</span></li>'
+            )
+            prev_phase = phase_label
+        for cid in cids:
+            ch = chapter_map[cid]
+            items.append(
+                f'    <li data-section="{cid}"><a href="#{cid}">'
+                f'<span class="toc-num">{ch[1]}</span>'
+                f'<span class="lang-zh-only">{ch[4]}</span>'
+                f'<span class="lang-en-only">{ch[5]}</span></a></li>'
+            )
+    return f"""<nav class="toc-side" aria-label="Side contents">
+  <div class="toc-label">CONTENTS</div>
+  <ol>
+{chr(10).join(items)}
+  </ol>
+</nav>"""
+
+
+def pipeline_bar() -> str:
+    cells = []
+    chapter_map = {c[0]: c for c in CHAPTERS}
+    for cid, *_ in CHAPTERS:
+        ch = chapter_map[cid]
+        cls = PIPELINE_COLORS.get(cid, "p2")
+        title = f"C{ch[1]} {ch[4]}"
+        cells.append(
+            f'        <div class="pb-cell {cls}" data-n="{ch[1]}" data-jump="#{cid}" title="{title}"></div>'
+        )
+    cells_html = "\n".join(cells)
+    return f"""    <div class="perf-bar">
+      <div class="pb-title">
+        <span class="lang-zh-only">一条用户消息 · 26 个站</span>
+        <span class="lang-en-only">One user message · 26 stations</span>
+        <span class="pb-pulse">▸ live trace</span>
+      </div>
+      <div class="pb-track" id="pbTrack">
+{cells_html}
+      </div>
+      <div class="pb-axis">
+        <span class="lang-zh-only">回车</span><span class="lang-en-only">Enter</span>
+        <span></span><span></span><span></span><span></span><span></span>
+        <span class="lang-zh-only">JSONL</span><span class="lang-en-only">JSONL</span>
+      </div>
+    </div>"""
+
+
+def hero() -> str:
+    return f"""  <header class="hero">
+    <div class="meta">
+      <span>FIELD&nbsp;NOTE&nbsp;/&nbsp;{FIELD_NOTE}</span>
+      <span class="lang-zh-only">DeepSeek Harness · Cordis 插件</span>
+      <span class="lang-en-only">DeepSeek Harness · Cordis plugins</span>
+      <span>{DATE[:4]}</span>
+    </div>
+    <h1 class="lang-zh-only">一条用户消息在<br><span class="copper">DeepSeek Harness</span>里的<span class="accent">一生</span>。</h1>
+    <h1 class="lang-en-only">The <span class="copper">life</span> of one user message<br>inside <span class="accent">DeepSeek Harness</span>.</h1>
+    <p class="subtitle lang-zh-only">{SUBTITLE_ZH.replace(" · ", ' <span class="arr">→</span> ')}</p>
+    <p class="subtitle lang-en-only">{SUBTITLE_EN.replace(" · ", ' <span class="arr">→</span> ')}</p>
+    <p class="deck lang-zh-only">{DECK_ZH}</p>
+    <p class="deck lang-en-only">{DECK_EN}</p>
+    <div class="byline">
+      <span><span class="label">AUTHOR</span><a class="value" href="https://ursb.me" target="_blank" rel="noopener">Airing</a></span>
+      <span><span class="label">SOURCE</span><span class="value">deepseek-ai/deepseek-harness · docs/</span></span>
+      <span><span class="label">FORMAT</span><span class="value">Long Read</span></span>
+    </div>
+
+    <aside class="hero-notice">
+      <div class="hn-tag">
+        <span class="lang-zh-only">这篇要解决什么</span>
+        <span class="lang-en-only">What this is for</span>
+      </div>
+      <p class="hn-body lang-zh-only">主线 prompt 固定为：<strong>「读取 README.md，用一句话告诉我这个项目做什么」</strong>——与 Pi 沉浸式文章相同，便于对照。这不是 DSH 的使用教程，而是<strong>把一条用户消息从 Web UI 回车追到 SessionEvent 落盘</strong>的源码级 walkthrough。对照生产仓库 <code>deepseek-ai/deepseek-harness</code> 与 <code>docs/architecture.md</code> 等官方文档，每一章对应一层 Cordis 抽象。</p>
+      <p class="hn-body lang-en-only">The through-line prompt is fixed: <strong>«read README.md and tell me what this project does in one sentence»</strong> — same as the Pi immersive article for comparison. This is not a DSH user guide but a <strong>source-level walkthrough from Enter to SessionEvent on disk</strong>. Cross-reading production <code>deepseek-ai/deepseek-harness</code> with official docs like <code>docs/architecture.md</code> — each chapter maps to one Cordis abstraction layer.</p>
+    </aside>
+
+    <aside class="tldr">
+      <div class="tldr-tag">
+        <span class="lang-zh-only">主线 · 七个里程碑</span>
+        <span class="lang-en-only">Through-line · seven milestones</span>
+      </div>
+      <div class="tldr-steps">
+        <div class="tldr-step">
+          <div class="tldr-step-n">01</div>
+          <div class="tldr-step-name lang-zh-only">用户消息</div>
+          <div class="tldr-step-name lang-en-only">user_message</div>
+          <div class="tldr-step-hint">owner=user</div>
+        </div>
+        <div class="tldr-step">
+          <div class="tldr-step-n">02</div>
+          <div class="tldr-step-name lang-zh-only">第一次 model</div>
+          <div class="tldr-step-name lang-en-only">model_start</div>
+          <div class="tldr-step-hint">turn=1 · toolUse</div>
+        </div>
+        <div class="tldr-step">
+          <div class="tldr-step-n">03</div>
+          <div class="tldr-step-name lang-zh-only">read 工具调用</div>
+          <div class="tldr-step-name lang-en-only">tool_start</div>
+          <div class="tldr-step-hint">call_1 · README</div>
+        </div>
+        <div class="tldr-step">
+          <div class="tldr-step-n">04</div>
+          <div class="tldr-step-name lang-zh-only">最终回答</div>
+          <div class="tldr-step-name lang-en-only">assistant stop</div>
+          <div class="tldr-step-hint">turn=2 · stopReason=stop</div>
+        </div>
+      </div>
+      <div class="tldr-skip">
+        <span class="lang-zh-only">已经懂 agent 基础? 直接跳到 → <a href="#c7">ctx.agents</a> · <a href="#c10">ReactLoopAgent</a> · <a href="#c14">ctx.llm</a> · <a href="#c17">Web UI</a> · <a href="#c22">SessionEvent</a> · <a href="#c24">vs Pi</a></span>
+        <span class="lang-en-only">Know agent basics? Skip to → <a href="#c7">ctx.agents</a> · <a href="#c10">ReactLoopAgent</a> · <a href="#c14">ctx.llm</a> · <a href="#c17">Web UI</a> · <a href="#c22">SessionEvent</a> · <a href="#c24">vs Pi</a></span>
+      </div>
+    </aside>
+
+{pipeline_bar()}
+  </header>"""
+
+
+def toc_v2() -> str:
+    chapter_map = {c[0]: c for c in CHAPTERS}
+    groups_html: list[str] = []
+    all_groups = TOC_GROUPS_BG + TOC_GROUPS
+    for gid, num, pzh, pen, sub, cnt, cids in all_groups:
+        chips = []
+        for cid in cids:
+            ch = chapter_map[cid]
+            special = " tc-special" if ch[8] else ""
+            chips.append(
+                f'        <a href="#{cid}" class="toc-chip{special}"><span class="tc-num">{ch[1]}</span>'
+                f'<div class="tc-name"><span class="lang-zh-only">{ch[4]}</span>'
+                f'<span class="lang-en-only">{ch[5]}</span>'
+                f'<span class="tc-en">{ch[7]}</span></div></a>'
+            )
+        groups_html.append(
+            f"""    <div class="toc-group" data-phase="{gid}">
+      <div class="toc-group-head">
+        <div class="tg-num">{num}</div>
+        <div class="tg-name lang-zh-only">{pzh}</div>
+        <div class="tg-name lang-en-only">{pen}</div>
+        <div class="tg-count">{cnt}</div>
+      </div>
+      <div class="tg-en">{sub}</div>
+      <div class="toc-chips">
+{chr(10).join(chips)}
+      </div>
+    </div>"""
+        )
+    return f"""  <nav class="toc-v2" aria-label="Contents">
+    <div class="tv-head">
+      <div class="tv-label lang-zh-only">CONTENTS · 目录</div>
+      <div class="tv-label lang-en-only">CONTENTS</div>
+      <div class="tv-meta"><span class="tv-now">26</span> <span class="lang-zh-only">章 · 8 个 Phase + Coda</span><span class="lang-en-only">chapters · 8 phases + coda</span></div>
+    </div>
+    <div class="tv-sub lang-zh-only">「<em>读取 README.md，用一句话告诉我这个项目做什么</em>」· 26 个站。点任意一格跳转。</div>
+    <div class="tv-sub lang-en-only">«<em>read README.md and tell me what this project does in one sentence</em>» · 26 stations. Click any chip.</div>
+
+{chr(10).join(groups_html)}
+  </nav>"""
+
+
+def filmstrip_nav() -> str:
+    cells = []
+    for ch in CHAPTERS:
+        cid, num = ch[0], ch[1]
+        cells.append(
+            f'      <a href="#{cid}" class="cf-cell" data-chap="{num}">'
+            f'<span class="cf-num">{num}</span></a>'
+        )
+    cells_html = "\n".join(cells)
+    return f"""<nav class="card-filmstrip" id="card-filmstrip" aria-label="26 chapters">
+  <div class="cf-inner">
+    <div class="cf-header">
+      <span><span class="lang-zh-only">主线 · 26 章</span><span class="lang-en-only">Through-line · 26 chapters</span></span>
+      <span><em id="cf-current">C01</em>&nbsp;/&nbsp;26</span>
+    </div>
+    <div class="cf-track" id="cf-track">
+{cells_html}
+    </div>
+  </div>
+</nav>"""
+
+
+def chapter_section(cid: str, body: str) -> str:
+    ch = next(c for c in CHAPTERS if c[0] == cid)
+    phase = ch[2].upper()
+    if phase == "CODA":
+        phase = "CODA"
+    elif ch[2] in ("引子", "背景"):
+        phase = ch[2].upper() if ch[2] == "引子" else "BACKGROUND"
+    else:
+        phase = ch[3].upper()
+    return f"""  <section class="chap" id="{cid}">
+    <div class="chap-num">CHAPTER&nbsp;{ch[1]}&nbsp;·&nbsp;{phase}</div>
+    <h2 class="chap-title lang-zh-only">{ch[4]}</h2>
+    <h2 class="chap-title lang-en-only">{ch[5]}</h2>
+    <p class="chap-en lang-zh-only">{ch[6]}</p>
+    <p class="chap-en lang-en-only">{ch[7]}</p>
+{chapter_compass(cid)}
+{body}
+  </section>"""
+
+
+def footer() -> str:
+    return f"""  <footer class="footer">
+    <div class="ft-rule"><span class="ft-mark">END · FIELD NOTE {FIELD_NOTE}</span></div>
+    <p class="lang-zh-only">这是 Field Note 系列的第十一篇。<strong>姐妹篇</strong>:</p>
+    <p class="lang-en-only">Eleventh in the Field Note series. <strong>Sister pieces</strong>:</p>
+    <div class="ft-links">
+      <a href="https://ursb.me/immersive/pi-agent/">Pi Agent · 26 站</a>
+      <a href="https://ursb.me/immersive/llm-inference-life/">LLM 推理 · 28 站</a>
+      <a href="https://ursb.me/immersive/chromium-renderer/">Chromium · 渲染管线</a>
+    </div>
+    <p class="lang-zh-only" style="margin-top:24px;font-style:italic;color:var(--ink-mute);">"一条用户消息看起来只是聊天框里的一行字——它真正做的事情，是在 Cordis 插件树里穿过 turn/step 边界，在 SessionEvent 日志上留下可 fork 的 seq 链，然后被 Web UI 从 session/event 流式渲染成你看到的 chunk。"</p>
+    <p class="lang-en-only" style="margin-top:24px;font-style:italic;color:var(--ink-mute);">"A user message looks like one line in the chat box. What it really does: cross turn/step boundaries in the Cordis plugin tree, leave a forkable seq chain on the SessionEvent log, then get streamed into chunks you see via session/event in the Web UI."</p>
+    <p style="margin-top:28px;">© 2026 <a href="https://ursb.me">Airing</a> · <span class="lang-zh-only">本文为 Field Note 长文,欢迎转载注明出处</span><span class="lang-en-only">long-form Field Note, attribution appreciated</span></p>
+  </footer>"""
+
+
+def interactive_footer() -> str:
+    text = TEMPLATE.read_text(encoding="utf-8")
+    start = text.index('<section class="ursb-interactive">')
+    end = text.index("</html>")
+    chunk = text[start:end]
+    chunk = chunk.replace("note/llm-inference-life", "note/dsh")
+    chunk = chunk.replace("llm-lang", "dsh-lang")
+    return chunk
+
+
+def scripts() -> str:
+    return """
+<script>
+(function() {
+  var zh = document.getElementById('lang-zh');
+  var en = document.getElementById('lang-en');
+  function setLang(lang) {
+    if (lang === 'en') {
+      document.body.classList.add('lang-en');
+      document.documentElement.lang = 'en';
+      en.classList.add('active'); en.setAttribute('aria-pressed', 'true');
+      zh.classList.remove('active'); zh.setAttribute('aria-pressed', 'false');
+    } else {
+      document.body.classList.remove('lang-en');
+      document.documentElement.lang = 'zh-CN';
+      zh.classList.add('active'); zh.setAttribute('aria-pressed', 'true');
+      en.classList.remove('active'); en.setAttribute('aria-pressed', 'false');
+    }
+    try { localStorage.setItem('dsh-lang', lang); } catch (e) {}
+  }
+  zh.addEventListener('click', function() { setLang('zh'); });
+  en.addEventListener('click', function() { setLang('en'); });
+  try {
+    var saved = localStorage.getItem('dsh-lang');
+    if (saved === 'en') setLang('en');
+  } catch (e) {}
+})();
+
+(function() {
+  var bar = document.getElementById('readProgress');
+  if (!bar) return;
+  function update() {
+    var h = document.documentElement.scrollHeight - window.innerHeight;
+    bar.style.width = (h > 0 ? (window.scrollY / h) * 100 : 0) + '%';
+  }
+  window.addEventListener('scroll', update, { passive: true });
+  update();
+})();
+
+(function() {
+  var cells = document.querySelectorAll('#pbTrack .pb-cell');
+  if (!cells.length) return;
+  var i = -1;
+  function tick() {
+    cells.forEach(function(c, idx) { c.classList.toggle('lit', idx <= i); });
+    i++;
+    if (i >= cells.length + 3) i = -1;
+    setTimeout(tick, 380);
+  }
+  tick();
+  cells.forEach(function(c) {
+    c.addEventListener('click', function() {
+      var target = document.querySelector(c.dataset.jump || '');
+      if (target) target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    });
+  });
+})();
+
+(function () {
+  var sideItems = Array.prototype.map.call(
+    document.querySelectorAll('.toc-side li[data-section]'),
+    function (li) { return { node: li, el: document.getElementById(li.dataset.section) }; }
+  ).filter(function (o) { return o.el; });
+  if (!sideItems.length) return;
+  function update() {
+    var offset = window.innerHeight * 0.32;
+    var activeIdx = 0;
+    for (var i = 0; i < sideItems.length; i++) {
+      if (sideItems[i].el.getBoundingClientRect().top - offset < 0) activeIdx = i;
+    }
+    var activeId = sideItems[activeIdx].el.id;
+    sideItems.forEach(function (o) {
+      o.node.classList.toggle('active', o.el.id === activeId);
+    });
+  }
+  window.addEventListener('scroll', update, { passive: true });
+  window.addEventListener('resize', update);
+  update();
+})();
+
+(function() {
+  var filmstrip = document.getElementById('card-filmstrip');
+  var cfTrack = document.getElementById('cf-track');
+  var cfCurrent = document.getElementById('cf-current');
+  if (!filmstrip || !cfTrack) return;
+  document.body.classList.add('has-filmstrip');
+  var cells = Array.prototype.slice.call(cfTrack.querySelectorAll('.cf-cell'));
+  var sections = cells.map(function(c) {
+    return { cell: c, el: document.querySelector(c.getAttribute('href')) };
+  }).filter(function(o) { return o.el; });
+
+  function updateFilmstrip() {
+    var offset = window.innerHeight * 0.25;
+    var activeIdx = 0;
+    for (var i = 0; i < sections.length; i++) {
+      if (sections[i].el.getBoundingClientRect().top - offset < 0) activeIdx = i;
+    }
+    var active = sections[activeIdx];
+    cells.forEach(function(c) { c.classList.remove('active'); });
+    if (active) {
+      active.cell.classList.add('active');
+      if (cfCurrent) cfCurrent.textContent = 'C' + (active.cell.dataset.chap || '');
+      active.cell.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'center' });
+    }
+    filmstrip.classList.toggle('is-visible', window.scrollY > 400);
+  }
+  window.addEventListener('scroll', updateFilmstrip, { passive: true });
+  updateFilmstrip();
+})();
+</script>
+"""

--- a/scripts/dsh_immersive/ultra_dive.py
+++ b/scripts/dsh_immersive/ultra_dive.py
@@ -1,0 +1,5 @@
+"""Optional ultra-depth blocks — disabled for DSH v1 (heart_trace carries source depth)."""
+
+
+def ultra_for(_cid: str) -> str:
+    return ""

--- a/scripts/dsh_immersive/visuals.py
+++ b/scripts/dsh_immersive/visuals.py
@@ -1,0 +1,613 @@
+"""SVG and HTML visualization blocks for Pi Agent immersive article."""
+from __future__ import annotations
+
+from _html_helpers import fig
+
+
+def svg_wrap(inner: str, viewbox: str = "0 0 720 280") -> str:
+    defs = """
+  <defs>
+    <marker id="pi-arr" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 Z" fill="#1f5c8c"/>
+    </marker>
+  </defs>"""
+    return f'<svg viewBox="{viewbox}" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true" class="pi-svg">{defs}{inner}</svg>'
+
+
+def viz_harness_spectrum() -> str:
+    inner = """
+  <defs>
+    <linearGradient id="g-spec" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#767c87"/>
+      <stop offset="50%" stop-color="#1f5c8c"/>
+      <stop offset="100%" stop-color="#2d6a4f"/>
+    </linearGradient>
+  </defs>
+  <text x="24" y="28" class="svg-label">SEALED PRODUCT</text>
+  <text x="620" y="28" text-anchor="end" class="svg-label">OPEN HARNESS</text>
+  <rect x="24" y="40" width="672" height="10" rx="5" fill="url(#g-spec)" opacity="0.85"/>
+  <circle cx="120" cy="45" r="14" fill="#faf6ed" stroke="#767c87" stroke-width="2"/>
+  <text x="120" y="49" text-anchor="middle" class="svg-tiny">CC</text>
+  <circle cx="280" cy="45" r="14" fill="#faf6ed" stroke="#767c87" stroke-width="2"/>
+  <text x="280" y="49" text-anchor="middle" class="svg-tiny">Cur</text>
+  <circle cx="560" cy="45" r="18" fill="#1f5c8c" stroke="#15171c" stroke-width="2"/>
+  <text x="560" y="50" text-anchor="middle" fill="#faf6ed" class="svg-tiny" font-weight="700">Pi</text>
+  <rect x="40" y="80" width="200" height="56" rx="4" class="svg-box muted"/>
+  <text x="140" y="104" text-anchor="middle" class="svg-body">MCP · Sub-agents</text>
+  <text x="140" y="122" text-anchor="middle" class="svg-mute">baked in</text>
+  <rect x="260" y="80" width="200" height="56" rx="4" class="svg-box muted"/>
+  <text x="360" y="104" text-anchor="middle" class="svg-body">IDE · Cloud sync</text>
+  <text x="360" y="122" text-anchor="middle" class="svg-mute">editor lock-in</text>
+  <rect x="480" y="72" width="200" height="72" rx="4" class="svg-box accent"/>
+  <text x="580" y="100" text-anchor="middle" class="svg-body">JSONL tree</text>
+  <text x="580" y="118" text-anchor="middle" class="svg-body">TS extensions</text>
+  <text x="580" y="136" text-anchor="middle" class="svg-mute">agent-loop.ts readable</text>
+  <path d="M140 136 L140 168 L580 168 L580 144" fill="none" class="svg-arrow"/>
+  <text x="360" y="190" text-anchor="middle" class="svg-mute">Pi trades features for observability</text>
+"""
+    return fig(
+        "Harness vs Product 光谱：密封产品在左，可组合 harness 在右；Pi 落在终端原生、JSONL 可读的一侧。",
+        "Harness vs product spectrum: sealed products left, composable harness right; Pi sits on the terminal-native, JSONL-readable side.",
+        f'<div class="pi-fig">{svg_wrap(inner)}</div>',
+    )
+
+
+def viz_seven_milestones() -> str:
+    steps = [
+        ("01", "user_message", "user", 48),
+        ("02", "model_start", "model", 148),
+        ("03", "assistant", "model", 248),
+        ("04", "tool_start", "loop", 348),
+        ("05", "tool_result", "tool", 448),
+        ("06", "model_start", "model", 548),
+        ("07", "assistant", "model", 648),
+    ]
+    colors = {"user": "#b35a1f", "model": "#1f5c8c", "loop": "#6b3aa3", "tool": "#2d6a4f"}
+    nodes = ""
+    for num, typ, owner, x in steps:
+        c = colors[owner]
+        nodes += f'''
+  <circle cx="{x}" cy="120" r="22" fill="{c}" opacity="0.15" stroke="{c}" stroke-width="2"/>
+  <text x="{x}" y="116" text-anchor="middle" class="svg-tiny" fill="{c}" font-weight="700">{num}</text>
+  <text x="{x}" y="130" text-anchor="middle" class="svg-micro">{typ.replace("_", " ")[:12]}</text>
+  <text x="{x}" y="158" text-anchor="middle" class="svg-mute">{owner}</text>'''
+    inner = f"""
+  <line x1="70" y1="120" x2="650" y2="120" stroke="#c7c4ba" stroke-width="2"/>
+  {nodes}
+  <text x="48" y="52" class="svg-label">pi-textbook checkpoint 00 · README read trace</text>
+  <rect x="230" y="190" width="260" height="58" rx="4" class="svg-box paper"/>
+  <text x="360" y="212" text-anchor="middle" class="svg-body">toolCallId = call_1</text>
+  <text x="360" y="232" text-anchor="middle" class="svg-mute">request (03) ↔ result (05) must pair</text>
+"""
+    return fig(
+        "七个里程碑：owner 分工——user 定目标，model 推理，loop 调度，tool 返回环境事实。",
+        "Seven milestones: owner roles — user sets goal, model reasons, loop dispatches, tool returns environment facts.",
+        f'<div class="pi-fig">{svg_wrap(inner, "0 0 720 260")}</div>',
+    )
+
+
+STATIONS_22: list[tuple[str, str, str, str]] = [
+    ("01", "CLI 解析", "cli.ts argv", "intake"),
+    ("02", "main 启动", "main.ts boot", "intake"),
+    ("03", "Session", "session factory", "intake"),
+    ("04", "AGENTS.md", "context stack", "intake"),
+    ("05", "prompt 入队", "prompt queued", "heart"),
+    ("06", "agent_start", "agent_start", "heart"),
+    ("07", "turn_start", "turn_start", "heart"),
+    ("08", "convertToLlm", "→ Message[]", "llm"),
+    ("09", "streamSimple", "pi-ai stream", "llm"),
+    ("10", "text_delta", "token stream", "llm"),
+    ("11", "toolcall_δ", "tool assembly", "llm"),
+    ("12", "toolUse", "read request", "heart"),
+    ("13", "executeTool", "tool dispatch", "heart"),
+    ("14", "read README", "filesystem I/O", "tool"),
+    ("15", "tool_result", "tool result", "tool"),
+    ("16", "stream #2", "turn 2 model", "llm"),
+    ("17", "assistant stop", "final answer", "llm"),
+    ("18", "message_end", "message_end", "heart"),
+    ("19", "JSONL append", "JSONL write", "persist"),
+    ("20", "TUI diff", "diff render", "terminal"),
+    ("21", "extensions", "extension hooks", "terminal"),
+    ("22", "compaction", "context check", "persist"),
+]
+
+PHASE_COLORS = {
+    "intake": "#767c87",
+    "heart": "#1f5c8c",
+    "llm": "#6b3aa3",
+    "tool": "#2d6a4f",
+    "terminal": "#3873a3",
+    "persist": "#b35a1f",
+}
+
+
+def station_track() -> str:
+    cells = []
+    for num, zh, en, phase in STATIONS_22:
+        color = PHASE_COLORS[phase]
+        cells.append(
+            f"""      <div class="st-cell" data-phase="{phase}" style="--st-color:{color}">
+        <div class="st-num">{num}</div>
+        <div class="st-name"><span class="lang-zh-only">{zh}</span><span class="lang-en-only">{en}</span></div>
+        <div class="st-phase">{phase}</div>
+      </div>"""
+        )
+    return f"""    <div class="station-track" role="list" aria-label="22 stations">
+      <div class="st-rail">
+{chr(10).join(cells)}
+      </div>
+    </div>"""
+
+
+def viz_22_stations_panorama() -> str:
+    """Full 22-station snake timeline SVG — the main C02 panorama."""
+    # Row 1: 01-11, Row 2: 12-22
+    row1 = STATIONS_22[:11]
+    row2 = STATIONS_22[11:]
+    nodes = ""
+    paths = ""
+    x0, y1, y2 = 48, 95, 195
+    dx = 88
+    prev = None
+    for i, (num, zh, _en, phase) in enumerate(row1):
+        x = x0 + i * dx
+        c = PHASE_COLORS[phase]
+        label = zh[:10] if len(zh) > 10 else zh
+        nodes += f'''
+  <rect x="{x-28}" y="{y1-28}" width="56" height="56" rx="4" fill="{c}" opacity="0.12" stroke="{c}" stroke-width="1.5"/>
+  <text x="{x}" y="{y1-8}" text-anchor="middle" class="svg-tiny" fill="{c}" font-weight="700">{num}</text>
+  <text x="{x}" y="{y1+10}" text-anchor="middle" class="svg-micro">{label}</text>'''
+        if prev:
+            paths += f'<line x1="{prev[0]+28}" y1="{y1}" x2="{x-28}" y2="{y1}" stroke="#c7c4ba" stroke-width="1.5"/>'
+        prev = (x, y1)
+    # connector 11 → 12
+    x11 = x0 + 10 * dx
+    x12 = x0
+    mid_y = (y1 + y2) // 2
+    paths += (
+        f'<path d="M{x11+28} {y1} L{x11+52} {y1} L{x11+52} {mid_y} '
+        f'L{x12-52} {mid_y} L{x12-52} {y2-28} L{x12-28} {y2-28}" '
+        f'fill="none" stroke="#c7c4ba" stroke-width="1.5"/>'
+    )
+    prev = None
+    for i, (num, zh, _en, phase) in enumerate(row2):
+        x = x0 + i * dx
+        c = PHASE_COLORS[phase]
+        label = zh[:10] if len(zh) > 10 else zh
+        nodes += f'''
+  <rect x="{x-28}" y="{y2-28}" width="56" height="56" rx="4" fill="{c}" opacity="0.12" stroke="{c}" stroke-width="1.5"/>
+  <text x="{x}" y="{y2-8}" text-anchor="middle" class="svg-tiny" fill="{c}" font-weight="700">{num}</text>
+  <text x="{x}" y="{y2+10}" text-anchor="middle" class="svg-micro">{label}</text>'''
+        if prev:
+            paths += f'<line x1="{prev[0]+28}" y1="{y2}" x2="{x-28}" y2="{y2}" stroke="#c7c4ba" stroke-width="1.5"/>'
+        prev = (x, y2)
+    # phase legend
+    legend = ""
+    lx = 48
+    for phase, color in PHASE_COLORS.items():
+        legend += f'<rect x="{lx}" y="248" width="10" height="10" fill="{color}" opacity="0.5"/>'
+        legend += f'<text x="{lx+14}" y="257" class="svg-micro">{phase}</text>'
+        lx += 72
+    inner = f"""
+  <text x="48" y="32" class="svg-label">22 stations · snake timeline · one user message</text>
+  <text x="48" y="52" class="svg-mute">Enter → … → JSONL on disk</text>
+  {paths}
+  {nodes}
+  {legend}
+"""
+    return fig(
+        "22 站全景：从 CLI 解析到 compaction 检查的完整蛇形时间线，颜色按 Phase 编码。",
+        "22-station panorama: snake timeline from CLI parse to compaction check, color-coded by phase.",
+        f'<div class="pi-fig panorama">{svg_wrap(inner, "0 0 1000 270")}</div>',
+    )
+
+
+def viz_stations_flow() -> str:
+    """Compact 22-station flow grouped by phase."""
+    groups = [
+        ("入口", "#767c87", ["CLI", "main", "Session", "AGENTS"]),
+        ("心脏", "#1f5c8c", ["loop", "stream", "tool", "event"]),
+        ("LLM", "#6b3aa3", ["provider", "delta", "auth"]),
+        ("终端", "#2d6a4f", ["TUI", "Editor"]),
+        ("持久化", "#b35a1f", ["JSONL", "compact"]),
+    ]
+    x = 24
+    rects = ""
+    for label, color, items in groups:
+        w = 28 * len(items) + 36
+        rects += f'<rect x="{x}" y="70" width="{w}" height="88" rx="4" fill="{color}" opacity="0.08" stroke="{color}" stroke-width="1.5"/>'
+        rects += f'<text x="{x + w/2}" y="58" text-anchor="middle" class="svg-label" fill="{color}">{label}</text>'
+        for i, it in enumerate(items):
+            rects += f'<rect x="{x + 18 + i*28}" y="98" width="22" height="44" rx="2" fill="#faf6ed" stroke="{color}" stroke-width="1"/>'
+            rects += f'<text x="{x + 29 + i*28}" y="126" text-anchor="middle" class="svg-micro">{it}</text>'
+        x += w + 16
+    inner = f"""
+  <text x="24" y="28" class="svg-label">22 stations · grouped by phase (C02 map)</text>
+  {rects}
+  <path d="M 60 200 L 660 200" stroke="#c7c4ba" stroke-dasharray="4 3"/>
+  <text x="360" y="230" text-anchor="middle" class="svg-mute">Enter → JSONL on disk · one user message</text>
+"""
+    return fig(
+        "22 站按 Phase 分组：入口四站、心脏四站、LLM 三站、终端两站、持久化两站——持住这张地图读完全文。",
+        "22 stations by phase: intake 4, heart 4, LLM 3, terminal 2, persistence 2 — hold this map through the article.",
+        f'<div class="pi-fig wide">{svg_wrap(inner, "0 0 720 250")}</div>',
+    )
+
+
+def viz_monorepo_layers() -> str:
+    layers = [
+        ("L6", "coding-agent", "CLI · AgentSession · tools", "#1f5c8c"),
+        ("L5", "agent-core", "agentLoop · AgentMessage", "#3873a3"),
+        ("L4", "pi-ai", "Models · streamSimple", "#6b3aa3"),
+        ("L3", "pi-tui", "diff render · Editor", "#2d6a4f"),
+        ("L2", "protocol", "JSONL RPC frames", "#b35a1f"),
+        ("L1", "server", "CBOR remote", "#767c87"),
+    ]
+    blocks = ""
+    y = 28
+    for tag, name, desc, color in layers:
+        blocks += f'''
+  <rect x="120" y="{y}" width="480" height="36" rx="3" fill="{color}" opacity="0.12" stroke="{color}" stroke-width="1.5"/>
+  <text x="140" y="{y+16}" class="svg-tiny" fill="{color}" font-weight="700">{tag}</text>
+  <text x="180" y="{y+16}" class="svg-body">{name}</text>
+  <text x="180" y="{y+30}" class="svg-mute">{desc}</text>'''
+        y += 42
+    inner = f"""
+  <text x="24" y="18" class="svg-label">pi-mono six-layer cake · dependency flows downward</text>
+  {blocks}
+  <path d="M360 250 L360 268" stroke="#1f5c8c" marker-end="url(#arr)"/>
+  <text x="360" y="285" text-anchor="middle" class="svg-mute">through-line prompt enters at L6</text>
+"""
+    return fig(
+        "六层蛋糕：coding-agent 组装下层；agent-core 不 import pi-ai/compat，由宿主注入 StreamFn。",
+        "Six-layer cake: coding-agent composes below; agent-core does not import pi-ai/compat — host injects StreamFn.",
+        f'<div class="pi-fig">{svg_wrap(inner, "0 0 720 300")}</div>',
+    )
+
+
+def viz_message_layers() -> str:
+    inner = """
+  <rect x="40" y="50" width="180" height="160" rx="4" class="svg-box accent"/>
+  <text x="130" y="78" text-anchor="middle" class="svg-label">CANONICAL</text>
+  <text x="130" y="110" text-anchor="middle" class="svg-body">AgentMessage[]</text>
+  <text x="130" y="130" text-anchor="middle" class="svg-mute">JSONL transcript</text>
+  <text x="130" y="150" text-anchor="middle" class="svg-mute">user · assistant</text>
+  <text x="130" y="168" text-anchor="middle" class="svg-mute">toolResult · custom</text>
+  <rect x="270" y="50" width="180" height="160" rx="4" class="svg-box copper"/>
+  <text x="360" y="78" text-anchor="middle" class="svg-label">LLM PROJECTION</text>
+  <text x="360" y="110" text-anchor="middle" class="svg-body">Message[]</text>
+  <text x="360" y="130" text-anchor="middle" class="svg-mute">convertToLlm()</text>
+  <text x="360" y="150" text-anchor="middle" class="svg-mute">streamSimple boundary</text>
+  <rect x="500" y="50" width="180" height="160" rx="4" class="svg-box gpu"/>
+  <text x="590" y="78" text-anchor="middle" class="svg-label">TUI PROJECTION</text>
+  <text x="590" y="110" text-anchor="middle" class="svg-body">Rendered cells</text>
+  <text x="590" y="130" text-anchor="middle" class="svg-mute">Markdown · tool cards</text>
+  <path d="M220 130 L270 130" class="svg-arrow"/>
+  <path d="M450 130 L500 130" class="svg-arrow"/>
+  <text x="245" y="122" class="svg-micro">convert</text>
+  <text x="475" y="122" class="svg-micro">render</text>
+"""
+    return fig(
+        "三层投影：transcript 是唯一真相源；LLM 与 TUI 各取所需字段。",
+        "Three projections: transcript is single source of truth; LLM and TUI each take needed fields.",
+        f'<div class="pi-fig">{svg_wrap(inner, "0 0 720 230")}</div>',
+    )
+
+
+def viz_runloop_twin() -> str:
+    inner = """
+  <rect x="30" y="40" width="660" height="200" rx="6" fill="none" stroke="#1f5c8c" stroke-width="2" stroke-dasharray="8 4"/>
+  <text x="50" y="64" class="svg-label" fill="#1f5c8c">OUTER LOOP · follow-up queue</text>
+  <rect x="60" y="80" width="600" height="140" rx="4" fill="none" stroke="#b35a1f" stroke-width="2"/>
+  <text x="80" y="104" class="svg-label" fill="#b35a1f">INNER LOOP · tools + steering</text>
+  <rect x="100" y="120" width="120" height="44" rx="3" class="svg-box accent"/>
+  <text x="160" y="148" text-anchor="middle" class="svg-body">stream</text>
+  <path d="M220 142 L250 142" class="svg-arrow"/>
+  <rect x="250" y="120" width="100" height="44" rx="3" class="svg-box copper"/>
+  <text x="300" y="148" text-anchor="middle" class="svg-body">toolUse?</text>
+  <path d="M350 142 L380 142" class="svg-arrow"/>
+  <rect x="380" y="120" width="100" height="44" rx="3" class="svg-box asm"/>
+  <text x="430" y="148" text-anchor="middle" class="svg-body">execute</text>
+  <path d="M480 142 L510 142" class="svg-arrow"/>
+  <rect x="510" y="120" width="120" height="44" rx="3" class="svg-box accent"/>
+  <text x="570" y="148" text-anchor="middle" class="svg-body">stream again</text>
+  <path d="M570 164 L570 188 L120 188 L120 164" fill="none" stroke="#b35a1f" stroke-dasharray="4 3"/>
+  <text x="360" y="210" text-anchor="middle" class="svg-mute">README prompt: 2× stream · 1× read tool</text>
+"""
+    return fig(
+        "runLoop 双环：外环处理 follow-up；内环处理 tool batch 与 steering 注入。",
+        "runLoop twin loops: outer handles follow-up; inner handles tool batch and steering injection.",
+        f'<div class="pi-fig">{svg_wrap(inner, "0 0 720 250")}</div>',
+    )
+
+
+def viz_session_tree() -> str:
+    inner = """
+  <circle cx="360" cy="36" r="8" fill="#b35a1f"/>
+  <text x="360" y="58" text-anchor="middle" class="svg-body">u-1 · user prompt</text>
+  <line x1="360" y1="44" x2="280" y2="88" stroke="#c7c4ba"/>
+  <line x1="360" y1="44" x2="480" y2="88" stroke="#c7c4ba"/>
+  <rect x="220" y="88" width="120" height="36" rx="3" class="svg-box accent"/>
+  <text x="280" y="110" text-anchor="middle" class="svg-micro">a-read · toolUse</text>
+  <rect x="420" y="88" width="120" height="36" rx="3" class="svg-box muted"/>
+  <text x="480" y="110" text-anchor="middle" class="svg-micro">a-alt · sibling</text>
+  <line x1="280" y1="124" x2="280" y2="148" stroke="#c7c4ba"/>
+  <rect x="220" y="148" width="120" height="36" rx="3" class="svg-box asm"/>
+  <text x="280" y="170" text-anchor="middle" class="svg-micro">r-read · toolResult</text>
+  <line x1="280" y1="184" x2="280" y2="208" stroke="#c7c4ba"/>
+  <rect x="220" y="208" width="120" height="36" rx="3" class="svg-box accent"/>
+  <text x="280" y="230" text-anchor="middle" class="svg-micro">a-final · stop</text>
+  <text x="520" y="170" class="svg-mute">pathTo(leaf) →</text>
+  <text x="520" y="188" class="svg-mute">u-1→a-read→r-read→a-final</text>
+"""
+    return fig(
+        "JSONL 会话树：parentId 构成有向树；sibling 分支不覆盖旧路径；leafId 选择 active path。",
+        "JSONL session tree: parentId forms directed tree; sibling branches don't overwrite; leafId selects active path.",
+        f'<div class="pi-fig">{svg_wrap(inner, "0 0 720 270")}</div>',
+    )
+
+
+def viz_compaction() -> str:
+    inner = """
+  <text x="24" y="24" class="svg-label">HISTORY (JSONL) — never deleted</text>
+  <rect x="24" y="36" width="672" height="48" rx="3" class="svg-box paper"/>
+  <text x="40" y="58" class="svg-mono">u1 · a1 · u2 · a2 · u3 · calls · r-read · r-test · a3 · ...</text>
+  <text x="40" y="74" class="svg-mute">full append-only log on disk</text>
+  <text x="24" y="110" class="svg-label">CONTEXT (model window) — rebuilt per request</text>
+  <rect x="24" y="122" width="200" height="48" rx="3" fill="#ebe5d8" stroke="#c7c4ba"/>
+  <text x="124" y="152" text-anchor="middle" class="svg-mute">dropped · summarized</text>
+  <rect x="240" y="122" width="456" height="48" rx="3" class="svg-box accent"/>
+  <text x="260" y="152" class="svg-body">compaction summary + recent suffix (full tool interactions)</text>
+  <path d="M360 170 L360 200" class="svg-arrow"/>
+  <rect x="200" y="200" width="320" height="40" rx="3" class="svg-box asm"/>
+  <text x="360" y="226" text-anchor="middle" class="svg-body">streamSimple(context) · token budget enforced</text>
+"""
+    return fig(
+        "Compaction：历史完整保留在 JSONL；发给模型的 context 按 token 预算重建，早期事实以摘要补回。",
+        "Compaction: history stays complete in JSONL; model context rebuilt under token budget with summary for early facts.",
+        f'<div class="pi-fig">{svg_wrap(inner, "0 0 720 260")}</div>',
+    )
+
+
+def viz_tui_diff() -> str:
+    inner = """
+  <text x="180" y="28" text-anchor="middle" class="svg-label">FULL REFRESH</text>
+  <text x="540" y="28" text-anchor="middle" class="svg-label">CSI 2026 DIFF</text>
+  <rect x="40" y="40" width="280" height="160" rx="4" class="svg-box muted"/>
+  <rect x="60" y="60" width="240" height="14" fill="#ebe5d8"/>
+  <rect x="60" y="78" width="240" height="14" fill="#ebe5d8"/>
+  <rect x="60" y="96" width="240" height="14" fill="#ebe5d8"/>
+  <rect x="60" y="114" width="240" height="14" fill="#ebe5d8"/>
+  <rect x="60" y="132" width="240" height="14" fill="#ebe5d8"/>
+  <text x="180" y="185" text-anchor="middle" class="svg-mute">O(screen) · flicker</text>
+  <rect x="400" y="40" width="280" height="160" rx="4" class="svg-box accent"/>
+  <rect x="420" y="60" width="240" height="14" fill="#faf6ed" opacity="0.4"/>
+  <rect x="420" y="78" width="240" height="14" fill="#faf6ed" opacity="0.4"/>
+  <rect x="420" y="96" width="240" height="14" fill="#c9dceb" stroke="#1f5c8c"/>
+  <rect x="420" y="114" width="240" height="14" fill="#faf6ed" opacity="0.4"/>
+  <rect x="420" y="132" width="240" height="14" fill="#faf6ed" opacity="0.4"/>
+  <text x="540" y="185" text-anchor="middle" class="svg-mute">O(changed lines) · stable stream</text>
+  <text x="540" y="220" text-anchor="middle" class="svg-body">firstChanged → lastChanged only</text>
+"""
+    return fig(
+        "TUI 差分渲染：只重绘变更行区间，流式 token 不触发全屏闪烁。",
+        "TUI differential render: redraw only changed line range; streaming tokens avoid full-screen flicker.",
+        f'<div class="pi-fig">{svg_wrap(inner, "0 0 720 240")}</div>',
+    )
+
+
+def viz_extension_hooks() -> str:
+    inner = """
+  <rect x="280" y="20" width="160" height="44" rx="4" class="svg-box accent"/>
+  <text x="360" y="48" text-anchor="middle" class="svg-body">AgentSession</text>
+  <line x1="360" y1="64" x2="360" y2="88" stroke="#c7c4ba"/>
+  <rect x="240" y="88" width="240" height="36" rx="3" class="svg-box copper"/>
+  <text x="360" y="110" text-anchor="middle" class="svg-body">ExtensionRunner</text>
+  <line x1="120" y1="124" x2="600" y2="124" stroke="#c7c4ba"/>
+  <rect x="60" y="140" width="110" height="56" rx="3" class="svg-box paper"/>
+  <text x="115" y="172" text-anchor="middle" class="svg-micro">session_start</text>
+  <rect x="190" y="140" width="110" height="56" rx="3" class="svg-box paper"/>
+  <text x="245" y="172" text-anchor="middle" class="svg-micro">tool_call</text>
+  <rect x="320" y="140" width="110" height="56" rx="3" class="svg-box paper"/>
+  <text x="375" y="172" text-anchor="middle" class="svg-micro">before_compact</text>
+  <rect x="450" y="140" width="110" height="56" rx="3" class="svg-box paper"/>
+  <text x="505" y="172" text-anchor="middle" class="svg-micro">registerTool</text>
+  <rect x="580" y="140" width="110" height="56" rx="3" class="svg-box paper"/>
+  <text x="635" y="172" text-anchor="middle" class="svg-micro">message_update</text>
+"""
+    return fig(
+        "Extension 钩子：ExtensionRunner 在 AgentSession 生命周期注入，无需 MCP 同进程协议。",
+        "Extension hooks: ExtensionRunner injects at AgentSession lifecycle — no MCP same-process protocol.",
+        f'<div class="pi-fig">{svg_wrap(inner, "0 0 720 220")}</div>',
+    )
+
+
+def viz_textbook_map() -> str:
+    rows = ""
+    y = 44
+    for cp, phase, title, _, _ in [
+        ("00", "0", "Prologue", "", ""),
+        ("03", "I", "Message IR", "", ""),
+        ("07", "II", "Agent Loop", "", ""),
+        ("10", "III", "Session Tree", "", ""),
+        ("11", "III", "Compaction", "", ""),
+        ("14", "IV", "Eval", "", ""),
+    ]:
+        rows += f'<text x="48" y="{y}" class="svg-micro" fill="#1f5c8c">cp {cp}</text>'
+        rows += f'<text x="100" y="{y}" class="svg-body">{title}</text>'
+        rows += f'<line x1="90" y1="{y-4}" x2="680" y2="{y-4}" stroke="#ebe5d8"/>'
+        y += 32
+    inner = f"""
+  <text x="24" y="24" class="svg-label">pi-textbook · 15 checkpoints → production pi-mono</text>
+  {rows}
+  <text x="360" y="250" text-anchor="middle" class="svg-mute">each checkpoint = one testable abstraction layer</text>
+"""
+    return fig(
+        "pi-textbook 15 checkpoint 与生产代码的映射关系（节选）。",
+        "pi-textbook 15 checkpoints mapped to production code (excerpt).",
+        f'<div class="pi-fig">{svg_wrap(inner, "0 0 720 270")}</div>',
+    )
+
+
+def viz_event_swimlane() -> str:
+    lanes = [("user", "#b35a1f", 40), ("model", "#1f5c8c", 140), ("loop", "#6b3aa3", 240), ("tool", "#2d6a4f", 340)]
+    inner = '<text x="24" y="22" class="svg-label">AgentEvent swimlane · README through-line</text>'
+    for name, color, y in lanes:
+        inner += f'<text x="24" y="{y+16}" class="svg-micro" fill="{color}">{name}</text>'
+        inner += f'<line x1="70" y1="{y+12}" x2="700" y2="{y+12}" stroke="#ebe5d8"/>'
+    events = [
+        (90, 40, "user_message"),
+        (160, 140, "model_start"),
+        (230, 140, "assistant toolUse"),
+        (300, 240, "tool_start"),
+        (370, 340, "tool_result"),
+        (440, 140, "model_start"),
+        (510, 140, "assistant stop"),
+    ]
+    for x, y, label in events:
+        inner += f'<rect x="{x}" y="{y}" width="56" height="24" rx="2" fill="#faf6ed" stroke="#c7c4ba"/>'
+        inner += f'<text x="{x+28}" y="{y+16}" text-anchor="middle" class="svg-micro">{label[:10]}</text>'
+    return fig(
+        "事件泳道图：同一主线在 user/model/loop/tool 四条泳道上的时序。",
+        "Event swimlane: through-line timing across user/model/loop/tool lanes.",
+        f'<div class="pi-fig wide">{svg_wrap(inner, "0 0 720 400")}</div>',
+    )
+
+
+def viz_turn_step() -> str:
+    inner = """
+  <text x="360" y="28" text-anchor="middle" class="svg-label">TURN · STEP · ReactLoopAgent</text>
+  <rect x="40" y="50" width="640" height="72" rx="4" class="svg-box accent"/>
+  <text x="360" y="78" text-anchor="middle" class="svg-body">turn/start → claim inbox → agent/pre-step</text>
+  <text x="360" y="98" text-anchor="middle" class="svg-mute">0..N steps per turn · reject closes turn with no step</text>
+  <rect x="80" y="140" width="560" height="100" rx="4" fill="#fde8e4" stroke="#c3573a" stroke-width="1.5"/>
+  <text x="360" y="168" text-anchor="middle" class="svg-body">step/start → user/message → deriveMessages</text>
+  <text x="360" y="188" text-anchor="middle" class="svg-body">llm/stream → assistant/chunk* → tool/call* → step/end</text>
+  <text x="360" y="208" text-anchor="middle" class="svg-mute">one model request + its tool batch</text>
+  <path d="M360 122 L360 140" stroke="#1f5c8c" stroke-width="2" marker-end="url(#pi-arr)"/>
+  <path d="M360 240 L360 258" stroke="#1f5c8c" stroke-width="2" marker-end="url(#pi-arr)"/>
+  <text x="360" y="278" text-anchor="middle" class="svg-mute">tools owe another request → next step · else turn/end</text>
+"""
+    return fig(
+        "Turn/Step 双环：外环 turn 管理 inbox 与 turn/end；内环 step 承载一次 llm/stream + 工具批次。",
+        "Turn/step twin loops: outer turn manages inbox and turn/end; inner step holds one llm/stream + tool batch.",
+        f'<div class="pi-fig">{svg_wrap(inner, "0 0 720 290")}</div>',
+    )
+
+
+def viz_cordis_layers() -> str:
+    layers = [
+        ("L6", "Profile patch", "cordis.patch.yml", "#b35a1f"),
+        ("L5", "dsh-web-app", "browser surface", "#3873a3"),
+        ("L4", "dsh-base", "core plugin rows", "#1f5c8c"),
+        ("L3", "Home patch", "$DSH_HOME/cordis.patch.yml", "#6b3aa3"),
+        ("L2", "--patch", "CLI overlay", "#767c87"),
+        ("L1", "empty root", "entry list []", "#2d6a4f"),
+    ]
+    inner = '<text x="48" y="28" class="svg-label">Profile × Bundle × Patch · boot composition</text>'
+    y = 48
+    for label, name, detail, color in layers:
+        inner += f'<rect x="120" y="{y}" width="480" height="32" rx="3" fill="{color}" opacity="0.12" stroke="{color}"/>'
+        inner += f'<text x="140" y="{y+20}" class="svg-body">{label} · {name}</text>'
+        inner += f'<text x="520" y="{y+20}" text-anchor="end" class="svg-mute">{detail}</text>'
+        y += 38
+    inner += '<text x="360" y="290" text-anchor="middle" class="svg-mute">dsh --profile web --dump-config prints the merged tree</text>'
+    return fig(
+        "Cordis 配置层：Bundle 按序 insert，Profile/Home/--patch 按 id 整行覆盖。",
+        "Cordis config layers: bundles insert in order; profile/home/--patch replace whole rows by id.",
+        f'<div class="pi-fig">{svg_wrap(inner, "0 0 720 310")}</div>',
+    )
+
+
+def viz_session_log() -> str:
+    inner = """
+  <text x="48" y="28" class="svg-label">SessionEvent log · append-only · model-visible means logged</text>
+  <rect x="48" y="44" width="624" height="180" rx="4" class="svg-box paper"/>
+  <text x="64" y="68" class="svg-micro">turn/start</text>
+  <text x="64" y="88" class="svg-micro">step/start</text>
+  <text x="64" y="108" class="svg-micro">user/message · 「读取 README.md…」</text>
+  <text x="64" y="128" class="svg-micro">assistant/chunk* · streaming tokens</text>
+  <text x="64" y="148" class="svg-micro">tool/call · read(path=README.md)</text>
+  <text x="64" y="168" class="svg-micro">tool/result · fixture content</text>
+  <text x="64" y="188" class="svg-micro">assistant/message · stop</text>
+  <text x="64" y="208" class="svg-micro">step/end · turn/end</text>
+  <path d="M520 80 L620 80 L620 180 L520 180" fill="none" stroke="#1f5c8c" stroke-width="1.5" stroke-dasharray="4 2"/>
+  <text x="570" y="132" text-anchor="middle" class="svg-body">deriveMessages()</text>
+  <text x="570" y="152" text-anchor="middle" class="svg-mute">projection</text>
+"""
+    return fig(
+        "SessionEvent 日志：唯一真相源；deriveMessages() 把日志投影成 LLM Message[]。",
+        "SessionEvent log: single source of truth; deriveMessages() projects log to LLM Message[].",
+        f'<div class="pi-fig wide">{svg_wrap(inner, "0 0 720 250")}</div>',
+    )
+
+
+def viz_plugin_spectrum() -> str:
+    inner = """
+  <text x="24" y="28" class="svg-label">DSH PLUGIN ECOSYSTEM</text>
+  <rect x="24" y="44" width="160" height="56" rx="4" class="svg-box accent"/>
+  <text x="104" y="68" text-anchor="middle" class="svg-body">core/*</text>
+  <text x="104" y="86" text-anchor="middle" class="svg-mute">session · loop</text>
+  <rect x="200" y="44" width="160" height="56" rx="4" class="svg-box gpu"/>
+  <text x="280" y="68" text-anchor="middle" class="svg-body">capability</text>
+  <text x="280" y="86" text-anchor="middle" class="svg-mute">fs · shell · mcp</text>
+  <rect x="376" y="44" width="160" height="56" rx="4" class="svg-box copper"/>
+  <text x="456" y="68" text-anchor="middle" class="svg-body">bundle</text>
+  <text x="456" y="86" text-anchor="middle" class="svg-mute">base · web · headless</text>
+  <rect x="552" y="44" width="144" height="56" rx="4" class="svg-box muted"/>
+  <text x="624" y="68" text-anchor="middle" class="svg-body">community</text>
+  <text x="624" y="86" text-anchor="middle" class="svg-mute">npm · git patch</text>
+  <text x="360" y="140" text-anchor="middle" class="svg-mute">everything mounts through Cordis · no privileged core</text>
+"""
+    return fig(
+        "插件光谱：core 脊柱、capability seam、官方 bundle、社区 npm/git 包共享同一 Cordis 树。",
+        "Plugin spectrum: core spine, capability seams, official bundles, community npm/git packages share one Cordis tree.",
+        f'<div class="pi-fig wide">{svg_wrap(inner, "0 0 720 160")}</div>',
+    )
+
+
+def viz_event_domains() -> str:
+    inner = """
+  <rect x="40" y="50" width="200" height="120" rx="4" fill="#1f5c8c" opacity="0.1" stroke="#1f5c8c"/>
+  <text x="140" y="78" text-anchor="middle" class="svg-label">session/*</text>
+  <text x="140" y="100" text-anchor="middle" class="svg-body">durable replay</text>
+  <text x="140" y="120" text-anchor="middle" class="svg-mute">turn/start · user/message</text>
+  <text x="140" y="140" text-anchor="middle" class="svg-mute">tool/result · session/event</text>
+  <rect x="260" y="50" width="200" height="120" rx="4" fill="#c3573a" opacity="0.1" stroke="#c3573a"/>
+  <text x="360" y="78" text-anchor="middle" class="svg-label">agent/*</text>
+  <text x="360" y="100" text-anchor="middle" class="svg-body">live coordination</text>
+  <text x="360" y="120" text-anchor="middle" class="svg-mute">pre-step · request</text>
+  <text x="360" y="140" text-anchor="middle" class="svg-mute">inbox · status</text>
+  <rect x="480" y="50" width="200" height="120" rx="4" fill="#2d6a4f" opacity="0.1" stroke="#2d6a4f"/>
+  <text x="580" y="78" text-anchor="middle" class="svg-label">capability/*</text>
+  <text x="580" y="100" text-anchor="middle" class="svg-body">policy seams</text>
+  <text x="580" y="120" text-anchor="middle" class="svg-mute">tools/* · fs/*</text>
+  <text x="580" y="140" text-anchor="middle" class="svg-mute">telemetry/*</text>
+"""
+    return fig(
+        "三事件域：session 可回放事实、agent 运行中协调、capability 策略接缝互不 import 循环。",
+        "Three event domains: session replay facts, agent live coordination, capability policy seams.",
+        f'<div class="pi-fig wide">{svg_wrap(inner, "0 0 720 200")}</div>',
+    )
+
+
+def viz_harness_compare() -> str:
+    inner = """
+  <text x="360" y="24" text-anchor="middle" class="svg-label">HARNESS COMPARISON · README through-line</text>
+  <text x="120" y="52" text-anchor="middle" class="svg-micro">Claude Code</text>
+  <text x="280" y="52" text-anchor="middle" class="svg-micro">Cursor</text>
+  <text x="440" y="52" text-anchor="middle" class="svg-micro">Pi</text>
+  <text x="600" y="52" text-anchor="middle" class="svg-micro" font-weight="700">DSH</text>
+  <rect x="40" y="60" width="640" height="8" rx="4" fill="#c7c4ba" opacity="0.5"/>
+  <circle cx="120" cy="64" r="10" fill="#767c87"/>
+  <circle cx="280" cy="64" r="10" fill="#767c87"/>
+  <circle cx="440" cy="64" r="10" fill="#1f5c8c"/>
+  <circle cx="600" cy="64" r="14" fill="#2d6a4f" stroke="#15171c" stroke-width="2"/>
+  <text x="360" y="110" text-anchor="middle" class="svg-body">DSH = Cordis composability + SessionEvent log + MCP/subagent/compaction</text>
+  <text x="360" y="132" text-anchor="middle" class="svg-mute">sealed products optimize UX · harnesses optimize traceability</text>
+"""
+    return fig(
+        "Harness 对比光谱：DSH 在可组合性与可观测性轴上最靠右，同时保留 MCP 与子 agent。",
+        "Harness comparison: DSH sits furthest on composability and traceability while keeping MCP and subagents.",
+        f'<div class="pi-fig wide">{svg_wrap(inner, "0 0 720 150")}</div>',
+    )

--- a/scripts/generate-dsh-immersive.py
+++ b/scripts/generate-dsh-immersive.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Generate DeepSeek Harness immersive HTML article."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+PKG = ROOT / "dsh_immersive"
+sys.path.insert(0, str(PKG))
+
+from chapters import build_all_chapters  # noqa: E402
+from deep_dive import deepen  # noqa: E402
+from expand import expand_chapter  # noqa: E402
+from meta import CHAPTERS  # noqa: E402
+from overview import forest_overview_section  # noqa: E402
+from section_num import number_body_sections  # noqa: E402
+from shell import (  # noqa: E402
+    chapter_section,
+    filmstrip_nav,
+    footer,
+    head,
+    hero,
+    interactive_footer,
+    lang_toggle_and_back,
+    scripts,
+    side_toc,
+    toc_v2,
+)
+
+OUT = Path(__file__).resolve().parents[1] / "public/immersive/dsh/index.html"
+
+
+def generate() -> str:
+    chapters = build_all_chapters()
+    parts = [
+        head(),
+        lang_toggle_and_back(),
+        filmstrip_nav(),
+        side_toc(),
+        '<div class="container">',
+        hero(),
+        toc_v2(),
+        forest_overview_section(),
+    ]
+    for cid, *_ in CHAPTERS:
+        ch_num = next(c[1] for c in CHAPTERS if c[0] == cid)
+        body = number_body_sections(ch_num, deepen(cid, expand_chapter(cid, chapters[cid])))
+        parts.append(chapter_section(cid, body))
+    parts.extend([
+        footer(),
+        "</div>",
+        scripts(),
+        interactive_footer(),
+        "</body>\n</html>",
+    ])
+    return "\n\n".join(parts)
+
+
+def main() -> None:
+    OUT.parent.mkdir(parents=True, exist_ok=True)
+    html = generate()
+    OUT.write_text(html, encoding="utf-8")
+    lines = html.count("\n") + 1
+    print(f"Wrote {OUT}")
+    print(f"Lines: {lines}")
+    print(f"Bytes: {OUT.stat().st_size}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/content/notes/dsh.mdx
+++ b/src/content/notes/dsh.mdx
@@ -1,0 +1,20 @@
+---
+title: "一条用户消息在 DeepSeek Harness 里的一生 —— 从回车到 SessionEvent 的 26 站"
+date: "2026-08-23"
+tags: [DSH, DeepSeek, Harness, Cordis, Agent, 源码阅读]
+public: true
+summary: 你在 Web UI 敲下「读取 README.md，用一句话告诉我这个项目做什么」之后，这串文字要穿过 26 道工序、跨 Cordis 插件树与 core spine，在 SessionEvent 日志里变形，最后才变成流式 chunk 与磁盘上的 session log。对照 deepseek-harness 生产源码，把 turn/step、agent/pre-step、deriveMessages 不变量全摊开。
+immersive:
+  url: /immersive/dsh/
+  label: 沉浸式
+---
+
+> 这是一篇沉浸式长文，建议在专属页面阅读 → [进入完整版](/immersive/dsh/)
+
+这是 Field Note 系列的第十一篇。姐妹篇是 [《一条用户消息在 Pi Agent 里的一生》](/immersive/pi-agent/)（同一主线 prompt，对照 Pi 的 runLoop 双环）和 [《一次 LLM 推理的一生》](/immersive/llm-inference-life/)。本篇聚焦 **DeepSeek Harness（DSH）**——「一切皆插件」的 Cordis 组合式 agent harness。
+
+### 主线：读取 README.md，用一句话告诉我这个项目做什么
+
+与 Pi 沉浸式文章使用相同 prompt，便于横向对照两种 harness 哲学。
+
+完整阅读：**[一条用户消息在 DeepSeek Harness 里的一生 — 26 站源码全景](/immersive/dsh/)**

--- a/src/content/notes/en/dsh.mdx
+++ b/src/content/notes/en/dsh.mdx
@@ -1,0 +1,16 @@
+---
+title: "The Life of a User Message Inside DeepSeek Harness — 26 Stations from Enter to SessionEvent"
+date: "2026-08-23"
+tags: [DSH, DeepSeek, Harness, Cordis, Agent, source reading]
+public: true
+summary: After you type «read README.md and tell me what this project does in one sentence», that string passes through 26 stations across the Cordis plugin tree and core spine, morphs in the SessionEvent log, and only then becomes streaming chunks and durable session events. Cross-reading deepseek-harness production source — turn/step, agent/pre-step, deriveMessages invariant laid bare.
+immersive:
+  url: /immersive/dsh/
+  label: Immersive
+---
+
+> Read the full immersive article → [open complete version](/immersive/dsh/)
+
+Eleventh in the Field Note series. Sister piece: [The Life of a User Message Inside Pi Agent](/immersive/pi-agent/) (same through-line prompt, Pi's runLoop twin loops). This one focuses on **DeepSeek Harness (DSH)** — Cordis-composable «everything is a plugin» agent harness.
+
+**Full read:** [The Life of a User Message Inside DeepSeek Harness — 26-station source panorama](/immersive/dsh/)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

新增 **DeepSeek Harness (DSH)** 沉浸式技术长文，结构与 Pi Agent 文章同构：26 章、同一主线 prompt、森林图 + compass 导航、心脏区 SOURCE TRACE。

### 访问路径
- 沉浸式页面：`/immersive/dsh/`
- Field Note #11：`/notes/dsh/`

### 内容结构
| Phase | 章节 | 主题 |
|---|---|---|
| 引子 | C01–02 | Harness ≠ Product · turn/step 全景 |
| 背景 | C03–05 | Cordis · core spine · 一切皆插件 |
| 入口 | C06–08 | dsh web 启动 · ctx.agents · system-prompt |
| 心脏 | C09–13 | Session log · ReactLoopAgent · pre-step · tools · 三域事件 |
| LLM | C14–16 | ctx.llm · assistant/chunk · deriveMessages |
| Web | C17–18 | ctx.web · tool-web |
| 扩展 | C19–21 | Cordis 插件 · bundle · patch |
| 持久化 | C22–23 | SessionEvent JSONL · compaction |
| 全景 | C24–25 | vs Pi · JSON-RPC/profiles |
| Coda | C26 | 自己 trace 一轮 |

### 技术实现
- 生成器：`scripts/generate-dsh-immersive.py` + `scripts/dsh_immersive/*`
- SOURCE TRACE：从 `/tmp/deepseek-harness` 嵌入 C09–C16 真实源码（心脏区 c10 ~31k、c12 ~41k 字符）
- 文档交叉引用：`doc_map.py` → `docs/architecture.md` 等官方文档

### 体量
- **~585 KB / 6,967 行** HTML
- 与 Pi 文章使用相同主线 prompt，便于横向对照 runLoop 双环 vs turn/step

## Testing
- `python3 scripts/generate-dsh-immersive.py` ✓
- `npm run build` ✓
- 浏览器验证 `/immersive/dsh/` 标题、C10/C14 章节 ✓

[DSH immersive hero](https://cursor.com/agents/bc-01a029c8-9f11-7081-af9b-7378a9e90695/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdsh_immersive_hero.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a029c8-9f11-7081-af9b-7378a9e90695?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a029c8-9f11-7081-af9b-7378a9e90695&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

