### PR TITLE
缩小语言切换高度，滚动离开首屏时渐隐语言/暗色切换

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -199,6 +199,33 @@ const description = rawDescription || "Airing's Homepage - Software Engineer @ S
         }
       });
       updateModeIcon();
+
+      // Fade lang toggle + dark-mode icon when leaving the first screen
+      var chromeEls = [];
+      var langToggle = document.getElementById('langToggle');
+      if (langToggle) chromeEls.push(langToggle);
+      if (switcher) chromeEls.push(switcher);
+      if (chromeEls.length) {
+        var away = false;
+        var hideAt = 0.4;  // hide after scrolling ~40% of viewport
+        var showAt = 0.25; // re-show only when back near top of first screen
+        function updateChromeFade() {
+          var vh = window.innerHeight || 800;
+          var y = window.scrollY || window.pageYOffset || 0;
+          var next = away
+            ? (y > vh * showAt)
+            : (y > vh * hideAt);
+          if (next === away) return;
+          away = next;
+          for (var i = 0; i < chromeEls.length; i++) {
+            chromeEls[i].classList.toggle('is-away', away);
+            chromeEls[i].setAttribute('aria-hidden', away ? 'true' : 'false');
+          }
+        }
+        window.addEventListener('scroll', updateChromeFade, { passive: true });
+        window.addEventListener('resize', updateChromeFade);
+        updateChromeFade();
+      }
     })();
   </script>
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -50,6 +50,12 @@
       display: flex;
       align-items: center;
       gap: 8px;
+      transition: opacity 0.4s ease, visibility 0.4s ease;
+    }
+    .theme-switcher.is-away {
+      opacity: 0;
+      visibility: hidden;
+      pointer-events: none;
     }
     .mode-toggle {
       width: 36px; height: 36px;
@@ -2971,13 +2977,21 @@
       top: max(16px, env(safe-area-inset-top));
       right: max(16px, env(safe-area-inset-right));
       display: flex;
-      gap: 4px;
-      padding: 4px;
-      font-size: 12px;
+      gap: 2px;
+      padding: 2px;
+      font-size: 11px;
       z-index: 100;
       background: var(--c-bg-alt);
       border: 1px solid var(--c-border);
-      border-radius: 8px;
+      border-radius: 6px;
+      transition: opacity 0.4s ease, visibility 0.4s ease;
+      line-height: 1.2;
+    }
+
+    .lang-toggle.is-away {
+      opacity: 0;
+      visibility: hidden;
+      pointer-events: none;
     }
 
     .lang-toggle button {
@@ -2985,14 +2999,15 @@
       border: none;
       color: var(--c-text-muted);
       font-family: inherit;
-      font-size: 12px;
+      font-size: 11px;
       font-weight: 600;
-      min-width: 36px;
-      min-height: 36px;
+      min-width: 28px;
+      min-height: 22px;
       padding: 0 8px;
       border-radius: 4px;
       cursor: pointer;
       transition: color 0.2s, background 0.2s;
+      line-height: 1.2;
     }
 
     .lang-toggle button:hover {
@@ -3012,12 +3027,16 @@
 
     @media (pointer: coarse) {
       .lang-toggle button {
-        min-width: 44px;
-        min-height: 44px;
+        min-width: 36px;
+        min-height: 32px;
       }
     }
 
     @media (prefers-reduced-motion: reduce) {
+      .lang-toggle,
+      .theme-switcher {
+        transition: none;
+      }
       .lang-toggle button { transition: none; }
     }
 

--- a/tests/checklist.md
+++ b/tests/checklist.md
@@ -383,6 +383,7 @@
 - [ ] DOM: `#modeToggle` 存在（明暗切换）
 - [ ] DOM: `#themeToggle` 存在（主题色切换）
 - [ ] 点击 `#modeToggle`，`<html>` 的 `data-mode` 属性变化
+- [ ] Scroll: 离开首屏后 `#themeSwitcher` 渐隐，回到首屏渐显（与首页 `#langToggle` 同步）
 
 ## Post Detail — Code Blocks (`/posts/js-string-to-number/`, `/posts/case-sensitivity/`)
 

--- a/tests/checklist.md
+++ b/tests/checklist.md
@@ -16,7 +16,9 @@
 ## Homepage (`/`)
 
 - [ ] Screenshot/CSS: 375 / 768 / 1280px 下右上角 EN/CN 切换器随明暗模式切换，使用细边框、柔和选中底色，无固定深色背景或重阴影；不遮挡小熊，不产生横向溢出。
-- [ ] Click/Keyboard: EN/CN 双向切换且刷新后保留；Tab 焦点清晰，Enter/Space 可操作；触屏按钮至少 44×44px，减少动态效果偏好下无过渡。
+- [ ] Screenshot/CSS: EN/CN 切换器高度偏矮（按钮约 22–28px 高，触屏约 32px），不过于显眼。
+- [ ] Click/Keyboard: EN/CN 双向切换且刷新后保留；Tab 焦点清晰，Enter/Space 可操作；减少动态效果偏好下无过渡。
+- [ ] Scroll: 离开首屏（约滚动超过 40% 视口高度）后，`#langToggle` 与 `#themeSwitcher`（暗色模式 icon）渐隐；滚回首屏（约 25% 视口内）再渐显；渐隐期间 `pointer-events: none`。
 
 - [ ] Screenshot/CSS: `/blog/` 和 `/en/blog/` 手机端仅缩写星期（如 TUE），保留完整月份、日、年；375 / 393 / 768px 下日期与文章数、在读人数、语言切换同一行完整显示；320px 空间不足可整组换行；1280px 保留完整星期，无文字拆分或横向溢出。
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- 降低首页右上角 EN/CN 语言切换器高度（桌面按钮约 22px，整体约 28px），减少视觉抢眼
- 离开首屏后，语言切换与右下角暗色模式 icon 同步渐隐；滚回首屏再渐显
- 更新 `tests/checklist.md` 对应验收条目

## Test plan
- [x] `npm run build` 成功
- [x] Playwright（390×844 light）：首屏高度 28px；滚动后两者 `is-away` + opacity 0；回顶恢复
- [x] 截图/录屏验证渐隐

### Evidence
[首屏：矮语言切换 + 暗色 icon 可见](https://cursor.com/agents/bc-4a1d8a88-c066-4ed5-a4b7-f62150972479/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flang_toggle_top_visible.png)
[滚动后两者已渐隐](https://cursor.com/agents/bc-4a1d8a88-c066-4ed5-a4b7-f62150972479/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flang_toggle_scrolled_faded.png)
[暗色 icon 首屏裁剪](https://cursor.com/agents/bc-4a1d8a88-c066-4ed5-a4b7-f62150972479/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftheme_icon_top.png)
[暗色 icon 滚动后裁剪为空](https://cursor.com/agents/bc-4a1d8a88-c066-4ed5-a4b7-f62150972479/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftheme_icon_scrolled.png)
[lang_theme_scroll_fade_demo_clean.mp4](https://cursor.com/agents/bc-4a1d8a88-c066-4ed5-a4b7-f62150972479/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flang_theme_scroll_fade_demo_clean.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4a1d8a88-c066-4ed5-a4b7-f62150972479?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a1d8a88-c066-4ed5-a4b7-f62150972479&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

