### PR TITLE
chore(cloud): add cloud-agent dev environment install script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,7 +139,10 @@ Pagefind、Cal.com 等第三方库动态注入的 DOM 不带 Astro 的 `data-ast
 ## Cursor Cloud specific instructions
 
 Dev scope is the root **Astro static site** (个人主页/blog). Dependencies are refreshed
-automatically on VM startup via the update script (`npm ci`), so no manual install is needed.
+automatically by the environment `install` step (`scripts/cloud-agent-install.sh`), which runs
+`npm ci` at the repo root and best-effort sets up the `blog-server` backend (see below), so no
+manual install is needed. The script is idempotent and mirrors the dashboard `install` command;
+keep the two in sync when changing setup behaviour.
 
 - **Dev server**: `npx astro dev --host 0.0.0.0 --port 4321`. Serves homepage + blog +
   content-collection posts/notes. No secrets required for the site to boot.
@@ -160,9 +163,12 @@ automatically on VM startup via the update script (`npm ci`), so no manual insta
 ### Backend (blog-api) — full-stack dev
 
 `services/` is a git submodule of the private repo `airingursb/blog-server` (SSH URL, so
-`git submodule update` won't work here). The update script clones it via the authenticated
-`gh` CLI, runs `npm ci` inside `services/blog-api`, and writes a local `services/blog-api/.env`
-with a generated `HMAC_SECRET` (that `.env` is gitignored and regenerated per fresh VM).
+`git submodule update` won't work here). `scripts/cloud-agent-install.sh` clones it via the
+authenticated `gh` CLI, runs `npm ci` inside `services/blog-api`, and writes a local
+`services/blog-api/.env` with a generated `HMAC_SECRET` (that `.env` is gitignored and
+regenerated per fresh VM). This backend setup is **best-effort**: if the build/agent token
+lacks access to the private repo, the step is skipped (non-fatal) and the environment remains a
+usable site-only checkout.
 
 - **Run backend**: `cd services/blog-api && npm run dev` (= `node --watch server.js`),
   listens on `http://localhost:3000`. Only `HMAC_SECRET` is required to boot; everything else

--- a/scripts/cloud-agent-install.sh
+++ b/scripts/cloud-agent-install.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# Cloud Agent install script for the ursb.me Astro site.
+#
+# Primary dev scope is the root Astro static site, so `npm ci` at the repo root
+# is the required step. The private blog-server backend (mounted at services/ via
+# an SSH submodule) is set up best-effort through the authenticated gh CLI so
+# full-stack work is possible when the token has access — but a failure there is
+# never fatal, keeping the environment usable as a site-only checkout.
+#
+# Idempotent: safe to re-run. This mirrors the environment's dashboard `install`
+# command; keep the two in sync when changing setup behaviour.
+
+set -uo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "[cloud-install] node $(node -v), npm $(npm -v)"
+
+echo "[cloud-install] installing root dependencies (npm ci)…"
+npm ci || exit 1
+
+if [ -f services/blog-api/package.json ]; then
+  echo "[cloud-install] services/blog-api present; refreshing backend deps…"
+  (cd services/blog-api && npm ci) || echo "[cloud-install] blog-api deps failed (non-fatal)"
+elif command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1 && rm -rf services && gh repo clone airingursb/blog-server services -- --depth 1; then
+  echo "[cloud-install] cloned blog-server; installing backend deps…"
+  (cd services/blog-api && npm ci) || echo "[cloud-install] blog-api deps failed (non-fatal)"
+  if [ ! -f services/blog-api/.env ]; then
+    echo "[cloud-install] writing services/blog-api/.env (dev defaults)…"
+    printf 'HMAC_SECRET=%s\nPORT=3000\nTRUST_PROXY=true\nALLOWED_ORIGINS=%s\n' \
+      "$(openssl rand -hex 32)" \
+      "https://ursb.me,https://www.ursb.me,https://airingursb.github.io,http://localhost:8111,http://localhost:4321,http://localhost:4322,http://localhost:4323" \
+      > services/blog-api/.env
+  fi
+else
+  echo "[cloud-install] blog-api backend unavailable (no gh access); continuing site-only"
+fi
+
+echo "[cloud-install] done."
+exit 0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the dashboard-managed Cloud Agent development environment so dependencies are actually installed on boot. The environment previously booted with an **empty `node_modules` and empty `services/`** (no user `install` step ran in the environment build), contradicting the documented behavior in `AGENTS.md`.

This PR adds a version-controlled, idempotent install script that mirrors the environment's `install` command, plus doc updates. The dashboard environment config itself is updated separately via the env-setup propose/Save flow (install/start scripts live in the DB config, not the repo) — a proposal has been recorded against a validated build for the owner to Save.

## Changes

- **`scripts/cloud-agent-install.sh`** (new): idempotent install script
  - `npm ci` at the repo root — the primary Astro static-site dev scope (required, fatal on failure)
  - Best-effort backend setup: clone the private `airingursb/blog-server` submodule via the authenticated `gh` CLI (the submodule uses an SSH URL, so `git submodule update` can't fetch it), `npm ci` in `services/blog-api`, and generate a dev `services/blog-api/.env` with a per-VM `HMAC_SECRET` + localhost CORS allowlist. **Non-fatal** — if the token lacks access to the private repo, the step is skipped and the env remains a usable site-only checkout.
- **`AGENTS.md`**: reference the new script and document that backend setup is best-effort.

## Validation

Validated locally on this VM and again on a **fresh Cloud Agent booted from the tested build** `bld-20260903-0d0e33f7-d9ce-473f-bef3-7ebac4fe3fc8` (built off `master`, promotable):

| Check | Fresh Cloud Agent result |
| --- | --- |
| Git branch | `master` |
| `node` / `npm` | v22.14.0 / 10.9.7 |
| Root `node_modules` | 583 entries (baked in) |
| Backend | `services/blog-api` cloned, 82 deps, `.env` with `HMAC_SECRET` present |
| `npm test` | 147 pass / 0 fail (exit 0) |
| `npm run build` | Complete — 355 pages, Pagefind indexed 159 pages (exit 0) |
| `astro dev` homepage | `GET /` → HTTP 200 |
| blog-api `/health` | `{"status":"ok",...}` |

The proposed dashboard `install` is self-contained (depends only on `package-lock.json` already on `master`), so the validated build is promotable. It is recorded as a proposal for the environment owner to review and Save.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fa7d8e57-d5d7-4308-a740-a22825197460?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa7d8e57-d5d7-4308-a740-a22825197460&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

